### PR TITLE
[spring-server] make ContextWebFilter conditionally created

### DIFF
--- a/docs/server/spring-beans.md
+++ b/docs/server/spring-beans.md
@@ -20,6 +20,7 @@ can be customized by providing custom beans in your application context. See sec
 
 | Bean                           | Description |
 |:-------------------------------|:------------|
+| ContextWebFilter               | Default web filter that populates GraphQL context in the reactor subscriber context. |
 | DataFetcherExceptionHandler    | GraphQL exception handler used from the various execution strategies, defaults to [KotlinDataFetcherExceptionHandler](https://github.com/ExpediaGroup/graphql-kotlin/blob/master/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/exception/KotlinDataFetcherExceptionHandler.kt). |
 | GraphQL                        | GraphQL query execution engine generated using `GraphQLSchema` with default async execution strategies. GraphQL engine can be customized by optionally providing a list of [Instrumentation](https://www.graphql-java.com/documentation/v13/instrumentation/) beans (which can be ordered by implementing Spring Ordered interface), [ExecutionIdProvider](https://github.com/graphql-java/graphql-java/blob/master/src/main/java/graphql/execution/ExecutionIdProvider.java) and [PreparsedDocumentProvider](https://github.com/graphql-java/graphql-java/blob/master/src/main/java/graphql/execution/preparsed/PreparsedDocumentProvider.java) in the application context. |
 | DataLoaderRegistryFactory      | Factory used to create DataLoaderRegistry instance per query execution. See [graphql-java documentation](https://www.graphql-java.com/documentation/v13/batching/) for more details. |
@@ -30,7 +31,6 @@ can be customized by providing custom beans in your application context. See sec
 
 The following beans are currently automatically created and cannot be disabled:
 
-* Web filter for generating and populating GraphQL context
 * Default routes for GraphQL queries/mutations and SDL endpoint
 * Default route for [Prisma Labs Playground](https://github.com/prisma-labs/graphql-playground), created only if playground is enabled
 * Default `ApolloSubscriptionProtocolHandler` for handling GraphQL subscriptions, created only if `Subscription` bean is available in the context

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/GraphQLAutoConfiguration.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/GraphQLAutoConfiguration.kt
@@ -40,7 +40,6 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Import
 import org.springframework.core.Ordered
-import org.springframework.web.server.WebFilter
 import java.util.Optional
 
 /**
@@ -119,8 +118,9 @@ class GraphQLAutoConfiguration {
     fun graphQLContextFactory(): GraphQLContextFactory<*> = EmptyContextFactory
 
     @Bean
+    @ConditionalOnMissingBean
     fun contextWebFilter(
         config: GraphQLConfigurationProperties,
         graphQLContextFactory: GraphQLContextFactory<*>
-    ): WebFilter = ContextWebFilter(config, graphQLContextFactory)
+    ): ContextWebFilter = ContextWebFilter(config, graphQLContextFactory)
 }

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/execution/ContextWebFilter.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/execution/ContextWebFilter.kt
@@ -33,9 +33,9 @@ const val GRAPHQL_CONTEXT_FILTER_ODER = 0
 /**
  * Default web filter that populates GraphQL context in the reactor subscriber context.
  */
-class ContextWebFilter(config: GraphQLConfigurationProperties, private val contextFactory: GraphQLContextFactory<Any>) : WebFilter, Ordered {
-    private val graphQLRoute = "/${config.endpoint}"
-    private val subscriptionsRoute = "/${config.subscriptions.endpoint}"
+open class ContextWebFilter(config: GraphQLConfigurationProperties, private val contextFactory: GraphQLContextFactory<Any>) : WebFilter, Ordered {
+    private val graphQLRoute = enforceAbsolutePath(config.endpoint)
+    private val subscriptionsRoute = enforceAbsolutePath(config.subscriptions.endpoint)
 
     @Suppress("ForbiddenVoid")
     override fun filter(exchange: ServerWebExchange, chain: WebFilterChain): Mono<Void> =
@@ -51,6 +51,8 @@ class ContextWebFilter(config: GraphQLConfigurationProperties, private val conte
 
     override fun getOrder(): Int = GRAPHQL_CONTEXT_FILTER_ODER
 
-    internal fun isApplicable(path: String): Boolean =
+    open fun isApplicable(path: String): Boolean =
         graphQLRoute.equals(path, ignoreCase = true) || subscriptionsRoute.equals(path, ignoreCase = true)
+
+    private fun enforceAbsolutePath(path: String) = if (path.startsWith("/")) { path } else { "/$path" }
 }


### PR DESCRIPTION
### :pencil: Description

ContextWebFilter is now an open class so it can be easily extended. Default implementation is now conditionally created.

### :link: Related Issues

Resolves: https://github.com/ExpediaGroup/graphql-kotlin/issues/452
