### PR TITLE
Update READMEs with new maven central link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,15 @@
 
 [![Build Status](https://travis-ci.org/ExpediaGroup/graphql-kotlin.svg?branch=master)](https://travis-ci.org/ExpediaGroup/graphql-kotlin)
 [![codecov](https://codecov.io/gh/ExpediaGroup/graphql-kotlin/branch/master/graph/badge.svg)](https://codecov.io/gh/ExpediaGroup/graphql-kotlin)
-[![Maven Central](https://img.shields.io/maven-central/v/com.expediagroup/graphql-kotlin.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22com.expediagroup%22%20AND%20a:%22graphql-kotlin%22)
 [![Awesome Kotlin Badge](https://kotlin.link/awesome-kotlin.svg)](https://github.com/KotlinBy/awesome-kotlin)
 
 GraphQL Kotlin consists of number of libraries that aim to simplify GraphQL integration for Kotlin applications.
 
 ## 📦 Modules
 
-* [graphql-kotlin-federation](/graphql-kotlin-federation) - Schema generator extension to build federated GraphQL schemas
 * [graphql-kotlin-schema-generator](/graphql-kotlin-schema-generator) - Code only GraphQL schema generation for Kotlin
-* [examples/spring](/examples/spring) - Example SpringBoot app that uses GraphQL Kotlin schema generator
-* [examples/federation](/examples/federation) - Example Federation module with multiple SpringBoot apps that use GraphQL Kotlin federation generator
+* [graphql-kotlin-federation](/graphql-kotlin-federation) - Schema generator extension to build federated GraphQL schemas
+* [examples](/examples) - Example apps that use graphql-kotlin libraries to test and demonstrate usages
 
 ## 📋 Documentation
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/ExpediaGroup/graphql-kotlin.svg?branch=master)](https://travis-ci.org/ExpediaGroup/graphql-kotlin)
 [![codecov](https://codecov.io/gh/ExpediaGroup/graphql-kotlin/branch/master/graph/badge.svg)](https://codecov.io/gh/ExpediaGroup/graphql-kotlin)
-[![Maven Central](https://img.shields.io/maven-central/v/com.expedia/graphql-kotlin.svg?label=maven%20central)](https://search.maven.org/artifact/com.expedia/graphql-kotlin)
+[![Maven Central](https://img.shields.io/maven-central/v/com.expediagroup/graphql-kotlin.svg?label=maven%20central)](https://search.maven.org/artifact/com.expediagroup/graphql-kotlin)
 [![Awesome Kotlin Badge](https://kotlin.link/awesome-kotlin.svg)](https://github.com/KotlinBy/awesome-kotlin)
 
 GraphQL Kotlin consists of number of libraries that aim to simplify GraphQL integration for Kotlin applications.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/ExpediaGroup/graphql-kotlin.svg?branch=master)](https://travis-ci.org/ExpediaGroup/graphql-kotlin)
 [![codecov](https://codecov.io/gh/ExpediaGroup/graphql-kotlin/branch/master/graph/badge.svg)](https://codecov.io/gh/ExpediaGroup/graphql-kotlin)
-[![Maven Central](https://img.shields.io/maven-central/v/com.expediagroup/graphql-kotlin.svg?label=maven%20central)](https://search.maven.org/artifact/com.expediagroup/graphql-kotlin)
+[![Maven Central](https://img.shields.io/maven-central/v/com.expediagroup/graphql-kotlin.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22com.expediagroup%22%20AND%20a:%22graphql-kotlin%22)
 [![Awesome Kotlin Badge](https://kotlin.link/awesome-kotlin.svg)](https://github.com/KotlinBy/awesome-kotlin)
 
 GraphQL Kotlin consists of number of libraries that aim to simplify GraphQL integration for Kotlin applications.

--- a/graphql-kotlin-federation/README.md
+++ b/graphql-kotlin-federation/README.md
@@ -1,6 +1,6 @@
 # GraphQL Kotlin Federated Schema Generator
-[![Maven Central](https://img.shields.io/maven-central/v/com.expedia/graphql-kotlin-federation.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22com.expedia%22%20AND%20a:%22graphql-kotlin-federation%22)
-[![Javadocs](https://img.shields.io/maven-central/v/com.expedia/graphql-kotlin-federation.svg?label=javadoc&colorB=brightgreen)](https://www.javadoc.io/doc/com.expedia/graphql-kotlin-federation)
+[![Maven Central](https://img.shields.io/maven-central/v/com.expediagroup/graphql-kotlin-federation.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22com.expediagroup%22%20AND%20a:%22graphql-kotlin-federation%22)
+[![Javadocs](https://img.shields.io/maven-central/v/com.expediagroup/graphql-kotlin-federation.svg?label=javadoc&colorB=brightgreen)](https://www.javadoc.io/doc/com.expediagroup/graphql-kotlin-federation)
 
 `graphql-kotlin-federation` extends the functionality of `graphql-kotlin-schema-generator` and allows you to easily generate federated GraphQL schemas directly from the code. Federated schemas rely on a number of directives to instrument the behavior of the underlying graph, see corresponding wiki pages to learn more about new directives. Once all the federated objects are annotated, you will also have to configure corresponding [FederatedTypeResolver]s that are used to instantiate federated objects and finally generate the schema using `toFederatedSchema` function ([link](https://github.com/ExpediaGroup/graphql-kotlin/blob/master/graphql-kotlin-federation/src/main/kotlin/com/expedia/graphql/federation/toFederatedSchema.kt#L18)).
 
@@ -24,7 +24,7 @@ With Maven:
 With Gradle:
 
 ```groovy
-compile(group: 'com.expedia', name: 'graphql-kotlin-federation', version: "$latestVersion")
+compile(group: 'com.expediagroup', name: 'graphql-kotlin-federation', version: "$latestVersion")
 ```
 
 ## Usage

--- a/graphql-kotlin-schema-generator/README.md
+++ b/graphql-kotlin-schema-generator/README.md
@@ -1,6 +1,6 @@
 # GraphQL Kotlin Schema Generator
-[![Maven Central](https://img.shields.io/maven-central/v/com.expedia/graphql-kotlin-schema-generator.svg?label=maven%20central)](https://search.maven.org/artifact/com.expedia/graphql-kotlin-schema-generator)
-[![Javadocs](https://img.shields.io/maven-central/v/com.expedia/graphql-kotlin-schema-generator.svg?label=javadoc&colorB=brightgreen)](https://www.javadoc.io/doc/com.expedia/graphql-kotlin-schema-generator)
+[![Maven Central](https://img.shields.io/maven-central/v/com.expediagroup/graphql-kotlin-schema-generator.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22com.expediagroup%22%20AND%20a:%22graphql-kotlin-schema-generator%22)
+[![Javadocs](https://img.shields.io/maven-central/v/com.expediagroup/graphql-kotlin-schema-generator.svg?label=javadoc&colorB=brightgreen)](https://www.javadoc.io/doc/com.expediagroup/graphql-kotlin-schema-generator)
 
 Most GraphQL libraries require developers to maintain two sources of truth for their GraphQL API: the schema and the corresponding code (data fetchers or resolvers, and types). Given the similarities between Kotlin and GraphQL, such as the ability to define nullable/non-nullable types, a schema can be generated from Kotlin code without any separate schema specification. `graphql-kotlin` builds upon `graphql-java` to allow code-only, or resolver-first, GraphQL services to be built.
 
@@ -25,7 +25,7 @@ With Maven:
 With Gradle:
 
 ```groovy
-compile(group: 'com.expedia', name: 'graphql-kotlin-schema-generator', version: "$latestVersion")
+compile(group: 'com.expediagroup', name: 'graphql-kotlin-schema-generator', version: "$latestVersion")
 ```
 
 ## Usage


### PR DESCRIPTION
Update the maven central badges and javadocs links for each module, also remove the maven central badge for the main README since `graphql-kotlin` is not a published library