### PR TITLE
[spring-server] simplify schema configuration auto configuration

### DIFF
--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/SchemaGeneratorConfig.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/SchemaGeneratorConfig.kt
@@ -26,7 +26,7 @@ import com.expediagroup.graphql.hooks.SchemaGeneratorHooks
 open class SchemaGeneratorConfig(
     open val supportedPackages: List<String>,
     open val topLevelNames: TopLevelNames = TopLevelNames(),
-    open val hooks: SchemaGeneratorHooks = NoopSchemaGeneratorHooks(),
+    open val hooks: SchemaGeneratorHooks = NoopSchemaGeneratorHooks,
     open val dataFetcherFactoryProvider: KotlinDataFetcherFactoryProvider = KotlinDataFetcherFactoryProvider(hooks)
 )
 

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/hooks/NoopSchemaGeneratorHooks.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/hooks/NoopSchemaGeneratorHooks.kt
@@ -17,7 +17,6 @@
 package com.expediagroup.graphql.hooks
 
 /**
- * Default hooks that do not override or set anything. Only used internally.
- * If you don't need hooks, the configuration will default to these.
+ * Default hooks that do not override or set anything. If you don't need hooks, the configuration will default to these.
  */
-internal class NoopSchemaGeneratorHooks : SchemaGeneratorHooks
+object NoopSchemaGeneratorHooks : SchemaGeneratorHooks

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/execution/CustomDataFetcherTests.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/execution/CustomDataFetcherTests.kt
@@ -66,7 +66,7 @@ data class Animal(
 
 data class AnimalDetails(val specialId: Int)
 
-class CustomDataFetcherFactoryProvider : KotlinDataFetcherFactoryProvider(NoopSchemaGeneratorHooks()) {
+class CustomDataFetcherFactoryProvider : KotlinDataFetcherFactoryProvider(NoopSchemaGeneratorHooks) {
 
     override fun propertyDataFetcherFactory(kClass: KClass<*>, kProperty: KProperty<*>): DataFetcherFactory<Any> =
         if (kProperty.isLateinit) {

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/extensions/KClassExtensionsTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/extensions/KClassExtensionsTest.kt
@@ -119,7 +119,7 @@ open class KClassExtensionsTest {
             kClass.simpleName?.contains("InvalidFunctionUnionInterface")?.not().isTrue()
     }
 
-    private val noopHooks = NoopSchemaGeneratorHooks()
+    private val noopHooks = NoopSchemaGeneratorHooks
 
     @Test
     fun `test getting valid properties with no hooks`() {

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/hooks/SchemaGeneratorHooksTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/hooks/SchemaGeneratorHooksTest.kt
@@ -206,7 +206,7 @@ class SchemaGeneratorHooksTest {
 
     @Test
     fun `willResolveMonad returns basic type`() {
-        val hooks = NoopSchemaGeneratorHooks()
+        val hooks = NoopSchemaGeneratorHooks
         val type = TestQuery::query.returnType
 
         assertEquals(expected = "SomeData", actual = hooks.willResolveMonad(type).getSimpleName())

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/FederationAutoConfiguration.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/FederationAutoConfiguration.kt
@@ -16,6 +16,8 @@
 
 package com.expediagroup.graphql.spring
 
+import com.expediagroup.graphql.TopLevelNames
+import com.expediagroup.graphql.execution.KotlinDataFetcherFactoryProvider
 import com.expediagroup.graphql.extensions.print
 import com.expediagroup.graphql.federation.FederatedSchemaGeneratorConfig
 import com.expediagroup.graphql.federation.FederatedSchemaGeneratorHooks
@@ -47,9 +49,20 @@ class FederationAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    fun federatedSchemaConfig(config: GraphQLConfigurationProperties, registry: FederatedTypeRegistry): FederatedSchemaGeneratorConfig = FederatedSchemaGeneratorConfig(
+    fun federatedSchemaGeneratorHooks(registry: FederatedTypeRegistry): FederatedSchemaGeneratorHooks = FederatedSchemaGeneratorHooks(registry)
+
+    @Bean
+    @ConditionalOnMissingBean
+    fun federatedSchemaConfig(
+        config: GraphQLConfigurationProperties,
+        hooks: FederatedSchemaGeneratorHooks,
+        topLevelNames: Optional<TopLevelNames>,
+        dataFetcherFactoryProvider: Optional<KotlinDataFetcherFactoryProvider>
+    ): FederatedSchemaGeneratorConfig = FederatedSchemaGeneratorConfig(
         supportedPackages = config.packages,
-        hooks = FederatedSchemaGeneratorHooks(registry)
+        topLevelNames = topLevelNames.orElse(TopLevelNames()),
+        hooks = hooks,
+        dataFetcherFactoryProvider = dataFetcherFactoryProvider.orElse(KotlinDataFetcherFactoryProvider(hooks))
     )
 
     @Bean

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/SchemaAutoConfiguration.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/SchemaAutoConfiguration.kt
@@ -17,8 +17,12 @@
 package com.expediagroup.graphql.spring
 
 import com.expediagroup.graphql.SchemaGeneratorConfig
+import com.expediagroup.graphql.TopLevelNames
 import com.expediagroup.graphql.TopLevelObject
+import com.expediagroup.graphql.execution.KotlinDataFetcherFactoryProvider
 import com.expediagroup.graphql.extensions.print
+import com.expediagroup.graphql.hooks.NoopSchemaGeneratorHooks
+import com.expediagroup.graphql.hooks.SchemaGeneratorHooks
 import com.expediagroup.graphql.spring.operations.Mutation
 import com.expediagroup.graphql.spring.operations.Query
 import com.expediagroup.graphql.spring.operations.Subscription
@@ -44,9 +48,20 @@ class SchemaAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    fun schemaConfig(config: GraphQLConfigurationProperties): SchemaGeneratorConfig = SchemaGeneratorConfig(
-            supportedPackages = config.packages
+    fun schemaConfig(
+        config: GraphQLConfigurationProperties,
+        topLevelNames: Optional<TopLevelNames>,
+        hooks: Optional<SchemaGeneratorHooks>,
+        dataFetcherFactoryProvider: Optional<KotlinDataFetcherFactoryProvider>
+    ): SchemaGeneratorConfig {
+        val generatorHooks = hooks.orElse(NoopSchemaGeneratorHooks)
+        return SchemaGeneratorConfig(
+            supportedPackages = config.packages,
+            topLevelNames = topLevelNames.orElse(TopLevelNames()),
+            hooks = generatorHooks,
+            dataFetcherFactoryProvider = dataFetcherFactoryProvider.orElse(KotlinDataFetcherFactoryProvider(generatorHooks))
         )
+    }
 
     @Bean
     @ConditionalOnMissingBean


### PR DESCRIPTION
### :pencil: Description

`SchemaGeneratorConfig`/`FederatedSchemaGeneratorConfig` auto config beans now accept optional parameters to set custom hooks, data fetcher factory provider and top level names.
