### PR TITLE
[spring-server] make sdl endpoint customizable

### DIFF
--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/GraphQLConfigurationProperties.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/GraphQLConfigurationProperties.kt
@@ -31,7 +31,8 @@ data class GraphQLConfigurationProperties(
     val packages: List<String>,
     val federation: FederationConfigurationProperties = FederationConfigurationProperties(),
     val subscriptions: SubscriptionConfigurationProperties = SubscriptionConfigurationProperties(),
-    val playground: PlaygroundConfigurationProperties = PlaygroundConfigurationProperties()
+    val playground: PlaygroundConfigurationProperties = PlaygroundConfigurationProperties(),
+    val sdl: SDLConfigurationProperties = SDLConfigurationProperties()
 )
 
 /**
@@ -60,4 +61,14 @@ data class PlaygroundConfigurationProperties(
     val enabled: Boolean = true,
     /** Prisma Labs Playground GraphQL IDE endpoint, defaults to 'playground' */
     val endpoint: String = "playground"
+)
+
+/**
+ * SDL endpoint configuration properties.
+ */
+data class SDLConfigurationProperties(
+    /** Boolean flag indicating whether SDL endpoint is enabled */
+    val enabled: Boolean = true,
+    /** GraphQL SDL endpoint */
+    val endpoint: String = "sdl"
 )

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/PlaygroundAutoConfiguration.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/PlaygroundAutoConfiguration.kt
@@ -16,7 +16,6 @@
 
 package com.expediagroup.graphql.spring
 
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean
@@ -39,7 +38,6 @@ class PlaygroundAutoConfiguration(
 ) {
 
     @Bean
-    @ExperimentalCoroutinesApi
     fun playgroundRoute(): RouterFunction<ServerResponse> {
         val body = playgroundHtml.inputStream.bufferedReader().use { reader ->
             reader.readText()

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/RoutesConfiguration.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/RoutesConfiguration.kt
@@ -23,7 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.type.MapType
 import com.fasterxml.jackson.databind.type.TypeFactory
 import graphql.schema.GraphQLSchema
-import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpMethod
@@ -49,7 +49,6 @@ class RoutesConfiguration(
     private val mapTypeReference: MapType = TypeFactory.defaultInstance().constructMapType(HashMap::class.java, String::class.java, Any::class.java)
 
     @Bean
-    @ExperimentalCoroutinesApi
     fun graphQLRoutes() = coRouter {
         (POST(config.endpoint) or GET(config.endpoint)).invoke { serverRequest ->
             val graphQLRequest = createGraphQLRequest(serverRequest)
@@ -60,7 +59,12 @@ class RoutesConfiguration(
                 badRequest().buildAndAwait()
             }
         }
-        GET("/sdl") {
+    }
+
+    @Bean
+    @ConditionalOnProperty(value = ["graphql.sdl.enabled"], havingValue = "true", matchIfMissing = true)
+    fun sdlRoute() = coRouter {
+        GET(config.sdl.endpoint) {
             ok().contentType(MediaType.TEXT_PLAIN).bodyValueAndAwait(schema.print())
         }
     }


### PR DESCRIPTION
### :pencil: Description

New configuration properties:
* `graphql.sdl.enabled` - Boolean flag to indicate whether SDL endpoint should be enabled, defaults to true
* `graphql.sdl.endpoint` - SDL endpoint, defaults to /sdl

### :link: Related Issues
