### PR TITLE
Missing @Component in ReadMe example

### DIFF
--- a/graphql-kotlin-spring-server/README.md
+++ b/graphql-kotlin-spring-server/README.md
@@ -38,10 +38,12 @@ graphql:
 In order to expose your queries, mutations and subscriptions in the GraphQL schema you simply need to implement corresponding marker interfaces and they will be automatically picked up by `graphql-kotlin-spring-server` autoconfiguration library.
 
 ```kotlin
+@Component
 class MyAwesomeQuery : Query { 
   fun myAwesomeQuery(): Widget { ... }
 }
 
+@Component
 class MyAwesomeMutation : Mutation {
   fun myAwesomeMutation(widget: Widget): Widget { ... }
 }


### PR DESCRIPTION
### :pencil: Description
Update the readme example with missing `@Component` annotation

