### PR TITLE
Subscription refactor

### DIFF
--- a/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/subscriptions/SimpleSubscription.kt
+++ b/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/subscriptions/SimpleSubscription.kt
@@ -21,6 +21,8 @@ import com.expediagroup.graphql.spring.operations.Subscription
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.reactive.asPublisher
 import org.reactivestreams.Publisher
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
@@ -30,11 +32,17 @@ import kotlin.random.Random
 @Component
 class SimpleSubscription : Subscription {
 
+    val logger: Logger = LoggerFactory.getLogger(SimpleSubscription::class.java)
+
     @GraphQLDescription("Returns a single value")
     fun singleValueSubscription(): Mono<Int> = Mono.just(1)
 
     @GraphQLDescription("Returns a random number every second")
-    fun counter(): Flux<Int> = Flux.interval(Duration.ofSeconds(1)).map { Random.nextInt() }
+    fun counter(): Flux<Int> = Flux.interval(Duration.ofSeconds(1)).map {
+        val value = Random.nextInt()
+        logger.info("Returning $value from counter")
+        value
+    }
 
     @GraphQLDescription("Returns a random number every second, errors if even")
     fun counterWithError(): Flux<Int> = Flux.interval(Duration.ofSeconds(1))


### PR DESCRIPTION
### :pencil: Description
Refactor of the websocket logic to keep sending the keep alive messages until the client calls `connection terminate`.

Clients can open a connection with `GQL_CONNECTION_INIT` but never call `GQL_START`. The keep alive messages from the server should still be sent in that case, which also means we don't need to save the websocket session. We can just stop the session only on `GQL_CONNECTION_TERMINATE`

This also cleans up the keep alive connections after `GQL_STOP` is sent by the client or the server sends `GQL_CONNECTION_ERROR`

https://github.com/apollographql/subscriptions-transport-ws/blob/master/PROTOCOL.md

### :link: Related Issues
* https://github.com/ExpediaGroup/graphql-kotlin/pull/510
* https://github.com/ExpediaGroup/graphql-kotlin/issues/499