### PR TITLE
spring server updates

### DIFF
--- a/examples/spring/src/main/kotlin/com/expediagroup/graphql/sample/context/MyGraphQLContextFactory.kt
+++ b/examples/spring/src/main/kotlin/com/expediagroup/graphql/sample/context/MyGraphQLContextFactory.kt
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Component
 @Component
 class MyGraphQLContextFactory: GraphQLContextFactory<MyGraphQLContext> {
 
-    override fun generateContext(request: ServerHttpRequest, response: ServerHttpResponse): MyGraphQLContext = MyGraphQLContext(
+    override suspend fun generateContext(request: ServerHttpRequest, response: ServerHttpResponse): MyGraphQLContext = MyGraphQLContext(
             myCustomValue = request.headers.getFirst("MyHeader") ?: "defaultContext",
             request = request,
             response = response)

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/SubscriptionAutoConfiguration.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/SubscriptionAutoConfiguration.kt
@@ -18,6 +18,7 @@ package com.expediagroup.graphql.spring
 
 import com.expediagroup.graphql.spring.execution.SimpleSubscriptionHandler
 import com.expediagroup.graphql.spring.execution.SubscriptionHandler
+import com.expediagroup.graphql.spring.execution.SubscriptionWebSocketHandler
 import com.expediagroup.graphql.spring.operations.Subscription
 import com.fasterxml.jackson.databind.ObjectMapper
 import graphql.GraphQL
@@ -39,13 +40,16 @@ class SubscriptionAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    fun subscriptionHandler(graphQL: GraphQL, objectMapper: ObjectMapper): SubscriptionHandler = SimpleSubscriptionHandler(graphQL, objectMapper)
+    fun subscriptionHandler(graphQL: GraphQL): SubscriptionHandler = SimpleSubscriptionHandler(graphQL)
 
     @Bean
     @ConditionalOnMissingBean
     fun websocketHandlerAdapter(): WebSocketHandlerAdapter = WebSocketHandlerAdapter()
 
     @Bean
-    fun subscriptionHandlerMapping(config: GraphQLConfigurationProperties, subscriptionHandler: SubscriptionHandler): HandlerMapping =
-        SimpleUrlHandlerMapping(mapOf(config.subscriptions.endpoint to subscriptionHandler), Ordered.HIGHEST_PRECEDENCE)
+    fun subscriptionWebSocketHandler(handler: SubscriptionHandler, objectMapper: ObjectMapper) = SubscriptionWebSocketHandler(handler, objectMapper)
+
+    @Bean
+    fun subscriptionHandlerMapping(config: GraphQLConfigurationProperties, subscriptionWebSocketHandler: SubscriptionWebSocketHandler): HandlerMapping =
+        SimpleUrlHandlerMapping(mapOf(config.subscriptions.endpoint to subscriptionWebSocketHandler), Ordered.HIGHEST_PRECEDENCE)
 }

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/execution/ContextWebFilter.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/execution/ContextWebFilter.kt
@@ -16,8 +16,8 @@
 
 package com.expediagroup.graphql.spring.execution
 
+import kotlinx.coroutines.reactor.mono
 import org.springframework.core.Ordered
-import org.springframework.core.annotation.Order
 import org.springframework.web.server.ServerWebExchange
 import org.springframework.web.server.WebFilter
 import org.springframework.web.server.WebFilterChain
@@ -25,19 +25,20 @@ import reactor.core.publisher.Mono
 
 /**
  * [org.springframework.core.Ordered] value used for the [ContextWebFilter] order in which it will be applied to the incoming requests.
+ * Smaller value take higher precedence.
  */
 const val GRAPHQL_CONTEXT_FILTER_ODER = 0
 
 /**
  * Default web filter that populates GraphQL context in the reactor subscriber context.
  */
-@Order(GRAPHQL_CONTEXT_FILTER_ODER)
 class ContextWebFilter(private val contextFactory: GraphQLContextFactory<Any>) : WebFilter, Ordered {
 
     @Suppress("ForbiddenVoid")
-    override fun filter(exchange: ServerWebExchange, chain: WebFilterChain): Mono<Void> {
-        val context = contextFactory.generateContext(exchange.request, exchange.response)
-        return chain.filter(exchange).subscriberContext { it.put(GRAPHQL_CONTEXT_KEY, context) }
+    override fun filter(exchange: ServerWebExchange, chain: WebFilterChain): Mono<Void> = mono {
+        contextFactory.generateContext(exchange.request, exchange.response)
+    }.flatMap { graphQLContext ->
+        chain.filter(exchange).subscriberContext { it.put(GRAPHQL_CONTEXT_KEY, graphQLContext) }
     }
 
     override fun getOrder(): Int = GRAPHQL_CONTEXT_FILTER_ODER

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/execution/GraphQLContextFactory.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/execution/GraphQLContextFactory.kt
@@ -33,7 +33,7 @@ interface GraphQLContextFactory<out T : Any> {
     /**
      * Generate GraphQL context based on the incoming request and the corresponding response.
      */
-    fun generateContext(request: ServerHttpRequest, response: ServerHttpResponse): T
+    suspend fun generateContext(request: ServerHttpRequest, response: ServerHttpResponse): T
 }
 
 /**
@@ -41,5 +41,5 @@ interface GraphQLContextFactory<out T : Any> {
  */
 internal object EmptyContextFactory : GraphQLContextFactory<GraphQLContext> {
 
-    override fun generateContext(request: ServerHttpRequest, response: ServerHttpResponse): GraphQLContext = GraphQLContext.newContext().build()
+    override suspend fun generateContext(request: ServerHttpRequest, response: ServerHttpResponse): GraphQLContext = GraphQLContext.newContext().build()
 }

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/execution/SubscriptionWebSocketHandler.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/execution/SubscriptionWebSocketHandler.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.spring.execution
+
+import com.expediagroup.graphql.spring.model.GraphQLRequest
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import org.slf4j.LoggerFactory
+import org.springframework.web.reactive.socket.WebSocketHandler
+import org.springframework.web.reactive.socket.WebSocketSession
+import reactor.core.publisher.Mono
+
+/**
+ * Default WebSocket handler for handling GraphQL subscriptions.
+ */
+class SubscriptionWebSocketHandler(
+    private val subscriptionHandler: SubscriptionHandler,
+    private val objectMapper: ObjectMapper
+) : WebSocketHandler {
+
+    private val logger = LoggerFactory.getLogger(SubscriptionWebSocketHandler::class.java)
+
+    @Suppress("ForbiddenVoid")
+    override fun handle(session: WebSocketSession): Mono<Void> {
+        val response = session.receive()
+            .concatMap {
+                val graphQLRequest = objectMapper.readValue<GraphQLRequest>(it.payloadAsText)
+                subscriptionHandler.executeSubscription(graphQLRequest)
+                    .doOnSubscribe { logger.trace("WebSocket GraphQL subscription subscribe, ID=${session.id}") }
+                    .doOnCancel { logger.trace("WebSocket GraphQL subscription cancel, ID=${session.id}") }
+                    .doOnComplete { logger.trace("WebSocket GraphQL subscription complete, ID=${session.id}") }
+                    .doFinally { session.close() }
+            }
+            .map { objectMapper.writeValueAsString(it) }
+            .map { session.textMessage(it) }
+
+        return session.send(response)
+    }
+
+    override fun getSubProtocols(): List<String> = listOf("graphql-ws")
+}

--- a/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/FederationConfigurationTest.kt
+++ b/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/FederationConfigurationTest.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.expediagroup.graphql.spring
 
 import com.expediagroup.graphql.SchemaGeneratorConfig

--- a/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/SchemaConfigurationTest.kt
+++ b/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/SchemaConfigurationTest.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.expediagroup.graphql.spring
 
 import com.expediagroup.graphql.SchemaGeneratorConfig

--- a/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/SubscriptionConfigurationTest.kt
+++ b/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/SubscriptionConfigurationTest.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.expediagroup.graphql.spring
 
 import com.expediagroup.graphql.SchemaGeneratorConfig
@@ -8,6 +24,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import graphql.GraphQL
 import graphql.schema.GraphQLSchema
+import io.mockk.every
 import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -99,7 +116,9 @@ class SubscriptionConfigurationTest {
         fun subscription(): Subscription = SimpleSubscription()
 
         @Bean
-        fun subscriptionHandler(): SubscriptionHandler = mockk()
+        fun subscriptionHandler(): SubscriptionHandler = mockk {
+            every { executeSubscription(any()) } returns Flux.empty()
+        }
 
         @Bean
         fun webSocketHandlerAdapter(): WebSocketHandlerAdapter = mockk()

--- a/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/execution/ContextWebFilterTest.kt
+++ b/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/execution/ContextWebFilterTest.kt
@@ -1,10 +1,25 @@
+/*
+ * Copyright 2019 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.expediagroup.graphql.spring.execution
 
 import graphql.GraphQLContext
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.Test
-import org.springframework.http.server.reactive.ServerHttpRequest
 import org.springframework.web.server.ServerWebExchange
 import org.springframework.web.server.WebFilterChain
 import reactor.core.publisher.Mono
@@ -15,13 +30,12 @@ class ContextWebFilterTest {
 
     @Test
     fun `verify web filter populates context in the subscriber context`() {
-        val mockRequest = mockk<ServerHttpRequest>()
-        val exchange = mockk<ServerWebExchange> {
-            every { request } returns mockRequest
+        val exchange: ServerWebExchange = mockk {
+            every { request } returns mockk()
             every { response } returns mockk()
         }
-        val chain = mockk<WebFilterChain> {
-            every { filter(exchange) } returns Mono.empty()
+        val chain: WebFilterChain = mockk {
+            every { filter(any()) } returns Mono.empty()
         }
 
         val contextFilter = ContextWebFilter(EmptyContextFactory)

--- a/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/execution/QueryHandlerTest.kt
+++ b/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/execution/QueryHandlerTest.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.expediagroup.graphql.spring.execution
 
 import com.expediagroup.graphql.SchemaGeneratorConfig
@@ -99,11 +115,11 @@ class QueryHandlerTest {
     @Test
     @ExperimentalCoroutinesApi
     fun `execute graphQL query with context`() = runBlockingTest(Context.of(GRAPHQL_CONTEXT_KEY, MyContext("JUNIT context value")).asCoroutineContext()) {
-        val request = GraphQLRequest(query = "query { context }")
+        val request = GraphQLRequest(query = "query { contextualValue }")
 
         val response = queryHandler.executeQuery(request)
         assertNotNull(response.data as? Map<*, *>) { data ->
-            assertNotNull(data["context"] as? String) { msg ->
+            assertNotNull(data["contextualValue"] as? String) { msg ->
                 assertEquals("JUNIT context value", msg)
             }
         }
@@ -137,7 +153,7 @@ class QueryHandlerTest {
 
         fun alwaysThrows(): String = throw GraphQLKotlinException("JUNIT Failure")
 
-        fun context(@GraphQLContext context: MyContext): String = context.value ?: "default"
+        fun contextualValue(@GraphQLContext context: MyContext): String = context.value ?: "default"
     }
 
     data class MyContext(val value: String? = null)

--- a/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/execution/SubscriptionHandlerTest.kt
+++ b/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/execution/SubscriptionHandlerTest.kt
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2019 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.spring.execution
+
+import com.expediagroup.graphql.SchemaGeneratorConfig
+import com.expediagroup.graphql.TopLevelObject
+import com.expediagroup.graphql.annotations.GraphQLContext
+import com.expediagroup.graphql.exceptions.GraphQLKotlinException
+import com.expediagroup.graphql.spring.model.GraphQLRequest
+import com.expediagroup.graphql.toSchema
+import graphql.ErrorType
+import graphql.GraphQL
+import graphql.schema.GraphQLSchema
+import org.junit.jupiter.api.Test
+import reactor.core.publisher.Flux
+import reactor.test.StepVerifier
+import java.time.Duration
+import kotlin.random.Random
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class SubscriptionHandlerTest {
+
+    private val testSchema: GraphQLSchema = toSchema(
+        config = SchemaGeneratorConfig(supportedPackages = listOf("com.expediagroup.graphql.spring.execution")),
+        queries = listOf(),
+        subscriptions = listOf(TopLevelObject(BasicSubscription()))
+    )
+    private val testGraphQL: GraphQL = GraphQL.newGraphQL(testSchema).build()
+    private val subscriptionHandler = SimpleSubscriptionHandler(testGraphQL)
+
+    @Test
+    fun `verify subscription`() {
+        val request = GraphQLRequest(query = "subscription { ticker }")
+        val responseFlux = subscriptionHandler.executeSubscription(request)
+
+        StepVerifier.create(responseFlux)
+            .thenConsumeWhile { response ->
+                assertNotNull(response.data as? Map<*, *>) { data ->
+                    assertNotNull(data["ticker"] as? Int)
+                }
+                assertNull(response.errors)
+                assertNull(response.extensions)
+                true
+            }
+            .expectComplete()
+            .verify()
+    }
+
+    @Test
+    fun `verify subscription with context`() {
+        val request = GraphQLRequest(query = "subscription { contextualTicker }")
+        val responseFlux = subscriptionHandler.executeSubscription(request)
+            .subscriberContext { it.put(GRAPHQL_CONTEXT_KEY, SubscriptionContext("junitHandler")) }
+
+        StepVerifier.create(responseFlux)
+            .thenConsumeWhile { response ->
+                assertNotNull(response.data as? Map<*, *>) { data ->
+                    assertNotNull(data["contextualTicker"] as? String) { tickerValue ->
+                        assertTrue(tickerValue.startsWith("junitHandler:"))
+                        assertNotNull(tickerValue.substringAfter("junitHandler:").toIntOrNull())
+                    }
+                }
+                assertNull(response.errors)
+                assertNull(response.extensions)
+                true
+            }
+            .expectComplete()
+            .verify()
+    }
+
+    @Test
+    fun `verify subscription to failing publisher`() {
+        val request = GraphQLRequest(query = "subscription { alwaysThrows }")
+        val responseFlux = subscriptionHandler.executeSubscription(request)
+
+        StepVerifier.create(responseFlux)
+            .assertNext { response ->
+                assertNull(response.data)
+                assertNotNull(response.errors) { errors ->
+                    assertEquals(1, errors.size)
+                    val error = errors.first()
+                    assertEquals("JUNIT subscription failure", error.message)
+                    assertEquals(ErrorType.DataFetchingException, error.errorType)
+                }
+                assertNull(response.extensions)
+            }
+            .expectComplete()
+            .verify()
+    }
+
+    class BasicSubscription {
+        fun ticker(): Flux<Int> = Flux.range(1, 5)
+            .delayElements(Duration.ofMillis(100))
+            .map { Random.nextInt() }
+
+        fun alwaysThrows(): Flux<String> = Flux.error(GraphQLKotlinException("JUNIT subscription failure"))
+
+        fun contextualTicker(@GraphQLContext context: SubscriptionContext): Flux<String> = Flux.range(1, 5)
+                .delayElements(Duration.ofMillis(100))
+                .map { "${context.value}:${Random.nextInt(100)}" }
+    }
+
+    data class SubscriptionContext(val value: String)
+}

--- a/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/routes/RouteConfigurationIT.kt
+++ b/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/routes/RouteConfigurationIT.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.expediagroup.graphql.spring.routes
 
 import com.expediagroup.graphql.annotations.GraphQLContext
@@ -28,8 +44,7 @@ class RouteConfigurationIT(@Autowired private val testClient: WebTestClient) {
 
         @Bean
         fun customContextFactory(): GraphQLContextFactory<CustomContext> = object : GraphQLContextFactory<CustomContext> {
-
-            override fun generateContext(request: ServerHttpRequest, response: ServerHttpResponse): CustomContext = CustomContext(
+            override suspend fun generateContext(request: ServerHttpRequest, response: ServerHttpResponse): CustomContext = CustomContext(
                 value = request.headers.getFirst("X-Custom-Header") ?: "default"
             )
         }


### PR DESCRIPTION
### :pencil: Description
`graphql-kotlin-spring-server` updates:

- update `GraphQLContextFactory` to use coroutines for building the context
- extract `SubscriptionHandler` logic from default `WebSocketHandler`, default subscription `WebSocketHandler` will now call available `SubscriberHandler` bean
- update `SimpleSubscriptionHandler` to use `GraphQLContext` - fixes https://github.com/ExpediaGroup/graphql-kotlin/issues/360
- add error handling to `SimpleSubscriptionHandler`

### :link: Related Issues
https://github.com/ExpediaGroup/graphql-kotlin/issues/360