### PR TITLE
Move spring-boot version to single location

### DIFF
--- a/examples/federation/base-app/pom.xml
+++ b/examples/federation/base-app/pom.xml
@@ -14,6 +14,7 @@
     <packaging>jar</packaging>
 
     <properties>
+        <project.root>${project.basedir}/../../..</project.root>
         <!-- skip release plugins -->
         <maven.source.skip>true</maven.source.skip>
     </properties>

--- a/examples/federation/base-app/pom.xml
+++ b/examples/federation/base-app/pom.xml
@@ -14,8 +14,6 @@
     <packaging>jar</packaging>
 
     <properties>
-        <spring-boot.version>2.2.0.M5</spring-boot.version>
-
         <!-- skip release plugins -->
         <maven.source.skip>true</maven.source.skip>
     </properties>

--- a/examples/federation/base-app/pom.xml
+++ b/examples/federation/base-app/pom.xml
@@ -3,9 +3,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.expediagroup</groupId>
-        <artifactId>graphql-kotlin</artifactId>
+        <artifactId>federation</artifactId>
         <version>1.1.1-SNAPSHOT</version>
-        <relativePath>../../..</relativePath>
+        <relativePath>..</relativePath>
     </parent>
 
     <artifactId>base-app</artifactId>

--- a/examples/federation/extend-app/pom.xml
+++ b/examples/federation/extend-app/pom.xml
@@ -14,6 +14,7 @@
     <packaging>jar</packaging>
 
     <properties>
+        <project.root>${project.basedir}/../../..</project.root>
         <!-- skip release plugins -->
         <maven.source.skip>true</maven.source.skip>
     </properties>

--- a/examples/federation/extend-app/pom.xml
+++ b/examples/federation/extend-app/pom.xml
@@ -14,8 +14,6 @@
     <packaging>jar</packaging>
 
     <properties>
-        <spring-boot.version>2.2.0.M5</spring-boot.version>
-
         <!-- skip release plugins -->
         <maven.source.skip>true</maven.source.skip>
     </properties>

--- a/examples/federation/extend-app/pom.xml
+++ b/examples/federation/extend-app/pom.xml
@@ -3,9 +3,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.expediagroup</groupId>
-        <artifactId>graphql-kotlin</artifactId>
+        <artifactId>federation</artifactId>
         <version>1.1.1-SNAPSHOT</version>
-        <relativePath>../../..</relativePath>
+        <relativePath>..</relativePath>
     </parent>
 
     <artifactId>extend-app</artifactId>

--- a/examples/federation/pom.xml
+++ b/examples/federation/pom.xml
@@ -2,10 +2,10 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <artifactId>graphql-kotlin</artifactId>
         <groupId>com.expediagroup</groupId>
+        <artifactId>examples</artifactId>
         <version>1.1.1-SNAPSHOT</version>
-        <relativePath>../..</relativePath>
+        <relativePath>..</relativePath>
     </parent>
 
     <artifactId>federation</artifactId>
@@ -78,7 +78,7 @@
                             <phase>validate</phase>
                             <configuration>
                                 <target name="ktlint">
-                                    <java taskname="ktlint" dir="${project.basedir}" fork="true" failonerror="true" classname="com.github.shyiko.ktlint.Main" classpathref="maven.plugin.classpath">
+                                    <java taskname="ktlint" dir="${project.basedir}" fork="true" failonerror="true" classname="com.pinterest.ktlint.Main" classpathref="maven.plugin.classpath">
                                         <arg value="src/**/*.kt" />
                                         <arg value="--reporter=plain" />
                                         <arg value="--reporter=checkstyle,output=${project.build.directory}/ktlint.xml" />
@@ -94,10 +94,10 @@
                         <dependency>
                             <groupId>io.gitlab.arturbosch.detekt</groupId>
                             <artifactId>detekt-cli</artifactId>
-                            <version>${detekt-cli.version}</version>
+                            <version>${detekt.version}</version>
                         </dependency>
                         <dependency>
-                            <groupId>com.github.shyiko</groupId>
+                            <groupId>com.pinterest</groupId>
                             <artifactId>ktlint</artifactId>
                             <version>${ktlint.version}</version>
                         </dependency>

