### PR TITLE
BREAKING CHANGE: Change GraphQLID to only use strings

### DIFF
--- a/examples/spring/src/main/kotlin/com/expediagroup/graphql/sample/query/ScalarQuery.kt
+++ b/examples/spring/src/main/kotlin/com/expediagroup/graphql/sample/query/ScalarQuery.kt
@@ -31,7 +31,7 @@ class ScalarQuery: Query {
     @GraphQLDescription("generates random UUID")
     fun generateRandomUUID() = UUID.randomUUID()
 
-    fun findPersonById(id: Int) = Person(id, "Nelson")
+    fun findPersonById(@GraphQLID id: String) = Person(id, "Nelson")
 }
 
 @Component
@@ -41,7 +41,6 @@ class ScalarMutation : Mutation {
 
 data class Person(
     @GraphQLID
-    val id: Int,
-
+    val id: String,
     val name: String
 )

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/exceptions/InvalidIdTypeException.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/exceptions/InvalidIdTypeException.kt
@@ -21,5 +21,5 @@ import kotlin.reflect.KClass
 /**
  * Throws when the KClass is not one of the supported types for a GraphQLID
  */
-class InvalidIdTypeException(kClass: KClass<*>, types: String)
-    : GraphQLKotlinException("${kClass.simpleName} is not a valid ID type, only $types are accepted")
+class InvalidIdTypeException(kClass: KClass<*>)
+    : GraphQLKotlinException("${kClass.simpleName} is not a valid ID type, only Strings are accepted")

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/ScalarBuilder.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/ScalarBuilder.kt
@@ -20,15 +20,14 @@ import com.expediagroup.graphql.exceptions.InvalidIdTypeException
 import com.expediagroup.graphql.generator.SchemaGenerator
 import com.expediagroup.graphql.generator.TypeBuilder
 import com.expediagroup.graphql.generator.extensions.getKClass
-import com.expediagroup.graphql.generator.extensions.getQualifiedName
 import com.expediagroup.graphql.generator.extensions.safeCast
 import graphql.Scalars
 import graphql.schema.GraphQLScalarType
 import java.math.BigDecimal
 import java.math.BigInteger
-import java.util.UUID
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
+import kotlin.reflect.full.isSubclassOf
 
 internal class ScalarBuilder(generator: SchemaGenerator) : TypeBuilder(generator) {
 
@@ -46,18 +45,14 @@ internal class ScalarBuilder(generator: SchemaGenerator) : TypeBuilder(generator
 
     @Throws(InvalidIdTypeException::class)
     private fun getId(kClass: KClass<*>): GraphQLScalarType? {
-        return if (validIdTypes.contains(kClass)) {
+        return if (kClass.isSubclassOf(String::class)) {
             Scalars.GraphQLID
         } else {
-            val types = validIdTypes.joinToString(prefix = "[", postfix = "]", separator = ", ") {
-                it.getQualifiedName()
-            }
-            throw InvalidIdTypeException(kClass, types)
+            throw InvalidIdTypeException(kClass)
         }
     }
 
     private companion object {
-        private val validIdTypes = listOf(Int::class, String::class, Long::class, UUID::class)
         private val defaultScalarsMap = mapOf(
             Int::class to Scalars.GraphQLInt,
             Long::class to Scalars.GraphQLLong,

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/SchemaGeneratorTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/SchemaGeneratorTest.kt
@@ -323,7 +323,7 @@ class SchemaGeneratorTest {
         val bobChildren = res?.get("children") as? List<Map<String, Any>>
         assertNotNull(bobChildren)
 
-        val firstChild = bobChildren.get(0)
+        val firstChild = bobChildren.first()
         assertEquals("Alice", firstChild["name"])
         assertNull(firstChild["children"])
     }
@@ -333,10 +333,7 @@ class SchemaGeneratorTest {
         val schema = toSchema(queries = listOf(TopLevelObject(QueryWithId())), config = testSchemaConfig)
 
         val placeType = schema.getObjectType("PlaceOfIds")
-        assertEquals(Scalars.GraphQLID, (placeType.getFieldDefinition("intId").type as? GraphQLNonNull)?.wrappedType)
-        assertEquals(Scalars.GraphQLID, (placeType.getFieldDefinition("longId").type as? GraphQLNonNull)?.wrappedType)
-        assertEquals(Scalars.GraphQLID, (placeType.getFieldDefinition("stringId").type as? GraphQLNonNull)?.wrappedType)
-        assertEquals(Scalars.GraphQLID, (placeType.getFieldDefinition("uuid").type as? GraphQLNonNull)?.wrappedType)
+        assertEquals(Scalars.GraphQLID, (placeType.getFieldDefinition("id").type as? GraphQLNonNull)?.wrappedType)
     }
 
     @Test
@@ -504,7 +501,7 @@ class SchemaGeneratorTest {
 
     data class Person(val name: String, val children: List<Person>? = null)
 
-    data class PlaceOfIds(@GraphQLID val stringId: String)
+    data class PlaceOfIds(@GraphQLID val id: String)
 
     data class InvalidIds(@GraphQLID val person: Person)
 

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/SchemaGeneratorTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/SchemaGeneratorTest.kt
@@ -504,17 +504,12 @@ class SchemaGeneratorTest {
 
     data class Person(val name: String, val children: List<Person>? = null)
 
-    data class PlaceOfIds(
-        @GraphQLID val intId: String,
-        @GraphQLID val longId: String,
-        @GraphQLID val stringId: String,
-        @GraphQLID val uuid: String
-    )
+    data class PlaceOfIds(@GraphQLID val stringId: String)
 
     data class InvalidIds(@GraphQLID val person: Person)
 
     class QueryWithId {
-        fun query(): PlaceOfIds = PlaceOfIds(42.toString(), 24L.toString(), "42", UUID.randomUUID().toString())
+        fun query(): PlaceOfIds = PlaceOfIds(UUID.randomUUID().toString())
     }
 
     class QueryWithInvalidId {

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/SchemaGeneratorTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/SchemaGeneratorTest.kt
@@ -341,11 +341,9 @@ class SchemaGeneratorTest {
 
     @Test
     fun `SchemaGenerator throws an exception for invalid GraphQLID`() {
-        val exception = assertFailsWith(InvalidIdTypeException::class) {
+        assertFailsWith(InvalidIdTypeException::class) {
             toSchema(queries = listOf(TopLevelObject(QueryWithInvalidId())), config = testSchemaConfig)
         }
-
-        assertEquals("Person is not a valid ID type, only [kotlin.Int, kotlin.String, kotlin.Long, java.util.UUID] are accepted", exception.message)
     }
 
     @Test
@@ -507,16 +505,16 @@ class SchemaGeneratorTest {
     data class Person(val name: String, val children: List<Person>? = null)
 
     data class PlaceOfIds(
-        @GraphQLID val intId: Int,
-        @GraphQLID val longId: Long,
+        @GraphQLID val intId: String,
+        @GraphQLID val longId: String,
         @GraphQLID val stringId: String,
-        @GraphQLID val uuid: UUID
+        @GraphQLID val uuid: String
     )
 
     data class InvalidIds(@GraphQLID val person: Person)
 
     class QueryWithId {
-        fun query(): PlaceOfIds = PlaceOfIds(42, 24, "42", UUID.randomUUID())
+        fun query(): PlaceOfIds = PlaceOfIds(42.toString(), 24L.toString(), "42", UUID.randomUUID().toString())
     }
 
     class QueryWithInvalidId {
@@ -568,7 +566,7 @@ class SchemaGeneratorTest {
     }
 
     data class Furniture(
-        @GraphQLID val serial: UUID,
+        @GraphQLID val serial: String,
         val type: String
     )
 

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/ArgumentBuilderTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/ArgumentBuilderTest.kt
@@ -21,6 +21,7 @@ import com.expediagroup.graphql.annotations.GraphQLID
 import com.expediagroup.graphql.annotations.GraphQLName
 import com.expediagroup.graphql.exceptions.InvalidInputFieldTypeException
 import com.expediagroup.graphql.test.utils.SimpleDirective
+import graphql.Scalars
 import graphql.schema.GraphQLNonNull
 import org.junit.jupiter.api.Test
 import kotlin.reflect.full.findParameterByName
@@ -47,7 +48,7 @@ internal class ArgumentBuilderTest : TypeTestHelper() {
 
         fun changeName(@GraphQLName("newName") input: String) = input
 
-        fun id(@GraphQLID idArg: Int) = "Your id is $idArg"
+        fun id(@GraphQLID idArg: String) = "Your id is $idArg"
 
         fun interfaceArg(input: MyInterface) = input.id
     }
@@ -90,7 +91,7 @@ internal class ArgumentBuilderTest : TypeTestHelper() {
         val result = builder.argument(kParameter)
 
         assertEquals(expected = "idArg", actual = result.name)
-        assertEquals("ID", (result.type as? GraphQLNonNull)?.wrappedType?.name)
+        assertEquals(Scalars.GraphQLID, (result.type as? GraphQLNonNull)?.wrappedType)
     }
 
     @Test

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/ScalarBuilderTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/ScalarBuilderTest.kt
@@ -62,9 +62,22 @@ internal class ScalarBuilderTest : TypeTestHelper() {
     @Test
     fun id() {
         verify(Ids::stringID.returnType, Scalars.GraphQLID, true)
-        verify(Ids::intID.returnType, Scalars.GraphQLID, true)
-        verify(Ids::longID.returnType, Scalars.GraphQLID, true)
-        verify(Ids::uuid.returnType, Scalars.GraphQLID, true)
+
+        assertFailsWith(InvalidIdTypeException::class) {
+            verify(Ids::intID.returnType, Scalars.GraphQLID, true)
+        }
+
+        assertFailsWith(InvalidIdTypeException::class) {
+            verify(Ids::longID.returnType, Scalars.GraphQLID, true)
+        }
+
+        assertFailsWith(InvalidIdTypeException::class) {
+            verify(Ids::uuid.returnType, Scalars.GraphQLID, true)
+        }
+
+        assertFailsWith(InvalidIdTypeException::class) {
+            verify(Ids::invalidID.returnType, Scalars.GraphQLID, true)
+        }
 
         assertFailsWith(InvalidIdTypeException::class) {
             verify(Ids::invalidID.returnType, Scalars.GraphQLID, true)


### PR DESCRIPTION
### :pencil: Description
Due to deserialization issues that can happen with UUID, we are only going to support Strings as the explicit type for GraphQLID. You can still use UUID in your data fetchers but you will have to do the parsing yourself and handle the exceptions if it is not a valid UUID.

Example of client input

![Screen Shot 2019-09-17 at 11 37 24 AM](https://user-images.githubusercontent.com/2446877/65069749-2f86ab80-d940-11e9-8458-0cee441612c7.png)


### :link: Related Issues
Fixes https://github.com/ExpediaGroup/graphql-kotlin/issues/317