### PR TITLE
spring-server: include path in SimpleKotlinGraphQLError error message

### DIFF
--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/exception/SimpleKotlinGraphQLError.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/exception/SimpleKotlinGraphQLError.kt
@@ -42,7 +42,7 @@ open class SimpleKotlinGraphQLError(
 
     override fun getLocations(): List<SourceLocation> = locations
 
-    override fun getMessage(): String = exception.message ?: "Exception was thrown while executing a GraphQL query"
+    override fun getMessage(): String = "Exception while fetching data (${path?.joinToString("/").orEmpty()}) : ${exception.message}"
 
     override fun getPath(): List<Any>? = path
 }

--- a/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/exception/SimpleKotlinGraphQLErrorTest.kt
+++ b/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/exception/SimpleKotlinGraphQLErrorTest.kt
@@ -45,8 +45,8 @@ internal class SimpleKotlinGraphQLErrorTest {
 
     @Test
     fun `Message comes from the exception if set`() {
-        val error = SimpleKotlinGraphQLError(Throwable("foo"))
-        assertEquals(expected = "foo", actual = error.message)
+        val error = SimpleKotlinGraphQLError(exception = Throwable("foo"), path = listOf("/foo"))
+        assertEquals(expected = "Exception while fetching data (/foo) : foo", actual = error.message)
     }
 
     @Test

--- a/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/execution/QueryHandlerTest.kt
+++ b/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/execution/QueryHandlerTest.kt
@@ -141,7 +141,7 @@ class QueryHandlerTest {
             val error = errors.first()
             assertTrue(error is SimpleKotlinGraphQLError)
             assertEquals(ErrorType.DataFetchingException, error.errorType)
-            assertEquals("Uncaught JUNIT", error.message)
+            assertEquals("Exception while fetching data () : Uncaught JUNIT", error.message)
         }
         assertNull(response.extensions)
     }

--- a/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/execution/SubscriptionHandlerTest.kt
+++ b/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/execution/SubscriptionHandlerTest.kt
@@ -96,7 +96,7 @@ class SubscriptionHandlerTest {
                 assertNotNull(response.errors) { errors ->
                     assertEquals(1, errors.size)
                     val error = errors.first()
-                    assertEquals("JUNIT subscription failure", error.message)
+                    assertEquals("Exception while fetching data () : JUNIT subscription failure", error.message)
                     assertEquals(ErrorType.DataFetchingException, error.errorType)
                 }
                 assertNull(response.extensions)


### PR DESCRIPTION
Update the exception message to include the path and original exception message