--- a/examples/federation/pom.xml
+++ b/examples/federation/pom.xml
@@ -47,64 +47,6 @@
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-antrun-plugin</artifactId>
-                    <version>1.8</version>
-                    <executions>
-                        <!-- those can be run separately with mvn clean antrun:run@<target_id> -->
-                        <execution>
-                            <id>detekt</id>
-                            <phase>validate</phase>
-                            <configuration>
-                                <target name="detekt">
-                                    <java taskname="detekt" dir="${project.basedir}" fork="true" failonerror="true" classname="io.gitlab.arturbosch.detekt.cli.Main" classpathref="maven.plugin.classpath">
-                                        <arg value="--fail-fast" />
-                                        <arg value="--input" />
-                                        <arg value="${project.basedir}${file.separator}src" />
-                                        <arg value="--config" />
-                                        <arg value="${project.parent.relativePath}${file.separator}detekt.yml" />
-                                        <arg value="--report" />
-                                        <arg value="html:${project.basedir}${file.separator}target${file.separator}site${file.separator}detekt.html" />
-                                        <arg value="--report" />
-                                        <arg value="xml:${project.basedir}${file.separator}target${file.separator}site${file.separator}detekt.xml" />
-                                    </java>
-                                </target>
-                            </configuration>
-                            <goals>
-                                <goal>run</goal>
-                            </goals>
-                        </execution>
-                        <execution>
-                            <id>ktlint</id>
-                            <phase>validate</phase>
-                            <configuration>
-                                <target name="ktlint">
-                                    <java taskname="ktlint" dir="${project.basedir}" fork="true" failonerror="true" classname="com.pinterest.ktlint.Main" classpathref="maven.plugin.classpath">
-                                        <arg value="src/**/*.kt" />
-                                        <arg value="--reporter=plain" />
-                                        <arg value="--reporter=checkstyle,output=${project.build.directory}/ktlint.xml" />
-                                    </java>
-                                </target>
-                            </configuration>
-                            <goals>
-                                <goal>run</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                    <dependencies>
-                        <dependency>
-                            <groupId>io.gitlab.arturbosch.detekt</groupId>
-                            <artifactId>detekt-cli</artifactId>
-                            <version>${detekt.version}</version>
-                        </dependency>
-                        <dependency>
-                            <groupId>com.pinterest</groupId>
-                            <artifactId>ktlint</artifactId>
-                            <version>${ktlint.version}</version>
-                        </dependency>
-                    </dependencies>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>2.22.1</version>
                     <!-- TODO enable below once we add unit tests to federation example app -->

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -2,8 +2,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <artifactId>graphql-kotlin</artifactId>
         <groupId>com.expediagroup</groupId>
+        <artifactId>graphql-kotlin</artifactId>
         <version>1.1.1-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>

