### PR TITLE
Throw exception on multi-level interface

### DIFF
--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/exceptions/InvalidInterfaceException.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/exceptions/InvalidInterfaceException.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.exceptions
+
+/**
+ * Thrown when a interface implements another interface or abstract class that is not exluded from the schema.
+ *
+ * This is an invalid schema until the GraphQL spec is updated
+ * https://github.com/ExpediaGroup/graphql-kotlin/issues/419
+ */
+class InvalidInterfaceException : GraphQLKotlinException("Interfaces can not have any superclasses")

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/extensions/kClassExtensions.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/extensions/kClassExtensions.kt
@@ -51,6 +51,9 @@ internal fun KClass<*>.getValidSuperclasses(hooks: SchemaGeneratorHooks): List<K
     this.superclasses
         .filter { hooks.isValidSuperclass(it) }
         .filter { kClass -> superclassFilters.all { it.invoke(kClass) } }
+        .ifEmpty {
+            this.superclasses.flatMap { it.getValidSuperclasses(hooks) }
+        }
 
 internal fun KClass<*>.findConstructorParamter(name: String): KParameter? =
     this.primaryConstructor?.findParameterByName(name)

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/filters/superclassFilters.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/filters/superclassFilters.kt
@@ -16,6 +16,7 @@
 
 package com.expediagroup.graphql.generator.filters
 
+import com.expediagroup.graphql.generator.extensions.isGraphQLIgnored
 import com.expediagroup.graphql.generator.extensions.isInterface
 import com.expediagroup.graphql.generator.extensions.isPublic
 import com.expediagroup.graphql.generator.extensions.isUnion
@@ -26,5 +27,6 @@ private typealias SuperclassFilter = (KClass<*>) -> Boolean
 private val isPublic: SuperclassFilter = { it.isPublic() }
 private val isInterface: SuperclassFilter = { it.isInterface() }
 private val isNotUnion: SuperclassFilter = { it.isUnion().not() }
+private val isNotIgnored: SuperclassFilter = { it.isGraphQLIgnored().not() }
 
-internal val superclassFilters: List<SuperclassFilter> = listOf(isPublic, isInterface, isNotUnion)
+internal val superclassFilters: List<SuperclassFilter> = listOf(isPublic, isInterface, isNotUnion, isNotIgnored)

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/InterfaceBuilder.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/InterfaceBuilder.kt
@@ -16,12 +16,14 @@
 
 package com.expediagroup.graphql.generator.types
 
+import com.expediagroup.graphql.exceptions.InvalidInterfaceException
 import com.expediagroup.graphql.generator.SchemaGenerator
 import com.expediagroup.graphql.generator.TypeBuilder
 import com.expediagroup.graphql.generator.extensions.getGraphQLDescription
 import com.expediagroup.graphql.generator.extensions.getSimpleName
 import com.expediagroup.graphql.generator.extensions.getValidFunctions
 import com.expediagroup.graphql.generator.extensions.getValidProperties
+import com.expediagroup.graphql.generator.extensions.getValidSuperclasses
 import com.expediagroup.graphql.generator.extensions.safeCast
 import graphql.TypeResolutionEnvironment
 import graphql.schema.GraphQLInterfaceType
