### PR TITLE
[chore] move dokka configuration to release profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -385,16 +385,7 @@
                             </execution>
                         </executions>
                     </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
-            <id>jdk8</id>
-            <activation>
-                <jdk>${java.version}</jdk>
-            </activation>
-            <build>
-                <plugins>
+                    <!-- dokka currently only works with Java 8 -->
                     <plugin>
                         <groupId>org.jetbrains.dokka</groupId>
                         <artifactId>dokka-maven-plugin</artifactId>


### PR DESCRIPTION
### :pencil: Description

In order to release to nexus we need to publish Javadocs. Currently dokka only works for JDK8 so we had it explicitly gated behind a profile that would only be activated when run using Java 8. Since we are explicitly gating Travis release job to run on Java 8 only so we don't need this separate profile.


### :link: Related Issues
