### PR TITLE
feature: abstract away creation of GraphQL context

### DIFF
--- a/examples/spring/src/main/kotlin/com/expediagroup/graphql/sample/context/MyGraphQLContextFactory.kt
+++ b/examples/spring/src/main/kotlin/com/expediagroup/graphql/sample/context/MyGraphQLContextFactory.kt
@@ -1,0 +1,18 @@
+package com.expediagroup.graphql.sample.context
+
+import com.expediagroup.graphql.spring.execution.GraphQLContextFactory
+import org.springframework.http.server.reactive.ServerHttpRequest
+import org.springframework.http.server.reactive.ServerHttpResponse
+import org.springframework.stereotype.Component
+
+/**
+ * [GraphQLContextFactory] that generates [MyGraphQLContext] that will be available when processing GraphQL requests.
+ */
+@Component
+class MyGraphQLContextFactory: GraphQLContextFactory<MyGraphQLContext> {
+
+    override fun generateContext(request: ServerHttpRequest, response: ServerHttpResponse): MyGraphQLContext = MyGraphQLContext(
+            myCustomValue = request.headers.getFirst("MyHeader") ?: "defaultContext",
+            request = request,
+            response = response)
+}

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/GraphQLAutoConfiguration.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/GraphQLAutoConfiguration.kt
@@ -17,6 +17,11 @@
 package com.expediagroup.graphql.spring
 
 import com.expediagroup.graphql.spring.exception.KotlinDataFetcherExceptionHandler
+import com.expediagroup.graphql.spring.execution.ContextWebFilter
+import com.expediagroup.graphql.spring.execution.EmptyContextFactory
+import com.expediagroup.graphql.spring.execution.GraphQLContextFactory
+import com.expediagroup.graphql.spring.execution.QueryHandler
+import com.expediagroup.graphql.spring.execution.SimpleQueryHandler
 import graphql.GraphQL
 import graphql.execution.AsyncExecutionStrategy
 import graphql.execution.AsyncSerialExecutionStrategy
@@ -31,6 +36,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Import
+import org.springframework.web.server.WebFilter
 import java.util.Optional
 
 /**
@@ -79,4 +85,11 @@ class GraphQLAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean
     fun graphQLQueryHandler(graphql: GraphQL): QueryHandler = SimpleQueryHandler(graphql)
+
+    @Bean
+    @ConditionalOnMissingBean
+    fun graphQLContextFactory(): GraphQLContextFactory<*> = EmptyContextFactory
+
+    @Bean
+    fun contextWebFilter(graphQLContextFactory: GraphQLContextFactory<*>): WebFilter = ContextWebFilter(graphQLContextFactory)
 }

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/RoutesConfiguration.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/RoutesConfiguration.kt
@@ -17,6 +17,7 @@
 package com.expediagroup.graphql.spring
 
 import com.expediagroup.graphql.extensions.print
+import com.expediagroup.graphql.spring.execution.QueryHandler
 import com.expediagroup.graphql.spring.model.GraphQLRequest
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.type.MapType

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/SubscriptionAutoConfiguration.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/SubscriptionAutoConfiguration.kt
@@ -16,6 +16,8 @@
 
 package com.expediagroup.graphql.spring
 
+import com.expediagroup.graphql.spring.execution.SimpleSubscriptionHandler
+import com.expediagroup.graphql.spring.execution.SubscriptionHandler
 import com.expediagroup.graphql.spring.operations.Subscription
 import com.fasterxml.jackson.databind.ObjectMapper
 import graphql.GraphQL

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/execution/GraphQLContextFactory.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/execution/GraphQLContextFactory.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.spring.execution
+
+import graphql.GraphQLContext
+import org.springframework.http.server.reactive.ServerHttpRequest
+import org.springframework.http.server.reactive.ServerHttpResponse
+
+/**
+ * Reactor SubscriberContext key for storing GraphQL context.
+ */
+const val GRAPHQL_CONTEXT_KEY = "graphQLContext"
+
+/**
+ * Factory that generates GraphQL context.
+ */
+interface GraphQLContextFactory<out T : Any> {
+
+    /**
+     * Generate GraphQL context based on the incoming request and the corresponding response.
+     */
+    fun generateContext(request: ServerHttpRequest, response: ServerHttpResponse): T
+}
+
+/**
+ * Default context factory that generates empty GraphQL context.
+ */
+internal object EmptyContextFactory : GraphQLContextFactory<GraphQLContext> {
+
+    override fun generateContext(request: ServerHttpRequest, response: ServerHttpResponse): GraphQLContext = GraphQLContext.newContext().build()
+}

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/execution/QueryHandler.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/execution/QueryHandler.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.expediagroup.graphql.spring
+package com.expediagroup.graphql.spring.execution
 
 import com.expediagroup.graphql.spring.exception.SimpleKotlinGraphQLError
 import com.expediagroup.graphql.spring.model.GraphQLRequest
