### PR TITLE
[chore] continous integration build upgrade

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -17,4 +17,4 @@ jobs:
         with:
           java-version: 1.8
       - name: Build with Maven
-        run: mvn clean package --file pom.xml
+        run: mvn clean verify --file pom.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,11 @@ before_install:
   - if [ ! -z "$GPG_SECRET_KEYS" ]; then echo $GPG_SECRET_KEYS | base64 --decode | $GPG_EXECUTABLE --import; fi
   - if [ ! -z "$GPG_OWNERTRUST" ]; then echo $GPG_OWNERTRUST | base64 --decode | $GPG_EXECUTABLE --import-ownertrust; fi
 
+install:
+  - ""
+
 script:
-  - ./mvnw install
+  - ./mvnw clean install
 
 deploy:
   provider: script


### PR DESCRIPTION
### :pencil: Description

* update Github CI Action to run verify goal instead of just package
* prevent Travis from running install goal twice - by default Travis will attempt to install the dependencies before running the actual build script, this results in running `mvn install` goal twice: once for installing dependencies and skipping the tests and another one from our build script. This PR disables the default dependency installation goal.

