### PR TITLE
[spring-server] use data classes for configuration properties

### DIFF
--- a/examples/federation/base-app/src/main/kotlin/com/expediagroup/graphql/examples/Application.kt
+++ b/examples/federation/base-app/src/main/kotlin/com/expediagroup/graphql/examples/Application.kt
@@ -16,10 +16,8 @@
 
 package com.expediagroup.graphql.examples
 
-import com.expediagroup.graphql.federation.FederatedSchemaGeneratorConfig
-import com.expediagroup.graphql.federation.FederatedSchemaGeneratorHooks
-import com.expediagroup.graphql.federation.execution.FederatedTypeRegistry
 import com.expediagroup.graphql.examples.extension.CustomFederationSchemaGeneratorHooks
+import com.expediagroup.graphql.federation.execution.FederatedTypeRegistry
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 import org.springframework.context.annotation.Bean
@@ -29,12 +27,6 @@ class Application {
     @Bean
     fun hooks(federatedTypeRegistry: FederatedTypeRegistry) =
         CustomFederationSchemaGeneratorHooks(federatedTypeRegistry)
-
-    @Bean
-    fun schemaConfig(hooks: FederatedSchemaGeneratorHooks): FederatedSchemaGeneratorConfig = FederatedSchemaGeneratorConfig(
-        supportedPackages = listOf("com.expediagroup"),
-        hooks = hooks
-    )
 }
 
 @Suppress("SpreadOperator")

--- a/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/Application.kt
+++ b/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/Application.kt
@@ -16,15 +16,13 @@
 
 package com.expediagroup.graphql.examples
 
-import com.expediagroup.graphql.SchemaGeneratorConfig
 import com.expediagroup.graphql.directives.KotlinDirectiveWiringFactory
-import com.expediagroup.graphql.execution.KotlinDataFetcherFactoryProvider
-import com.expediagroup.graphql.hooks.SchemaGeneratorHooks
 import com.expediagroup.graphql.examples.datafetchers.CustomDataFetcherFactoryProvider
 import com.expediagroup.graphql.examples.datafetchers.SpringDataFetcherFactory
 import com.expediagroup.graphql.examples.directives.CustomDirectiveWiringFactory
 import com.expediagroup.graphql.examples.exceptions.CustomDataFetcherExceptionHandler
 import com.expediagroup.graphql.examples.extension.CustomSchemaGeneratorHooks
