### PR TITLE
Allow to override FunctionDataFetcher objectmapper

### DIFF
--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/execution/FunctionDataFetcher.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/execution/FunctionDataFetcher.kt
@@ -45,7 +45,7 @@ import kotlin.reflect.full.valueParameters
 open class FunctionDataFetcher(
     private val target: Any?,
     private val fn: KFunction<*>,
-    private val objectMapper: ObjectMapper = jacksonObjectMapper()
+    open val objectMapper: ObjectMapper = jacksonObjectMapper()
 ) : DataFetcher<Any> {
 
     override fun get(environment: DataFetchingEnvironment): Any? {


### PR DESCRIPTION
Currently it is not possible to provide my object mapper

(I use Vert.x and they provide core mapper instance, which I would like to use to handle  (de)serialization of dates/timestamps)

### :pencil: Description


### :link: Related Issues
