### PR TITLE
Update default exception handler to use SimpleKotlinGraphQLError

### DIFF
--- a/examples/spring/src/main/kotlin/com/expediagroup/graphql/sample/exceptions/CustomDataFetcherExceptionHandler.kt
+++ b/examples/spring/src/main/kotlin/com/expediagroup/graphql/sample/exceptions/CustomDataFetcherExceptionHandler.kt
@@ -16,6 +16,7 @@
 
 package com.expediagroup.graphql.sample.exceptions
 
+import com.expediagroup.graphql.spring.exception.SimpleKotlinGraphQLError
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import graphql.ErrorType
 import graphql.ErrorType.ValidationError
@@ -38,7 +39,7 @@ class CustomDataFetcherExceptionHandler : DataFetcherExceptionHandler {
 
         val error: GraphQLError = when(exception) {
             is ValidationException -> ValidationDataFetchingGraphQLError(exception.constraintErrors, path, exception, sourceLocation)
-            else -> ExceptionWhileDataFetching(path, exception, sourceLocation)
+            else -> SimpleKotlinGraphQLError(exception = exception, locations = listOf(sourceLocation), path = path.toList())
         }
         log.warn(error.message, exception)
         return DataFetcherExceptionHandlerResult.newResult().error(error).build()

--- a/examples/spring/src/main/kotlin/com/expediagroup/graphql/sample/query/DataAndErrors.kt
+++ b/examples/spring/src/main/kotlin/com/expediagroup/graphql/sample/query/DataAndErrors.kt
@@ -16,8 +16,8 @@
 
 package com.expediagroup.graphql.sample.query
 
+import com.expediagroup.graphql.spring.exception.SimpleKotlinGraphQLError
 import com.expediagroup.graphql.spring.operations.Query
-import graphql.ExceptionWhileDataFetching
 import graphql.execution.DataFetcherResult
 import graphql.execution.ExecutionPath
 import graphql.language.SourceLocation
@@ -28,7 +28,7 @@ import java.util.concurrent.CompletableFuture
 class DataAndErrors : Query {
 
     fun returnDataAndErrors(): DataFetcherResult<String> {
-        val error = ExceptionWhileDataFetching(ExecutionPath.rootPath(), RuntimeException(), SourceLocation(1, 1))
+        val error = SimpleKotlinGraphQLError(RuntimeException(), listOf(SourceLocation(1, 1)), ExecutionPath.rootPath().toList())
         return DataFetcherResult.newResult<String>()
             .data("Hello from data fetcher")
             .error(error)
@@ -36,7 +36,7 @@ class DataAndErrors : Query {
     }
 
     fun completableFutureDataAndErrors(): CompletableFuture<DataFetcherResult<String>> {
-        val error = ExceptionWhileDataFetching(ExecutionPath.rootPath(), RuntimeException(), SourceLocation(1, 1))
+        val error = SimpleKotlinGraphQLError(RuntimeException(), listOf(SourceLocation(1, 1)), ExecutionPath.rootPath().toList())
         val dataFetcherResult = DataFetcherResult.newResult<String>()
             .data("Hello from data fetcher")
             .error(error)

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/exception/KotlinDataFetcherExceptionHandler.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/exception/KotlinDataFetcherExceptionHandler.kt
@@ -35,7 +35,7 @@ class KotlinDataFetcherExceptionHandler : DataFetcherExceptionHandler {
         val sourceLocation = handlerParameters.sourceLocation
         val path = handlerParameters.path
 
-        val error: GraphQLError = ExceptionWhileDataFetching(path, exception, sourceLocation)
+        val error: GraphQLError = SimpleKotlinGraphQLError(exception = exception, locations = listOf(sourceLocation), path = path.toList())
         logger.warn(error.message, exception)
         return DataFetcherExceptionHandlerResult.newResult(error).build()
     }


### PR DESCRIPTION
### :pencil: Description

By default, our default exception handler was wrapping all the runtime exceptions in `graphql-java` `ExceptionWhileDataFetching` GraphQLError. Since this default GraphQL error exposes `exception` field it was also getting serialized in the response. While this is was still valid GraphQL response, per [spec](https://graphql.github.io/graphql-spec/June2018/#sec-Errors) `exception` field is not part of the defined error fields and instead should be included in the error `extensions` entry field instead (if at all).

Note: the above serialization issue could also be solved by using `graphql-java` `ExecutionResult#toSpecification` method to generate final results but that would also imply that we would need to return `Map` instead of a `GraphQLResponse`.

### :link: Related Issues

https://github.com/ExpediaGroup/graphql-kotlin/issues/366 - [question] how to disable stacktrace in error responses