### PR TITLE
federation: add tests to verify custom directive support

### DIFF
--- a/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/FederatedSchemaGeneratorHooks.kt
+++ b/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/FederatedSchemaGeneratorHooks.kt
@@ -43,7 +43,8 @@ import kotlin.reflect.full.findAnnotation
  */
 open class FederatedSchemaGeneratorHooks(private val federatedTypeRegistry: FederatedTypeRegistry) : SchemaGeneratorHooks {
     private val directiveDefinitionRegex = "(^#.+$[\\r\\n])?^directive @\\w+.+$[\\r\\n]*".toRegex(setOf(RegexOption.MULTILINE, RegexOption.IGNORE_CASE))
-    private val customDirectivesRegex = "@(?!extends)(?!external)(?!key)(?!provides)(?!requires)(?!deprecated)\\w+(?:\\(.*(?=\\))\\))?".toRegex(setOf(RegexOption.MULTILINE, RegexOption.IGNORE_CASE))
+    private val customDirectivesRegex = "\\s*@(?!extends)(?!external)(?!key)(?!provides)(?!requires)(?!deprecated)\\w+(?:\\(.*(?=\\))\\))?".toRegex(
+        setOf(RegexOption.MULTILINE, RegexOption.IGNORE_CASE))
     private val scalarDefinitionRegex = "(^#.+$[\\r\\n])?^scalar (_FieldSet|_Any)$[\\r\\n]*".toRegex(setOf(RegexOption.MULTILINE, RegexOption.IGNORE_CASE))
     private val emptyQueryRegex = "^type Query \\{$\\s+^\\}$\\s+".toRegex(setOf(RegexOption.MULTILINE, RegexOption.IGNORE_CASE))
     private val validator = FederatedSchemaValidator()

--- a/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/FederatedSchemaGeneratorTest.kt
+++ b/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/FederatedSchemaGeneratorTest.kt
@@ -40,6 +40,8 @@ directive @extends on OBJECT | INTERFACE
 #Specifies the base type field set that will be selectable by the gateway
 directive @provides(fields: _FieldSet!) on FIELD_DEFINITION
 
+directive @custom on SCHEMA | SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
 #Space separated list of primary keys needed to access federated object
 directive @key(fields: _FieldSet!) on OBJECT | INTERFACE
 
@@ -68,7 +70,8 @@ type Query @extends {
 }
 
 type Review {
-  body: String!
+  body: String! @custom
+  content: String @deprecated(reason : "no longer supported, replace with use Review.body instead")
   id: String!
 }
 

--- a/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/execution/ServiceQueryResolverTest.kt
+++ b/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/execution/ServiceQueryResolverTest.kt
@@ -42,6 +42,7 @@ type Book implements Product @extends @key(fields : "id") {
 
 type Review {
   body: String!
+  content: String @deprecated(reason : "no longer supported, replace with use Review.body instead")
   id: String!
 }
 

--- a/graphql-kotlin-federation/src/test/kotlin/test/data/queries/federated/Product.kt
+++ b/graphql-kotlin-federation/src/test/kotlin/test/data/queries/federated/Product.kt
@@ -16,6 +16,7 @@
 
 package test.data.queries.federated
 
+import com.expediagroup.graphql.annotations.GraphQLDirective
 import com.expediagroup.graphql.annotations.GraphQLIgnore
 import com.expediagroup.graphql.federation.directives.ExtendsDirective
 import com.expediagroup.graphql.federation.directives.ExternalDirective
@@ -94,7 +95,11 @@ type Review {
   id: String!
 }
  */
-data class Review(val id: String, val body: String)
+data class Review(
+    val id: String,
+    @CustomDirective val body: String,
+    @Deprecated(message = "no longer supported", replaceWith = ReplaceWith("use Review.body instead")) val content: String? = null
+)
 
 /*
 type User {
@@ -108,3 +113,6 @@ data class User(
     @ExternalDirective val userId: Int,
     @ExternalDirective val name: String
 )
+
+@GraphQLDirective(name = "custom")
+annotation class CustomDirective


### PR DESCRIPTION
### :pencil: Description

Add tests that verify that generated federated schema does not return custom directives in the `_service { sdl }` query.

### :link: Related Issues
https://github.com/ExpediaGroup/graphql-kotlin/issues/373
https://github.com/ExpediaGroup/graphql-kotlin/pull/374