### PR TITLE
[federation] federated type resolvers should have access to environment

### DIFF
--- a/examples/federation/extend-app/src/main/kotlin/com/expediagroup/graphql/examples/extend/Widget.kt
+++ b/examples/federation/extend-app/src/main/kotlin/com/expediagroup/graphql/examples/extend/Widget.kt
@@ -21,6 +21,7 @@ import com.expediagroup.graphql.federation.directives.ExternalDirective
 import com.expediagroup.graphql.federation.directives.FieldSet
 import com.expediagroup.graphql.federation.directives.KeyDirective
 import com.expediagroup.graphql.federation.execution.FederatedTypeResolver
+import graphql.schema.DataFetchingEnvironment
 import kotlin.random.Random
 
 @KeyDirective(fields = FieldSet("id"))
@@ -36,7 +37,7 @@ class Widget(
 class InvalidWidgetIdException : RuntimeException()
 
 val widgetResolver = object : FederatedTypeResolver<Widget> {
-    override suspend fun resolve(representations: List<Map<String, Any>>): List<Widget?> = representations.map {
+    override suspend fun resolve(environment: DataFetchingEnvironment, representations: List<Map<String, Any>>): List<Widget?> = representations.map {
         // Extract the 'id' from the other service
         val id = it["id"]?.toString()?.toIntOrNull() ?: throw InvalidWidgetIdException()
 

--- a/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/execution/EntityResolver.kt
+++ b/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/execution/EntityResolver.kt
@@ -50,7 +50,7 @@ open class EntityResolver(private val federatedTypeRegistry: FederatedTypeRegist
             val errors = mutableListOf<GraphQLError>()
             indexedBatchRequestsByType.map { (typeName, indexedRequests) ->
                 async {
-                    resolveType(typeName, indexedRequests, federatedTypeRegistry)
+                    resolveType(env, typeName, indexedRequests, federatedTypeRegistry)
                 }
             }.awaitAll()
                 .flatten()

--- a/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/execution/FederatedTypeResolver.kt
+++ b/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/execution/FederatedTypeResolver.kt
@@ -16,6 +16,8 @@
 
 package com.expediagroup.graphql.federation.execution
 
+import graphql.schema.DataFetchingEnvironment
+
 /**
  * Resolver used to retrieve target federated types.
  */
@@ -26,8 +28,9 @@ interface FederatedTypeResolver<out T> {
      * need to be resolved in the same order they were specified by the list of representations. Each passed
      * in representation should either be resolved to a target entity OR NULL if entity cannot be resolved.
      *
+     * @param environment DataFetchingEnvironment for executing this query
      * @param representations _entity query representations that are required to instantiate the target type
      * @return list of the target federated type instances
      */
-    suspend fun resolve(representations: List<Map<String, Any>>): List<T?>
+    suspend fun resolve(environment: DataFetchingEnvironment, representations: List<Map<String, Any>>): List<T?>
 }

--- a/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/data/TestResolvers.kt
+++ b/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/data/TestResolvers.kt
@@ -19,9 +19,10 @@ package com.expediagroup.graphql.federation.data
 import com.expediagroup.graphql.federation.data.queries.federated.Book
 import com.expediagroup.graphql.federation.data.queries.federated.User
 import com.expediagroup.graphql.federation.execution.FederatedTypeResolver
+import graphql.schema.DataFetchingEnvironment
 
 internal class BookResolver : FederatedTypeResolver<Book> {
-    override suspend fun resolve(representations: List<Map<String, Any>>): List<Book?> {
+    override suspend fun resolve(environment: DataFetchingEnvironment, representations: List<Map<String, Any>>): List<Book?> {
         val results = mutableListOf<Book?>()
         for (keys in representations) {
             val book = Book(keys["id"].toString())
@@ -36,7 +37,7 @@ internal class BookResolver : FederatedTypeResolver<Book> {
 }
 
 internal class UserResolver : FederatedTypeResolver<User> {
-    override suspend fun resolve(representations: List<Map<String, Any>>): List<User?> {
+    override suspend fun resolve(environment: DataFetchingEnvironment, representations: List<Map<String, Any>>): List<User?> {
         val results = mutableListOf<User?>()
         for (keys in representations) {
             val id = keys["userId"].toString().toInt()

--- a/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/execution/ResolversKtTest.kt
+++ b/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/execution/ResolversKtTest.kt
@@ -34,14 +34,14 @@ internal class ResolversKtTest {
         val indexedValue = mapOf<String, Any>()
         val indexedRequests: List<IndexedValue<Map<String, Any>>> = listOf(IndexedValue(7, indexedValue))
         val mockResolver: FederatedTypeResolver<*> = mockk()
-        coEvery { mockResolver.resolve(any()) } returns listOf("foo")
+        coEvery { mockResolver.resolve(any(), any()) } returns listOf("foo")
         val registry = FederatedTypeRegistry(mapOf("MyType" to mockResolver))
 
         runBlocking {
-            val result = resolveType("MyType", indexedRequests, registry)
+            val result = resolveType(mockk(), "MyType", indexedRequests, registry)
             assertTrue(result.isNotEmpty())
             assertEquals(expected = 7 to "foo", actual = result.first())
-            coVerify(exactly = 1) { mockResolver.resolve(any()) }
+            coVerify(exactly = 1) { mockResolver.resolve(any(), any()) }
         }
     }
 
@@ -50,17 +50,17 @@ internal class ResolversKtTest {
         val indexedValue = mapOf<String, Any>()
         val indexedRequests: List<IndexedValue<Map<String, Any>>> = listOf(IndexedValue(7, indexedValue))
         val mockResolver: FederatedTypeResolver<*> = mockk()
-        coEvery { mockResolver.resolve(any()) } returns listOf("foo")
+        coEvery { mockResolver.resolve(any(), any()) } returns listOf("foo")
         val registry: FederatedTypeRegistry = mockk()
         every { registry.getFederatedResolver(any()) } returns null
 
         runBlocking {
-            val result = resolveType("MyType", indexedRequests, registry)
+            val result = resolveType(mockk(), "MyType", indexedRequests, registry)
             assertTrue(result.isNotEmpty())
             val mappedValue = result.first()
             val response = mappedValue.second
             assertTrue(response is InvalidFederatedRequest)
-            coVerify(exactly = 0) { mockResolver.resolve(any()) }
+            coVerify(exactly = 0) { mockResolver.resolve(any(), any()) }
         }
     }
 
@@ -69,16 +69,16 @@ internal class ResolversKtTest {
         val indexedValue = mapOf<String, Any>()
         val indexedRequests: List<IndexedValue<Map<String, Any>>> = listOf(IndexedValue(7, indexedValue))
         val mockResolver: FederatedTypeResolver<*> = mockk()
-        coEvery { mockResolver.resolve(any()) } throws Exception("custom exception")
+        coEvery { mockResolver.resolve(any(), any()) } throws Exception("custom exception")
         val registry = FederatedTypeRegistry(mapOf("MyType" to mockResolver))
 
         runBlocking {
-            val result = resolveType("MyType", indexedRequests, registry)
+            val result = resolveType(mockk(), "MyType", indexedRequests, registry)
             assertTrue(result.isNotEmpty())
             val mappedValue = result.first()
             val response = mappedValue.second
             assertTrue(response is FederatedRequestFailure)
-            coVerify(exactly = 1) { mockResolver.resolve(any()) }
+            coVerify(exactly = 1) { mockResolver.resolve(any(), any()) }
         }
     }
 
@@ -90,16 +90,16 @@ internal class ResolversKtTest {
             IndexedValue(5, indexedValue)
         )
         val mockResolver: FederatedTypeResolver<*> = mockk()
-        coEvery { mockResolver.resolve(any()) } returns listOf("foo")
+        coEvery { mockResolver.resolve(any(), any()) } returns listOf("foo")
         val registry = FederatedTypeRegistry(mapOf("MyType" to mockResolver))
 
         runBlocking {
-            val result = resolveType("MyType", indexedRequests, registry)
+            val result = resolveType(mockk(), "MyType", indexedRequests, registry)
             assertEquals(expected = 2, actual = result.size)
             val mappedValue = result.first()
             val response = mappedValue.second
             assertTrue(response is FederatedRequestFailure)
-            coVerify(exactly = 1) { mockResolver.resolve(any()) }
+            coVerify(exactly = 1) { mockResolver.resolve(any(), any()) }
         }
     }
 }


### PR DESCRIPTION
### :pencil: Description

When resolving the federated types we currently don't have access to GraphQLContext. GraphQLContext can contain some important information (e.g. related to auth) that might be needed for type resolution so the resolvers should be able to access it. This PR updates the `FederatedTypeResolver` interface to also accept `DataFetchingEnvironment` when batch resolving the types.

### :link: Related Issues

Resolves: https://github.com/ExpediaGroup/graphql-kotlin/issues/472
