### PR TITLE
Do not close session on subscription GQL_STOP

### DIFF
--- a/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/subscriptions/SimpleSubscription.kt
+++ b/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/subscriptions/SimpleSubscription.kt
@@ -21,6 +21,8 @@ import com.expediagroup.graphql.spring.operations.Subscription
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.reactive.asPublisher
 import org.reactivestreams.Publisher
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
@@ -30,11 +32,17 @@ import kotlin.random.Random
 @Component
 class SimpleSubscription : Subscription {
 
+    val logger: Logger = LoggerFactory.getLogger(SimpleSubscription::class.java)
+
     @GraphQLDescription("Returns a single value")
     fun singleValueSubscription(): Mono<Int> = Mono.just(1)
 
     @GraphQLDescription("Returns a random number every second")
-    fun counter(): Flux<Int> = Flux.interval(Duration.ofSeconds(1)).map { Random.nextInt() }
+    fun counter(): Flux<Int> = Flux.interval(Duration.ofSeconds(1)).map {
+        val value = Random.nextInt()
+        logger.info("Returning $value from counter")
+        value
+    }
 
     @GraphQLDescription("Returns a random number every second, errors if even")
     fun counterWithError(): Flux<Int> = Flux.interval(Duration.ofSeconds(1))

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/execution/ApolloSubscriptionProtocolHandler.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/execution/ApolloSubscriptionProtocolHandler.kt
@@ -152,9 +152,9 @@ class ApolloSubscriptionProtocolHandler(
     }
 
     private fun terminateSubscription(session: WebSocketSession) {
-        subscriptionsForClient[session.id]?.let { subscriptions ->
-            subscriptions.forEach { this.subscriptions[it]?.cancel() }
-            subscriptions.forEach { this.subscriptions.remove(it) }
+        subscriptionsForClient[session.id]?.let { subscriptionsForSession ->
+            subscriptionsForSession.forEach { subscriptions[it]?.cancel() }
+            subscriptionsForSession.forEach { subscriptions.remove(it) }
         }
         subscriptionsForClient.remove(session.id)
         session.close()

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/execution/ApolloSubscriptionProtocolHandler.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/execution/ApolloSubscriptionProtocolHandler.kt
@@ -147,7 +147,7 @@ class ApolloSubscriptionProtocolHandler(
     }
 
     private fun terminateSession(session: WebSocketSession) {
-        activeOperations[session.id]?.forEach { it.value.cancel() }
+        activeOperations[session.id]?.forEach { _, subscription ->  subscription.cancel() }
         activeOperations.remove(session.id)
         activeSessions[session.id]?.cancel()
         activeSessions.remove(session.id)

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/execution/ApolloSubscriptionProtocolHandler.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/execution/ApolloSubscriptionProtocolHandler.kt
@@ -71,11 +71,12 @@ class ApolloSubscriptionProtocolHandler(
                         // Send the GQL_CONNECTION_KEEP_ALIVE message every interval until the connection is closed or terminated
                         val keepAliveFlux = Flux.interval(Duration.ofMillis(keepAliveInterval))
                             .map { keepAliveMessage }
+                            .doOnSubscribe { activeSessions[session.id] = it }
 
                         return flux.concatWith(keepAliveFlux)
                     }
 
-                    return flux.doOnSubscribe { activeSessions[session.id] = it }
+                    return flux
                 }
                 GQL_START.type -> startSubscription(operationMessage, session)
                 GQL_STOP.type -> {

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/execution/ApolloSubscriptionProtocolHandler.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/execution/ApolloSubscriptionProtocolHandler.kt
@@ -147,7 +147,7 @@ class ApolloSubscriptionProtocolHandler(
     }
 
     private fun terminateSession(session: WebSocketSession) {
-        activeOperations[session.id]?.forEach { _, subscription ->  subscription.cancel() }
+        activeOperations[session.id]?.forEach { _, subscription -> subscription.cancel() }
         activeOperations.remove(session.id)
         activeSessions[session.id]?.cancel()
         activeSessions.remove(session.id)

--- a/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/execution/ApolloSubscriptionProtocolHandlerTest.kt
+++ b/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/execution/ApolloSubscriptionProtocolHandlerTest.kt
@@ -47,6 +47,8 @@ class ApolloSubscriptionProtocolHandlerTest {
 
     private val objectMapper = jacksonObjectMapper()
 
+    private fun SubscriptionOperationMessage.toJson() = objectMapper.writeValueAsString(this)
+
     @Test
     fun `Return GQL_CONNECTION_ERROR when payload is not a SubscriptionOperationMessage`() {
         val config: GraphQLConfigurationProperties = mockk()
@@ -64,12 +66,12 @@ class ApolloSubscriptionProtocolHandlerTest {
     @Test
     fun `Return GQL_CONNECTION_ERROR when SubscriptionOperationMessage type is not valid`() {
         val config: GraphQLConfigurationProperties = mockk()
-        val operationMessage = SubscriptionOperationMessage("", id = "abc")
+        val operationMessage = SubscriptionOperationMessage("", id = "abc").toJson()
         val session: WebSocketSession = mockk()
         val subscriptionHandler: SubscriptionHandler = mockk()
 
         val handler = ApolloSubscriptionProtocolHandler(config, subscriptionHandler, objectMapper)
-        val flux = handler.handle(objectMapper.writeValueAsString(operationMessage), session)
+        val flux = handler.handle(operationMessage, session)
 
         val message = flux.blockFirst(Duration.ofSeconds(2))
         assertNotNull(message)
@@ -84,14 +86,14 @@ class ApolloSubscriptionProtocolHandlerTest {
                 every { keepAliveInterval } returns null
             }
         }
-        val operationMessage = SubscriptionOperationMessage(GQL_CONNECTION_INIT.type)
+        val operationMessage = SubscriptionOperationMessage(GQL_CONNECTION_INIT.type).toJson()
         val session: WebSocketSession = mockk {
             every { id } returns "123"
         }
         val subscriptionHandler: SubscriptionHandler = mockk()
 
         val handler = ApolloSubscriptionProtocolHandler(config, subscriptionHandler, objectMapper)
-        val flux = handler.handle(objectMapper.writeValueAsString(operationMessage), session)
+        val flux = handler.handle(operationMessage, session)
 
         val message = flux.blockFirst(Duration.ofSeconds(2))
         assertNotNull(message)
@@ -105,14 +107,14 @@ class ApolloSubscriptionProtocolHandlerTest {
                 every { keepAliveInterval } returns 500
             }
         }
-        val operationMessage = SubscriptionOperationMessage(GQL_CONNECTION_INIT.type)
+        val operationMessage = SubscriptionOperationMessage(GQL_CONNECTION_INIT.type).toJson()
         val session: WebSocketSession = mockk {
             every { id } returns "123"
         }
         val subscriptionHandler: SubscriptionHandler = mockk()
 
         val handler = ApolloSubscriptionProtocolHandler(config, subscriptionHandler, objectMapper)
-        val flux = handler.handle(objectMapper.writeValueAsString(operationMessage), session)
+        val flux = handler.handle(operationMessage, session)
 
         val message = flux.blockFirst(Duration.ofSeconds(2))
         assertNotNull(message)
@@ -126,7 +128,7 @@ class ApolloSubscriptionProtocolHandlerTest {
                 every { keepAliveInterval } returns 500
             }
         }
-        val operationMessage = SubscriptionOperationMessage(GQL_CONNECTION_INIT.type, id = "abc")
+        val operationMessage = SubscriptionOperationMessage(GQL_CONNECTION_INIT.type, id = "abc").toJson()
         val session: WebSocketSession = mockk {
             every { id } returns "1"
         }
@@ -134,7 +136,7 @@ class ApolloSubscriptionProtocolHandlerTest {
 
         val handler = ApolloSubscriptionProtocolHandler(config, subscriptionHandler, objectMapper)
 
-        val initFlux = handler.handle(objectMapper.writeValueAsString(operationMessage), session)
+        val initFlux = handler.handle(operationMessage, session)
 
         val message = initFlux.blockFirst(Duration.ofSeconds(2))
         assertNotNull(message)
@@ -164,7 +166,7 @@ class ApolloSubscriptionProtocolHandlerTest {
     @Test
     fun `Close session when sending GQL_CONNECTION_TERMINATE with id`() {
         val config: GraphQLConfigurationProperties = mockk()
-        val operationMessage = SubscriptionOperationMessage(GQL_CONNECTION_TERMINATE.type, id = "123")
+        val operationMessage = SubscriptionOperationMessage(GQL_CONNECTION_TERMINATE.type, id = "123").toJson()
         val session: WebSocketSession = mockk {
             every { close() } returns mockk()
             every { id } returns "abc"
@@ -172,7 +174,7 @@ class ApolloSubscriptionProtocolHandlerTest {
         val subscriptionHandler: SubscriptionHandler = mockk()
 
         val handler = ApolloSubscriptionProtocolHandler(config, subscriptionHandler, objectMapper)
-        val flux = handler.handle(objectMapper.writeValueAsString(operationMessage), session)
+        val flux = handler.handle(operationMessage, session)
 
         StepVerifier.create(flux)
             .expectNextCount(0)
@@ -185,14 +187,14 @@ class ApolloSubscriptionProtocolHandlerTest {
     @Test
     fun `Stop sending messages but keep connection open when sending GQL_STOP`() {
         val config: GraphQLConfigurationProperties = mockk()
-        val operationMessage = SubscriptionOperationMessage(GQL_STOP.type)
+        val operationMessage = SubscriptionOperationMessage(GQL_STOP.type).toJson()
         val session: WebSocketSession = mockk {
             every { close() } returns mockk()
         }
         val subscriptionHandler: SubscriptionHandler = mockk()
 
         val handler = ApolloSubscriptionProtocolHandler(config, subscriptionHandler, objectMapper)
-        val flux = handler.handle(objectMapper.writeValueAsString(operationMessage), session)
+        val flux = handler.handle(operationMessage, session)
 
         StepVerifier.create(flux)
             .expectNextCount(0)
@@ -203,14 +205,47 @@ class ApolloSubscriptionProtocolHandlerTest {
     }
 
     @Test
+    fun `Stop sending messages but keep connection open and keep sending GQL_CONNECTION_KEEP_ALIVE when client sends GQL_STOP`() {
+        val config: GraphQLConfigurationProperties = mockk {
+            every { subscriptions } returns mockk {
+                every { keepAliveInterval } returns 1
+            }
+        }
+        val session: WebSocketSession = mockk {
+            every { close() } returns mockk()
+        }
+        val subscriptionHandler: SubscriptionHandler = mockk()
+        val handler = ApolloSubscriptionProtocolHandler(config, subscriptionHandler, objectMapper)
+
+        val initMessage = SubscriptionOperationMessage(GQL_CONNECTION_INIT.type).toJson()
+        val stopMessage = SubscriptionOperationMessage(GQL_STOP.type).toJson()
+        val initFlux = handler.handle(initMessage, session)
+        val stopFlux = handler.handle(stopMessage, session)
+
+        StepVerifier.create(initFlux)
+            .expectSubscription()
+            .expectNextMatches { it.type == "connection_ack" }
+            .expectNextMatches { it.type == "ka" }
+            .thenCancel()
+            .verify()
+
+        StepVerifier.create(stopFlux)
+            .expectSubscription()
+            .thenCancel()
+            .verify()
+
+        verify(exactly = 0) { session.close() }
+    }
+
+    @Test
     fun `Return GQL_CONNECTION_ERROR when sending GQL_START but id is null`() {
         val config: GraphQLConfigurationProperties = mockk()
-        val operationMessage = SubscriptionOperationMessage(type = GQL_START.type, id = null)
+        val operationMessage = SubscriptionOperationMessage(type = GQL_START.type, id = null).toJson()
         val session: WebSocketSession = mockk()
         val subscriptionHandler: SubscriptionHandler = mockk()
 
         val handler = ApolloSubscriptionProtocolHandler(config, subscriptionHandler, objectMapper)
-        val flux = handler.handle(objectMapper.writeValueAsString(operationMessage), session)
+        val flux = handler.handle(operationMessage, session)
 
         val message = flux.blockFirst(Duration.ofSeconds(2))
         assertNotNull(message)
@@ -220,12 +255,12 @@ class ApolloSubscriptionProtocolHandlerTest {
     @Test
     fun `Return GQL_CONNECTION_ERROR when sending GQL_START but payload is null`() {
         val config: GraphQLConfigurationProperties = mockk()
-        val operationMessage = SubscriptionOperationMessage(type = GQL_START.type, id = "abc", payload = null)
+        val operationMessage = SubscriptionOperationMessage(type = GQL_START.type, id = "abc", payload = null).toJson()
         val session: WebSocketSession = mockk()
         val subscriptionHandler: SubscriptionHandler = mockk()
 
         val handler = ApolloSubscriptionProtocolHandler(config, subscriptionHandler, objectMapper)
-        val flux = handler.handle(objectMapper.writeValueAsString(operationMessage), session)
+        val flux = handler.handle(operationMessage, session)
 
         val message = flux.blockFirst(Duration.ofSeconds(2))
         assertNotNull(message)
@@ -236,12 +271,12 @@ class ApolloSubscriptionProtocolHandlerTest {
     @Test
     fun `Return GQL_CONNECTION_ERROR when sending GQL_START but payload is invalid GraphQLRequest`() {
         val config: GraphQLConfigurationProperties = mockk()
-        val operationMessage = SubscriptionOperationMessage(type = GQL_START.type, id = "abc", payload = "")
+        val operationMessage = SubscriptionOperationMessage(type = GQL_START.type, id = "abc", payload = "").toJson()
         val session: WebSocketSession = mockk()
         val subscriptionHandler: SubscriptionHandler = mockk()
 
         val handler = ApolloSubscriptionProtocolHandler(config, subscriptionHandler, objectMapper)
-        val flux = handler.handle(objectMapper.writeValueAsString(operationMessage), session)
+        val flux = handler.handle(operationMessage, session)
 
         val message = flux.blockFirst(Duration.ofSeconds(2))
         assertNotNull(message)
@@ -253,7 +288,7 @@ class ApolloSubscriptionProtocolHandlerTest {
     fun `Return GQL_DATA when sending GQL_START with valid GraphQLRequest`() {
         val config: GraphQLConfigurationProperties = mockk()
         val graphQLRequest = GraphQLRequest("{ message }")
-        val operationMessage = SubscriptionOperationMessage(type = GQL_START.type, id = "abc", payload = graphQLRequest)
+        val operationMessage = SubscriptionOperationMessage(type = GQL_START.type, id = "abc", payload = graphQLRequest).toJson()
         val session: WebSocketSession = mockk {
             every { close() } returns mockk()
             every { id } returns "123"
@@ -263,7 +298,7 @@ class ApolloSubscriptionProtocolHandlerTest {
         }
 
         val handler = ApolloSubscriptionProtocolHandler(config, subscriptionHandler, objectMapper)
-        val flux = handler.handle(objectMapper.writeValueAsString(operationMessage), session)
+        val flux = handler.handle(operationMessage, session)
 
         val message = flux.blockFirst(Duration.ofSeconds(2))
         assertNotNull(message)
@@ -282,7 +317,7 @@ class ApolloSubscriptionProtocolHandlerTest {
     fun `Return GQL_ERROR when sending GQL_START with valid GraphQLRequest but response has errors`() {
         val config: GraphQLConfigurationProperties = mockk()
         val graphQLRequest = GraphQLRequest("{ message }")
-        val operationMessage = SubscriptionOperationMessage(type = GQL_START.type, id = "abc", payload = graphQLRequest)
+        val operationMessage = SubscriptionOperationMessage(type = GQL_START.type, id = "abc", payload = graphQLRequest).toJson()
         val session: WebSocketSession = mockk {
             every { close() } returns mockk()
             every { id } returns "123"
@@ -293,7 +328,7 @@ class ApolloSubscriptionProtocolHandlerTest {
         }
 
         val handler = ApolloSubscriptionProtocolHandler(config, subscriptionHandler, objectMapper)
-        val flux = handler.handle(objectMapper.writeValueAsString(operationMessage), session)
+        val flux = handler.handle(operationMessage, session)
 
         assertEquals(expected = 2, actual = flux.count().block())
         val message = flux.blockFirst(Duration.ofSeconds(2))

--- a/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/execution/ApolloSubscriptionProtocolHandlerTest.kt
+++ b/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/execution/ApolloSubscriptionProtocolHandlerTest.kt
@@ -67,7 +67,9 @@ class ApolloSubscriptionProtocolHandlerTest {
     fun `Return GQL_CONNECTION_ERROR when SubscriptionOperationMessage type is not valid`() {
         val config: GraphQLConfigurationProperties = mockk()
         val operationMessage = SubscriptionOperationMessage("", id = "abc").toJson()
-        val session: WebSocketSession = mockk()
+        val session: WebSocketSession = mockk {
+            every { id } returns "abc"
+        }
         val subscriptionHandler: SubscriptionHandler = mockk()
 
         val handler = ApolloSubscriptionProtocolHandler(config, subscriptionHandler, objectMapper)
@@ -213,6 +215,7 @@ class ApolloSubscriptionProtocolHandlerTest {
         }
         val session: WebSocketSession = mockk {
             every { close() } returns mockk()
+            every { id } returns "abc"
         }
         val subscriptionHandler: SubscriptionHandler = mockk()
         val handler = ApolloSubscriptionProtocolHandler(config, subscriptionHandler, objectMapper)
@@ -256,7 +259,9 @@ class ApolloSubscriptionProtocolHandlerTest {
     fun `Return GQL_CONNECTION_ERROR when sending GQL_START but payload is null`() {
         val config: GraphQLConfigurationProperties = mockk()
         val operationMessage = SubscriptionOperationMessage(type = GQL_START.type, id = "abc", payload = null).toJson()
-        val session: WebSocketSession = mockk()
+        val session: WebSocketSession = mockk {
+            every { id } returns "abc"
+        }
         val subscriptionHandler: SubscriptionHandler = mockk()
 
         val handler = ApolloSubscriptionProtocolHandler(config, subscriptionHandler, objectMapper)
@@ -272,7 +277,9 @@ class ApolloSubscriptionProtocolHandlerTest {
     fun `Return GQL_CONNECTION_ERROR when sending GQL_START but payload is invalid GraphQLRequest`() {
         val config: GraphQLConfigurationProperties = mockk()
         val operationMessage = SubscriptionOperationMessage(type = GQL_START.type, id = "abc", payload = "").toJson()
-        val session: WebSocketSession = mockk()
+        val session: WebSocketSession = mockk {
+            every { id } returns "abc"
+        }
         val subscriptionHandler: SubscriptionHandler = mockk()
 
         val handler = ApolloSubscriptionProtocolHandler(config, subscriptionHandler, objectMapper)

--- a/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/execution/SubscriptionWebSocketHandlerIT.kt
+++ b/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/execution/SubscriptionWebSocketHandlerIT.kt
@@ -45,7 +45,7 @@ import kotlin.random.Random
 
 @SpringBootTest(
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
-    properties = ["graphql.packages=com.expediagroup.graphql.spring.execution", "graphql.subscriptions.keepAliveInterval=1"]
+    properties = ["graphql.packages=com.expediagroup.graphql.spring.execution"]
 )
 @EnableAutoConfiguration
 class SubscriptionWebSocketHandlerIT(@LocalServerPort private var port: Int) {


### PR DESCRIPTION
### :pencil: Description
Refactor of the websocket logic to keep sending the keep alive messages until the client calls `connection terminate`.

Clients can open a connection with `GQL_CONNECTION_INIT` but never call `GQL_START`. The keep alive messages from the server should still be sent in that case, which also means we don't need to save the websocket session. We can just stop the session only on `GQL_CONNECTION_TERMINATE`

This also cleans up the keep alive connections after `GQL_STOP` is sent by the client or the server sends `GQL_CONNECTION_ERROR`

https://github.com/apollographql/subscriptions-transport-ws/blob/master/PROTOCOL.md

### :link: Related Issues
* https://github.com/ExpediaGroup/graphql-kotlin/pull/510
* https://github.com/ExpediaGroup/graphql-kotlin/issues/499