### PR TITLE
Make FederatedSchemaGenerator open

### DIFF
--- a/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/FederatedSchemaGenerator.kt
+++ b/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/FederatedSchemaGenerator.kt
@@ -26,7 +26,7 @@ import kotlin.reflect.full.createType
 /**
  * Generates federated GraphQL schemas based on the specified configuration.
  */
-class FederatedSchemaGenerator(generatorConfig: FederatedSchemaGeneratorConfig) : SchemaGenerator(generatorConfig) {
+open class FederatedSchemaGenerator(generatorConfig: FederatedSchemaGeneratorConfig) : SchemaGenerator(generatorConfig) {
 
     override fun generate(
         queries: List<TopLevelObject>,


### PR DESCRIPTION
### :pencil: Description
Open FederatedSchemaGenerator so that it can be inherited from.

### :link: Related Issues
#384 