### PR TITLE
[schema-generator] support GraphQLInputNullable

### DIFF
--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/annotations/GraphQLInputNullable.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/annotations/GraphQLInputNullable.kt
@@ -1,0 +1,6 @@
+package com.expediagroup.graphql.annotations
+
+/**
+ * Set the GraphQL Input nullability to be picked up by the schema generator.
+ */
+annotation class GraphQLInputNullable(val value: Boolean)

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/TypeBuilder.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/TypeBuilder.kt
@@ -22,7 +22,7 @@ import com.expediagroup.graphql.generator.extensions.isEnum
 import com.expediagroup.graphql.generator.extensions.isInterface
 import com.expediagroup.graphql.generator.extensions.isListType
 import com.expediagroup.graphql.generator.extensions.isUnion
-import com.expediagroup.graphql.generator.extensions.wrapInNonNull
+import com.expediagroup.graphql.generator.extensions.wrapByNullable
 import com.expediagroup.graphql.generator.state.KGraphQLType
 import com.expediagroup.graphql.generator.state.SchemaGeneratorState
 import com.expediagroup.graphql.generator.state.TypesCacheKey
@@ -39,7 +39,7 @@ internal open class TypeBuilder constructor(protected val generator: SchemaGener
     protected val subTypeMapper: SubTypeMapper = generator.subTypeMapper
     protected val codeRegistry: GraphQLCodeRegistry.Builder = generator.codeRegistry
 
-    internal fun graphQLTypeOf(type: KType, inputType: Boolean = false, annotatedAsID: Boolean = false): GraphQLType {
+    internal fun graphQLTypeOf(type: KType, inputType: Boolean = false, annotatedAsID: Boolean = false, nullable: Boolean? = null): GraphQLType {
         val hookGraphQLType = config.hooks.willGenerateGraphQLType(type)
         val graphQLType = hookGraphQLType
             ?: generator.scalarType(type, annotatedAsID)
@@ -47,7 +47,7 @@ internal open class TypeBuilder constructor(protected val generator: SchemaGener
 
         // Do not call the hook on GraphQLTypeReference as we have not generated the type yet
         val unwrappedType = GraphQLTypeUtil.unwrapType(graphQLType).lastElement()
-        val typeWithNullability = graphQLType.wrapInNonNull(type)
+        val typeWithNullability = graphQLType.wrapByNullable(type, nullable)
         if (unwrappedType !is GraphQLTypeReference) {
             return config.hooks.didGenerateGraphQLType(type, typeWithNullability)
         }

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/extensions/annotationExtensions.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/extensions/annotationExtensions.kt
@@ -17,6 +17,7 @@
 package com.expediagroup.graphql.generator.extensions
 
 import com.expediagroup.graphql.annotations.GraphQLDescription
+import com.expediagroup.graphql.annotations.GraphQLInputNullable
 import com.expediagroup.graphql.annotations.GraphQLID
 import com.expediagroup.graphql.annotations.GraphQLIgnore
 import com.expediagroup.graphql.annotations.GraphQLName
@@ -44,3 +45,5 @@ internal fun Deprecated.getReason(): String? {
 
     return builder.toString()
 }
+
+internal fun KAnnotatedElement.getGraphQLInputNullable(): Boolean? = this.findAnnotation<GraphQLInputNullable>()?.value

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/extensions/graphQLExtensions.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/extensions/graphQLExtensions.kt
@@ -34,6 +34,15 @@ internal fun GraphQLType.wrapInNonNull(type: KType): GraphQLType = when {
     else -> GraphQLNonNull.nonNull(this)
 }
 
+internal fun GraphQLType.wrapByNullable(type: KType, nullable: Boolean? = null): GraphQLType {
+    val canBeNull = if (nullable != null) nullable else type.isMarkedNullable
+    return when {
+        this is GraphQLNonNull -> this
+        canBeNull -> this
+        else -> GraphQLNonNull.nonNull(this)
+    }
+}
+
 @Throws(CouldNotCastGraphQLType::class)
 internal inline fun <reified T : GraphQLType> GraphQLType.safeCast(): T {
     if (this !is T) throw CouldNotCastGraphQLType(this, T::class)

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/extensions/kPropertyExtensions.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/extensions/kPropertyExtensions.kt
@@ -39,6 +39,9 @@ internal fun KProperty<*>.isPropertyGraphQLIgnored(parentClass: KClass<*>): Bool
 internal fun KProperty<*>.getPropertyDeprecationReason(parentClass: KClass<*>): String? =
     this.getDeprecationReason() ?: getConstructorParameter(parentClass)?.getDeprecationReason()
 
+internal fun KProperty<*>.getPropertyNullable(parentClass: KClass<*>): Boolean? =
+    this.getGraphQLInputNullable() ?: getConstructorParameter(parentClass)?.getGraphQLInputNullable()
+
 internal fun KProperty<*>.getPropertyDescription(parentClass: KClass<*>): String? =
     this.getGraphQLDescription() ?: getConstructorParameter(parentClass)?.getGraphQLDescription()
 

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/ArgumentBuilder.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/ArgumentBuilder.kt
@@ -20,10 +20,12 @@ import com.expediagroup.graphql.exceptions.InvalidInputFieldTypeException
 import com.expediagroup.graphql.generator.SchemaGenerator
 import com.expediagroup.graphql.generator.TypeBuilder
 import com.expediagroup.graphql.generator.extensions.getGraphQLDescription
+import com.expediagroup.graphql.generator.extensions.getGraphQLInputNullable
 import com.expediagroup.graphql.generator.extensions.getName
 import com.expediagroup.graphql.generator.extensions.isGraphQLID
 import com.expediagroup.graphql.generator.extensions.isInterface
 import com.expediagroup.graphql.generator.extensions.safeCast
+
 import graphql.schema.GraphQLArgument
 import kotlin.reflect.KParameter
 
@@ -36,7 +38,7 @@ internal class ArgumentBuilder(generator: SchemaGenerator) : TypeBuilder(generat
             throw InvalidInputFieldTypeException(parameter)
         }
 
-        val graphQLType = graphQLTypeOf(parameter.type, inputType = true, annotatedAsID = parameter.isGraphQLID())
+        val graphQLType = graphQLTypeOf(parameter.type, inputType = true, annotatedAsID = parameter.isGraphQLID(), nullable = parameter.getGraphQLInputNullable())
 
         // Deprecation of arguments is currently unsupported: https://github.com/facebook/graphql/issues/197
         val builder = GraphQLArgument.newArgument()

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/InputPropertyBuilder.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/InputPropertyBuilder.kt
@@ -20,6 +20,7 @@ import com.expediagroup.graphql.generator.SchemaGenerator
 import com.expediagroup.graphql.generator.TypeBuilder
 import com.expediagroup.graphql.generator.extensions.getPropertyDescription
 import com.expediagroup.graphql.generator.extensions.getPropertyName
+import com.expediagroup.graphql.generator.extensions.getPropertyNullable
 import com.expediagroup.graphql.generator.extensions.isPropertyGraphQLID
 import com.expediagroup.graphql.generator.extensions.safeCast
 import graphql.schema.GraphQLInputObjectField
@@ -34,7 +35,7 @@ internal class InputPropertyBuilder(generator: SchemaGenerator) : TypeBuilder(ge
 
         builder.description(prop.getPropertyDescription(parentClass))
         builder.name(prop.getPropertyName(parentClass))
-        builder.type(graphQLTypeOf(prop.returnType, true, prop.isPropertyGraphQLID(parentClass)).safeCast<GraphQLInputType>())
+        builder.type(graphQLTypeOf(prop.returnType, true, prop.isPropertyGraphQLID(parentClass), prop.getPropertyNullable(parentClass)).safeCast<GraphQLInputType>())
 
         generator.directives(prop, parentClass).forEach {
             builder.withDirective(it)

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/extensions/GraphQLExtensionsTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/extensions/GraphQLExtensionsTest.kt
@@ -75,6 +75,30 @@ internal class GraphQLExtensionsTest {
     }
 
     @Test
+    fun `wrapByNullable twice returns object`() {
+        val nonNull = GraphQLNonNull(basicType)
+        val mockKType: KType = mockk()
+        assertEquals(nonNull, nonNull.wrapByNullable(mockKType, false))
+    }
+
+    @Test
+    fun `wrapByNullable with null kotlin type does nothing`() {
+        val mockKType: KType = mockk()
+        every { mockKType.isMarkedNullable } returns true
+
+        assertFalse(basicType.wrapByNullable(mockKType, true) is GraphQLNonNull)
+        assertEquals(expected = basicType, actual = basicType.wrapByNullable(mockKType, true))
+    }
+
+    @Test
+    fun `wrapByNullable override kotlin type nullability`() {
+        val mockKType: KType = mockk()
+        every { mockKType.isMarkedNullable } returns true
+
+        assertTrue(basicType.wrapByNullable(mockKType, false) is GraphQLNonNull)
+    }
+
+    @Test
     fun `GraphQLDirectiveContainer with no directives`() {
         val container: GraphQLDirectiveContainer = mockk()
         every { container.directives } returns emptyList()

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/ArgumentBuilderTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/ArgumentBuilderTest.kt
@@ -18,6 +18,7 @@ package com.expediagroup.graphql.generator.types
 
 import com.expediagroup.graphql.annotations.GraphQLDescription
 import com.expediagroup.graphql.annotations.GraphQLID
+import com.expediagroup.graphql.annotations.GraphQLInputNullable
 import com.expediagroup.graphql.annotations.GraphQLName
 import com.expediagroup.graphql.exceptions.InvalidInputFieldTypeException
 import com.expediagroup.graphql.test.utils.SimpleDirective
@@ -28,6 +29,7 @@ import kotlin.reflect.full.findParameterByName
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 internal class ArgumentBuilderTest : TypeTestHelper() {
 
@@ -51,6 +53,8 @@ internal class ArgumentBuilderTest : TypeTestHelper() {
         fun id(@GraphQLID idArg: String) = "Your id is $idArg"
 
         fun interfaceArg(input: MyInterface) = input.id
+
+        fun changeNullability(@GraphQLInputNullable(false) input: String? = null) = "Your input is $input"
     }
 
     @Test
@@ -102,5 +106,13 @@ internal class ArgumentBuilderTest : TypeTestHelper() {
         assertFailsWith(InvalidInputFieldTypeException::class) {
             builder.argument(kParameter)
         }
+    }
+
+    @Test
+    fun `Argument Nullability can be changed with @GraphQLInputNullable`() {
+        val kParameter = ArgumentTestClass::changeNullability.findParameterByName("input")
+        assertNotNull(kParameter)
+        val result = builder.argument(kParameter)
+        assertTrue(result.type is GraphQLNonNull)
     }
 }

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/InputPropertyBuilderTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/InputPropertyBuilderTest.kt
@@ -17,10 +17,13 @@
 package com.expediagroup.graphql.generator.types
 
 import com.expediagroup.graphql.annotations.GraphQLDescription
+import com.expediagroup.graphql.annotations.GraphQLInputNullable
 import com.expediagroup.graphql.annotations.GraphQLName
 import com.expediagroup.graphql.test.utils.SimpleDirective
+import graphql.schema.GraphQLNonNull
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 internal class InputPropertyBuilderTest : TypeTestHelper() {
 
@@ -41,7 +44,10 @@ internal class InputPropertyBuilderTest : TypeTestHelper() {
         val directiveWithNoPrefix: String,
 
         @property:SimpleDirective
-        val directiveWithPrefix: String
+        val directiveWithPrefix: String,
+
+        @GraphQLInputNullable(false)
+        val changeNullability: String? = null
     )
 
     @Test
@@ -65,5 +71,11 @@ internal class InputPropertyBuilderTest : TypeTestHelper() {
         val resultWithPrefix = builder.inputProperty(InputPropertyTestClass::directiveWithPrefix, InputPropertyTestClass::class)
         assertEquals(1, resultWithPrefix.directives.size)
         assertEquals("simpleDirective", resultWithPrefix.directives.first().name)
+    }
+
+    @Test
+    fun `Input Nullability can be changed with @GraphQLInputNullable`() {
+        val result = builder.inputProperty(InputPropertyTestClass::changeNullability, InputPropertyTestClass::class)
+        assertTrue(result.type is GraphQLNonNull)
     }
 }


### PR DESCRIPTION
### :pencil: Description
support @GraphQLInputNullable which can override the default nullability from kotlin type.

example:
```
class SomeInput {
    @GraphQLInputNullable(true)
    val someNumber: Int = 0
}

class TestQuery1 {
    fun query(@GraphQLInputNullable(false) input: SomeInput? = null): Int=0
}
```
will generate schema:
```
schema:type Query {
  query(input: SomeInput!): Int!
}

input SomeInput {
  someNumber: Int
}
```
@GraphQLInputNullable support Argument and InputProperty.