### PR TITLE
[generator] update generator hooks to include target kclass info

### DIFF
--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/extensions/kClassExtensions.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/extensions/kClassExtensions.kt
@@ -39,12 +39,12 @@ private const val INPUT_SUFFIX = "Input"
 
 internal fun KClass<*>.getValidProperties(hooks: SchemaGeneratorHooks): List<KProperty<*>> =
     this.memberProperties
-        .filter { hooks.isValidProperty(it) }
+        .filter { prop -> hooks.isValidProperty(this, prop) }
         .filter { prop -> propertyFilters.all { it.invoke(prop, this) } }
 
 internal fun KClass<*>.getValidFunctions(hooks: SchemaGeneratorHooks): List<KFunction<*>> =
     this.memberFunctions
-        .filter { hooks.isValidFunction(it) }
+        .filter { func -> hooks.isValidFunction(this, func) }
         .filter { func -> functionFilters.all { it.invoke(func) } }
 
 internal fun KClass<*>.getValidSuperclasses(hooks: SchemaGeneratorHooks): List<KClass<*>> =

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/MutationBuilder.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/MutationBuilder.kt
@@ -47,7 +47,7 @@ internal class MutationBuilder(generator: SchemaGenerator) : TypeBuilder(generat
             mutation.kClass.getValidFunctions(config.hooks)
                 .forEach {
                     val function = generator.function(it, config.topLevelNames.mutation, mutation.obj)
-                    val functionFromHook = config.hooks.didGenerateMutationType(it, function)
+                    val functionFromHook = config.hooks.didGenerateMutationType(mutation.kClass, it, function)
                     mutationBuilder.field(functionFromHook)
                 }
         }

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/QueryBuilder.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/QueryBuilder.kt
@@ -42,7 +42,7 @@ internal class QueryBuilder(generator: SchemaGenerator) : TypeBuilder(generator)
             query.kClass.getValidFunctions(config.hooks)
                 .forEach {
                     val function = generator.function(it, config.topLevelNames.query, query.obj)
-                    val functionFromHook = config.hooks.didGenerateQueryType(it, function)
+                    val functionFromHook = config.hooks.didGenerateQueryType(query.kClass, it, function)
                     queryBuilder.field(functionFromHook)
                 }
         }

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/SubscriptionBuilder.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/SubscriptionBuilder.kt
@@ -49,7 +49,7 @@ internal class SubscriptionBuilder(generator: SchemaGenerator) : TypeBuilder(gen
                     }
 
                     val function = generator.function(it, config.topLevelNames.subscription, subscription.obj)
