### PR TITLE
Mark junit as test scoped dependency

### DIFF
--- a/graphql-kotlin-federation/pom.xml
+++ b/graphql-kotlin-federation/pom.xml
@@ -34,6 +34,7 @@
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
             <version>${junit-jupiter.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Hi, we just noticed that the junit dependency was not marked as test dependency.

What do you think?

best regards
Lars