### PR TITLE
Remove reflections lib in favor of ClassGraph

### DIFF
--- a/graphql-kotlin-federation/pom.xml
+++ b/graphql-kotlin-federation/pom.xml
@@ -34,6 +34,10 @@
             <version>${project.parent.version}</version>
         </dependency>
         <dependency>
+            <groupId>io.github.classgraph</groupId>
+            <artifactId>classgraph</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
             <version>${junit-jupiter.version}</version>

--- a/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/FederatedSchemaGeneratorTest.kt
+++ b/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/FederatedSchemaGeneratorTest.kt
@@ -18,12 +18,12 @@ package com.expediagroup.graphql.federation
 
 import com.expediagroup.graphql.TopLevelObject
 import com.expediagroup.graphql.extensions.print
+import com.expediagroup.graphql.federation.data.queries.simple.NestedQuery
+import com.expediagroup.graphql.federation.data.queries.simple.SimpleQuery
 import com.expediagroup.graphql.federation.execution.FederatedTypeRegistry
 import graphql.schema.GraphQLUnionType
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
-import test.data.queries.simple.NestedQuery
-import test.data.queries.simple.SimpleQuery
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
@@ -104,7 +104,7 @@ class FederatedSchemaGeneratorTest {
     @Test
     fun `verify can generate federated schema`() {
         val config = FederatedSchemaGeneratorConfig(
-            supportedPackages = listOf("test.data.queries.federated"),
+            supportedPackages = listOf("com.expediagroup.graphql.federation.data.queries.federated"),
             hooks = FederatedSchemaGeneratorHooks(FederatedTypeRegistry())
         )
 
@@ -137,7 +137,7 @@ class FederatedSchemaGeneratorTest {
         """.trimIndent()
 
         val config = FederatedSchemaGeneratorConfig(
-            supportedPackages = listOf("test.data.queries.simple"),
+            supportedPackages = listOf("com.expediagroup.graphql.federation.data.queries.simple"),
             hooks = FederatedSchemaGeneratorHooks(FederatedTypeRegistry())
         )
 
@@ -169,7 +169,7 @@ class FederatedSchemaGeneratorTest {
         """.trimIndent()
 
         val config = FederatedSchemaGeneratorConfig(
-            supportedPackages = listOf("test.data.queries.simple"),
+            supportedPackages = listOf("com.expediagroup.graphql.federation.data.queries.simple"),
             hooks = FederatedSchemaGeneratorHooks(FederatedTypeRegistry())
         )
 

--- a/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/data/TestResolvers.kt
+++ b/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/data/TestResolvers.kt
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-package test.data
+package com.expediagroup.graphql.federation.data
 
+import com.expediagroup.graphql.federation.data.queries.federated.Book
+import com.expediagroup.graphql.federation.data.queries.federated.User
 import com.expediagroup.graphql.federation.execution.FederatedTypeResolver
-import test.data.queries.federated.Book
-import test.data.queries.federated.User
 
 internal class BookResolver : FederatedTypeResolver<Book> {
     override suspend fun resolve(representations: List<Map<String, Any>>): List<Book?> {

--- a/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/data/TestSchema.kt
+++ b/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/data/TestSchema.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package test.data
+package com.expediagroup.graphql.federation.data
 
 import com.expediagroup.graphql.federation.FederatedSchemaGeneratorConfig
 import com.expediagroup.graphql.federation.FederatedSchemaGeneratorHooks
@@ -25,7 +25,7 @@ import graphql.schema.GraphQLSchema
 
 internal fun federatedTestSchema(federatedTypeResolvers: Map<String, FederatedTypeResolver<*>> = emptyMap()): GraphQLSchema {
     val config = FederatedSchemaGeneratorConfig(
-        supportedPackages = listOf("test.data.queries.federated"),
+        supportedPackages = listOf("com.expediagroup.graphql.federation.data.queries.federated"),
         hooks = FederatedSchemaGeneratorHooks(FederatedTypeRegistry(federatedTypeResolvers))
     )
 

--- a/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/data/queries/federated/Product.kt
+++ b/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/data/queries/federated/Product.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package test.data.queries.federated
+package com.expediagroup.graphql.federation.data.queries.federated
 
 import com.expediagroup.graphql.annotations.GraphQLDirective
 import com.expediagroup.graphql.annotations.GraphQLIgnore

--- a/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/data/queries/simple/NestedQuery.kt
+++ b/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/data/queries/simple/NestedQuery.kt
@@ -14,13 +14,16 @@
  * limitations under the License.
  */
 
-package test.data.queries.simple
+package com.expediagroup.graphql.federation.data.queries.simple
 
-/*
-type Query {
-  hello: String!
+import kotlin.random.Random
+
+class NestedQuery {
+    fun getSimpleNestedObject(): List<SelfReferenceObject?> = listOf(SelfReferenceObject())
 }
- */
-class SimpleQuery {
-    fun hello(name: String): String = "Hello $name"
+
+class SelfReferenceObject {
+    val description: String? = "SelfReferenceObject"
+    val id = Random.nextInt()
+    fun nextObject(): List<SelfReferenceObject?> = listOf(SelfReferenceObject())
 }

--- a/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/data/queries/simple/SimpleQuery.kt
+++ b/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/data/queries/simple/SimpleQuery.kt
@@ -14,16 +14,13 @@
  * limitations under the License.
  */
 
-package test.data.queries.simple
+package com.expediagroup.graphql.federation.data.queries.simple
 
-import kotlin.random.Random
-
-class NestedQuery {
-    fun getSimpleNestedObject(): List<SelfReferenceObject?> = listOf(SelfReferenceObject())
+/*
+type Query {
+  hello: String!
 }
-
-class SelfReferenceObject {
-    val description: String? = "SelfReferenceObject"
-    val id = Random.nextInt()
-    fun nextObject(): List<SelfReferenceObject?> = listOf(SelfReferenceObject())
+ */
+class SimpleQuery {
+    fun hello(name: String): String = "Hello $name"
 }

--- a/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/execution/EntityQueryResolverTest.kt
+++ b/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/execution/EntityQueryResolverTest.kt
@@ -24,10 +24,10 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.spyk
 import org.junit.jupiter.api.Test
-import test.data.BookResolver
-import test.data.UserResolver
-import test.data.queries.federated.Book
-import test.data.queries.federated.User
+import com.expediagroup.graphql.federation.data.BookResolver
+import com.expediagroup.graphql.federation.data.UserResolver
+import com.expediagroup.graphql.federation.data.queries.federated.Book
+import com.expediagroup.graphql.federation.data.queries.federated.User
 import kotlin.test.assertEquals
 
 class EntityQueryResolverTest {

--- a/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/execution/FederatedQueryResolverTest.kt
+++ b/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/execution/FederatedQueryResolverTest.kt
@@ -19,9 +19,9 @@ package com.expediagroup.graphql.federation.execution
 import graphql.ExecutionInput
 import graphql.GraphQL
 import org.junit.jupiter.api.Test
-import test.data.BookResolver
-import test.data.UserResolver
-import test.data.federatedTestSchema
+import com.expediagroup.graphql.federation.data.BookResolver
+import com.expediagroup.graphql.federation.data.UserResolver
+import com.expediagroup.graphql.federation.data.federatedTestSchema
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull

--- a/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/execution/ServiceQueryResolverTest.kt
+++ b/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/execution/ServiceQueryResolverTest.kt
@@ -23,8 +23,8 @@ import com.expediagroup.graphql.federation.toFederatedSchema
 import graphql.ExecutionInput
 import graphql.GraphQL
 import org.junit.jupiter.api.Test
-import test.data.queries.simple.NestedQuery
-import test.data.queries.simple.SimpleQuery
+import com.expediagroup.graphql.federation.data.queries.simple.NestedQuery
+import com.expediagroup.graphql.federation.data.queries.simple.SimpleQuery
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 
@@ -72,7 +72,7 @@ class ServiceQueryResolverTest {
     @Test
     fun `verify can retrieve SDL using _service query`() {
         val config = FederatedSchemaGeneratorConfig(
-            supportedPackages = listOf("test.data.queries.federated"),
+            supportedPackages = listOf("com.expediagroup.graphql.federation.data.queries.federated"),
             hooks = FederatedSchemaGeneratorHooks(FederatedTypeRegistry())
         )
 
@@ -101,7 +101,7 @@ class ServiceQueryResolverTest {
     @Test
     fun `verify can retrieve SDL using _service query for non-federated schemas`() {
         val config = FederatedSchemaGeneratorConfig(
-            supportedPackages = listOf("test.data.queries.simple"),
+            supportedPackages = listOf("com.expediagroup.graphql.federation.data.queries.simple"),
             hooks = FederatedSchemaGeneratorHooks(FederatedTypeRegistry())
         )
 

--- a/graphql-kotlin-schema-generator/pom.xml
+++ b/graphql-kotlin-schema-generator/pom.xml
@@ -16,6 +16,7 @@
     <properties>
         <project.root>${project.basedir}/..</project.root>
         <rxjava2.version>2.2.12</rxjava2.version>
+        <guava.version>28.0-jre</guava.version>
     </properties>
 
     <dependencies>
@@ -32,8 +33,13 @@
             <artifactId>kotlin-reflect</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.reflections</groupId>
-            <artifactId>reflections</artifactId>
+            <groupId>io.github.classgraph</groupId>
+            <artifactId>classgraph</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${guava.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/SubTypeMapper.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/SubTypeMapper.kt
@@ -22,7 +22,7 @@ import io.github.classgraph.ClassInfoList
 import kotlin.reflect.KClass
 import kotlin.reflect.jvm.jvmName
 
-internal class SubTypeMapper(val supportedPackages: List<String>) {
+internal class SubTypeMapper(supportedPackages: List<String>) {
 
     @Suppress("Detekt.SpreadOperator")
     private val scanResult = ClassGraph()

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/SubTypeMapperTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/SubTypeMapperTest.kt
@@ -22,6 +22,10 @@ import kotlin.test.assertEquals
 @Suppress("Detekt.UnusedPrivateClass")
 internal class SubTypeMapperTest {
 
+    private interface NoSubTypesInterface
+
+    private abstract class NoSubTypesClass
+
     private interface MyInterface {
         fun getValue(): Int
     }
@@ -72,6 +76,22 @@ internal class SubTypeMapperTest {
 
         val mapper = SubTypeMapper(listOf("com.example"))
         val list = mapper.getSubTypesOf(MyInterface::class)
+
+        assertEquals(expected = 0, actual = list.size)
+    }
+
+    @Test
+    fun `interface with no subtypes`() {
+        val mapper = SubTypeMapper(listOf("com.expediagroup.graphql"))
+        val list = mapper.getSubTypesOf(NoSubTypesInterface::class)
+
+        assertEquals(expected = 0, actual = list.size)
+    }
+
+    @Test
+    fun `abstract class with no subtypes`() {
+        val mapper = SubTypeMapper(listOf("com.expediagroup.graphql"))
+        val list = mapper.getSubTypesOf(NoSubTypesClass::class)
 
         assertEquals(expected = 0, actual = list.size)
     }

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <jackson-module-kotlin.version>2.10.0</jackson-module-kotlin.version>
         <kotlin.version>1.3.50</kotlin.version>
         <kotlin-coroutines.version>1.3.2</kotlin-coroutines.version>
-        <reflections.version>0.9.11</reflections.version>
+        <classgraph.version>4.8.52</classgraph.version>
         <spring-boot.version>2.2.0.RELEASE</spring-boot.version>
 
         <!-- Test Dependency Versions -->
@@ -273,9 +273,9 @@
                 <version>${kotlin.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.reflections</groupId>
-                <artifactId>reflections</artifactId>
-                <version>${reflections.version}</version>
+                <groupId>io.github.classgraph</groupId>
+                <artifactId>classgraph</artifactId>
+                <version>${classgraph.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.module</groupId>


### PR DESCRIPTION
### :pencil: Description
There is a security issue with one of the dependencies of `org.reflections:reflection:0.9.11`. Instead of resolving the dep issue we should migrate away from this library since the last version was released in 2017.

https://github.com/classgraph/classgraph is an active supported library with reported faster implementation of reflection.

The security issue was in `com.google.guava:guava:20.0` but since we were still using some guava code in our library I have added `com.google.guava:guava:28-jre` as an explicit dependency

### :link: Related Issues
Fixes https://github.com/ExpediaGroup/graphql-kotlin/issues/449