### PR TITLE
switch state from internal to public

### DIFF
--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/SchemaGenerator.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/SchemaGenerator.kt
@@ -49,7 +49,7 @@ import kotlin.reflect.KType
 @Suppress("LeakingThis")
 open class SchemaGenerator(val config: SchemaGeneratorConfig) {
 
-    internal val state = SchemaGeneratorState(config.supportedPackages)
+    val state = SchemaGeneratorState(config.supportedPackages)
     internal val subTypeMapper = SubTypeMapper(config.supportedPackages)
     internal val codeRegistry = GraphQLCodeRegistry.newCodeRegistry()
 

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/state/KGraphQLType.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/state/KGraphQLType.kt
@@ -22,4 +22,4 @@ import kotlin.reflect.KClass
 /**
  * Container for the types cache information.
  */
-internal data class KGraphQLType(val kClass: KClass<*>, val graphQLType: GraphQLType)
+data class KGraphQLType(val kClass: KClass<*>, val graphQLType: GraphQLType)

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/state/SchemaGeneratorState.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/state/SchemaGeneratorState.kt
@@ -23,7 +23,7 @@ import graphql.schema.GraphQLType
 import java.util.concurrent.ConcurrentHashMap
 
 @Suppress("UseDataClass")
-internal class SchemaGeneratorState(supportedPackages: List<String>) {
+class SchemaGeneratorState(supportedPackages: List<String>) {
     val cache = TypesCache(supportedPackages)
     val additionalTypes = mutableSetOf<GraphQLType>()
     val directives = ConcurrentHashMap<String, GraphQLDirective>()

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/state/TypesCache.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/state/TypesCache.kt
@@ -29,7 +29,7 @@ import kotlin.reflect.KType
 import kotlin.reflect.full.createType
 import kotlin.reflect.full.isSubclassOf
 
-internal class TypesCache(private val supportedPackages: List<String>) {
+class TypesCache(private val supportedPackages: List<String>) {
 
     private val cache: MutableMap<String, KGraphQLType> = mutableMapOf()
     private val typeUnderConstruction: MutableSet<KClass<*>> = mutableSetOf()

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/state/TypesCacheKey.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/state/TypesCacheKey.kt
@@ -18,4 +18,4 @@ package com.expediagroup.graphql.generator.state
 
 import kotlin.reflect.KType
 
-internal data class TypesCacheKey(val type: KType, val inputType: Boolean)
+data class TypesCacheKey(val type: KType, val inputType: Boolean)


### PR DESCRIPTION
### :pencil: Description
Switch state in `SchemaGenerator` (along with corresponding classes) from internal to public. I was running into the following error while trying to override the `objectType` function because an object was being used while being built:

Caused by: java.lang.ClassCastException: class graphql.schema.GraphQLTypeReference cannot be cast to class graphql.schema.GraphQLUnmodifiedType (graphql.schema.GraphQLTypeReference and graphql.schema.GraphQLUnmodifiedType are in unnamed module of loader 'app')
