### PR TITLE
[spring-server] fix: handle graphql request with charset coding

### DIFF
--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/RoutesConfiguration.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/RoutesConfiguration.kt
@@ -77,10 +77,13 @@ class RoutesConfiguration(
             }
             GraphQLRequest(query = query, operationName = operationName, variables = graphQLVariables)
         }
-        serverRequest.method() == HttpMethod.POST -> when (serverRequest.headers().contentType().orElse(MediaType.APPLICATION_JSON)) {
-            MediaType.APPLICATION_JSON -> serverRequest.awaitBody()
-            graphQLMediaType -> GraphQLRequest(query = serverRequest.awaitBody())
-            else -> null
+        serverRequest.method() == HttpMethod.POST -> {
+            val contentType = serverRequest.headers().contentType().orElse(MediaType.APPLICATION_JSON)
+            when {
+                contentType.includes(MediaType.APPLICATION_JSON) -> serverRequest.awaitBody()
+                contentType.includes(graphQLMediaType) -> GraphQLRequest(query = serverRequest.awaitBody())
+                else -> null
+            }
         }
         else -> null
     }

--- a/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/routes/RouteConfigurationIT.kt
+++ b/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/routes/RouteConfigurationIT.kt
@@ -215,6 +215,23 @@ directive @deprecated(reason: String = "No longer supported") on FIELD_DEFINITIO
             .jsonPath("$.extensions").doesNotExist()
     }
 
+    @Test
+    fun `verify POST graphQL request with explicit charset`() {
+        val request = GraphQLRequest(
+            query = "query helloWorldQuery(\$name: String!) { hello(name: \$name) }",
+            variables = mapOf("name" to "JUNIT route with charset encoding"),
+            operationName = "helloWorldQuery"
+        )
+
+        testClient.post()
+            .uri("/graphql")
+            .accept(MediaType.APPLICATION_JSON_UTF8)
+            .contentType(MediaType.APPLICATION_JSON_UTF8)
+            .bodyValue(request)
+            .exchange()
+            .verifyGraphQLRoute("Hello JUNIT route with charset encoding!")
+    }
+
     private fun WebTestClient.ResponseSpec.verifyGraphQLRoute(expected: String) = this.expectStatus().isOk
         .expectBody()
         .jsonPath("$.data.hello").isEqualTo(expected)


### PR DESCRIPTION
### :pencil: Description

In our default GraphQL route we were explicitly checking if `Content-Type` header is just `application/json`. If request was also specifying charset, e.g. `application/json;charset=UTF-8` our logic would fail to match it and result in HTTP 400 (Bad Request) response.
