### PR TITLE
[spring-server] SimplQueryHandler support for DataLoaderRegistry

### DIFF
--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/GraphQLAutoConfiguration.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/GraphQLAutoConfiguration.kt
@@ -31,6 +31,7 @@ import graphql.execution.SubscriptionExecutionStrategy
 import graphql.execution.instrumentation.Instrumentation
 import graphql.execution.preparsed.PreparsedDocumentProvider
 import graphql.schema.GraphQLSchema
+import org.dataloader.DataLoaderRegistry
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
@@ -85,7 +86,11 @@ class GraphQLAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    fun graphQLQueryHandler(graphql: GraphQL): QueryHandler = SimpleQueryHandler(graphql)
+    fun dataLoaderRegistry(): DataLoaderRegistry = DataLoaderRegistry()
+
+    @Bean
+    @ConditionalOnMissingBean
+    fun graphQLQueryHandler(graphql: GraphQL, dataLoaderRegistry: DataLoaderRegistry): QueryHandler = SimpleQueryHandler(graphql, dataLoaderRegistry)
 
     @Bean
     @ConditionalOnMissingBean

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/execution/QueryHandler.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/execution/QueryHandler.kt
@@ -25,6 +25,7 @@ import graphql.GraphQL
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.future.await
 import kotlinx.coroutines.reactor.ReactorContext
+import org.dataloader.DataLoaderRegistry
 import kotlin.coroutines.coroutineContext
 
 /**
@@ -41,14 +42,14 @@ interface QueryHandler {
 /**
  * Default GraphQL query handler.
  */