@@ -34,6 +36,11 @@ import kotlin.reflect.full.createType
 internal class InterfaceBuilder(generator: SchemaGenerator) : TypeBuilder(generator) {
     internal fun interfaceType(kClass: KClass<*>): GraphQLType {
         return state.cache.buildIfNotUnderConstruction(kClass) {
+
+            if (kClass.getValidSuperclasses(generator.config.hooks).isNotEmpty()) {
+                throw InvalidInterfaceException()
+            }
+
             val builder = GraphQLInterfaceType.newInterface()
 
             builder.name(kClass.getSimpleName())

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/InterfaceBuilder.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/InterfaceBuilder.kt
@@ -37,7 +37,8 @@ internal class InterfaceBuilder(generator: SchemaGenerator) : TypeBuilder(genera
     internal fun interfaceType(kClass: KClass<*>): GraphQLType {
         return state.cache.buildIfNotUnderConstruction(kClass) {
 
-            if (kClass.getValidSuperclasses(generator.config.hooks).isNotEmpty()) {
+            // Interfaces can not implement another interface in GraphQL
+            if (kClass.getValidSuperclasses(config.hooks).isNotEmpty()) {
                 throw InvalidInterfaceException()
             }
 

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/extensions/KClassExtensionsTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/extensions/KClassExtensionsTest.kt
@@ -89,7 +89,32 @@ open class KClassExtensionsTest {
         val id: String
     }
 
+    @GraphQLIgnore
+    interface IgnoredSecondLevelInterface : SomeInterface
+
+    internal class ClassWithSecondLevelInterface : IgnoredSecondLevelInterface {
+        override val someField: String = "hello"
+
+        override fun someFunction(): String? = null
+    }
+
+    @GraphQLIgnore
+    abstract class IgnoredAbstractClass : SomeInterface
+
+    @GraphQLIgnore
+    abstract class IgnoredSecondAbstractClass : IgnoredAbstractClass()
+
     internal class ClassWithNoValidSuperclass(override val id: String) : IgnoredInterface
+
+    internal class ClassWithSecondLevelAbstractClass : IgnoredAbstractClass() {
+        override val someField: String = "foo"
+        override fun someFunction(): String? = "bar"
+    }
+
+    internal class ClassWithThirdLevelAbstractClass : IgnoredSecondAbstractClass() {
+        override val someField: String = "foo"
+        override fun someFunction(): String? = "bar"
+    }
 
     internal class InterfaceSuperclass : InvalidFunctionUnionInterface {
         override fun getTest() = 2
@@ -187,6 +212,24 @@ open class KClassExtensionsTest {
     fun `Superclasses are not included when marked as ignored`() {
         val superclasses = ClassWithNoValidSuperclass::class.getValidSuperclasses(noopHooks)
         assertTrue(superclasses.isEmpty())
+    }
+
+    @Test
+    fun `Return superclasses from abstract class two levels deep`() {
+        val superclasses = ClassWithSecondLevelAbstractClass::class.getValidSuperclasses(noopHooks)
+        assertEquals(expected = 1, actual = superclasses.size)
+    }
+
+    @Test
+    fun `Return superclasses from abstract class three levels deep`() {
+        val superclasses = ClassWithThirdLevelAbstractClass::class.getValidSuperclasses(noopHooks)
+        assertEquals(expected = 1, actual = superclasses.size)
+    }
+
+    @Test
+    fun `Return superclasses from interface two levels deep`() {
+        val superclasses = ClassWithSecondLevelInterface::class.getValidSuperclasses(noopHooks)
+        assertEquals(expected = 1, actual = superclasses.size)
     }
 
     @Test

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/extensions/KClassExtensionsTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/extensions/KClassExtensionsTest.kt
@@ -16,6 +16,7 @@
 
 package com.expediagroup.graphql.generator.extensions
 
+import com.expediagroup.graphql.annotations.GraphQLIgnore
 import com.expediagroup.graphql.annotations.GraphQLName
 import com.expediagroup.graphql.exceptions.CouldNotGetNameOfKClassException
 import com.expediagroup.graphql.hooks.NoopSchemaGeneratorHooks
@@ -82,6 +83,13 @@ open class KClassExtensionsTest {
     class MyPublicClass
 
     internal class UnionSuperclass : TestInterface
+
+    @GraphQLIgnore
+    internal interface IgnoredInterface {
+        val id: String
+    }
+
+    internal class ClassWithNoValidSuperclass(override val id: String) : IgnoredInterface
 
     internal class InterfaceSuperclass : InvalidFunctionUnionInterface {
         override fun getTest() = 2
@@ -172,6 +180,12 @@ open class KClassExtensionsTest {
     @Test
     fun `test getting invalid superclass with no hooks`() {
         val superclasses = UnionSuperclass::class.getValidSuperclasses(noopHooks)
+        assertTrue(superclasses.isEmpty())
+    }
+
+    @Test
+    fun `Superclasses are not included when marked as ignored`() {
+        val superclasses = ClassWithNoValidSuperclass::class.getValidSuperclasses(noopHooks)
         assertTrue(superclasses.isEmpty())
     }
 

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/test/integration/InterfaceOfInterfaceTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/test/integration/InterfaceOfInterfaceTest.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.test.integration
+
+import com.expediagroup.graphql.TopLevelObject
+import com.expediagroup.graphql.exceptions.InvalidInterfaceException
+import com.expediagroup.graphql.testSchemaConfig
+import com.expediagroup.graphql.toSchema
+import org.junit.jupiter.api.Test
+import kotlin.test.assertFailsWith
+
+class InterfaceOfInterfaceTest {
+
+    @Test
+    fun `interface of interface`() {
+        val queries = listOf(TopLevelObject(InterfaceOfInterfaceQuery()))
+
+        assertFailsWith(InvalidInterfaceException::class) {
+            toSchema(queries = queries, config = testSchemaConfig)
+        }
+    }
+
+    interface FirstLevel {
+        val id: String
+    }
+
+    interface SecondLevel : FirstLevel {
+        val name: String
+    }
+
+    class MyClass(override val id: String, override val name: String) : SecondLevel
+
+    class InterfaceOfInterfaceQuery {
+        fun getClass() = MyClass(id = "1", name = "fooBar")
+    }
+}


### PR DESCRIPTION
### :pencil: Description
According to the spec, an interface can not implement another interface. This is not caught by our schema generator but instead just returns the first level interface as the type in the schema. We are now throwing an exception to help translate this understanding of GraphQL through the Kotlin code


Is this a breaking change? Someone may be using 1.0.0 today and just by updating their version they will have to fix something.

### :link: Related Issues
Resolves https://github.com/ExpediaGroup/graphql-kotlin/issues/419