@@ -26,11 +26,6 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.future.await
 import kotlinx.coroutines.reactor.ReactorContext
 import kotlin.coroutines.coroutineContext
-
-/**
- * Reactor SubscriberContext key for storing GraphQL context.
- */
-const val GRAPHQL_CONTEXT_KEY = "graphQLContext"
 
 /**
  * GraphQL query handler.

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/execution/SubscriptionHandler.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/execution/SubscriptionHandler.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.expediagroup.graphql.spring
+package com.expediagroup.graphql.spring.execution
 
 import com.expediagroup.graphql.spring.model.GraphQLRequest
 import com.expediagroup.graphql.spring.model.GraphQLResponse

--- a/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/FederationConfigurationTest.kt
+++ b/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/FederationConfigurationTest.kt
@@ -1,4 +1,4 @@
-package com.expediagroup.graphql.spring.federation
+package com.expediagroup.graphql.spring
 
 import com.expediagroup.graphql.SchemaGeneratorConfig
 import com.expediagroup.graphql.TopLevelObject
@@ -9,8 +9,8 @@ import com.expediagroup.graphql.federation.directives.ExternalDirective
 import com.expediagroup.graphql.federation.directives.FieldSet
 import com.expediagroup.graphql.federation.directives.KeyDirective
 import com.expediagroup.graphql.federation.execution.FederatedTypeRegistry
-import com.expediagroup.graphql.spring.GraphQLAutoConfiguration
-import com.expediagroup.graphql.spring.QueryHandler
+import com.expediagroup.graphql.spring.execution.GraphQLContextFactory
+import com.expediagroup.graphql.spring.execution.QueryHandler
 import com.expediagroup.graphql.spring.operations.Query
 import com.expediagroup.graphql.toSchema
 import com.fasterxml.jackson.databind.ObjectMapper
@@ -35,11 +35,11 @@ class FederationConfigurationTest {
     @Test
     fun `verify federated schema auto configuration`() {
         contextRunner.withUserConfiguration(FederatedConfiguration::class.java)
-            .withPropertyValues("graphql.packages=com.expediagroup.graphql.spring.federation", "graphql.federation.enabled=true")
+            .withPropertyValues("graphql.packages=com.expediagroup.graphql.spring", "graphql.federation.enabled=true")
             .run { ctx ->
                 assertThat(ctx).hasSingleBean(SchemaGeneratorConfig::class.java)
                 val schemaGeneratorConfig = ctx.getBean(SchemaGeneratorConfig::class.java)
-                assertEquals(listOf("com.expediagroup.graphql.spring.federation"), schemaGeneratorConfig.supportedPackages)
+                assertEquals(listOf("com.expediagroup.graphql.spring"), schemaGeneratorConfig.supportedPackages)
 
                 assertThat(ctx).hasSingleBean(GraphQLSchema::class.java)
                 val schema = ctx.getBean(GraphQLSchema::class.java)
@@ -60,6 +60,7 @@ class FederationConfigurationTest {
 
                 assertThat(ctx).hasSingleBean(GraphQL::class.java)
                 assertThat(ctx).hasSingleBean(QueryHandler::class.java)
+                assertThat(ctx).hasSingleBean(GraphQLContextFactory::class.java)
             }
     }
 
@@ -79,12 +80,14 @@ class FederationConfigurationTest {
 
                 assertThat(ctx).hasSingleBean(GraphQL::class.java)
                 assertThat(ctx).hasSingleBean(QueryHandler::class.java)
+                assertThat(ctx).hasSingleBean(GraphQLContextFactory::class.java)
             }
     }
 
     @Configuration
     class FederatedConfiguration {
 
+        // in regular apps object mapper will be created by JacksonAutoConfiguration
         @Bean
         fun objectMapper(): ObjectMapper = jacksonObjectMapper()
 
@@ -95,6 +98,7 @@ class FederationConfigurationTest {
     @Configuration
     class CustomFederatedConfiguration {
 
+        // in regular apps object mapper will be created by JacksonAutoConfiguration
         @Bean
         fun objectMapper(): ObjectMapper = jacksonObjectMapper()
 

--- a/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/SubscriptionConfigurationTest.kt
+++ b/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/SubscriptionConfigurationTest.kt
@@ -1,13 +1,8 @@
-package com.expediagroup.graphql.spring.subscription
+package com.expediagroup.graphql.spring
 
 import com.expediagroup.graphql.SchemaGeneratorConfig
-import com.expediagroup.graphql.federation.directives.ExtendsDirective
-import com.expediagroup.graphql.federation.directives.ExternalDirective
-import com.expediagroup.graphql.federation.directives.FieldSet
-import com.expediagroup.graphql.federation.directives.KeyDirective
-import com.expediagroup.graphql.spring.GraphQLAutoConfiguration
-import com.expediagroup.graphql.spring.QueryHandler
-import com.expediagroup.graphql.spring.SubscriptionHandler
+import com.expediagroup.graphql.spring.execution.QueryHandler
+import com.expediagroup.graphql.spring.execution.SubscriptionHandler
 import com.expediagroup.graphql.spring.operations.Subscription
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
@@ -36,11 +31,11 @@ class SubscriptionConfigurationTest {
     @Test
     fun `verify subscription auto configuration`() {
         contextRunner.withUserConfiguration(SubscriptionConfiguration::class.java)
-            .withPropertyValues("graphql.packages=com.expediagroup.graphql.spring.subscription")
+            .withPropertyValues("graphql.packages=com.expediagroup.graphql.spring")
             .run { ctx ->
                 assertThat(ctx).hasSingleBean(SchemaGeneratorConfig::class.java)
                 val schemaGeneratorConfig = ctx.getBean(SchemaGeneratorConfig::class.java)
-                assertEquals(listOf("com.expediagroup.graphql.spring.subscription"), schemaGeneratorConfig.supportedPackages)
+                assertEquals(listOf("com.expediagroup.graphql.spring"), schemaGeneratorConfig.supportedPackages)
 
                 assertThat(ctx).hasSingleBean(GraphQLSchema::class.java)
                 val schema = ctx.getBean(GraphQLSchema::class.java)
@@ -60,7 +55,7 @@ class SubscriptionConfigurationTest {
     }
 
     @Test
-    fun `verify subscriptionauto configuration backs off in beans are defined by user`() {
+    fun `verify subscription auto configuration backs off in beans are defined by user`() {
         contextRunner.withUserConfiguration(CustomSubscriptionConfiguration::class.java)
             .run { ctx ->
                 val customConfiguration = ctx.getBean(CustomSubscriptionConfiguration::class.java)
@@ -85,6 +80,7 @@ class SubscriptionConfigurationTest {
     @Configuration
     class SubscriptionConfiguration {
 
+        // in regular apps object mapper will be created by JacksonAutoConfiguration
         @Bean
         fun objectMapper(): ObjectMapper = jacksonObjectMapper()
 
@@ -95,6 +91,7 @@ class SubscriptionConfigurationTest {
     @Configuration
     class CustomSubscriptionConfiguration {
 
+        // in regular apps object mapper will be created by JacksonAutoConfiguration
         @Bean
         fun objectMapper(): ObjectMapper = jacksonObjectMapper()
 
@@ -113,8 +110,4 @@ class SubscriptionConfigurationTest {
             .delayElements(Duration.ofMillis(100))
             .map { Random.nextInt() }
     }
-
-    @ExtendsDirective
-    @KeyDirective(fields = FieldSet("id"))
-    data class Widget(@ExternalDirective val id: Int, val name: String)
 }

--- a/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/execution/ContextWebFilterTest.kt
+++ b/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/execution/ContextWebFilterTest.kt
@@ -1,0 +1,39 @@
+package com.expediagroup.graphql.spring.execution
+
+import graphql.GraphQLContext
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import org.springframework.http.server.reactive.ServerHttpRequest
+import org.springframework.web.server.ServerWebExchange
+import org.springframework.web.server.WebFilterChain
+import reactor.core.publisher.Mono
+import reactor.test.StepVerifier
+import kotlin.test.assertNotNull
+
+class ContextWebFilterTest {
+
+    @Test
+    fun `verify web filter populates context in the subscriber context`() {
+        val mockRequest = mockk<ServerHttpRequest>()
+        val exchange = mockk<ServerWebExchange> {
+            every { request } returns mockRequest
+            every { response } returns mockk()
+        }
+        val chain = mockk<WebFilterChain> {
+            every { filter(exchange) } returns Mono.empty()
+        }
+
+        val contextFilter = ContextWebFilter(EmptyContextFactory)
+        StepVerifier.create(contextFilter.filter(exchange, chain))
+            .expectAccessibleContext()
+            .hasSize(1)
+            .hasKey(GRAPHQL_CONTEXT_KEY)
+            .assertThat {
+                val graphQLContext = it.getOrDefault<GraphQLContext>(GRAPHQL_CONTEXT_KEY, null)
+                assertNotNull(graphQLContext)
+            }
+            .then()
+            .verifyComplete()
+    }
+}

--- a/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/execution/QueryHandlerTest.kt
+++ b/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/execution/QueryHandlerTest.kt
@@ -1,4 +1,4 @@
-package com.expediagroup.graphql.spring
+package com.expediagroup.graphql.spring.execution
 
 import com.expediagroup.graphql.SchemaGeneratorConfig
 import com.expediagroup.graphql.TopLevelObject
@@ -27,7 +27,7 @@ import kotlin.test.assertTrue
 class QueryHandlerTest {
 
     private val testSchema: GraphQLSchema = toSchema(
-        config = SchemaGeneratorConfig(supportedPackages = listOf("com.expediagroup.graphql.spring")),
+        config = SchemaGeneratorConfig(supportedPackages = listOf("com.expediagroup.graphql.spring.execution")),
         queries = listOf(TopLevelObject(BasicQuery()))
     )
     private val testGraphQL: GraphQL = GraphQL.newGraphQL(testSchema).build()

--- a/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/execution/SubscriptionHandlerIT.kt
+++ b/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/execution/SubscriptionHandlerIT.kt
@@ -1,4 +1,4 @@
-package com.expediagroup.graphql.spring.subscription
+package com.expediagroup.graphql.spring.execution
 
 import com.expediagroup.graphql.spring.model.GraphQLRequest
 import com.expediagroup.graphql.spring.operations.Subscription
@@ -19,7 +19,7 @@ import java.net.URI
 import java.time.Duration
 import kotlin.random.Random
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = ["graphql.packages=com.expediagroup.graphql.spring.subscription"])
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = ["graphql.packages=com.expediagroup.graphql.spring.execution"])
 @EnableAutoConfiguration
 class SubscriptionHandlerIT(@LocalServerPort private var port: Int) {
 


### PR DESCRIPTION
# :pencil: Description
Abstracts creation of GraphQL context by introducing GraphQLContextFactory interface and provides default WebFilter that utilizes it to populate GraphQL context in the reactor subscriber context.

### :link: Related Issues
https://github.com/ExpediaGroup/graphql-kotlin/pull/329 - Add new module graphql-kotlin-spring-server

