### PR TITLE
Validate subscription return type

### DIFF
--- a/graphql-kotlin-schema-generator/pom.xml
+++ b/graphql-kotlin-schema-generator/pom.xml
@@ -15,7 +15,9 @@
 
     <properties>
         <project.root>${project.basedir}/..</project.root>
-        <rxjava2.version>2.2.12</rxjava2.version>
+
+        <!-- Test Dependencies -->
+        <rxjava2.version>2.2.14</rxjava2.version>
     </properties>
 
     <dependencies>

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/exceptions/InvalidSubscriptionTypeException.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/exceptions/InvalidSubscriptionTypeException.kt
@@ -16,7 +16,13 @@
 
 package com.expediagroup.graphql.exceptions
 
+import com.expediagroup.graphql.generator.extensions.getSimpleName
 import kotlin.reflect.KClass
+import kotlin.reflect.KFunction
 
-class InvalidSubscriptionTypeException(kClass: KClass<*>) :
-    GraphQLKotlinException("Schema requires all subscriptions to be public, ${kClass.simpleName} has ${kClass.visibility} visibility modifier")
+class InvalidSubscriptionTypeException(kClass: KClass<*>, kFunction: KFunction<*>? = null) :
+    GraphQLKotlinException(
+        "Schema requires all subscriptions to be public and return a type of Publisher. " +
+        "${kClass.simpleName} has ${kClass.visibility} visibility modifier. " +
+        if (kFunction != null) "The function return type is ${kFunction.returnType.getSimpleName()}" else ""
+    )

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/SubscriptionBuilder.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/SubscriptionBuilder.kt
@@ -22,7 +22,9 @@ import com.expediagroup.graphql.generator.SchemaGenerator
 import com.expediagroup.graphql.generator.TypeBuilder
 import com.expediagroup.graphql.generator.extensions.getValidFunctions
 import com.expediagroup.graphql.generator.extensions.isNotPublic
+import com.expediagroup.graphql.generator.extensions.isSubclassOf
 import graphql.schema.GraphQLObjectType
+import org.reactivestreams.Publisher
 
 internal class SubscriptionBuilder(generator: SchemaGenerator) : TypeBuilder(generator) {
 
@@ -42,6 +44,10 @@ internal class SubscriptionBuilder(generator: SchemaGenerator) : TypeBuilder(gen
 
             subscription.kClass.getValidFunctions(config.hooks)
                 .forEach {
+                    if (it.returnType.isSubclassOf(Publisher::class).not()) {
+                        throw InvalidSubscriptionTypeException(subscription.kClass, it)
+                    }
+
                     val function = generator.function(it, config.topLevelNames.subscription, subscription.obj)
                     val functionFromHook = config.hooks.didGenerateSubscriptionType(it, function)
                     subscriptionBuilder.field(functionFromHook)

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/SubscriptionBuilderTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/SubscriptionBuilderTest.kt
@@ -41,7 +41,7 @@ internal class SubscriptionBuilderTest : TypeTestHelper() {
     }
 
     @Test
-    fun `give a valid list, it should properly set the top level name`() {
+    fun `give a valid subscription class, it should properly set the top level name`() {
         val builder = SubscriptionBuilder(generator)
         val subscriptions = listOf(TopLevelObject(MyPublicTestSubscription()))
         every { config.topLevelNames } returns TopLevelNames(subscription = "FooBar")
@@ -54,6 +54,16 @@ internal class SubscriptionBuilderTest : TypeTestHelper() {
     fun `given a private class, it should throw an exception`() {
         val builder = SubscriptionBuilder(generator)
         val subscriptions = listOf(TopLevelObject(MyPrivateTestSubscription()))
+
+        assertFailsWith(InvalidSubscriptionTypeException::class) {
+            builder.getSubscriptionObject(subscriptions)
+        }
+    }
+
+    @Test
+    fun `given a class with a function that does not return Publisher, it should throw an exception`() {
+        val builder = SubscriptionBuilder(generator)
+        val subscriptions = listOf(TopLevelObject(MyInvalidSubscriptionClass()))
 
         assertFailsWith(InvalidSubscriptionTypeException::class) {
             builder.getSubscriptionObject(subscriptions)
@@ -119,6 +129,11 @@ class MyPublicTestSubscription {
     fun flowabelCounter(): Flowable<Int> = Flowable.just(1)
 
     fun filterMe(): Publisher<Int> = Flowable.just(2)
+}
+
+class MyInvalidSubscriptionClass {
+    @Suppress("Detekt.FunctionOnlyReturningConstant")
+    fun number(): Int = 1
 }
 
 private class MyPrivateTestSubscription {

--- a/pom.xml
+++ b/pom.xml
@@ -63,10 +63,10 @@
 
         <!-- Dependency Versions -->
         <graphql-java.version>13.0</graphql-java.version>
-        <jackson-module-kotlin.version>2.10.0</jackson-module-kotlin.version>
+        <jackson-module-kotlin.version>2.10.1</jackson-module-kotlin.version>
         <kotlin.version>1.3.50</kotlin.version>
         <kotlin-coroutines.version>1.3.2</kotlin-coroutines.version>
-        <classgraph.version>4.8.52</classgraph.version>
+        <classgraph.version>4.8.53</classgraph.version>
         <spring-boot.version>2.2.1.RELEASE</spring-boot.version>
 
         <!-- Test Dependency Versions -->


### PR DESCRIPTION
### :pencil: Description
Subscriptions must return a `org.reactivestreams.Publisher` for graphql-java to work properly. An exception will now be thrown if any return type of a top level subscription is not a subclass of Publisher

### :link: Related Issues
Fixes https://github.com/ExpediaGroup/graphql-kotlin/issues/359