### PR TITLE
Fix subscription caching logic

### DIFF
--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/execution/ApolloSubscriptionSessionState.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/execution/ApolloSubscriptionSessionState.kt
@@ -58,6 +58,10 @@ internal class ApolloSubscriptionSessionState {
             val operationsForSession = activeOperations[session.id]
             operationsForSession?.get(operationMessage.id)?.cancel()
             operationsForSession?.remove(operationMessage.id)
+
+            if (operationsForSession?.isEmpty() == true) {
+                activeOperations.remove(session.id)
+            }
         }
     }
 

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/execution/ApolloSubscriptionSessionState.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/execution/ApolloSubscriptionSessionState.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2019 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.spring.execution
+
+import com.expediagroup.graphql.spring.model.SubscriptionOperationMessage
+import org.reactivestreams.Subscription
+import org.springframework.web.reactive.socket.WebSocketSession
+import java.util.concurrent.ConcurrentHashMap
+
+internal class ApolloSubscriptionSessionState {
+
+    // Sessions are saved by web socket session id
+    internal val activeKeepAliveSessions = ConcurrentHashMap<String, Subscription>()
+
+    // Operations are saved by web socket session id, then operation id
+    internal val activeOperations = ConcurrentHashMap<String, ConcurrentHashMap<String, Subscription>>()
+
+    /**
+     * Save the session that is sending keep alive messages.
+     * This will override values without cancelling the subscription so it is the responsbility of the consumer to cancel.
+     * These messages will be stopped on [terminateSession].
+     */
+    fun saveKeepAliveSubscription(session: WebSocketSession, subscription: Subscription) {
+        activeKeepAliveSessions[session.id] = subscription
+    }
+
+    /**
+     * Save the operation that is sending data to the client.
+     * This will override values without cancelling the subscription so it is the responsbility of the consumer to cancel.
+     * These messages will be stopped on [stopOperation].
+     */
+    fun saveOperation(session: WebSocketSession, operationMessage: SubscriptionOperationMessage, subscription: Subscription) {
+        if (operationMessage.id != null) {
+            val operationsForSession: ConcurrentHashMap<String, Subscription> = activeOperations.getOrPut(session.id) { ConcurrentHashMap() }
+            operationsForSession[operationMessage.id] = subscription
+        }
+    }
+
+    /**
+     * Stop the subscription sending data. Does NOT terminate the session.
+     */
+    fun stopOperation(session: WebSocketSession, operationMessage: SubscriptionOperationMessage) {
+        if (operationMessage.id != null) {
+            val operationsForSession = activeOperations[session.id]
+            operationsForSession?.get(operationMessage.id)?.cancel()
+            operationsForSession?.remove(operationMessage.id)
+        }
+    }
+
+    /**
+     * Terminate the session, cancelling the keep alive messages and all operations active for this session.
+     */
+    fun terminateSession(session: WebSocketSession) {
+        activeOperations[session.id]?.forEach { _, subscription -> subscription.cancel() }
+        activeOperations.remove(session.id)
+        activeKeepAliveSessions[session.id]?.cancel()
+        activeKeepAliveSessions.remove(session.id)
+        session.close()
+    }
+}

