### PR TITLE
[spring-server] upgrade to SpringBoot 2.2.1.RELEASE

### DIFF
--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/GraphQLConfigurationProperties.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/GraphQLConfigurationProperties.kt
@@ -38,6 +38,7 @@ data class GraphQLConfigurationProperties(
 /**
  * Apollo Federation configuration properties.
  */
+@ConstructorBinding
 data class FederationConfigurationProperties(
     /** Boolean flag indicating whether to generate federated GraphQL model */
     val enabled: Boolean = false
@@ -46,6 +47,7 @@ data class FederationConfigurationProperties(
 /**
  * GraphQL subscription configuration properties.
  */
+@ConstructorBinding
 data class SubscriptionConfigurationProperties(
     /** GraphQL subscriptions endpoint, defaults to 'subscriptions' */
     val endpoint: String = "subscriptions",
@@ -56,6 +58,7 @@ data class SubscriptionConfigurationProperties(
 /**
  * Playground configuration properties.
  */
+@ConstructorBinding
 data class PlaygroundConfigurationProperties(
     /** Boolean flag indicating whether to enabled Prisma Labs Playground GraphQL IDE */
     val enabled: Boolean = true,
@@ -66,6 +69,7 @@ data class PlaygroundConfigurationProperties(
 /**
  * SDL endpoint configuration properties.
  */
+@ConstructorBinding
 data class SDLConfigurationProperties(
     /** Boolean flag indicating whether SDL endpoint is enabled */
     val enabled: Boolean = true,

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <kotlin.version>1.3.50</kotlin.version>
         <kotlin-coroutines.version>1.3.2</kotlin-coroutines.version>
         <classgraph.version>4.8.52</classgraph.version>
-        <spring-boot.version>2.2.0.RELEASE</spring-boot.version>
+        <spring-boot.version>2.2.1.RELEASE</spring-boot.version>
 
         <!-- Test Dependency Versions -->
         <junit-jupiter.version>5.5.2</junit-jupiter.version>


### PR DESCRIPTION
### :pencil: Description

With 2.2.1.RELEASE SpringBoot team changed the behavior that was automatically applying constructor binding to all classes referenced from the top level properties. New behavior requires explicitly specifying that we want to use constructor binding on all classes.

See https://github.com/spring-projects/spring-boot/issues/18919 for more details

### :link: Related Issues
