### PR TITLE
Allow data and errors to be returned with DataFetcherResult

### DIFF
--- a/examples/spring/src/main/kotlin/com/expediagroup/graphql/sample/query/DataAndErrors.kt
+++ b/examples/spring/src/main/kotlin/com/expediagroup/graphql/sample/query/DataAndErrors.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.sample.query
+
+import graphql.ExceptionWhileDataFetching
+import graphql.execution.DataFetcherResult
+import graphql.execution.ExecutionPath
+import graphql.language.SourceLocation
+import org.springframework.stereotype.Component
+
+@Component
+class DataAndErrors : Query {
+
+    fun returnDataAndErrors(): DataFetcherResult<String> {
+        val error = ExceptionWhileDataFetching(ExecutionPath.rootPath(), RuntimeException(), SourceLocation(1, 1))
+        return DataFetcherResult("Hello from data fetcher", listOf(error))
+    }
+}


### PR DESCRIPTION
### :pencil: Description
Kotlin functions can now return a DataFetcherResult instead of just their return type which allows you to modify the errors field with any extra data you need

### :link: Related Issues
Fixes https://github.com/ExpediaGroup/graphql-kotlin/issues/244
Rebase of https://github.com/ExpediaGroup/graphql-kotlin/pull/245