-open class SimpleQueryHandler(private val graphql: GraphQL) : QueryHandler {
+open class SimpleQueryHandler(private val graphql: GraphQL, private val dataLoaderRegistry: DataLoaderRegistry? = null) : QueryHandler {
 
     @Suppress("TooGenericExceptionCaught")
     @ExperimentalCoroutinesApi
     override suspend fun executeQuery(request: GraphQLRequest): GraphQLResponse {
         val reactorContext = coroutineContext[ReactorContext]
         val graphQLContext = reactorContext?.context?.getOrDefault<Any>(GRAPHQL_CONTEXT_KEY, null)
-        val input = request.toExecutionInput(graphQLContext)
+        val input = request.toExecutionInput(graphQLContext, dataLoaderRegistry)
 
         return try {
             graphql.executeAsync(input)

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/model/GraphQLRequest.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/model/GraphQLRequest.kt
@@ -18,6 +18,7 @@ package com.expediagroup.graphql.spring.model
 
 import graphql.ExecutionInput
 import graphql.GraphQLContext
+import org.dataloader.DataLoaderRegistry
 
 data class GraphQLRequest(
     val query: String,
@@ -25,10 +26,11 @@ data class GraphQLRequest(
     val variables: Map<String, Any>? = null
 )
 
-fun GraphQLRequest.toExecutionInput(graphQLContext: Any? = null): ExecutionInput =
+fun GraphQLRequest.toExecutionInput(graphQLContext: Any? = null, dataLoaderRegistry: DataLoaderRegistry? = null): ExecutionInput =
     ExecutionInput.newExecutionInput()
         .query(this.query)
         .operationName(this.operationName)
         .variables(this.variables ?: emptyMap())
         .context(graphQLContext ?: GraphQLContext.newContext().build())
+        .dataLoaderRegistry(dataLoaderRegistry ?: DataLoaderRegistry())
         .build()

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/model/GraphQLResponse.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/model/GraphQLResponse.kt
@@ -28,7 +28,7 @@ data class GraphQLResponse(
     val extensions: Map<Any, Any>? = null
 )
 
-internal fun ExecutionResult.toGraphQLResponse(): GraphQLResponse {
+fun ExecutionResult.toGraphQLResponse(): GraphQLResponse {
     val filteredErrors = if (errors?.isNotEmpty() == true) errors else null
     val filteredExtensions = if (extensions?.isNotEmpty() == true) extensions else null
     return GraphQLResponse(getData(), filteredErrors, filteredExtensions)

--- a/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/SchemaConfigurationTest.kt
+++ b/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/SchemaConfigurationTest.kt
@@ -31,6 +31,7 @@ import graphql.schema.GraphQLSchema
 import graphql.schema.GraphQLTypeUtil
 import io.mockk.mockk
 import org.assertj.core.api.AssertionsForInterfaceTypes.assertThat
+import org.dataloader.DataLoaderRegistry
 import org.junit.jupiter.api.Test
 import org.springframework.boot.autoconfigure.AutoConfigurations
 import org.springframework.boot.test.context.runner.ReactiveWebApplicationContextRunner
@@ -72,6 +73,7 @@ class SchemaConfigurationTest {
                 assertNull(result["errors"])
                 assertNotNull(result["extensions"])
 
+                assertThat(ctx).hasSingleBean(DataLoaderRegistry::class.java)
                 assertThat(ctx).hasSingleBean(QueryHandler::class.java)
                 assertThat(ctx).hasSingleBean(GraphQLContextFactory::class.java)
             }
@@ -94,6 +96,10 @@ class SchemaConfigurationTest {
                 assertThat(ctx).hasSingleBean(GraphQL::class.java)
                 assertThat(ctx).getBean(GraphQL::class.java)
                     .isSameAs(customConfiguration.myGraphQL())
+
+                assertThat(ctx).hasSingleBean(DataLoaderRegistry::class.java)
+                assertThat(ctx).getBean(DataLoaderRegistry::class.java)
+                    .isSameAs(customConfiguration.myDataLoaderRegistry())
 
                 assertThat(ctx).hasSingleBean(QueryHandler::class.java)
 
@@ -142,6 +148,9 @@ class SchemaConfigurationTest {
 
         @Bean
         fun myCustomContextFactory(): GraphQLContextFactory<Map<String, Any>> = mockk()
+
+        @Bean
+        fun myDataLoaderRegistry(): DataLoaderRegistry = mockk()
     }
 
     class BasicQuery : Query {

--- a/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/model/GraphQLRequestTest.kt
+++ b/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/model/GraphQLRequestTest.kt
@@ -1,0 +1,54 @@
+package com.expediagroup.graphql.spring.model
+
+import graphql.GraphQLContext
+import io.mockk.mockk
+import org.dataloader.DataLoaderRegistry
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class GraphQLRequestTest {
+
+    @Test
+    fun `verify can convert simple request to execution input with defaults`() {
+        val request = GraphQLRequest(query = "query { whatever }")
+        val executionInput = request.toExecutionInput()
+        assertEquals(request.query, executionInput.query)
+        assertTrue(executionInput.context is GraphQLContext)
+        assertNotNull(executionInput.dataLoaderRegistry)
+    }
+
+    @Test
+    fun `verify can convert request with variables to execution input`() {
+        val request = GraphQLRequest(
+            query = "query testOperation{ whatever(id: \$id) }",
+            variables = mapOf("id" to 123),
+            operationName = "testOperation"
+        )
+        val executionInput = request.toExecutionInput()
+        assertEquals(request.query, executionInput.query)
+        assertEquals(request.variables, executionInput.variables)
+        assertEquals(request.operationName, executionInput.operationName)
+    }
+
+    @Test
+    fun `verify can convert request with context to execution input`() {
+        val request = GraphQLRequest(query = "query { whatever }")
+        val context = mapOf("contextValue" to 12_345)
+        val executionInput = request.toExecutionInput(graphQLContext = context)
+        assertEquals(request.query, executionInput.query)
+        assertEquals(context, executionInput.context)
+    }
+
+    @Test
+    fun `verify can convert request with data loader registry to execution input`() {
+        val request = GraphQLRequest(query = "query { whatever }")
+        val dataLoaderRegistry = DataLoaderRegistry()
+        dataLoaderRegistry.register("abc", mockk())
+
+        val executionInput = request.toExecutionInput(dataLoaderRegistry = dataLoaderRegistry)
+        assertEquals(request.query, executionInput.query)
+        assertEquals(dataLoaderRegistry, executionInput.dataLoaderRegistry)
+    }
+}

--- a/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/model/GraphQLResponseKtTest.kt
+++ b/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/model/GraphQLResponseKtTest.kt
@@ -27,7 +27,7 @@ import kotlin.test.assertNull
 class GraphQLResponseKtTest {
 
     @Test
-    fun `null data, errors, and extenstions can still be mapped`() {
+    fun `null data, errors, and extensions can still be mapped`() {
         val executionResult: ExecutionResult = mockk {
             every { getData<Any>() } returns null
             every { errors } returns null


### PR DESCRIPTION
# :pencil: Description
When creating new `ExecutionInput` we should automatically register `DataLoaderRegistry` if it is present in the application context.

### :link: Related Issues
https://github.com/ExpediaGroup/graphql-kotlin/issues/381
https://github.com/ExpediaGroup/graphql-kotlin/pull/396