--- a/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/execution/ApolloSubscriptionSessionStateTest.kt
+++ b/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/execution/ApolloSubscriptionSessionStateTest.kt
@@ -1,0 +1,228 @@
+/*
+ * Copyright 2019 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.spring.execution
+
+import com.expediagroup.graphql.spring.model.SubscriptionOperationMessage
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+import org.reactivestreams.Subscription
+import org.springframework.web.reactive.socket.WebSocketSession
+import reactor.core.publisher.Mono
+import kotlin.test.assertEquals
+
+class ApolloSubscriptionSessionStateTest {
+
+    @Test
+    fun `saveKeepAliveSubscription saves the subscription by session id`() {
+        val state = ApolloSubscriptionSessionState()
+        val mockSubscription: Subscription = mockk()
+        val mockSession: WebSocketSession = mockk { every { id } returns "123" }
+
+        assertEquals(expected = 0, actual = state.activeKeepAliveSessions.size)
+
+        state.saveKeepAliveSubscription(mockSession, mockSubscription)
+
+        assertEquals(expected = 1, actual = state.activeKeepAliveSessions.size)
+        assertEquals(expected = mockSubscription, actual = state.activeKeepAliveSessions["123"])
+    }
+
+    @Test
+    fun `saveOperation does not save the subscription if operation id is null`() {
+        val state = ApolloSubscriptionSessionState()
+        val mockSubscription: Subscription = mockk()
+        val mockSession: WebSocketSession = mockk { every { id } returns "123" }
+        val mockOperationMessage: SubscriptionOperationMessage = mockk { every { id } returns null }
+
+        assertEquals(expected = 0, actual = state.activeOperations.size)
+
+        state.saveOperation(mockSession, mockOperationMessage, mockSubscription)
+
+        assertEquals(expected = 0, actual = state.activeOperations.size)
+    }
+
+    @Test
+    fun `saveOperation saves the subscription if operation id is valid`() {
+        val state = ApolloSubscriptionSessionState()
+        val mockSubscription: Subscription = mockk()
+        val mockSession: WebSocketSession = mockk { every { id } returns "123" }
+        val mockOperationMessage: SubscriptionOperationMessage = mockk { every { id } returns "abc" }
+
+        assertEquals(expected = 0, actual = state.activeOperations.size)
+
+        state.saveOperation(mockSession, mockOperationMessage, mockSubscription)
+
+        assertEquals(expected = 1, actual = state.activeOperations.size)
+        assertEquals(expected = mockSubscription, actual = state.activeOperations["123"]?.get("abc"))
+    }
+
+    @Test
+    fun `saveOperation saves the subscription and does not duplicate session ids if operation id is valid`() {
+        val state = ApolloSubscriptionSessionState()
+        val mockSubscription: Subscription = mockk()
+        val mockSession: WebSocketSession = mockk { every { id } returns "123" }
+        val mockOperationMessage1: SubscriptionOperationMessage = mockk { every { id } returns "abc" }
+        val mockOperationMessage2: SubscriptionOperationMessage = mockk { every { id } returns "def" }
+
+        assertEquals(expected = 0, actual = state.activeOperations.size)
+
+        state.saveOperation(mockSession, mockOperationMessage1, mockSubscription)
+
+        assertEquals(expected = 1, actual = state.activeOperations.size)
+        assertEquals(expected = 1, actual = state.activeOperations["123"]?.size)
+
+        state.saveOperation(mockSession, mockOperationMessage2, mockSubscription)
+
+        assertEquals(expected = 1, actual = state.activeOperations.size)
+        assertEquals(expected = 2, actual = state.activeOperations["123"]?.size)
+    }
+
+    @Test
+    fun `stopOperation does not cancel the subscription if operation id is null`() {
+        val state = ApolloSubscriptionSessionState()
+        val mockSubscription: Subscription = mockk()
+        val mockSession: WebSocketSession = mockk { every { id } returns "123" }
+        val inputOperation: SubscriptionOperationMessage = mockk { every { id } returns "abc" }
+
+        state.saveOperation(mockSession, inputOperation, mockSubscription)
+
+        assertEquals(expected = 1, actual = state.activeOperations.size)
+
+        val cancelOperation: SubscriptionOperationMessage = mockk { every { id } returns null }
+        state.stopOperation(mockSession, cancelOperation)
+
+        assertEquals(expected = 1, actual = state.activeOperations.size)
+        assertEquals(expected = mockSubscription, actual = state.activeOperations["123"]?.get("abc"))
+        verify(exactly = 0) { mockSubscription.cancel() }
+    }
+
+    @Test
+    fun `stopOperation does not cancel the subscription if operation id not match`() {
+        val state = ApolloSubscriptionSessionState()
+        val mockSubscription: Subscription = mockk()
+        val mockSession: WebSocketSession = mockk { every { id } returns "123" }
+        val inputOperation: SubscriptionOperationMessage = mockk { every { id } returns "abc" }
+
+        state.saveOperation(mockSession, inputOperation, mockSubscription)
+
+        assertEquals(expected = 1, actual = state.activeOperations.size)
+
+        val cancelOperation: SubscriptionOperationMessage = mockk { every { id } returns "xyz" }
+        state.stopOperation(mockSession, cancelOperation)
+
+        assertEquals(expected = 1, actual = state.activeOperations.size)
+        assertEquals(expected = mockSubscription, actual = state.activeOperations["123"]?.get("abc"))
+        verify(exactly = 0) { mockSubscription.cancel() }
+    }
+
+    @Test
+    fun `stopOperation cancels the subscription if operation id is valid`() {
+        val state = ApolloSubscriptionSessionState()
+        val mockSubscription: Subscription = mockk { every { cancel() } returns Unit }
+        val mockSession: WebSocketSession = mockk { every { id } returns "123" }
+        val inputOperation: SubscriptionOperationMessage = mockk { every { id } returns "abc" }
+
+        state.saveOperation(mockSession, inputOperation, mockSubscription)
+
+        assertEquals(expected = 1, actual = state.activeOperations.size)
+        assertEquals(expected = 1, actual = state.activeOperations["123"]?.size)
+
+        state.stopOperation(mockSession, inputOperation)
+
+        assertEquals(expected = 1, actual = state.activeOperations.size)
+        assertEquals(expected = 0, actual = state.activeOperations["123"]?.size)
+        verify(exactly = 1) { mockSubscription.cancel() }
+    }
+
+    @Test
+    fun `terminateSession cancels the keep alive subscription`() {
+        val state = ApolloSubscriptionSessionState()
+        val mockSubscription: Subscription = mockk { every { cancel() } returns Unit }
+        val mockSession: WebSocketSession = mockk {
+            every { id } returns "123"
+            every { close() } returns Mono.empty()
+        }
+
+        state.saveKeepAliveSubscription(mockSession, mockSubscription)
+
+        assertEquals(expected = 1, actual = state.activeKeepAliveSessions.size)
+
+        state.terminateSession(mockSession)
+
+        assertEquals(expected = 0, actual = state.activeKeepAliveSessions.size)
+        verify(exactly = 1) { mockSubscription.cancel() }
+        verify(exactly = 1) { mockSession.close() }
+    }
+
+    @Test
+    fun `terminateSession cancels all subscriptions for the session and operations`() {
+        val state = ApolloSubscriptionSessionState()
+        val mockSessionSubscription: Subscription = mockk { every { cancel() } returns Unit }
+        val mockOperationSubscription: Subscription = mockk { every { cancel() } returns Unit }
+        val inputOperation: SubscriptionOperationMessage = mockk { every { id } returns "abc" }
+        val mockSession: WebSocketSession = mockk {
+            every { id } returns "123"
+            every { close() } returns Mono.empty()
+        }
+
+        state.saveKeepAliveSubscription(mockSession, mockSessionSubscription)
+        state.saveOperation(mockSession, inputOperation, mockOperationSubscription)
+
+        assertEquals(expected = 1, actual = state.activeKeepAliveSessions.size)
+        assertEquals(expected = 1, actual = state.activeOperations.size)
+
+        state.terminateSession(mockSession)
+
+        assertEquals(expected = 0, actual = state.activeKeepAliveSessions.size)
+        assertEquals(expected = 0, actual = state.activeOperations.size)
+        verify(exactly = 1) { mockSessionSubscription.cancel() }
+        verify(exactly = 1) { mockOperationSubscription.cancel() }
+        verify(exactly = 1) { mockSession.close() }
+    }
+
+    @Test
+    fun `terminateSession does not cancel any subscriptions if the session id does not match`() {
+        val state = ApolloSubscriptionSessionState()
+        val mockSessionSubscription: Subscription = mockk { every { cancel() } returns Unit }
+        val mockOperationSubscription: Subscription = mockk { every { cancel() } returns Unit }
+        val inputOperation: SubscriptionOperationMessage = mockk { every { id } returns "abc" }
+        val mockSession: WebSocketSession = mockk {
+            every { id } returns "123"
+            every { close() } returns Mono.empty()
+        }
+
+        state.saveKeepAliveSubscription(mockSession, mockSessionSubscription)
+        state.saveOperation(mockSession, inputOperation, mockOperationSubscription)
+
+        assertEquals(expected = 1, actual = state.activeKeepAliveSessions.size)
+        assertEquals(expected = 1, actual = state.activeOperations.size)
+
+        val nonMatchingSession: WebSocketSession = mockk {
+            every { id } returns "xyz"
+            every { close() } returns Mono.empty()
+        }
+        state.terminateSession(nonMatchingSession)
+
+        assertEquals(expected = 1, actual = state.activeKeepAliveSessions.size)
+        assertEquals(expected = 1, actual = state.activeOperations.size)
+        verify(exactly = 0) { mockSessionSubscription.cancel() }
+        verify(exactly = 0) { mockOperationSubscription.cancel() }
+        verify(exactly = 0) { mockSession.close() }
+        verify(exactly = 1) { nonMatchingSession.close() }
+    }
+}


### PR DESCRIPTION
### :pencil: Description
Please merge this first: https://github.com/ExpediaGroup/graphql-kotlin/pull/514

Move the saving of subscriptions to a separate class so we can verify the logic with unit tests and simplify the`ApolloSubscriptionProtocolHandler`. This also exposed a bug that we were not saving the operation subscriptions to be stopped properly. This is now covered by the unit tests


### :link: Related Issues
* Builds on top of https://github.com/ExpediaGroup/graphql-kotlin/pull/514 for testing purposes
* Hopefully will help with subscription performance: #499