+import com.expediagroup.graphql.hooks.SchemaGeneratorHooks
 import graphql.execution.DataFetcherExceptionHandler
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
@@ -44,13 +42,6 @@ class Application {
     @Bean
     fun dataFetcherFactoryProvider(springDataFetcherFactory: SpringDataFetcherFactory, hooks: SchemaGeneratorHooks) =
         CustomDataFetcherFactoryProvider(springDataFetcherFactory, hooks)
-
-    @Bean
-    fun schemaConfig(hooks: SchemaGeneratorHooks, dataFetcherFactoryProvider: KotlinDataFetcherFactoryProvider): SchemaGeneratorConfig = SchemaGeneratorConfig(
-        supportedPackages = listOf("com.expediagroup"),
-        hooks = hooks,
-        dataFetcherFactoryProvider = dataFetcherFactoryProvider
-    )
 
     @Bean
     fun dataFetcherExceptionHandler(): DataFetcherExceptionHandler = CustomDataFetcherExceptionHandler()

--- a/examples/spring/src/main/resources/application.yml
+++ b/examples/spring/src/main/resources/application.yml
@@ -1,8 +1,5 @@
 graphql:
+  packages: "com.expediagroup.graphql.examples"
   subscriptions:
     # Send a ka message every 1000 ms (1 second)
     keepAliveInterval: 1000
-
-  playground:
-    enabled: true
-    endpoint: "/"

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/GraphQLConfigurationProperties.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/GraphQLConfigurationProperties.kt
@@ -17,45 +17,47 @@
 package com.expediagroup.graphql.spring
 
 import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.ConstructorBinding
 
 /**
  * [ConfigurationProperties] bean that defines supported GraphQL configuration options.
  */
+@ConstructorBinding
 @ConfigurationProperties("graphql")
-class GraphQLConfigurationProperties {
+data class GraphQLConfigurationProperties(
     /** GraphQL server endpoint, defaults to 'graphql' */
-    var endpoint: String = "graphql"
+    val endpoint: String = "graphql",
     /** List of supported packages that can contain GraphQL schema type definitions */
-    var packages: List<String> = emptyList()
-    var federation: FederationConfigurationProperties = FederationConfigurationProperties()
-    var subscriptions: SubscriptionConfigurationProperties = SubscriptionConfigurationProperties()
-    var playground: PlaygroundConfigurationProperties = PlaygroundConfigurationProperties()
-}
+    val packages: List<String>,
+    val federation: FederationConfigurationProperties = FederationConfigurationProperties(),
+    val subscriptions: SubscriptionConfigurationProperties = SubscriptionConfigurationProperties(),
+    val playground: PlaygroundConfigurationProperties = PlaygroundConfigurationProperties()
+)
 
 /**
  * Apollo Federation configuration properties.
  */
-class FederationConfigurationProperties {
+data class FederationConfigurationProperties(
     /** Boolean flag indicating whether to generate federated GraphQL model */
-    var enabled: Boolean = false
-}
+    val enabled: Boolean = false
+)
 
 /**
  * GraphQL subscription configuration properties.
  */
-class SubscriptionConfigurationProperties {
+data class SubscriptionConfigurationProperties(
     /** GraphQL subscriptions endpoint, defaults to 'subscriptions' */
-    var endpoint: String = "subscriptions"
+    val endpoint: String = "subscriptions",
     /** Keep the websocket alive and send a message to the client every interval in ms. Default to not sending messages */
-    var keepAliveInterval: Long? = null
-}
+    val keepAliveInterval: Long? = null
+)
 
 /**
  * Playground configuration properties.
  */
-class PlaygroundConfigurationProperties {
+data class PlaygroundConfigurationProperties(
     /** Boolean flag indicating whether to enabled Prisma Labs Playground GraphQL IDE */
-    var enabled: Boolean = true
-    /** Prisma Labs Playground GraphQL IDE endpoint, defaults to "/playground" */
-    var endpoint: String = "/playground"
-}
+    val enabled: Boolean = true,
+    /** Prisma Labs Playground GraphQL IDE endpoint, defaults to 'playground' */
+    val endpoint: String = "playground"
+)

--- a/graphql-kotlin-spring-server/src/main/resources/META-INF/spring-configuration-metadata.json
+++ b/graphql-kotlin-spring-server/src/main/resources/META-INF/spring-configuration-metadata.json
@@ -38,7 +38,7 @@
       "name": "graphql.playground.endpoint",
       "type": "java.lang.String",
       "sourceType": "com.expediagroup.graphql.spring.PlaygroundConfigurationProperties",
-      "defaultValue": "/playground"
+      "defaultValue": "playground"
     }
   ]
 }

