### PR TITLE
federation documentation cleanup

### DIFF
--- a/graphql-kotlin-federation/README.md
+++ b/graphql-kotlin-federation/README.md
@@ -85,7 +85,7 @@ Extended federated GraphQL schemas provide additional functionality to the types
 ```kotlin
 @KeyDirective(fields = FieldSet("id"))
 @ExtendsDirective
-data class Product(@property:ExternalDirective val id: Int) {
+data class Product(@ExternalDirective val id: Int) {
 
     fun reviews(): List<Review> {
         // returns list of product reviews

--- a/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/directives/ExtendsDirective.kt
+++ b/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/directives/ExtendsDirective.kt
@@ -36,7 +36,7 @@ private const val DESCRIPTION = "Marks target object as extending part of the fe
  * ```kotlin
  * @KeyDirective(FieldSet("id"))
  * @ExtendsDirective
- * class Product(@property:ExternalDirective val id: String) {
+ * class Product(@ExternalDirective val id: String) {
  *   fun newFunctionality(): String = "whatever"
  * }
  * ```

--- a/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/directives/ExternalDirective.kt
+++ b/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/directives/ExternalDirective.kt
@@ -33,7 +33,7 @@ import graphql.introspection.Introspection
  * ```kotlin
  * @KeyDirective(FieldSet("id"))
  * @ExtendsDirective
- * class Product(@property:ExternalDirective val id: String) {
+ * class Product(@ExternalDirective val id: String) {
  *   fun newFunctionality(): String = "whatever"
  * }
  * ```

--- a/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/directives/ProvidesDirective.kt
+++ b/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/directives/ProvidesDirective.kt
@@ -41,8 +41,8 @@ import graphql.introspection.Introspection
  * @KeyDirective(FieldSet("userId"))
  * @ExtendsDirective
  * class User(
- *   @property:ExternalDirective val userId: String,
- *   @property:ExternalDirective val name: String
+ *   @ExternalDirective val userId: String,
+ *   @ExternalDirective val name: String
  * )
  * ```
  *

--- a/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/directives/RequiresDirective.kt
+++ b/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/directives/RequiresDirective.kt
@@ -41,7 +41,7 @@ import graphql.introspection.Introspection
  * ```kotlin
  * @KeyDirective(FieldSet("id"))
  * @ExtendsDirective
- * class Product(@property:ExternalDirective val id: String) {
+ * class Product(@ExternalDirective val id: String) {
  *
  *   @ExternalDirective
  *   var weight: Double by Delegates.notNull()

--- a/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/validation/FederatedSchemaValidatorKeyDirectiveTest.kt
+++ b/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/validation/FederatedSchemaValidatorKeyDirectiveTest.kt
@@ -20,11 +20,11 @@ import com.expediagroup.graphql.federation.FederatedSchemaGenerator
 import com.expediagroup.graphql.federation.FederatedSchemaGeneratorConfig
 import com.expediagroup.graphql.federation.FederatedSchemaGeneratorHooks
 import com.expediagroup.graphql.federation.FederatedSchemaValidator
-import com.expediagroup.graphql.federation.exception.InvalidFederatedSchema
 import com.expediagroup.graphql.federation.directives.ExtendsDirective
 import com.expediagroup.graphql.federation.directives.ExternalDirective
 import com.expediagroup.graphql.federation.directives.FieldSet
 import com.expediagroup.graphql.federation.directives.KeyDirective
+import com.expediagroup.graphql.federation.exception.InvalidFederatedSchema
 import graphql.schema.GraphQLObjectType
 import io.mockk.mockk
 import org.junit.jupiter.api.BeforeEach
@@ -123,7 +123,7 @@ class FederatedSchemaValidatorKeyDirectiveTest {
      */
     @KeyDirective(fields = FieldSet("id"))
     @ExtendsDirective
-    private data class FederatedSimpleKey(@property:ExternalDirective val id: String, val description: String)
+    private data class FederatedSimpleKey(@ExternalDirective val id: String, val description: String)
 
     /*
     type KeyWithMultipleFields @key(fields : "id type") {
@@ -144,7 +144,7 @@ class FederatedSchemaValidatorKeyDirectiveTest {
      */
     @KeyDirective(fields = FieldSet("id type"))
     @ExtendsDirective
-    private data class FederatedKeyWithMultipleFields(@property:ExternalDirective val id: String, @property:ExternalDirective val type: String, val description: String)
+    private data class FederatedKeyWithMultipleFields(@ExternalDirective val id: String, @ExternalDirective val type: String, val description: String)
 
     /*
     type KeyWithNestedFields @key(fields : "id { uuid }") {
@@ -173,11 +173,11 @@ class FederatedSchemaValidatorKeyDirectiveTest {
      */
     @KeyDirective(fields = FieldSet("id { uuid }"))
     @ExtendsDirective
-    private data class FederatedKeyWithNestedFields(@property:ExternalDirective val id: FederatedNestedId, val description: String)
+    private data class FederatedKeyWithNestedFields(@ExternalDirective val id: FederatedNestedId, val description: String)
 
     @KeyDirective(fields = FieldSet("uuid"))
     @ExtendsDirective
-    private data class FederatedNestedId(@property:ExternalDirective val uuid: String)
+    private data class FederatedNestedId(@ExternalDirective val uuid: String)
 
     /*
     type FederatedMissingKey @extends {
@@ -186,7 +186,7 @@ class FederatedSchemaValidatorKeyDirectiveTest {
     }
      */
     @ExtendsDirective
-    private data class FederatedMissingKey(@property:ExternalDirective val id: String, val description: String)
+    private data class FederatedMissingKey(@ExternalDirective val id: String, val description: String)
 
     /*
     type KeyMissingFieldSelection @key(fields : "") {
@@ -213,7 +213,7 @@ class FederatedSchemaValidatorKeyDirectiveTest {
     }
      */
     @KeyDirective(fields = FieldSet("id"))
-    data class BaseKeyReferencingExternalFields(@property:ExternalDirective val id: String, val description: String)
+    data class BaseKeyReferencingExternalFields(@ExternalDirective val id: String, val description: String)
 
     /*
     type ExternalKeyReferencingLocalField @extends @key(fields : "id") {

--- a/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/validation/FederatedSchemaValidatorProvidesDirectiveTest.kt
+++ b/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/validation/FederatedSchemaValidatorProvidesDirectiveTest.kt
@@ -20,12 +20,12 @@ import com.expediagroup.graphql.federation.FederatedSchemaGenerator
 import com.expediagroup.graphql.federation.FederatedSchemaGeneratorConfig
 import com.expediagroup.graphql.federation.FederatedSchemaGeneratorHooks
 import com.expediagroup.graphql.federation.FederatedSchemaValidator
-import com.expediagroup.graphql.federation.exception.InvalidFederatedSchema
 import com.expediagroup.graphql.federation.directives.ExtendsDirective
 import com.expediagroup.graphql.federation.directives.ExternalDirective
 import com.expediagroup.graphql.federation.directives.FieldSet
 import com.expediagroup.graphql.federation.directives.KeyDirective
 import com.expediagroup.graphql.federation.directives.ProvidesDirective
+import com.expediagroup.graphql.federation.exception.InvalidFederatedSchema
 import graphql.schema.GraphQLObjectType
 import graphql.schema.GraphQLTypeUtil
 import io.mockk.mockk
@@ -122,8 +122,8 @@ class FederatedSchemaValidatorProvidesDirectiveTest {
     @KeyDirective(fields = FieldSet("id"))
     @ExtendsDirective
     private data class ProvidedType(
-        @property:ExternalDirective val id: String,
-        @property:ExternalDirective val text: String
+        @ExternalDirective val id: String,
+        @ExternalDirective val text: String
     )
 
     /*
@@ -169,7 +169,7 @@ class FederatedSchemaValidatorProvidesDirectiveTest {
     @KeyDirective(fields = FieldSet("id"))
     @ExtendsDirective
     private data class ProvidedWithLocalField(
-        @property:ExternalDirective val id: String,
+        @ExternalDirective val id: String,
         val text: String
     )
 
@@ -242,8 +242,8 @@ class FederatedSchemaValidatorProvidesDirectiveTest {
     @KeyDirective(fields = FieldSet("id"))
     @ExtendsDirective
     private data class ProvidedWithList(
-        @property:ExternalDirective val id: String,
-        @property:ExternalDirective val text: List<String>
+        @ExternalDirective val id: String,
+        @ExternalDirective val text: List<String>
     )
 
     /*
@@ -273,7 +273,7 @@ class FederatedSchemaValidatorProvidesDirectiveTest {
     @KeyDirective(fields = FieldSet("id"))
     @ExtendsDirective
     private data class ProvidedWithInterface(
-        @property:ExternalDirective val id: String,
-        @property:ExternalDirective val data: ProvidedInterface = throw UnsupportedOperationException("not implemented")
+        @ExternalDirective val id: String,
+        @ExternalDirective val data: ProvidedInterface = throw UnsupportedOperationException("not implemented")
     )
 }

--- a/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/validation/FederatedSchemaValidatorRequiresDirectiveTest.kt
+++ b/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/validation/FederatedSchemaValidatorRequiresDirectiveTest.kt
@@ -20,12 +20,12 @@ import com.expediagroup.graphql.federation.FederatedSchemaGenerator
 import com.expediagroup.graphql.federation.FederatedSchemaGeneratorConfig
 import com.expediagroup.graphql.federation.FederatedSchemaGeneratorHooks
 import com.expediagroup.graphql.federation.FederatedSchemaValidator
-import com.expediagroup.graphql.federation.exception.InvalidFederatedSchema
 import com.expediagroup.graphql.federation.directives.ExtendsDirective
 import com.expediagroup.graphql.federation.directives.ExternalDirective
 import com.expediagroup.graphql.federation.directives.FieldSet
 import com.expediagroup.graphql.federation.directives.KeyDirective
 import com.expediagroup.graphql.federation.directives.RequiresDirective
+import com.expediagroup.graphql.federation.exception.InvalidFederatedSchema
 import graphql.schema.GraphQLObjectType
 import io.mockk.mockk
 import org.junit.jupiter.api.BeforeEach
@@ -105,7 +105,7 @@ class FederatedSchemaValidatorRequiresDirectiveTest {
      */
     @KeyDirective(fields = FieldSet("id"))
     @ExtendsDirective
-    private class SimpleRequires(@property:ExternalDirective val id: String, val description: String) {
+    private class SimpleRequires(@ExternalDirective val id: String, val description: String) {
         @ExternalDirective
         var weight: Double by Delegates.notNull()
 
@@ -123,7 +123,7 @@ class FederatedSchemaValidatorRequiresDirectiveTest {
      */
     @KeyDirective(fields = FieldSet("id"))
     @ExtendsDirective
-    private class RequiresLocalField(@property:ExternalDirective val id: String, val description: String) {
+    private class RequiresLocalField(@ExternalDirective val id: String, val description: String) {
 
         var weight: Double = 0.0
 
@@ -141,7 +141,7 @@ class FederatedSchemaValidatorRequiresDirectiveTest {
      */
     @KeyDirective(fields = FieldSet("id"))
     @ExtendsDirective
-    class RequiresNonExistentField(@property:ExternalDirective val id: String, val description: String) {
+    class RequiresNonExistentField(@ExternalDirective val id: String, val description: String) {
 
         @ExternalDirective
         var weight: Double by Delegates.notNull()

--- a/graphql-kotlin-federation/src/test/kotlin/test/data/queries/federated/Product.kt
+++ b/graphql-kotlin-federation/src/test/kotlin/test/data/queries/federated/Product.kt
@@ -50,7 +50,7 @@ type Book implements Product @extends @key(fields : "id") {
 @ExtendsDirective
 @KeyDirective(FieldSet("id"))
 class Book(
-    @property:ExternalDirective override val id: String
+    @ExternalDirective override val id: String
 ) : Product {
 
     // optionally provided as it is not part of the @key field set
@@ -105,6 +105,6 @@ type User {
 @ExtendsDirective
 @KeyDirective(FieldSet("userId"))
 data class User(
-    @property:ExternalDirective val userId: Int,
-    @property:ExternalDirective val name: String
+    @ExternalDirective val userId: Int,
+    @ExternalDirective val name: String
 )


### PR DESCRIPTION
### :pencil: Description

Removes unnecessary `@property:` prefix from the annotations

### :link: Related Issues

* https://github.com/ExpediaGroup/graphql-kotlin/pull/320 - Directives on constructor args with no prefix
