### PR TITLE
Fixed link to Gateway Readme

### DIFF
--- a/examples/federation/README.md
+++ b/examples/federation/README.md
@@ -28,4 +28,4 @@ Once the app has started you can explore the example schema by opening Playgroun
 
 ### Gateway
 
-See the instructions in the [README](/gateway/README.md) for this folder
+See the instructions in the [README](./gateway/README.md) for this folder


### PR DESCRIPTION
### :pencil: Description
The current link was causing a 404 as it was using an absolute path

### :link: Related Issues
None