--- a/examples/spring/README.md
+++ b/examples/spring/README.md
@@ -3,16 +3,18 @@
 One way to run a GraphQL server is with [Spring Boot](https://github.com/spring-projects/spring-boot). This example app uses [Spring Webflux](https://docs.spring.io/spring/docs/current/spring-framework-reference/web-reactive.html) together with `graphql-kotlin` and [graphql-playground](https://github.com/prisma/graphql-playground).
 
 ### Running locally
-Build the application
 
-```bash
+First you must build all the other modules since this is a multi-module project.
+
+From the root directory:
+
+```shell script
 mvn clean install
 ```
 
-Start the server:
+Then to start the server:
 
 * Run `Application.kt` directly from your IDE
-* Alternatively you can also use the spring boot maven plugin by running `mvn spring-boot:run` from the command line.
+* Alternatively you can also use the spring boot maven plugin by running `mvn spring-boot:run` from the command line in the spring example directory.
 
-
-Once the app has started you can explore the example schema by opening Playground endpoint at http://localhost:8080/playground.
+Once the app has started you can explore the example schema by opening the GraphQL Playground endpoint at http://localhost:8080/playground.

--- a/examples/spring/pom.xml
+++ b/examples/spring/pom.xml
@@ -3,9 +3,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.expediagroup</groupId>
-        <artifactId>graphql-kotlin</artifactId>
+        <artifactId>examples</artifactId>
         <version>1.1.1-SNAPSHOT</version>
-        <relativePath>../..</relativePath>
+        <relativePath>..</relativePath>
     </parent>
 
     <artifactId>spring-example</artifactId>

--- a/examples/spring/pom.xml
+++ b/examples/spring/pom.xml
@@ -14,6 +14,7 @@
     <packaging>jar</packaging>
 
     <properties>
+        <project.root>${project.basedir}/../..</project.root>
         <!-- skip release plugins -->
         <maven.source.skip>true</maven.source.skip>
     </properties>

--- a/examples/spring/pom.xml
+++ b/examples/spring/pom.xml
@@ -14,8 +14,6 @@
     <packaging>jar</packaging>
 
     <properties>
-        <spring-boot.version>2.2.0.M5</spring-boot.version>
-
         <!-- skip release plugins -->
         <maven.source.skip>true</maven.source.skip>
     </properties>

--- a/graphql-kotlin-federation/pom.xml
+++ b/graphql-kotlin-federation/pom.xml
@@ -10,8 +10,11 @@
     </parent>
 
     <artifactId>graphql-kotlin-federation</artifactId>
-    <name>graphql-kotlin-federation</name>
     <packaging>jar</packaging>
+
+    <properties>
+        <project.root>${project.basedir}/..</project.root>
+    </properties>
 
     <build>
         <sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>

--- a/graphql-kotlin-schema-generator/pom.xml
+++ b/graphql-kotlin-schema-generator/pom.xml
@@ -14,6 +14,7 @@
     <packaging>jar</packaging>
 
     <properties>
+        <project.root>${project.basedir}/..</project.root>
         <rxjava2.version>2.2.12</rxjava2.version>
     </properties>
 

--- a/graphql-kotlin-spring-server/pom.xml
+++ b/graphql-kotlin-spring-server/pom.xml
@@ -12,7 +12,6 @@
     <packaging>jar</packaging>
 
     <properties>
-        <spring-boot.version>2.2.0.RC1</spring-boot.version>
         <reactor.version>3.3.0.RELEASE</reactor.version>
         <reactor-kotlin-extensions.version>1.0.0.RELEASE</reactor-kotlin-extensions.version>
     </properties>

--- a/graphql-kotlin-spring-server/pom.xml
+++ b/graphql-kotlin-spring-server/pom.xml
@@ -12,6 +12,7 @@
     <packaging>jar</packaging>
 
     <properties>
+        <project.root>${project.basedir}/..</project.root>
         <reactor.version>3.3.0.RELEASE</reactor.version>
         <reactor-kotlin-extensions.version>1.0.0.RELEASE</reactor-kotlin-extensions.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,7 @@
         <kotlin.version>1.3.50</kotlin.version>
         <kotlin-coroutines.version>1.3.2</kotlin-coroutines.version>
         <reflections.version>0.9.11</reflections.version>
+        <spring-boot.version>2.2.0.RC1</spring-boot.version>
 
         <!-- Test Dependency Versions -->
         <junit-jupiter.version>5.5.2</junit-jupiter.version>

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,7 @@
         <!-- Project Versions -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
+        <project.root>${project.basedir}</project.root>
 
         <!-- Dependency Versions -->
         <graphql-java.version>13.0</graphql-java.version>
@@ -133,7 +134,7 @@
                                         <arg value="--input" />
                                         <arg value="${project.basedir}${file.separator}src" />
                                         <arg value="--config" />
-                                        <arg value="${project.parent.relativePath}${file.separator}detekt.yml" />
+                                        <arg value="${project.root}${file.separator}detekt.yml" />
                                         <arg value="--report" />
                                         <arg value="html:${project.basedir}${file.separator}target${file.separator}site${file.separator}detekt.html" />
                                         <arg value="--report" />


### PR DESCRIPTION
### :pencil: Description
Move the declared version of spring-boot to the root so we use the same version across all the modules and examples

### :link: Related Issues
Fixes https://github.com/ExpediaGroup/graphql-kotlin/issues/429