### PR TITLE
Exclude docs from coverage reports/checks

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -3,6 +3,8 @@
 # See the docs here: https://docs.codecov.io/docs/codecov-yaml
 #
 
-# Ingore the example app from coverage reports
+# Ingore the example apps and docs from coverage reports
 ignore:
-  - "examples/**/*"
+  - "examples/**"
+  - "website/**"
+  - "docs/**"


### PR DESCRIPTION
### :pencil: Description
Update the code coverage reports so they don't need to be checked on documentation updates