### PR TITLE
Add unit tests for renaming input type fields

### DIFF
--- a/docs/customizing-schemas/renaming-fields.md
+++ b/docs/customizing-schemas/renaming-fields.md
@@ -5,7 +5,7 @@ title: Renaming Fields
 
 By default, the schema generator will use the simple name of the underlying class for the type names and function/property names for fields.
 You can change this default behavior by annotating the target class/field with `@GraphQLName`. The following Kotlin `Widget` class
-will be renamed to `MyCustomName` GraphQL type and it's fields will also be renamed.
+will be renamed to `MyCustomName` GraphQL type and its fields will also be renamed.
 
 ```kotlin
 @GraphQLName("MyCustomName")

--- a/docs/customizing-schemas/renaming-fields.md
+++ b/docs/customizing-schemas/renaming-fields.md
@@ -3,17 +3,46 @@ id: renaming-fields
 title: Renaming Fields
 ---
 
-By default, schema generator will use simple name of the underlying class for the type names and function/property names for field names.
-You can change this default behavior by annotating target class/field with `@GraphQLName` annotation. The following Kotlin `Widget` class 
-will be renamed to `MyCustomName` GraphQL type.
+By default, the schema generator will use the simple name of the underlying class for the type names and function/property names for fields.
+You can change this default behavior by annotating the target class/field with `@GraphQLName`. The following Kotlin `Widget` class
+will be renamed to `MyCustomName` GraphQL type and it's fields will also be renamed.
 
 ```kotlin
 @GraphQLName("MyCustomName")
-data class Widget(val value: Int?)
+data class Widget(
+    @GraphQLName("myCustomField")
+    val value: Int?
+)
 ```
 
 ```graphql
 type MyCustomName {
-  value: Int
+  myCustomField: Int
+}
+```
+
+### Known Issues
+> NOTE: Due to how we deserialize input classes, if you rename a field of an input class you must also annotate the field with the Jackson annotation @JsonProperty. See [issue 493](https://github.com/ExpediaGroup/graphql-kotlin/issues/493) for more info.
+
+```kotlin
+data class MyInputClass(
+    @JsonProperty("renamedField")
+    @GraphQLName("renamedField")
+    val field1: String
+)
+
+class QueryClass {
+  fun parseData(arg: MyInputClass) = "You sent ${arg.field1}"
+}
+```
+
+```graphql
+input MyInputClassInput {
+  # This only works if both @JsonProperty and @GraphQLName are present
+  renamedField: String!
+}
+
+type Query {
+  parseData(arg: MyInputClass!): String!
 }
 ```

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/execution/FunctionDataFetcherTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/execution/FunctionDataFetcherTest.kt
@@ -36,7 +36,7 @@ import kotlin.test.assertTrue
 
 internal class FunctionDataFetcherTest {
 
-    class MyClass {
+    internal class MyClass {
         fun print(string: String) = string
 
         fun printArray(items: Array<String>) = items.joinToString(separator = ":")
@@ -62,7 +62,7 @@ internal class FunctionDataFetcherTest {
     }
 
     @GraphQLName("MyInputClassRenamed")
-    data class MyInputClass(
+    internal data class MyInputClass(
         @JsonProperty("jacksonField")
         @GraphQLName("jacksonField")
         val field1: String

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/InputObjectBuilderTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/InputObjectBuilderTest.kt
@@ -41,6 +41,7 @@ internal class InputObjectBuilderTest : TypeTestHelper() {
     @Suppress("Detekt.UnusedPrivateClass")
     @GraphQLName("InputClassRenamed")
     private class InputClassCustomName {
+        @GraphQLName("myFieldRenamed")
         val myField: String = "car"
     }
 
@@ -51,9 +52,16 @@ internal class InputObjectBuilderTest : TypeTestHelper() {
     }
 
     @Test
-    fun `Test custom naming`() {
+    fun `Test custom naming on classes`() {
         val result = builder.inputObjectType(InputClassCustomName::class)
         assertEquals("InputClassRenamedInput", result.name)
+    }
+
+    @Test
+    fun `Test custom naming on arguments`() {
+        val result = builder.inputObjectType(InputClassCustomName::class)
+        assertEquals(expected = 1, actual = result.fields.size)
+        assertEquals("myFieldRenamed", result.fields.first().name)
     }
 
     @Test


### PR DESCRIPTION
### :pencil: Description
Currently we can only parse renamed input class fields if they include the Jackson annotation @JsonProperty. This is because when we get the java class for the argument it doesn't have any information for jackson to know that the constructor field has been renamed. I tried looking into adding a custom deserializer but we can't dynamically have one for all classes. Until we can find a better solution this unit test serves as documentation for the only way to make this work for now

### :link: Related Issues
https://github.com/ExpediaGroup/graphql-kotlin/issues/493