--- a/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/FederationConfigurationTest.kt
+++ b/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/FederationConfigurationTest.kt
@@ -83,6 +83,7 @@ class FederationConfigurationTest {
     @Test
     fun `verify federated schema auto configuration backs off in beans are defined by user`() {
         contextRunner.withUserConfiguration(CustomFederatedConfiguration::class.java)
+            .withPropertyValues("graphql.packages=com.expediagroup.graphql.spring", "graphql.federation.enabled=true")
             .run { ctx ->
                 val customConfiguration = ctx.getBean(CustomFederatedConfiguration::class.java)
 
@@ -119,7 +120,7 @@ class FederationConfigurationTest {
         fun objectMapper(): ObjectMapper = jacksonObjectMapper()
 
         @Bean
-        fun customSchemaConfig(): SchemaGeneratorConfig = FederatedSchemaGeneratorConfig(
+        fun customSchemaConfig(): FederatedSchemaGeneratorConfig = FederatedSchemaGeneratorConfig(
             supportedPackages = listOf("com.expediagroup"),
             hooks = FederatedSchemaGeneratorHooks(FederatedTypeRegistry())
         )

--- a/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/SchemaConfigurationTest.kt
+++ b/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/SchemaConfigurationTest.kt
@@ -82,6 +82,7 @@ class SchemaConfigurationTest {
     @Test
     fun `verify schema auto configuration backs off in beans are defined by user`() {
         contextRunner.withUserConfiguration(CustomConfiguration::class.java)
+            .withPropertyValues("graphql.packages=com.expediagroup.graphql.spring")
             .run { ctx ->
                 val customConfiguration = ctx.getBean(CustomConfiguration::class.java)
 

--- a/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/SubscriptionConfigurationTest.kt
+++ b/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/SubscriptionConfigurationTest.kt
@@ -74,6 +74,7 @@ class SubscriptionConfigurationTest {
     @Test
     fun `verify subscription auto configuration backs off in beans are defined by user`() {
         contextRunner.withUserConfiguration(CustomSubscriptionConfiguration::class.java)
+            .withPropertyValues("graphql.packages=com.expediagroup.graphql.spring")
             .run { ctx ->
                 val customConfiguration = ctx.getBean(CustomSubscriptionConfiguration::class.java)
 

--- a/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/context/ContextWebFilterTest.kt
+++ b/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/context/ContextWebFilterTest.kt
@@ -17,6 +17,7 @@
 package com.expediagroup.graphql.spring.context
 
 import com.expediagroup.graphql.spring.GraphQLConfigurationProperties
+import com.expediagroup.graphql.spring.SubscriptionConfigurationProperties
 import com.expediagroup.graphql.spring.execution.ContextWebFilter
 import com.expediagroup.graphql.spring.execution.GRAPHQL_CONTEXT_KEY
 import com.expediagroup.graphql.spring.execution.GraphQLContextFactory
@@ -58,7 +59,7 @@ class ContextWebFilterTest {
             coEvery { generateContext(any(), any()) } returns GraphQLContext.newContext().build()
         }
 
-        val contextFilter = ContextWebFilter(GraphQLConfigurationProperties(), simpleFactory)
+        val contextFilter = ContextWebFilter(GraphQLConfigurationProperties(packages = listOf("com.expediagroup.graphql")), simpleFactory)
         StepVerifier.create(contextFilter.filter(exchange, chain))
             .verifyComplete()
 
@@ -69,7 +70,7 @@ class ContextWebFilterTest {
 
     @Test
     fun `verify web filter order`() {
-        val contextFilter = ContextWebFilter(GraphQLConfigurationProperties(), mockk())
+        val contextFilter = ContextWebFilter(GraphQLConfigurationProperties(packages = listOf("com.expediagroup.graphql")), mockk())
         assertEquals(expected = 0, actual = contextFilter.order)
     }
 
@@ -94,7 +95,7 @@ class ContextWebFilterTest {
             coEvery { generateContext(any(), any()) } returns GraphQLContext.newContext().build()
         }
 
-        val contextFilter = ContextWebFilter(GraphQLConfigurationProperties(), simpleFactory)
+        val contextFilter = ContextWebFilter(GraphQLConfigurationProperties(packages = listOf("com.expediagroup.graphql")), simpleFactory)
         StepVerifier.create(contextFilter.filter(exchange, chain))
             .verifyComplete()
 
@@ -104,7 +105,7 @@ class ContextWebFilterTest {
 
     @Test
     fun `verify context web filter is applicable on default graphql routes`() {
-        val contextFilter = ContextWebFilter(GraphQLConfigurationProperties(), mockk())
+        val contextFilter = ContextWebFilter(GraphQLConfigurationProperties(packages = listOf("com.expediagroup.graphql")), mockk())
         for (path in listOf("/graphql", "/subscriptions")) {
             assertTrue(contextFilter.isApplicable(path))
         }
@@ -114,9 +115,10 @@ class ContextWebFilterTest {
     fun `verify context web filter is applicable on non-default graphql routes`() {
         val graphQLRoute = "myGraphQL"
         val subscriptionRoute = "mySubscription"
-        val props = GraphQLConfigurationProperties()
-        props.endpoint = graphQLRoute
-        props.subscriptions.endpoint = subscriptionRoute
+        val props = GraphQLConfigurationProperties(
+            endpoint = graphQLRoute,
+            packages = listOf("com.expediagroup.graphql"),
+            subscriptions = SubscriptionConfigurationProperties(endpoint = subscriptionRoute))
 
         val contextFilter = ContextWebFilter(props, mockk())
         for (path in listOf("/${graphQLRoute.toLowerCase()}", "/${subscriptionRoute.toLowerCase()}")) {
@@ -126,7 +128,7 @@ class ContextWebFilterTest {
 
     @Test
     fun `verify context web filter is not applicable on non graphql routes`() {
-        val contextFilter = ContextWebFilter(GraphQLConfigurationProperties(), mockk())
+        val contextFilter = ContextWebFilter(GraphQLConfigurationProperties(packages = listOf("com.expediagroup.graphql")), mockk())
         assertFalse(contextFilter.isApplicable("/whatever"))
     }
 }


### PR DESCRIPTION
### :pencil: Description

SpringBoot 2.2 supports using immutable data classes for `ConfigurationProperties` by specifying `@ConstructorBinding`.

### :link: Related Issues
