### PR TITLE
Revert "Update publish-docs to use github tokens"

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -26,9 +26,13 @@ jobs:
       run: |
         cd website
         npm install
-        git config --global user.name "${GITHUB_ACTOR}"
-        echo "machine github.com login ${GITHUB_ACTOR} password ${{ secrets.GITHUB_TOKEN }}" > ~/.netrc
-        GIT_USER="${GITHUB_ACTOR}" npm run publish-gh-pages
+        git config --global user.name "${GH_USERNAME}"
+        echo "machine github.com login ${GH_USERNAME} password ${{ secrets.GH_PERSONAL_TOKEN }}" > ~/.netrc
+        GIT_USER="${GH_USERNAME}" npm run publish-gh-pages
       env:
         CI: true
         CURRENT_BRANCH: master
+
+        # The following settings will only work with the personal access token we are using
+        # Until GH Actions have a way to publish directly we are using this method
+        GH_USERNAME: eg-oss-ci

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -27,7 +27,7 @@ jobs:
         cd website
         npm install
         git config --global user.name "${GH_USERNAME}"
-        echo "machine github.com login ${GH_USERNAME} password ${{ secrets.GH_PERSONAL_TOKEN }}" > ~/.netrc
+        echo "machine github.com login ${GH_USERNAME} password ${{ secrets.EG_CI_USER_TOKEN }}" > ~/.netrc
         GIT_USER="${GH_USERNAME}" npm run publish-gh-pages
       env:
         CI: true


### PR DESCRIPTION
Reverts ExpediaGroup/graphql-kotlin#504

We need to use the token of a verified user that has admin access to our repo to publish to Github Pages

So we can not use the auto token for Actions, we are going back to using @eg-oss-ci 

https://help.github.com/en/github/working-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site#troubleshooting-publishing-problems-with-your-github-pages-site

