### PR TITLE
Fix Apollo subscription message handling

### DIFF
--- a/detekt.yml
+++ b/detekt.yml
@@ -29,6 +29,10 @@ complexity:
   ComplexInterface:
     threshold: 15
 
+naming:
+  FunctionMaxLength:
+    maximumFunctionNameLength: 35
+
 style:
   MagicNumber:
     ignoreEnums: true

--- a/examples/spring/src/main/kotlin/com/expediagroup/graphql/sample/subscriptions/SimpleSubscription.kt
+++ b/examples/spring/src/main/kotlin/com/expediagroup/graphql/sample/subscriptions/SimpleSubscription.kt
@@ -18,6 +18,9 @@ package com.expediagroup.graphql.sample.subscriptions
 
 import com.expediagroup.graphql.annotations.GraphQLDescription
 import com.expediagroup.graphql.spring.operations.Subscription
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.reactive.asPublisher
+import org.reactivestreams.Publisher
 import org.springframework.stereotype.Component
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
@@ -32,4 +35,17 @@ class SimpleSubscription : Subscription {
 
     @GraphQLDescription("Returns a random number every second")
     fun counter(): Flux<Int> = Flux.interval(Duration.ofSeconds(1)).map { Random.nextInt() }
+
+    @GraphQLDescription("Returns a random number every second, errors if even")
+    fun counterWithError(): Flux<Int> = Flux.interval(Duration.ofSeconds(1))
+        .map {
+            val value = Random.nextInt()
+            if (value % 2 == 0) {
+                throw Exception("Value is even $value")
+            }
+            else value
+        }
+
+    @GraphQLDescription("Returns list of values")
+    fun flow(): Publisher<Int> = flowOf(1, 2, 4).asPublisher()
 }

--- a/examples/spring/src/main/resources/application.yml
+++ b/examples/spring/src/main/resources/application.yml
@@ -1,6 +1,4 @@
 graphql:
-  packages:
-    - "com.expediagroup.graphql.sample"
   subscriptions:
     # Send a ka message every 1000 ms (1 second)
     keepAliveInterval: 1000

--- a/examples/spring/src/main/resources/application.yml
+++ b/examples/spring/src/main/resources/application.yml
@@ -1,0 +1,3 @@
+graphql:
+  packages:
+    - "com.expediagroup.graphql.sample"

--- a/examples/spring/src/main/resources/application.yml
+++ b/examples/spring/src/main/resources/application.yml
@@ -1,3 +1,6 @@
 graphql:
   packages:
     - "com.expediagroup.graphql.sample"
