### PR TITLE
[spring-server] support for creating data loader registry per execution

### DIFF
--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/GraphQLAutoConfiguration.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/GraphQLAutoConfiguration.kt
@@ -18,7 +18,9 @@ package com.expediagroup.graphql.spring
 
 import com.expediagroup.graphql.spring.exception.KotlinDataFetcherExceptionHandler
 import com.expediagroup.graphql.spring.execution.ContextWebFilter
+import com.expediagroup.graphql.spring.execution.DataLoaderRegistryFactory
 import com.expediagroup.graphql.spring.execution.EmptyContextFactory
+import com.expediagroup.graphql.spring.execution.EmptyDataLoaderRegistryFactory
 import com.expediagroup.graphql.spring.execution.GraphQLContextFactory
 import com.expediagroup.graphql.spring.execution.QueryHandler
 import com.expediagroup.graphql.spring.execution.SimpleQueryHandler
@@ -32,7 +34,6 @@ import graphql.execution.instrumentation.ChainedInstrumentation
 import graphql.execution.instrumentation.Instrumentation
 import graphql.execution.preparsed.PreparsedDocumentProvider
 import graphql.schema.GraphQLSchema
-import org.dataloader.DataLoaderRegistry
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
@@ -104,11 +105,14 @@ class GraphQLAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    fun dataLoaderRegistry(): DataLoaderRegistry = DataLoaderRegistry()
+    fun dataLoaderRegistryFactory(): DataLoaderRegistryFactory = EmptyDataLoaderRegistryFactory()
 
     @Bean
     @ConditionalOnMissingBean
-    fun graphQLQueryHandler(graphql: GraphQL, dataLoaderRegistry: DataLoaderRegistry): QueryHandler = SimpleQueryHandler(graphql, dataLoaderRegistry)
+    fun graphQLQueryHandler(
+        graphql: GraphQL,
+        dataLoaderRegistryFactory: DataLoaderRegistryFactory
+    ): QueryHandler = SimpleQueryHandler(graphql, dataLoaderRegistryFactory)
 
     @Bean
     @ConditionalOnMissingBean

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/execution/DataLoaderRegistryFactory.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/execution/DataLoaderRegistryFactory.kt
@@ -1,0 +1,21 @@
+package com.expediagroup.graphql.spring.execution
+
+import org.dataloader.DataLoaderRegistry
+
+/**
+ * Factory used to generate [DataLoaderRegistry] per GraphQL execution.
+ */
+interface DataLoaderRegistryFactory {
+
+    /**
+     * Generate [DataLoaderRegistry] to be used for GraphQL query execution.
+     */
+    fun generate(): DataLoaderRegistry
+}
+
+/**
+ * Default [DataLoaderRegistryFactory] that generates empty data loader registry.
+ */
+class EmptyDataLoaderRegistryFactory : DataLoaderRegistryFactory {
+    override fun generate() = DataLoaderRegistry()
+}

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/execution/QueryHandler.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/execution/QueryHandler.kt
@@ -25,7 +25,6 @@ import graphql.GraphQL
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.future.await
 import kotlinx.coroutines.reactor.ReactorContext
-import org.dataloader.DataLoaderRegistry
 import kotlin.coroutines.coroutineContext
 
 /**
@@ -42,14 +41,14 @@ interface QueryHandler {
 /**
  * Default GraphQL query handler.
  */
-open class SimpleQueryHandler(private val graphql: GraphQL, private val dataLoaderRegistry: DataLoaderRegistry? = null) : QueryHandler {
+open class SimpleQueryHandler(private val graphql: GraphQL, private val dataLoaderRegistryFactory: DataLoaderRegistryFactory? = null) : QueryHandler {
 
     @Suppress("TooGenericExceptionCaught")
     @ExperimentalCoroutinesApi
     override suspend fun executeQuery(request: GraphQLRequest): GraphQLResponse {
         val reactorContext = coroutineContext[ReactorContext]
         val graphQLContext = reactorContext?.context?.getOrDefault<Any>(GRAPHQL_CONTEXT_KEY, null)
-        val input = request.toExecutionInput(graphQLContext, dataLoaderRegistry)
+        val input = request.toExecutionInput(graphQLContext, dataLoaderRegistryFactory?.generate())
 
         return try {
             graphql.executeAsync(input)

--- a/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/SchemaConfigurationTest.kt
+++ b/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/SchemaConfigurationTest.kt
@@ -18,6 +18,7 @@ package com.expediagroup.graphql.spring
 
 import com.expediagroup.graphql.SchemaGeneratorConfig
 import com.expediagroup.graphql.TopLevelObject
+import com.expediagroup.graphql.spring.execution.DataLoaderRegistryFactory
 import com.expediagroup.graphql.spring.execution.GraphQLContextFactory
 import com.expediagroup.graphql.spring.execution.QueryHandler
 import com.expediagroup.graphql.spring.operations.Query
@@ -31,7 +32,6 @@ import graphql.schema.GraphQLSchema
 import graphql.schema.GraphQLTypeUtil
 import io.mockk.mockk
 import org.assertj.core.api.AssertionsForInterfaceTypes.assertThat
-import org.dataloader.DataLoaderRegistry
 import org.junit.jupiter.api.Test
 import org.springframework.boot.autoconfigure.AutoConfigurations
 import org.springframework.boot.test.context.runner.ReactiveWebApplicationContextRunner
@@ -73,7 +73,7 @@ class SchemaConfigurationTest {
                 assertNull(result["errors"])
                 assertNotNull(result["extensions"])
 
-                assertThat(ctx).hasSingleBean(DataLoaderRegistry::class.java)
+                assertThat(ctx).hasSingleBean(DataLoaderRegistryFactory::class.java)
                 assertThat(ctx).hasSingleBean(QueryHandler::class.java)
                 assertThat(ctx).hasSingleBean(GraphQLContextFactory::class.java)
             }
@@ -97,9 +97,9 @@ class SchemaConfigurationTest {
                 assertThat(ctx).getBean(GraphQL::class.java)
                     .isSameAs(customConfiguration.myGraphQL())
 
-                assertThat(ctx).hasSingleBean(DataLoaderRegistry::class.java)
-                assertThat(ctx).getBean(DataLoaderRegistry::class.java)
-                    .isSameAs(customConfiguration.myDataLoaderRegistry())
+                assertThat(ctx).hasSingleBean(DataLoaderRegistryFactory::class.java)
+                assertThat(ctx).getBean(DataLoaderRegistryFactory::class.java)
+                    .isSameAs(customConfiguration.myDataLoaderRegistryFactory())
 
                 assertThat(ctx).hasSingleBean(QueryHandler::class.java)
 
@@ -150,7 +150,7 @@ class SchemaConfigurationTest {
         fun myCustomContextFactory(): GraphQLContextFactory<Map<String, Any>> = mockk()
 
         @Bean
-        fun myDataLoaderRegistry(): DataLoaderRegistry = mockk()
+        fun myDataLoaderRegistryFactory(): DataLoaderRegistryFactory = mockk()
     }
 
     class BasicQuery : Query {


### PR DESCRIPTION
### :pencil: Description
Instance of `DataLoaderRegistry` should be created per GraphQL query execution instead of being a singleton. Developers can create their custom instance of `DataLoaderRegistry` by providing custom `DataLoaderRegistryFactory` bean.

### :link: Related Issues
https://github.com/ExpediaGroup/graphql-kotlin/issues/381
https://github.com/ExpediaGroup/graphql-kotlin/pull/396
https://github.com/ExpediaGroup/graphql-kotlin/pull/400