### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,6 @@ before_install:
   - if [ ! -z "$GPG_SECRET_KEYS" ]; then echo $GPG_SECRET_KEYS | base64 --decode | $GPG_EXECUTABLE --import; fi
   - if [ ! -z "$GPG_OWNERTRUST" ]; then echo $GPG_OWNERTRUST | base64 --decode | $GPG_EXECUTABLE --import-ownertrust; fi
 
-script:
-  - ./mvnw install
-
 deploy:
   provider: script
   script: .travis/deploy.sh


### PR DESCRIPTION
Remove simple install step and just use default travis commands

https://docs.travis-ci.com/user/languages/java/

Testing this out to figure out why JDK 8 does not include all modules...