### PR TITLE
Allow for subscription request on the same endpoint

### DIFF
--- a/examples/spring/src/main/resources/application.yml
+++ b/examples/spring/src/main/resources/application.yml
@@ -3,3 +3,4 @@ graphql:
   subscriptions:
     # Send a ka message every 1000 ms (1 second)
     keepAliveInterval: 1000
+    endpoint: graphql

--- a/examples/spring/src/main/resources/application.yml
+++ b/examples/spring/src/main/resources/application.yml
@@ -3,4 +3,3 @@ graphql:
   subscriptions:
     # Send a ka message every 1000 ms (1 second)
     keepAliveInterval: 1000
-    endpoint: graphql

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/RoutesConfiguration.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/RoutesConfiguration.kt
@@ -52,8 +52,10 @@ class RoutesConfiguration(
     fun graphQLRoutes() = coRouter {
         val isEndpointRequest = POST(config.endpoint) or GET(config.endpoint)
         val isNotWebsocketRequest = headers {
-            it.header("Connection").contains("Upgrade").not()
-        }
+            // These headers are defined in the HTTP Protocol upgrade mechanism
+            // https://developer.mozilla.org/en-US/docs/Web/HTTP/Protocol_upgrade_mechanism
+            it.header("Connection").contains("Upgrade").and(it.header("Upgrade").contains("websocket"))
+        }.not()
 
         (isEndpointRequest and isNotWebsocketRequest).invoke { serverRequest ->
             val graphQLRequest = createGraphQLRequest(serverRequest)

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/RoutesConfiguration.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/RoutesConfiguration.kt
@@ -50,11 +50,10 @@ class RoutesConfiguration(
 
     @Bean
     fun graphQLRoutes() = coRouter {
-        val isNotWebsocketRequest = headers {
-            it.asHttpHeaders()["Upgrade"]?.contains("websocket")?.not() == true
-        }
-
         val isEndpointRequest = POST(config.endpoint) or GET(config.endpoint)
+        val isNotWebsocketRequest = headers {
+            it.header("Connection").contains("Upgrade").not()
+        }
 
         (isEndpointRequest and isNotWebsocketRequest).invoke { serverRequest ->
             val graphQLRequest = createGraphQLRequest(serverRequest)

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/RoutesConfiguration.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/RoutesConfiguration.kt
@@ -54,7 +54,9 @@ class RoutesConfiguration(
         val isNotWebsocketRequest = headers {
             // These headers are defined in the HTTP Protocol upgrade mechanism
             // https://developer.mozilla.org/en-US/docs/Web/HTTP/Protocol_upgrade_mechanism
-            it.header("Connection").contains("Upgrade").and(it.header("Upgrade").contains("websocket"))
+            val isUpgrade = requestContainsHeader(it, "Connection", "Upgrade")
+            val isWebSocket = requestContainsHeader(it, "Upgrade", "websocket")
+            isUpgrade.and(isWebSocket)
         }.not()
 
         (isEndpointRequest and isNotWebsocketRequest).invoke { serverRequest ->
@@ -67,6 +69,9 @@ class RoutesConfiguration(
             }
         }
     }
+
+    private fun requestContainsHeader(headers: ServerRequest.Headers, headerName: String, headerValue: String): Boolean =
+        headers.header(headerName).map { it.toLowerCase() }.contains(headerValue.toLowerCase())
 
     @Bean
     @ConditionalOnProperty(value = ["graphql.sdl.enabled"], havingValue = "true", matchIfMissing = true)

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/RoutesConfiguration.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/RoutesConfiguration.kt
@@ -50,7 +50,13 @@ class RoutesConfiguration(
 
     @Bean
     fun graphQLRoutes() = coRouter {
-        (POST(config.endpoint) or GET(config.endpoint)).invoke { serverRequest ->
+        val isNotWebsocketRequest = headers {
+            it.asHttpHeaders()["Upgrade"]?.contains("websocket")?.not() == true
+        }
+
+        val isEndpointRequest = POST(config.endpoint) or GET(config.endpoint)
+
+        (isEndpointRequest and isNotWebsocketRequest).invoke { serverRequest ->
             val graphQLRequest = createGraphQLRequest(serverRequest)
             if (graphQLRequest != null) {
                 val graphQLResult = queryHandler.executeQuery(graphQLRequest)

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/RoutesConfiguration.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/RoutesConfiguration.kt
@@ -56,7 +56,7 @@ class RoutesConfiguration(
             // https://developer.mozilla.org/en-US/docs/Web/HTTP/Protocol_upgrade_mechanism
             val isUpgrade = requestContainsHeader(it, "Connection", "Upgrade")
             val isWebSocket = requestContainsHeader(it, "Upgrade", "websocket")
-            isUpgrade.and(isWebSocket)
+            isUpgrade and isWebSocket
         }.not()
 
         (isEndpointRequest and isNotWebsocketRequest).invoke { serverRequest ->

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/SubscriptionAutoConfiguration.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/SubscriptionAutoConfiguration.kt
@@ -38,16 +38,6 @@ import org.springframework.web.reactive.socket.server.support.WebSocketHandlerAd
 @ConditionalOnBean(Subscription::class)
 class SubscriptionAutoConfiguration {
 
-    /**
-     * This value is needed so that this url handler is run without a drastically different order
-     * to the graphql routes in [RoutesConfiguration]. If we use [org.springframework.core.Ordered] to set as extreme
-     * high or low, then the requests are not handled properly.
-     *
-     * Hopefully we can eventually move the url handler to the same router DSL.
-     * https://github.com/spring-projects/spring-framework/issues/19476
-     */
-    private val urlHandlerOrder = 0
-
     @Bean
     @ConditionalOnMissingBean
     fun subscriptionHandler(graphQL: GraphQL): SubscriptionHandler = SimpleSubscriptionHandler(graphQL)
@@ -66,5 +56,17 @@ class SubscriptionAutoConfiguration {
 
     @Bean
     fun subscriptionHandlerMapping(config: GraphQLConfigurationProperties, subscriptionWebSocketHandler: SubscriptionWebSocketHandler): HandlerMapping =
-        SimpleUrlHandlerMapping(mapOf(config.subscriptions.endpoint to subscriptionWebSocketHandler), urlHandlerOrder)
+        SimpleUrlHandlerMapping(mapOf(config.subscriptions.endpoint to subscriptionWebSocketHandler), URL_HANDLER_ORDER)
+
+    private companion object {
+        /**
+         * This value is needed so that this url handler is run without a drastically different order
+         * to the graphql routes in [RoutesConfiguration]. If we use [org.springframework.core.Ordered] to set as extreme
+         * high or low, then the requests are not handled properly.
+         *
+         * Hopefully we can eventually move the url handler to the same router DSL.
+         * https://github.com/spring-projects/spring-framework/issues/19476
+         */
+        private const val URL_HANDLER_ORDER = 0
+    }
 }

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/SubscriptionAutoConfiguration.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/SubscriptionAutoConfiguration.kt
@@ -27,7 +27,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.core.Ordered
 import org.springframework.web.reactive.HandlerMapping
 import org.springframework.web.reactive.handler.SimpleUrlHandlerMapping
 import org.springframework.web.reactive.socket.server.support.WebSocketHandlerAdapter
@@ -57,5 +56,5 @@ class SubscriptionAutoConfiguration {
 
     @Bean
     fun subscriptionHandlerMapping(config: GraphQLConfigurationProperties, subscriptionWebSocketHandler: SubscriptionWebSocketHandler): HandlerMapping =
-        SimpleUrlHandlerMapping(mapOf(config.subscriptions.endpoint to subscriptionWebSocketHandler), Ordered.HIGHEST_PRECEDENCE)
+        SimpleUrlHandlerMapping(mapOf(config.subscriptions.endpoint to subscriptionWebSocketHandler), 1)
 }

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/SubscriptionAutoConfiguration.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/SubscriptionAutoConfiguration.kt
@@ -32,6 +32,16 @@ import org.springframework.web.reactive.handler.SimpleUrlHandlerMapping
 import org.springframework.web.reactive.socket.server.support.WebSocketHandlerAdapter
 
 /**
+ * This value is needed so that this url handler is run without a drastically different order
+ * to the graphql routes in [RoutesConfiguration]. If we use [org.springframework.core.Ordered] to set as extreme
+ * high or low, then the requests are not handled properly.
+ *
+ * Hopefully we can eventually move the url handler to the same router DSL.
+ * https://github.com/spring-projects/spring-framework/issues/19476
+ */
+private const val URL_HANDLER_ORDER = 0
+
+/**
  * SpringBoot auto-configuration that creates default WebSocket handler for GraphQL subscriptions.
  */
 @Configuration
@@ -57,16 +67,4 @@ class SubscriptionAutoConfiguration {
     @Bean
     fun subscriptionHandlerMapping(config: GraphQLConfigurationProperties, subscriptionWebSocketHandler: SubscriptionWebSocketHandler): HandlerMapping =
         SimpleUrlHandlerMapping(mapOf(config.subscriptions.endpoint to subscriptionWebSocketHandler), URL_HANDLER_ORDER)
-
-    private companion object {
-        /**
-         * This value is needed so that this url handler is run without a drastically different order
-         * to the graphql routes in [RoutesConfiguration]. If we use [org.springframework.core.Ordered] to set as extreme
-         * high or low, then the requests are not handled properly.
-         *
-         * Hopefully we can eventually move the url handler to the same router DSL.
-         * https://github.com/spring-projects/spring-framework/issues/19476
-         */
-        private const val URL_HANDLER_ORDER = 0
-    }
 }

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/SubscriptionAutoConfiguration.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/SubscriptionAutoConfiguration.kt
@@ -38,6 +38,16 @@ import org.springframework.web.reactive.socket.server.support.WebSocketHandlerAd
 @ConditionalOnBean(Subscription::class)
 class SubscriptionAutoConfiguration {
 
+    /**
+     * This value is needed so that this url handler is run without a drastically different order
+     * to the graphql routes in [RoutesConfiguration]. If we use [org.springframework.core.Ordered] to set as extreme
+     * high or low, then the requests are not handled properly.
+     *
+     * Hopefully we can eventually move the url handler to the same router DSL.
+     * https://github.com/spring-projects/spring-framework/issues/19476
+     */
+    private val urlHandlerOrder = 0
+
     @Bean
     @ConditionalOnMissingBean
     fun subscriptionHandler(graphQL: GraphQL): SubscriptionHandler = SimpleSubscriptionHandler(graphQL)
@@ -56,5 +66,5 @@ class SubscriptionAutoConfiguration {
 
     @Bean
     fun subscriptionHandlerMapping(config: GraphQLConfigurationProperties, subscriptionWebSocketHandler: SubscriptionWebSocketHandler): HandlerMapping =
-        SimpleUrlHandlerMapping(mapOf(config.subscriptions.endpoint to subscriptionWebSocketHandler), 1)
+        SimpleUrlHandlerMapping(mapOf(config.subscriptions.endpoint to subscriptionWebSocketHandler), urlHandlerOrder)
 }

--- a/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/execution/SubscriptionWebSocketHandlerIT.kt
+++ b/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/execution/SubscriptionWebSocketHandlerIT.kt
@@ -44,7 +44,10 @@ import java.net.URI
 import java.time.Duration
 import kotlin.random.Random
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = ["graphql.packages=com.expediagroup.graphql.spring.execution"])
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = ["graphql.packages=com.expediagroup.graphql.spring.execution"]
+)
 @EnableAutoConfiguration
 class SubscriptionWebSocketHandlerIT(@LocalServerPort private var port: Int) {
 

--- a/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/routes/RouteConfigurationIT.kt
+++ b/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/routes/RouteConfigurationIT.kt
@@ -237,14 +237,41 @@ directive @deprecated(reason: String = "No longer supported") on FIELD_DEFINITIO
 
     @Test
     fun `verify POST graphQL request with websocket header fails`() {
-        testClient.get()
+        val request = GraphQLRequest(
+            query = "query helloWorldQuery(\$name: String!) { hello(name: \$name) }",
+            variables = mapOf("name" to "JUNIT route"),
+            operationName = "helloWorldQuery"
+        )
+
+        testClient.post()
             .uri("/graphql")
             .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
             .header("Connection", "Upgrade")
             .header("Upgrade", "websocket")
+            .bodyValue(request)
             .exchange()
             .expectStatus()
             .isNotFound
+    }
+
+    @Test
+    fun `verify POST graphQL request with partially missing websocket header still passes`() {
+        val request = GraphQLRequest(
+            query = "query helloWorldQuery(\$name: String!) { hello(name: \$name) }",
+            variables = mapOf("name" to "JUNIT route"),
+            operationName = "helloWorldQuery"
+        )
+
+        testClient.post()
+            .uri("/graphql")
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .header("Connection", "upgrade")
+            .bodyValue(request)
+            .exchange()
+            .expectStatus()
+            .isOk
     }
 
     private fun WebTestClient.ResponseSpec.verifyGraphQLRoute(expected: String) = this.expectStatus().isOk

--- a/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/routes/RouteConfigurationIT.kt
+++ b/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/routes/RouteConfigurationIT.kt
@@ -33,7 +33,10 @@ import org.springframework.http.server.reactive.ServerHttpResponse
 import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.test.web.reactive.server.expectBody
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = ["graphql.packages=com.expediagroup.graphql.spring.routes"])
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = ["graphql.packages=com.expediagroup.graphql.spring.routes"]
+)
 @EnableAutoConfiguration
 class RouteConfigurationIT(@Autowired private val testClient: WebTestClient) {
 
@@ -234,19 +237,11 @@ directive @deprecated(reason: String = "No longer supported") on FIELD_DEFINITIO
 
     @Test
     fun `verify POST graphQL request with websocket header fails`() {
-        val request = GraphQLRequest(
-            query = "query helloWorldQuery(\$name: String!) { hello(name: \$name) }",
-            variables = mapOf("name" to "JUNIT route"),
-            operationName = "helloWorldQuery"
-        )
-
-        testClient.post()
+        testClient.get()
             .uri("/graphql")
             .accept(MediaType.APPLICATION_JSON)
-            .contentType(MediaType.APPLICATION_JSON)
             .header("Connection", "Upgrade")
             .header("Upgrade", "websocket")
-            .bodyValue(request)
             .exchange()
             .expectStatus()
             .isNotFound

--- a/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/routes/RouteConfigurationIT.kt
+++ b/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/routes/RouteConfigurationIT.kt
@@ -232,6 +232,26 @@ directive @deprecated(reason: String = "No longer supported") on FIELD_DEFINITIO
             .verifyGraphQLRoute("Hello JUNIT route with charset encoding!")
     }
 
+    @Test
+    fun `verify POST graphQL request with websocket header fails`() {
+        val request = GraphQLRequest(
+            query = "query helloWorldQuery(\$name: String!) { hello(name: \$name) }",
+            variables = mapOf("name" to "JUNIT route"),
+            operationName = "helloWorldQuery"
+        )
+
+        testClient.post()
+            .uri("/graphql")
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .header("Connection", "Upgrade")
+            .header("Upgrade", "websocket")
+            .bodyValue(request)
+            .exchange()
+            .expectStatus()
+            .isNotFound
+    }
+
     private fun WebTestClient.ResponseSpec.verifyGraphQLRoute(expected: String) = this.expectStatus().isOk
         .expectBody()
         .jsonPath("$.data.hello").isEqualTo(expected)

--- a/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/routes/SubscriptionRoutesConfigurationIT.kt
+++ b/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/routes/SubscriptionRoutesConfigurationIT.kt
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2019 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.spring.routes
+
+import com.expediagroup.graphql.spring.model.GraphQLRequest
+import com.expediagroup.graphql.spring.model.SubscriptionOperationMessage
+import com.expediagroup.graphql.spring.operations.Query
+import com.expediagroup.graphql.spring.operations.Subscription
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.web.server.LocalServerPort
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.MediaType
+import org.springframework.test.web.reactive.server.WebTestClient
+import org.springframework.web.reactive.socket.WebSocketMessage
+import org.springframework.web.reactive.socket.client.ReactorNettyWebSocketClient
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import reactor.core.publisher.ReplayProcessor
+import reactor.test.StepVerifier
+import java.net.URI
+
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = [
+        "graphql.packages=com.expediagroup.graphql.spring.routes",
+        "graphql.endpoint=foo",
+        "graphql.subscriptions.endpoint=foo"
+    ]
+)
+@EnableAutoConfiguration
+class SubscriptionRoutesConfigurationIT(
+    @Autowired private val testClient: WebTestClient,
+    @LocalServerPort private var port: Int
+) {
+
+    val objectMapper = jacksonObjectMapper().registerKotlinModule()
+
+    @Configuration
+    class TestConfiguration {
+        @Bean
+        fun query(): Query = SimpleQuery()
+
+        @Bean
+        fun subscription(): Subscription = SimpleSubscription()
+    }
+
+    class SimpleQuery : Query {
+        fun hello(name: String) = "Hello $name!"
+    }
+
+    class SimpleSubscription : Subscription {
+        fun getNumber(): Flux<Int> = Flux.just(42)
+    }
+
+    @Test
+    fun `verify POST graphQL request`() {
+        val request = GraphQLRequest(
+            query = "query helloWorldQuery(\$name: String!) { hello(name: \$name) }",
+            variables = mapOf("name" to "JUNIT route"),
+            operationName = "helloWorldQuery"
+        )
+
+        testClient.post()
+            .uri("/foo")
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(request)
+            .exchange()
+            .verifyGraphQLRoute("Hello JUNIT route!")
+    }
+
+    @Test
+    fun `verify GET graphQL request`() {
+        val query = "query { hello(name: \"JUNIT GET\") }"
+        testClient.get()
+            .uri { builder ->
+                builder.path("/foo")
+                    .queryParam("query", "{query}")
+                    .build(query)
+            }
+            .exchange()
+            .verifyGraphQLRoute("Hello JUNIT GET!")
+    }
+
+    @Test
+    fun `verify subscription`() {
+        val request = GraphQLRequest("subscription { getNumber }")
+        val message = SubscriptionOperationMessage(SubscriptionOperationMessage.ClientMessages.GQL_START.type, id = "1", payload = request)
+        val output = ReplayProcessor.create<String>()
+
+        val client = ReactorNettyWebSocketClient()
+        val uri = URI.create("ws://localhost:$port/foo")
+
+        val sessionMono = client.execute(uri) { session ->
+            session.send(Mono.just(session.textMessage(objectMapper.writeValueAsString(message))))
+                .thenMany(session.receive()
+                    .map(WebSocketMessage::getPayloadAsText)
+                    .map { objectMapper.readValue<SubscriptionOperationMessage>(it) }
+                    .map { objectMapper.writeValueAsString(it.payload) }
+                )
+                .subscribeWith(output)
+                .take(1)
+                .then()
+        }
+
+        StepVerifier.create(output.doOnSubscribe { sessionMono.subscribe() })
+            .expectNext("{\"data\":{\"getNumber\":42}}")
+            .expectComplete()
+            .verify()
+    }
+
+    private fun WebTestClient.ResponseSpec.verifyGraphQLRoute(expected: String) = this.expectStatus().isOk
+        .expectBody()
+        .jsonPath("$.data.hello").isEqualTo(expected)
+        .jsonPath("$.errors").doesNotExist()
+        .jsonPath("$.extensions").doesNotExist()
+}


### PR DESCRIPTION
### :pencil: Description
Filter out request over http that contain websocket headers and lower the order for when the ws:// protocol is handled so you can have both `http://app/graphql` and `ws://app/graphql`

### :link: Related Issues
Fixes #484