### PR TITLE
[spring-server] enable support for specifying instrumentation order

### DIFF
--- a/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/instrumentation/InstrumentationIT.kt
+++ b/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/instrumentation/InstrumentationIT.kt
@@ -1,0 +1,74 @@
+package com.expediagroup.graphql.spring.instrumentation
+
+import com.expediagroup.graphql.spring.DEFAULT_INSTRUMENTATION_ORDER
+import com.expediagroup.graphql.spring.model.GraphQLRequest
+import com.expediagroup.graphql.spring.operations.Query
+import graphql.ExecutionResult
+import graphql.ExecutionResultImpl
+import graphql.execution.instrumentation.Instrumentation
+import graphql.execution.instrumentation.SimpleInstrumentation
+import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.core.Ordered
+import org.springframework.http.MediaType
+import org.springframework.test.web.reactive.server.WebTestClient
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.atomic.AtomicInteger
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = ["graphql.packages=com.expediagroup.graphql.spring.instrumentation"])
+@EnableAutoConfiguration
+class InstrumentationIT(@Autowired private val testClient: WebTestClient) {
+
+    @Configuration
+    class TestConfiguration {
+        private val atomicCounter = AtomicInteger()
+
+        @Bean
+        fun query(): Query = BasicQuery()
+
+        @Bean
+        fun firstInstrumentation(): Instrumentation = OrderedInstrumentation(DEFAULT_INSTRUMENTATION_ORDER, atomicCounter)
+
+        @Bean
+        fun secondInstrumentation(): Instrumentation = OrderedInstrumentation(DEFAULT_INSTRUMENTATION_ORDER + 1, atomicCounter)
+    }
+
+    class BasicQuery : Query {
+        fun helloWorld(name: String) = "Hello $name!"
+    }
+
+    class OrderedInstrumentation(private val instrumentationOrder: Int, private val counter: AtomicInteger) : SimpleInstrumentation(), Ordered {
+        override fun instrumentExecutionResult(executionResult: ExecutionResult, parameters: InstrumentationExecutionParameters): CompletableFuture<ExecutionResult> {
+            val extensions = mutableMapOf<Any, Any>()
+            extensions[instrumentationOrder] = counter.getAndIncrement()
+            val currentExt: Map<Any, Any>? = executionResult.extensions
+            if (currentExt != null) {
+                extensions.putAll(currentExt)
+            }
+            return CompletableFuture.completedFuture(ExecutionResultImpl(executionResult.getData(), executionResult.errors, extensions))
+        }
+
+        override fun getOrder(): Int = instrumentationOrder
+    }
+
+    @Test
+    fun `verify instrumentations are applied in the specified order`() {
+        testClient.post()
+            .uri("/graphql")
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(GraphQLRequest("query { helloWorld(name: \"World\") }"))
+            .exchange()
+            .expectBody()
+            .jsonPath("$.data.helloWorld").isEqualTo("Hello World!")
+            .jsonPath("$.errors").doesNotExist()
+            .jsonPath("$.extensions").exists()
+            .jsonPath("$.extensions.0").isEqualTo(0)
+            .jsonPath("$.extensions.1").isEqualTo(1)
+    }
+}


### PR DESCRIPTION
### :pencil: Description
`graphql-java` allows for applying various `Instrumentations` to the GraphQL execution. If multilple instrumentations are to be applied they need to be wrapped in an instance of `ChainedInstrumentation` that has an explicit order of the instrumentations.

In order to simplify Spring configuration we should allow users to either create a single instrumentation bean (could be a chained one) or multiple instrumentation beans and then automatically wrap them in chained instrumentation if necessary. Unfortunately, by default `graphql-java` `Instrumentation` does not specify order in which it should be applied (as it is generally explicitly configured). In order to support proper ordering of the instrumentations we can simply check if they implement `Ordered` interface and use their order value OR default to order of `0` otherwise (unordered behavior).