### PR TITLE
Log schema with starting newline

### DIFF
--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/FederationAutoConfiguration.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/FederationAutoConfiguration.kt
@@ -80,7 +80,8 @@ class FederationAutoConfiguration {
             subscriptions = subscriptions.orElse(emptyList()).toTopLevelObjects()
         )
 
-        logger.info(schema.print())
+        logger.info("\n${schema.print()}")
+
         return schema
     }
 }

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/SchemaAutoConfiguration.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/SchemaAutoConfiguration.kt
@@ -78,7 +78,8 @@ class SchemaAutoConfiguration {
             subscriptions = subscriptions.orElse(emptyList()).toTopLevelObjects()
         )
 
-        logger.info(schema.print())
+        logger.info("\n${schema.print()}")
+
         return schema
     }
 }


### PR DESCRIPTION
### :pencil: Description
On startup of server, prepend a newline so the schema is slightly more readable

![Screen Shot 2019-12-05 at 11 36 35 AM](https://user-images.githubusercontent.com/2446877/70267583-96ec1480-1753-11ea-9797-43a9aea3207c.png)