-                    val functionFromHook = config.hooks.didGenerateSubscriptionType(it, function)
+                    val functionFromHook = config.hooks.didGenerateSubscriptionType(subscription.kClass, it, function)
                     subscriptionBuilder.field(functionFromHook)
                 }
         }

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/hooks/SchemaGeneratorHooks.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/hooks/SchemaGeneratorHooks.kt
@@ -71,14 +71,14 @@ interface SchemaGeneratorHooks {
      * If any filter returns false, it is rejected.
      */
     @Suppress("Detekt.FunctionOnlyReturningConstant")
-    fun isValidProperty(property: KProperty<*>): Boolean = true
+    fun isValidProperty(kClass: KClass<*>, property: KProperty<*>): Boolean = true
 
     /**
      * Called when looking at the KClass functions to determine if it valid for adding to the generated schema.
      * If any filter returns false, it is rejected.
      */
     @Suppress("Detekt.FunctionOnlyReturningConstant")
-    fun isValidFunction(function: KFunction<*>): Boolean = true
+    fun isValidFunction(kClass: KClass<*>, function: KFunction<*>): Boolean = true
 
     /**
      * Called after `willGenerateGraphQLType` and before `didGenerateGraphQLType`.
@@ -95,17 +95,17 @@ interface SchemaGeneratorHooks {
     /**
      * Called after converting the function to a field definition but before adding to the schema to allow customization
      */
-    fun didGenerateQueryType(function: KFunction<*>, fieldDefinition: GraphQLFieldDefinition): GraphQLFieldDefinition = fieldDefinition
+    fun didGenerateQueryType(kClass: KClass<*>, function: KFunction<*>, fieldDefinition: GraphQLFieldDefinition): GraphQLFieldDefinition = fieldDefinition
 
     /**
      * Called after converting the function to a field definition but before adding to the schema to allow customization
      */
-    fun didGenerateMutationType(function: KFunction<*>, fieldDefinition: GraphQLFieldDefinition): GraphQLFieldDefinition = fieldDefinition
+    fun didGenerateMutationType(kClass: KClass<*>, function: KFunction<*>, fieldDefinition: GraphQLFieldDefinition): GraphQLFieldDefinition = fieldDefinition
 
     /**
      * Called after converting the function to a field definition but before adding to the schema to allow customization
      */
-    fun didGenerateSubscriptionType(function: KFunction<*>, fieldDefinition: GraphQLFieldDefinition): GraphQLFieldDefinition = fieldDefinition
+    fun didGenerateSubscriptionType(kClass: KClass<*>, function: KFunction<*>, fieldDefinition: GraphQLFieldDefinition): GraphQLFieldDefinition = fieldDefinition
 
     val wiringFactory: KotlinDirectiveWiringFactory
         get() = KotlinDirectiveWiringFactory()

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/extensions/KClassExtensionsTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/extensions/KClassExtensionsTest.kt
@@ -142,10 +142,10 @@ open class KClassExtensionsTest {
     }
 
     private class FilterHooks : SchemaGeneratorHooks {
-        override fun isValidProperty(property: KProperty<*>) =
+        override fun isValidProperty(kClass: KClass<*>, property: KProperty<*>) =
             property.name.contains("filteredProperty").not()
 
-        override fun isValidFunction(function: KFunction<*>) =
+        override fun isValidFunction(kClass: KClass<*>, function: KFunction<*>) =
             function.name.contains("filteredFunction").not()
 
         override fun isValidSuperclass(kClass: KClass<*>) =

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/MutationBuilderTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/MutationBuilderTest.kt
@@ -25,6 +25,7 @@ import com.expediagroup.graphql.hooks.SchemaGeneratorHooks
 import com.expediagroup.graphql.test.utils.SimpleDirective
 import graphql.schema.GraphQLFieldDefinition
 import org.junit.jupiter.api.Test
+import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -37,9 +38,9 @@ internal class MutationBuilderTest : TypeTestHelper() {
 
     internal class SimpleHooks : SchemaGeneratorHooks {
         var calledHook = false
-        override fun didGenerateMutationType(function: KFunction<*>, fieldDefinition: GraphQLFieldDefinition): GraphQLFieldDefinition {
+        override fun didGenerateMutationType(kClass: KClass<*>, function: KFunction<*>, fieldDefinition: GraphQLFieldDefinition): GraphQLFieldDefinition {
             calledHook = true
-            return super.didGenerateMutationType(function, fieldDefinition)
+            return super.didGenerateMutationType(kClass, function, fieldDefinition)
         }
     }
 

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/QueryBuilderTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/QueryBuilderTest.kt
@@ -25,6 +25,7 @@ import com.expediagroup.graphql.hooks.SchemaGeneratorHooks
 import com.expediagroup.graphql.test.utils.SimpleDirective
 import graphql.schema.GraphQLFieldDefinition
 import org.junit.jupiter.api.Test
+import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -36,9 +37,9 @@ internal class QueryBuilderTest : TypeTestHelper() {
 
     internal class SimpleHooks : SchemaGeneratorHooks {
         var calledHook = false
-        override fun didGenerateQueryType(function: KFunction<*>, fieldDefinition: GraphQLFieldDefinition): GraphQLFieldDefinition {
+        override fun didGenerateQueryType(kClass: KClass<*>, function: KFunction<*>, fieldDefinition: GraphQLFieldDefinition): GraphQLFieldDefinition {
             calledHook = true
-            return super.didGenerateQueryType(function, fieldDefinition)
+            return super.didGenerateQueryType(kClass, function, fieldDefinition)
         }
     }
 

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/SubscriptionBuilderTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/SubscriptionBuilderTest.kt
@@ -25,6 +25,7 @@ import io.mockk.every
 import io.reactivex.Flowable
 import org.junit.jupiter.api.Test
 import org.reactivestreams.Publisher
+import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -90,7 +91,7 @@ internal class SubscriptionBuilderTest : TypeTestHelper() {
         val subscriptions = listOf(TopLevelObject(MyPublicTestSubscription()))
 
         class CustomHooks : SchemaGeneratorHooks {
-            override fun isValidFunction(function: KFunction<*>) = function.name != "filterMe"
+            override fun isValidFunction(kClass: KClass<*>, function: KFunction<*>) = function.name != "filterMe"
         }
 
         every { config.hooks } returns CustomHooks()
@@ -107,7 +108,7 @@ internal class SubscriptionBuilderTest : TypeTestHelper() {
         val subscriptions = listOf(TopLevelObject(MyPublicTestSubscription()))
 
         class CustomHooks : SchemaGeneratorHooks {
-            override fun didGenerateSubscriptionType(function: KFunction<*>, fieldDefinition: GraphQLFieldDefinition): GraphQLFieldDefinition {
+            override fun didGenerateSubscriptionType(kClass: KClass<*>, function: KFunction<*>, fieldDefinition: GraphQLFieldDefinition): GraphQLFieldDefinition {
                 return if (fieldDefinition.name == "filterMe") {
                     fieldDefinition.transform { fieldBuilder -> fieldBuilder.name("changedField") }
                 } else fieldDefinition

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/hooks/SchemaGeneratorHooksTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/hooks/SchemaGeneratorHooksTest.kt
@@ -27,6 +27,7 @@ import graphql.schema.GraphQLSchema
 import graphql.schema.GraphQLType
 import org.junit.jupiter.api.Test
 import kotlin.random.Random
+import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
 import kotlin.reflect.KProperty
 import kotlin.reflect.KType
@@ -63,7 +64,7 @@ class SchemaGeneratorHooksTest {
         class MockSchemaGeneratorHooks : SchemaGeneratorHooks {
             var calledFilterFunction = false
 
-            override fun isValidProperty(property: KProperty<*>): Boolean {
+            override fun isValidProperty(kClass: KClass<*>, property: KProperty<*>): Boolean {
                 calledFilterFunction = true
                 return false
             }
@@ -84,7 +85,7 @@ class SchemaGeneratorHooksTest {
         class MockSchemaGeneratorHooks : SchemaGeneratorHooks {
             var calledFilterFunction = false
 
-            override fun isValidFunction(function: KFunction<*>): Boolean {
+            override fun isValidFunction(kClass: KClass<*>, function: KFunction<*>): Boolean {
                 calledFilterFunction = true
                 return false
             }
@@ -155,6 +156,7 @@ class SchemaGeneratorHooksTest {
     fun `calls hook before adding query to schema`() {
         class MockSchemaGeneratorHooks : SchemaGeneratorHooks {
             override fun didGenerateQueryType(
+                kClass: KClass<*>,
                 function: KFunction<*>,
                 fieldDefinition: GraphQLFieldDefinition
             ): GraphQLFieldDefinition {
@@ -181,6 +183,7 @@ class SchemaGeneratorHooksTest {
     fun `calls hook before adding mutation to schema`() {
         class MockSchemaGeneratorHooks : SchemaGeneratorHooks {
             override fun didGenerateMutationType(
+                kClass: KClass<*>,
                 function: KFunction<*>,
                 fieldDefinition: GraphQLFieldDefinition
             ): GraphQLFieldDefinition {


### PR DESCRIPTION
### :pencil: Description
Update SchemaGeneratorHooks interface to specify target kClass info for isValidProperty, isValidFunction, didGenerateQueryType, didGenerateMutationType and didGenerateSubscriptionType hooks.


### :link: Related Issues
Resolves: https://github.com/ExpediaGroup/graphql-kotlin/issues/526