+  subscriptions:
+    # Send a ka message every 1000 ms (1 second)
+    keepAliveInterval: 1000

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/GraphQLConfigurationProperties.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/GraphQLConfigurationProperties.kt
@@ -45,4 +45,6 @@ class FederationConfigurationProperties {
 class SubscriptionConfigurationProperties {
     /** GraphQL subscriptions endpoint, defaults to 'subscriptions' */
     var endpoint: String = "subscriptions"
+    /** Keep the websocket alive and send a message to the client every interval in ms. Default to not sending messages */
+    var keepAliveInterval: Long? = null
 }

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/SubscriptionAutoConfiguration.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/SubscriptionAutoConfiguration.kt
@@ -16,6 +16,7 @@
 
 package com.expediagroup.graphql.spring
 
+import com.expediagroup.graphql.spring.execution.ApolloSubscriptionProtocolHandler
 import com.expediagroup.graphql.spring.execution.SimpleSubscriptionHandler
 import com.expediagroup.graphql.spring.execution.SubscriptionHandler
 import com.expediagroup.graphql.spring.execution.SubscriptionWebSocketHandler
@@ -47,7 +48,12 @@ class SubscriptionAutoConfiguration {
     fun websocketHandlerAdapter(): WebSocketHandlerAdapter = WebSocketHandlerAdapter()
 
     @Bean
-    fun subscriptionWebSocketHandler(handler: SubscriptionHandler, objectMapper: ObjectMapper) = SubscriptionWebSocketHandler(handler, objectMapper)
+    fun apolloSubscriptionProtocolHandler(handler: SubscriptionHandler, objectMapper: ObjectMapper) =
+        ApolloSubscriptionProtocolHandler(handler, objectMapper)
+
+    @Bean
+    fun subscriptionWebSocketHandler(handler: ApolloSubscriptionProtocolHandler, objectMapper: ObjectMapper) =
+        SubscriptionWebSocketHandler(handler, objectMapper)
 
     @Bean
     fun subscriptionHandlerMapping(config: GraphQLConfigurationProperties, subscriptionWebSocketHandler: SubscriptionWebSocketHandler): HandlerMapping =

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/SubscriptionAutoConfiguration.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/SubscriptionAutoConfiguration.kt
@@ -48,8 +48,8 @@ class SubscriptionAutoConfiguration {
     fun websocketHandlerAdapter(): WebSocketHandlerAdapter = WebSocketHandlerAdapter()
 
     @Bean
-    fun apolloSubscriptionProtocolHandler(handler: SubscriptionHandler, objectMapper: ObjectMapper) =
-        ApolloSubscriptionProtocolHandler(handler, objectMapper)
+    fun apolloSubscriptionProtocolHandler(config: GraphQLConfigurationProperties, handler: SubscriptionHandler, objectMapper: ObjectMapper) =
+        ApolloSubscriptionProtocolHandler(config, handler, objectMapper)
 
     @Bean
     fun subscriptionWebSocketHandler(handler: ApolloSubscriptionProtocolHandler, objectMapper: ObjectMapper) =

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/exception/UknownSubscriptionOperationType.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/exception/UknownSubscriptionOperationType.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2019 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.spring.exception
+
+import com.expediagroup.graphql.spring.model.SubscriptionOperationMessage
+
+class UknownSubscriptionOperationType(operationMessage: SubscriptionOperationMessage) :
+    IllegalArgumentException("Unknown subscription operation $operationMessage")

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/execution/ApolloSubscriptionProtocolHandler.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/execution/ApolloSubscriptionProtocolHandler.kt
@@ -16,6 +16,7 @@
 
 package com.expediagroup.graphql.spring.execution
 
+import com.expediagroup.graphql.spring.GraphQLConfigurationProperties
 import com.expediagroup.graphql.spring.model.GraphQLRequest
 import com.expediagroup.graphql.spring.model.SubscriptionOperationMessage
 import com.expediagroup.graphql.spring.model.SubscriptionOperationMessage.ClientMessages.GQL_CONNECTION_INIT
@@ -25,21 +26,31 @@ import com.expediagroup.graphql.spring.model.SubscriptionOperationMessage.Client
 import com.expediagroup.graphql.spring.model.SubscriptionOperationMessage.ServerMessages.GQL_COMPLETE
 import com.expediagroup.graphql.spring.model.SubscriptionOperationMessage.ServerMessages.GQL_CONNECTION_ACK
 import com.expediagroup.graphql.spring.model.SubscriptionOperationMessage.ServerMessages.GQL_CONNECTION_ERROR
+import com.expediagroup.graphql.spring.model.SubscriptionOperationMessage.ServerMessages.GQL_CONNECTION_KEEP_ALIVE
 import com.expediagroup.graphql.spring.model.SubscriptionOperationMessage.ServerMessages.GQL_DATA
 import com.expediagroup.graphql.spring.model.SubscriptionOperationMessage.ServerMessages.GQL_ERROR
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.convertValue
 import com.fasterxml.jackson.module.kotlin.readValue
+import org.reactivestreams.Subscription
 import org.slf4j.LoggerFactory
 import org.springframework.web.reactive.socket.WebSocketSession
 import reactor.core.publisher.Flux
+import java.time.Duration
+import java.util.concurrent.ConcurrentHashMap
 
 class ApolloSubscriptionProtocolHandler(
+    private val config: GraphQLConfigurationProperties,
     private val subscriptionHandler: SubscriptionHandler,
     private val objectMapper: ObjectMapper
 ) {
+    // Keep Alive subscriptions are saved by web socket session id since they are sent on connection init
+    private val keepAliveSubscriptions = ConcurrentHashMap<String, Subscription>()
+    // Data subscriptions are saved by SubscriptionOperationMessage.id
+    private val subscriptions = ConcurrentHashMap<String, Subscription>()
 
     private val logger = LoggerFactory.getLogger(ApolloSubscriptionProtocolHandler::class.java)
+    private val keepAliveMessage = SubscriptionOperationMessage(type = GQL_CONNECTION_KEEP_ALIVE.type)
 
     @Suppress("Detekt.TooGenericExceptionCaught")
     fun handle(payload: String, session: WebSocketSession): Flux<SubscriptionOperationMessage> {
@@ -47,9 +58,28 @@ class ApolloSubscriptionProtocolHandler(
             val operationMessage: SubscriptionOperationMessage = objectMapper.readValue(payload)
 
             return when {
-                operationMessage.type == GQL_CONNECTION_INIT.type -> Flux.just(SubscriptionOperationMessage(GQL_CONNECTION_ACK.type))
+                operationMessage.type == GQL_CONNECTION_INIT.type -> {
+                    val flux = Flux.just(SubscriptionOperationMessage(GQL_CONNECTION_ACK.type))
+                    val keepAliveInterval = config.subscriptions.keepAliveInterval
+                    if (keepAliveInterval != null) {
+                        // Send the GQL_CONNECTION_KEEP_ALIVE message every interval until the connection is closed or terminated
+                        val keepAliveFlux = Flux.interval(Duration.ofMillis(keepAliveInterval))
+                            .map { keepAliveMessage }
+                            .doOnSubscribe {
+                                keepAliveSubscriptions[session.id] = it
+                            }
+                        return flux.concatWith(keepAliveFlux)
+                    }
+
+                    return flux
+                }
                 operationMessage.type == GQL_START.type -> startSubscription(operationMessage, session)
-                operationMessage.type == GQL_CONNECTION_TERMINATE.type || operationMessage.type == GQL_STOP.type -> {
+                operationMessage.type == GQL_STOP.type -> {
+                    stopSubscription(operationMessage, session)
+                    Flux.empty()
+                }
+                operationMessage.type == GQL_CONNECTION_TERMINATE.type -> {
+                    stopSubscription(operationMessage, session)
                     session.close()
                     Flux.empty()
                 }
@@ -66,6 +96,11 @@ class ApolloSubscriptionProtocolHandler(
 
     @Suppress("Detekt.TooGenericExceptionCaught")
     private fun startSubscription(operationMessage: SubscriptionOperationMessage, session: WebSocketSession): Flux<SubscriptionOperationMessage> {
+        if (operationMessage.id == null) {
+            logger.error("Operation id is required")
+            return Flux.just(SubscriptionOperationMessage(type = GQL_CONNECTION_ERROR.type))
+        }
+
         val payload = operationMessage.payload
 
         if (payload == null) {
@@ -83,18 +118,23 @@ class ApolloSubscriptionProtocolHandler(
                         SubscriptionOperationMessage(type = GQL_DATA.type, id = operationMessage.id, payload = it)
                     }
                 }
-                .doOnSubscribe { logger.trace("WebSocket GraphQL subscription subscribe, WebSocketID=${session.id} OperationMessageID=${operationMessage.id}") }
-                .doOnCancel { logger.trace("WebSocket GraphQL subscription cancel, WebSocketID=${session.id} OperationMessageID=${operationMessage.id}") }
-                .doOnComplete { logger.trace("WebSocket GraphQL subscription complete, WebSocketID=${session.id} OperationMessageID=${operationMessage.id}") }
-                .doFinally {
-                    val completeMessage = SubscriptionOperationMessage(type = GQL_COMPLETE.type, id = operationMessage.id)
-                    val text = objectMapper.writeValueAsString(completeMessage)
-                    session.send(Flux.just(session.textMessage(text)))
-                    session.close()
+                .concatWith(Flux.just(SubscriptionOperationMessage(type = GQL_COMPLETE.type, id = operationMessage.id)))
+                .doOnSubscribe {
+                    logger.trace("WebSocket GraphQL subscription subscribe, WebSocketSessionID=${session.id} OperationMessageID=${operationMessage.id}")
+                    subscriptions[operationMessage.id] = it
                 }
+                .doOnCancel { logger.trace("WebSocket GraphQL subscription cancel, WebSocketSessionID=${session.id} OperationMessageID=${operationMessage.id}") }
+                .doOnComplete { logger.trace("WebSocket GraphQL subscription complete, WebSocketSessionID=${session.id} OperationMessageID=${operationMessage.id}") }
         } catch (exception: Exception) {
             logger.error("Error running graphql subscription", exception)
             Flux.just(SubscriptionOperationMessage(type = GQL_CONNECTION_ERROR.type, id = operationMessage.id))
+        }
+    }
+
+    private fun stopSubscription(operationMessage: SubscriptionOperationMessage, session: WebSocketSession) {
+        if (operationMessage.id != null) {
+            keepAliveSubscriptions[session.id]?.cancel()
+            subscriptions[operationMessage.id]?.cancel()
         }
     }
 }

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/execution/ApolloSubscriptionProtocolHandler.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/execution/ApolloSubscriptionProtocolHandler.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2019 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.spring.execution
+
+import com.expediagroup.graphql.spring.model.GraphQLRequest
+import com.expediagroup.graphql.spring.model.SubscriptionOperationMessage
+import com.expediagroup.graphql.spring.model.SubscriptionOperationMessage.ClientMessages.GQL_CONNECTION_INIT
+import com.expediagroup.graphql.spring.model.SubscriptionOperationMessage.ClientMessages.GQL_CONNECTION_TERMINATE
+import com.expediagroup.graphql.spring.model.SubscriptionOperationMessage.ClientMessages.GQL_START
+import com.expediagroup.graphql.spring.model.SubscriptionOperationMessage.ClientMessages.GQL_STOP
+import com.expediagroup.graphql.spring.model.SubscriptionOperationMessage.ServerMessages.GQL_COMPLETE
+import com.expediagroup.graphql.spring.model.SubscriptionOperationMessage.ServerMessages.GQL_CONNECTION_ACK
+import com.expediagroup.graphql.spring.model.SubscriptionOperationMessage.ServerMessages.GQL_CONNECTION_ERROR
+import com.expediagroup.graphql.spring.model.SubscriptionOperationMessage.ServerMessages.GQL_DATA
+import com.expediagroup.graphql.spring.model.SubscriptionOperationMessage.ServerMessages.GQL_ERROR
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.convertValue
+import com.fasterxml.jackson.module.kotlin.readValue
+import org.slf4j.LoggerFactory
+import org.springframework.web.reactive.socket.WebSocketSession
+import reactor.core.publisher.Flux
+
+class ApolloSubscriptionProtocolHandler(
+    private val subscriptionHandler: SubscriptionHandler,
+    private val objectMapper: ObjectMapper
+) {
+
+    private val logger = LoggerFactory.getLogger(ApolloSubscriptionProtocolHandler::class.java)
+
+    @Suppress("Detekt.TooGenericExceptionCaught")
+    fun handle(payload: String, session: WebSocketSession): Flux<SubscriptionOperationMessage> {
+        try {
+            val operationMessage: SubscriptionOperationMessage = objectMapper.readValue(payload)
+
+            return when {
+                operationMessage.type == GQL_CONNECTION_INIT.type -> Flux.just(SubscriptionOperationMessage(GQL_CONNECTION_ACK.type))
+                operationMessage.type == GQL_START.type -> startSubscription(operationMessage, session)
+                operationMessage.type == GQL_CONNECTION_TERMINATE.type || operationMessage.type == GQL_STOP.type -> {
+                    session.close()
+                    Flux.empty()
+                }
+                else -> {
+                    logger.error("Unknown subscription operation $operationMessage")
+                    Flux.just(SubscriptionOperationMessage(type = GQL_CONNECTION_ERROR.type, id = operationMessage.id))
+                }
+            }
+        } catch (exception: Exception) {
+            logger.error("Error parsing the subscription message", exception)
+            return Flux.just(SubscriptionOperationMessage(type = GQL_CONNECTION_ERROR.type))
+        }
+    }
+
+    @Suppress("Detekt.TooGenericExceptionCaught")
+    private fun startSubscription(operationMessage: SubscriptionOperationMessage, session: WebSocketSession): Flux<SubscriptionOperationMessage> {
+        val payload = operationMessage.payload
+
+        if (payload == null) {
+            logger.error("Payload was null instead of a GraphQLRequest object")
+            return Flux.just(SubscriptionOperationMessage(type = GQL_CONNECTION_ERROR.type, id = operationMessage.id))
+        }
+
+        return try {
+            val request = objectMapper.convertValue<GraphQLRequest>(payload)
+            subscriptionHandler.executeSubscription(request)
+                .map {
+                    if (it.errors?.isNotEmpty() == true) {
+                        SubscriptionOperationMessage(type = GQL_ERROR.type, id = operationMessage.id, payload = it)
+                    } else {
+                        SubscriptionOperationMessage(type = GQL_DATA.type, id = operationMessage.id, payload = it)
+                    }
+                }
+                .doOnSubscribe { logger.trace("WebSocket GraphQL subscription subscribe, WebSocketID=${session.id} OperationMessageID=${operationMessage.id}") }
+                .doOnCancel { logger.trace("WebSocket GraphQL subscription cancel, WebSocketID=${session.id} OperationMessageID=${operationMessage.id}") }
+                .doOnComplete { logger.trace("WebSocket GraphQL subscription complete, WebSocketID=${session.id} OperationMessageID=${operationMessage.id}") }
+                .doFinally {
+                    val completeMessage = SubscriptionOperationMessage(type = GQL_COMPLETE.type, id = operationMessage.id)
+                    val text = objectMapper.writeValueAsString(completeMessage)
+                    session.send(Flux.just(session.textMessage(text)))
+                    session.close()
+                }
+        } catch (exception: Exception) {
+            logger.error("Error running graphql subscription", exception)
+            Flux.just(SubscriptionOperationMessage(type = GQL_CONNECTION_ERROR.type, id = operationMessage.id))
+        }
+    }
+}

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/model/SubscriptionOperationMessage.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/model/SubscriptionOperationMessage.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.spring.model
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+
+/**
+ * The `graphql-ws` protocol from Apollo Client has some special text messages to signal events.
+ * Along with the HTTP WebSocket event handling we need to have some extra logic
+ *
+ * https://github.com/apollographql/subscriptions-transport-ws/blob/master/PROTOCOL.md
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class SubscriptionOperationMessage(
+    val type: String,
+    val id: String? = null,
+    val payload: Any? = null
+) {
+    enum class ClientMessages(val type: String) {
+        GQL_CONNECTION_INIT("connection_init"),
+        GQL_START("start"),
+        GQL_STOP("stop"),
+        GQL_CONNECTION_TERMINATE("connection_terminate")
+    }
+
+    enum class ServerMessages(val type: String) {
+        GQL_CONNECTION_ACK("connection_ack"),
+        GQL_CONNECTION_ERROR("connection_error"),
+        GQL_DATA("data"),
+        GQL_ERROR("error"),
+        GQL_COMPLETE("complete"),
+        GQL_CONNECTION_KEEP_ALIVE("ka")
+    }
+}

--- a/graphql-kotlin-spring-server/src/main/resources/META-INF/spring-configuration-metadata.json
+++ b/graphql-kotlin-spring-server/src/main/resources/META-INF/spring-configuration-metadata.json
@@ -21,6 +21,12 @@
       "type": "java.lang.String",
       "defaultValue": "subscriptions",
       "sourceType": "com.expediagroup.graphql.spring.SubscriptionConfigurationProperties"
+    },
+    {
+      "name": "graphql.subscriptions.keepAliveInterval",
+      "type": "java.lang.Long",
+      "defaultValue": "null",
+      "sourceType": "com.expediagroup.graphql.spring.SubscriptionConfigurationProperties"
     }
   ]
 }

--- a/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/execution/ApolloSubscriptionProtocolHandlerTest.kt
+++ b/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/execution/ApolloSubscriptionProtocolHandlerTest.kt
@@ -1,0 +1,217 @@
+/*
+ * Copyright 2019 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.spring.execution
+
+import com.expediagroup.graphql.spring.exception.SimpleKotlinGraphQLError
+import com.expediagroup.graphql.spring.model.GraphQLRequest
+import com.expediagroup.graphql.spring.model.GraphQLResponse
+import com.expediagroup.graphql.spring.model.SubscriptionOperationMessage
+import com.expediagroup.graphql.spring.model.SubscriptionOperationMessage.ClientMessages.GQL_CONNECTION_INIT
+import com.expediagroup.graphql.spring.model.SubscriptionOperationMessage.ClientMessages.GQL_CONNECTION_TERMINATE
+import com.expediagroup.graphql.spring.model.SubscriptionOperationMessage.ClientMessages.GQL_START
+import com.expediagroup.graphql.spring.model.SubscriptionOperationMessage.ClientMessages.GQL_STOP
+import com.expediagroup.graphql.spring.model.SubscriptionOperationMessage.ServerMessages.GQL_COMPLETE
+import com.expediagroup.graphql.spring.model.SubscriptionOperationMessage.ServerMessages.GQL_CONNECTION_ACK
+import com.expediagroup.graphql.spring.model.SubscriptionOperationMessage.ServerMessages.GQL_CONNECTION_ERROR
+import com.expediagroup.graphql.spring.model.SubscriptionOperationMessage.ServerMessages.GQL_DATA
+import com.expediagroup.graphql.spring.model.SubscriptionOperationMessage.ServerMessages.GQL_ERROR
+import com.fasterxml.jackson.module.kotlin.convertValue
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+import org.springframework.web.reactive.socket.WebSocketSession
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class ApolloSubscriptionProtocolHandlerTest {
+
+    private val objectMapper = jacksonObjectMapper().registerKotlinModule()
+
+    @Test
+    fun `Return GQL_CONNECTION_ERROR when payload is not a SubscriptionOperationMessage`() {
+        val session: WebSocketSession = mockk()
+        val subscriptionHandler: SubscriptionHandler = mockk()
+
+        val handler = ApolloSubscriptionProtocolHandler(subscriptionHandler, objectMapper)
+        val flux = handler.handle("", session)
+
+        val message = flux.blockFirst()
+        assertNotNull(message)
+        assertEquals(expected = GQL_CONNECTION_ERROR.type, actual = message.type)
+    }
+
+    @Test
+    fun `Return GQL_CONNECTION_ERROR when SubscriptionOperationMessage type is not valid`() {
+        val operationMessage = SubscriptionOperationMessage("", id = "abc")
+        val session: WebSocketSession = mockk()
+        val subscriptionHandler: SubscriptionHandler = mockk()
+
+        val handler = ApolloSubscriptionProtocolHandler(subscriptionHandler, objectMapper)
+        val flux = handler.handle(objectMapper.writeValueAsString(operationMessage), session)
+
+        val message = flux.blockFirst()
+        assertNotNull(message)
+        assertEquals(expected = GQL_CONNECTION_ERROR.type, actual = message.type)
+        assertEquals(expected = "abc", actual = message.id)
+    }
+
+    @Test
+    fun `Return GQL_CONNECTION_ACK when type is GQL_CONNECTION_INIT`() {
+        val operationMessage = SubscriptionOperationMessage(GQL_CONNECTION_INIT.type)
+        val session: WebSocketSession = mockk()
+        val subscriptionHandler: SubscriptionHandler = mockk()
+
+        val handler = ApolloSubscriptionProtocolHandler(subscriptionHandler, objectMapper)
+        val flux = handler.handle(objectMapper.writeValueAsString(operationMessage), session)
+
+        val message = flux.blockFirst()
+        assertNotNull(message)
+        assertEquals(expected = GQL_CONNECTION_ACK.type, actual = message.type)
+    }
+
+    @Test
+    fun `Close session when type is GQL_CONNECTION_TERMINATE`() {
+        val operationMessage = SubscriptionOperationMessage(GQL_CONNECTION_TERMINATE.type)
+        val session: WebSocketSession = mockk {
+            every { close() } returns mockk()
+        }
+        val subscriptionHandler: SubscriptionHandler = mockk()
+
+        val handler = ApolloSubscriptionProtocolHandler(subscriptionHandler, objectMapper)
+        val flux = handler.handle(objectMapper.writeValueAsString(operationMessage), session)
+
+        assertNull(flux.blockFirst())
+        verify(exactly = 1) { session.close() }
+    }
+
+    @Test
+    fun `Close session when type is GQL_STOP`() {
+        val operationMessage = SubscriptionOperationMessage(GQL_STOP.type)
+        val session: WebSocketSession = mockk {
+            every { close() } returns mockk()
+        }
+        val subscriptionHandler: SubscriptionHandler = mockk()
+
+        val handler = ApolloSubscriptionProtocolHandler(subscriptionHandler, objectMapper)
+        val flux = handler.handle(objectMapper.writeValueAsString(operationMessage), session)
+
+        assertNull(flux.blockFirst())
+        verify(exactly = 1) { session.close() }
+    }
+
+    @Test
+    fun `Return GQL_CONNECTION_ERROR is returned when type is GQL_START but payload is null`() {
+        val operationMessage = SubscriptionOperationMessage(type = GQL_START.type, id = "abc", payload = null)
+        val session: WebSocketSession = mockk()
+        val subscriptionHandler: SubscriptionHandler = mockk()
+
+        val handler = ApolloSubscriptionProtocolHandler(subscriptionHandler, objectMapper)
+        val flux = handler.handle(objectMapper.writeValueAsString(operationMessage), session)
+
+        val message = flux.blockFirst()
+        assertNotNull(message)
+        assertEquals(expected = GQL_CONNECTION_ERROR.type, actual = message.type)
+        assertEquals(expected = "abc", actual = message.id)
+    }
+
+    @Test
+    fun `Return GQL_CONNECTION_ERROR when type is GQL_START but payload is is valid GraphQLRequest`() {
+        val operationMessage = SubscriptionOperationMessage(type = GQL_START.type, id = "abc", payload = "")
+        val session: WebSocketSession = mockk()
+        val subscriptionHandler: SubscriptionHandler = mockk()
+
+        val handler = ApolloSubscriptionProtocolHandler(subscriptionHandler, objectMapper)
+        val flux = handler.handle(objectMapper.writeValueAsString(operationMessage), session)
+
+        val message = flux.blockFirst()
+        assertNotNull(message)
+        assertEquals(expected = GQL_CONNECTION_ERROR.type, actual = message.type)
+        assertEquals(expected = "abc", actual = message.id)
+    }
+
+    @Test
+    fun `Return GQL_DATA when type is GQL_START with valid GraphQLRequest`() {
+        val graphQLRequest = GraphQLRequest("{ message }")
+        val operationMessage = SubscriptionOperationMessage(type = GQL_START.type, id = "abc", payload = graphQLRequest)
+        val session: WebSocketSession = mockk {
+            every { textMessage(any()) } returns mockk()
+            every { send(any()) } returns Mono.empty()
+            every { close() } returns mockk()
+            every { id } returns "123"
+        }
+        val subscriptionHandler: SubscriptionHandler = mockk {
+            every { executeSubscription(eq(graphQLRequest)) } returns Flux.just(GraphQLResponse("myData"))
+        }
+
+        val handler = ApolloSubscriptionProtocolHandler(subscriptionHandler, objectMapper)
+        val flux = handler.handle(objectMapper.writeValueAsString(operationMessage), session)
+
+        val message = flux.blockFirst()
+        assertNotNull(message)
+        assertEquals(expected = GQL_DATA.type, actual = message.type)
+        assertEquals(expected = "abc", actual = message.id)
+        val payload = message.payload
+        assertNotNull(payload)
+        val graphQLResponse: GraphQLResponse = objectMapper.convertValue(payload)
+        assertEquals(expected = "myData", actual = graphQLResponse.data)
+
+        val completeMessage = SubscriptionOperationMessage(type = GQL_COMPLETE.type, id = "abc")
+        verify(exactly = 1) { session.textMessage(eq(objectMapper.writeValueAsString(completeMessage))) }
+        verify(exactly = 1) { session.send(any()) }
+        verify(exactly = 1) { session.close() }
+    }
+
+    @Test
+    fun `Return GQL_ERROR when type is GQL_START with valid GraphQLRequest but response has errors`() {
+        val graphQLRequest = GraphQLRequest("{ message }")
+        val operationMessage = SubscriptionOperationMessage(type = GQL_START.type, id = "abc", payload = graphQLRequest)
+        val session: WebSocketSession = mockk {
+            every { textMessage(any()) } returns mockk()
+            every { send(any()) } returns Mono.empty()
+            every { close() } returns mockk()
+            every { id } returns "123"
+        }
+        val errors = listOf(SimpleKotlinGraphQLError(Throwable("My GraphQL Error")))
+        val subscriptionHandler: SubscriptionHandler = mockk {
+            every { executeSubscription(eq(graphQLRequest)) } returns Flux.just(GraphQLResponse(errors = errors))
+        }
+
+        val handler = ApolloSubscriptionProtocolHandler(subscriptionHandler, objectMapper)
+        val flux = handler.handle(objectMapper.writeValueAsString(operationMessage), session)
+
+        val message = flux.blockFirst()
+        assertNotNull(message)
+        assertEquals(expected = GQL_ERROR.type, actual = message.type)
+        assertEquals(expected = "abc", actual = message.id)
+        val payload = message.payload
+        assertNotNull(payload)
+        val graphQLResponse: GraphQLResponse = objectMapper.convertValue(payload)
+        assertTrue(graphQLResponse.errors?.isNotEmpty() == true)
+
+        val completeMessage = SubscriptionOperationMessage(type = GQL_COMPLETE.type, id = "abc")
+        verify(exactly = 1) { session.textMessage(eq(objectMapper.writeValueAsString(completeMessage))) }
+        verify(exactly = 1) { session.send(any()) }
+        verify(exactly = 1) { session.close() }
+    }
+}

--- a/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/execution/SubscriptionWebSocketHandlerIT.kt
+++ b/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/execution/SubscriptionWebSocketHandlerIT.kt
@@ -53,7 +53,7 @@ class SubscriptionWebSocketHandlerIT(@LocalServerPort private var port: Int) {
     @Test
     fun `verify subscription`() {
         val request = GraphQLRequest("subscription { characters }")
-        val message = SubscriptionOperationMessage(GQL_START.type, payload = request)
+        val message = SubscriptionOperationMessage(GQL_START.type, id = "1", payload = request)
         val output = ReplayProcessor.create<String>()
 
         val client = ReactorNettyWebSocketClient()
@@ -109,7 +109,7 @@ class SubscriptionWebSocketHandlerIT(@LocalServerPort private var port: Int) {
     @Test
     fun `verify subscription to counter`() {
         val request = GraphQLRequest("subscription { counter }")
-        val message = SubscriptionOperationMessage(GQL_START.type, payload = request)
+        val message = SubscriptionOperationMessage(GQL_START.type, id = "2", payload = request)
         val output = ReplayProcessor.create<String>()
 
         val client = ReactorNettyWebSocketClient()
@@ -136,7 +136,7 @@ class SubscriptionWebSocketHandlerIT(@LocalServerPort private var port: Int) {
     @Test
     fun `verify subscription with context`() {
         val request = GraphQLRequest("subscription { ticker }")
-        val message = SubscriptionOperationMessage(GQL_START.type, payload = request)
+        val message = SubscriptionOperationMessage(GQL_START.type, id = "3", payload = request)
         val output = ReplayProcessor.create<String>()
 
         val httpClient = HttpClient.create().headers { it.set("X-Custom-Header", "junit") }


### PR DESCRIPTION
### :pencil: Description
Support the messages that come from the Apollo client subscriptions.

https://github.com/apollographql/subscriptions-transport-ws/blob/master/PROTOCOL.md

We need to wrap the GraphQLRequest and GraphQLResponse in a special message before we send it over the web socket. That message structure is implemented in the handler for the `graphql-ws` protocol

### :link: Related Issues
Fixes https://github.com/ExpediaGroup/graphql-kotlin/issues/370