### PR TITLE
Refactor schema generator to remove cyclic dependencies

### DIFF
--- a/detekt.yml
+++ b/detekt.yml
@@ -13,11 +13,11 @@ complexity:
     threshold: 10
     active: true
   TooManyFunctions:
-    thresholdInInterfaces: 20
-    thresholdInClasses: 20
-    thresholdInFiles: 20
+    thresholdInInterfaces: 15
+    thresholdInClasses: 15
+    thresholdInFiles: 15
   ComplexInterface:
-    threshold: 20
+    threshold: 15
 
 naming:
   FunctionMaxLength:

--- a/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/FederatedSchemaGenerator.kt
+++ b/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/FederatedSchemaGenerator.kt
@@ -43,7 +43,7 @@ open class FederatedSchemaGenerator(generatorConfig: FederatedSchemaGeneratorCon
      * Scans specified packages for all the federated (extended) types and adds them to the target schema before generating the rest of the schema
      */
     @Suppress("Detekt.SpreadOperator")
-    fun GraphQLSchema.Builder.federation(supportedPackages: List<String>): GraphQLSchema.Builder {
+    private fun GraphQLSchema.Builder.federation(supportedPackages: List<String>): GraphQLSchema.Builder {
         val scanResult = ClassGraph().enableAllInfo().whitelistPackages(*supportedPackages.toTypedArray()).scan()
 
         scanResult.getClassesWithAnnotation(ExtendsDirective::class.jvmName)

--- a/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/validation/FederatedSchemaValidatorKeyDirectiveTest.kt
+++ b/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/validation/FederatedSchemaValidatorKeyDirectiveTest.kt
@@ -34,6 +34,7 @@ import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import java.util.stream.Stream
 import kotlin.reflect.KClass
+import kotlin.reflect.full.createType
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
@@ -90,7 +91,8 @@ class FederatedSchemaValidatorKeyDirectiveTest {
     @MethodSource("keyDirectiveValidations")
     @Suppress("UnusedPrivateMember")
     fun `validate @key directive`(testCase: String, targetClass: KClass<*>, expectedError: String?) {
-        val validatedType = schemaGenerator.objectType(targetClass) as? GraphQLObjectType
+        // TODO: This is failing because createType drops annonation information
+        val validatedType = schemaGenerator.graphQLTypeOf(targetClass.createType()) as? GraphQLObjectType
         assertNotNull(validatedType)
         assertEquals(targetClass.simpleName, validatedType.name)
 

--- a/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/validation/FederatedSchemaValidatorKeyDirectiveTest.kt
+++ b/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/validation/FederatedSchemaValidatorKeyDirectiveTest.kt
@@ -14,18 +14,18 @@
  * limitations under the License.
  */
 
-package com.expediagroup.graphql.federation.validation.key
+package com.expediagroup.graphql.federation.validation
 
 import com.expediagroup.graphql.federation.FederatedSchemaGenerator
 import com.expediagroup.graphql.federation.FederatedSchemaGeneratorConfig
 import com.expediagroup.graphql.federation.FederatedSchemaGeneratorHooks
-import com.expediagroup.graphql.federation.FederatedSchemaValidator
 import com.expediagroup.graphql.federation.directives.ExtendsDirective
 import com.expediagroup.graphql.federation.directives.ExternalDirective
 import com.expediagroup.graphql.federation.directives.FieldSet
 import com.expediagroup.graphql.federation.directives.KeyDirective
 import com.expediagroup.graphql.federation.exception.InvalidFederatedSchema
 import graphql.schema.GraphQLObjectType
+import graphql.schema.GraphQLTypeUtil
 import io.mockk.mockk
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.TestInstance
@@ -34,14 +34,13 @@ import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import java.util.stream.Stream
 import kotlin.reflect.KClass
-import kotlin.reflect.full.createType
+import kotlin.reflect.full.starProjectedType
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class FederatedSchemaValidatorKeyDirectiveTest {
-    private val validator = FederatedSchemaValidator()
     private lateinit var schemaGenerator: FederatedSchemaGenerator
 
     /**
@@ -81,7 +80,7 @@ class FederatedSchemaValidatorKeyDirectiveTest {
     @BeforeEach
     fun beforeTest() {
         val config = FederatedSchemaGeneratorConfig(
-            supportedPackages = listOf("com.expediagroup.graphql.federation.validation.key"),
+            supportedPackages = listOf("com.expediagroup.graphql.federation.validation"),
             hooks = FederatedSchemaGeneratorHooks(mockk())
         )
         schemaGenerator = FederatedSchemaGenerator(config)
@@ -91,18 +90,15 @@ class FederatedSchemaValidatorKeyDirectiveTest {
     @MethodSource("keyDirectiveValidations")
     @Suppress("UnusedPrivateMember")
     fun `validate @key directive`(testCase: String, targetClass: KClass<*>, expectedError: String?) {
-        // TODO: This is failing because createType drops annonation information
-        val validatedType = schemaGenerator.graphQLTypeOf(targetClass.createType()) as? GraphQLObjectType
-        assertNotNull(validatedType)
-        assertEquals(targetClass.simpleName, validatedType.name)
-
         if (expectedError != null) {
             val exception = assertFailsWith(InvalidFederatedSchema::class) {
-                validator.validateGraphQLType(validatedType)
+                schemaGenerator.graphQLTypeOf(targetClass.starProjectedType)
             }
             assertEquals(expectedError, exception.message)
         } else {
-            validator.validateGraphQLType(validatedType)
+            val validatedType = GraphQLTypeUtil.unwrapNonNull(schemaGenerator.graphQLTypeOf(targetClass.starProjectedType)) as? GraphQLObjectType
+            assertNotNull(validatedType)
+            assertEquals(targetClass.simpleName, validatedType.name)
             assertNotNull(validatedType.getDirective("key"))
         }
     }

--- a/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/validation/FederatedSchemaValidatorProvidesDirectiveTest.kt
+++ b/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/validation/FederatedSchemaValidatorProvidesDirectiveTest.kt
@@ -38,6 +38,8 @@ import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import java.util.stream.Stream
 import kotlin.reflect.KClass
+import kotlin.reflect.full.createType
+import kotlin.reflect.full.starProjectedType
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
@@ -80,7 +82,8 @@ class FederatedSchemaValidatorProvidesDirectiveTest {
     @MethodSource("providesDirectiveValidations")
     @Suppress("UnusedPrivateMember")
     fun `validate @provide directive`(testCase: String, targetClass: KClass<*>, expectedError: String?) {
-        val validatedType = schemaGenerator.objectType(targetClass) as? GraphQLObjectType
+        // TODO: This is failing because createType drops annonation information
+        val validatedType = schemaGenerator.graphQLTypeOf(targetClass.createType()) as? GraphQLObjectType
         assertNotNull(validatedType)
         assertEquals(targetClass.simpleName, validatedType.name)
 
@@ -106,13 +109,16 @@ class FederatedSchemaValidatorProvidesDirectiveTest {
         // order of object instantiation matters
         // - BUG #397 - typeA -> typeB with provides (apply validation) -> reference typeA
         // - NO ISSUE - typeB with provides -> typeA (no validation) -> reference typeB
-        val validatedType = schemaGenerator.objectType(NestedProvidedType::class) as? GraphQLObjectType
+
+        // TODO: This is failing because createType drops annonation information
+        val validatedType = schemaGenerator.graphQLTypeOf(NestedProvidedType::class.createType()) as? GraphQLObjectType
         assertNotNull(validatedType)
         assertEquals(NestedProvidedType::class.simpleName, validatedType.name)
         validator.validateGraphQLType(validatedType)
         assertNotNull(validatedType.getDirective("key"))
 
-        val typeWithProvides = schemaGenerator.objectType(NestedProvides::class) as? GraphQLObjectType
+        // TODO: This is failing because createType drops annonation information
+        val typeWithProvides = schemaGenerator.graphQLTypeOf(NestedProvides::class.createType()) as? GraphQLObjectType
         assertNotNull(typeWithProvides)
         validator.validateGraphQLType(typeWithProvides)
         val providedField = typeWithProvides.getFieldDefinition("provided")

--- a/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/validation/FederatedSchemaValidatorProvidesDirectiveTest.kt
+++ b/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/validation/FederatedSchemaValidatorProvidesDirectiveTest.kt
@@ -55,7 +55,6 @@ import org.junit.jupiter.params.provider.MethodSource
 import java.util.stream.Stream
 import kotlin.reflect.KClass
 import kotlin.reflect.full.createType
-import kotlin.reflect.full.starProjectedType
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
@@ -100,7 +99,7 @@ class FederatedSchemaValidatorProvidesDirectiveTest {
     fun `validate @provide directive`(testCase: String, targetClass: KClass<*>, expectedError: String?) {
         if (expectedError != null) {
             val exception = assertFailsWith(InvalidFederatedSchema::class) {
-                schemaGenerator.graphQLTypeOf(targetClass.starProjectedType)
+                schemaGenerator.graphQLTypeOf(targetClass.createType())
             }
             assertEquals(expectedError, exception.message)
         } else {

--- a/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/validation/FederatedSchemaValidatorRequiresDirectiveTest.kt
+++ b/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/validation/FederatedSchemaValidatorRequiresDirectiveTest.kt
@@ -14,13 +14,11 @@
  * limitations under the License.
  */
 
-package com.expediagroup.graphql.federation.validation.requires
+package com.expediagroup.graphql.federation.validation
 
-import com.expediagroup.graphql.TopLevelObject
 import com.expediagroup.graphql.federation.FederatedSchemaGenerator
 import com.expediagroup.graphql.federation.FederatedSchemaGeneratorConfig
 import com.expediagroup.graphql.federation.FederatedSchemaGeneratorHooks
-import com.expediagroup.graphql.federation.FederatedSchemaValidator
 import com.expediagroup.graphql.federation.directives.ExtendsDirective
 import com.expediagroup.graphql.federation.directives.ExternalDirective
 import com.expediagroup.graphql.federation.directives.FieldSet
@@ -28,6 +26,7 @@ import com.expediagroup.graphql.federation.directives.KeyDirective
 import com.expediagroup.graphql.federation.directives.RequiresDirective
 import com.expediagroup.graphql.federation.exception.InvalidFederatedSchema
 import graphql.schema.GraphQLObjectType
+import graphql.schema.GraphQLTypeUtil
 import io.mockk.mockk
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.TestInstance
@@ -37,13 +36,13 @@ import org.junit.jupiter.params.provider.MethodSource
 import java.util.stream.Stream
 import kotlin.properties.Delegates
 import kotlin.reflect.KClass
+import kotlin.reflect.full.starProjectedType
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class FederatedSchemaValidatorRequiresDirectiveTest {
-    private val validator = FederatedSchemaValidator()
     private lateinit var schemaGenerator: FederatedSchemaGenerator
 
     /**
@@ -52,19 +51,19 @@ class FederatedSchemaValidatorRequiresDirectiveTest {
      * @sample <testName>, <testClass>, (Optional)<expectedValidationError>
      */
     fun requiresDirectiveValidations() = Stream.of(
-        Arguments.of("[OK] @requires references valid fields", SimpleRequiresQuery::class, SimpleRequires::class, null),
-        Arguments.of("[ERROR] @requires references local fields", RequiresLocalFieldQuery::class, RequiresLocalField::class, "Invalid federated schema:\n" +
+        Arguments.of("[OK] @requires references valid fields", SimpleRequires::class, null),
+        Arguments.of("[ERROR] @requires references local fields", RequiresLocalField::class, "Invalid federated schema:\n" +
             " - @requires(fields = weight) directive on RequiresLocalField.shippingCost specifies invalid field set - extended type incorrectly references local field=weight"),
-        Arguments.of("[ERROR] @requires references non-existent fields", RequiresNonExistentFieldQuery::class, RequiresNonExistentField::class, "Invalid federated schema:\n" +
+        Arguments.of("[ERROR] @requires references non-existent fields", RequiresNonExistentField::class, "Invalid federated schema:\n" +
             " - @requires(fields = zipCode) directive on RequiresNonExistentField.shippingCost specifies invalid field set - field set specifies fields that do not exist"),
-        Arguments.of("[ERROR] @requires declared on local type", RequiresOnLocalTypeQuery::class, RequiresOnLocalType::class, "Invalid federated schema:\n" +
+        Arguments.of("[ERROR] @requires declared on local type", RequiresOnLocalType::class, "Invalid federated schema:\n" +
             " - base RequiresOnLocalType type has fields marked with @requires directive, validatedField=shippingCost")
     )
 
     @BeforeEach
     fun beforeTest() {
         val config = FederatedSchemaGeneratorConfig(
-            supportedPackages = listOf("com.expediagroup.graphql.federation.validation.requires"),
+            supportedPackages = listOf("com.expediagroup.graphql.federation.validation"),
             hooks = FederatedSchemaGeneratorHooks(mockk())
         )
         schemaGenerator = FederatedSchemaGenerator(config)
@@ -73,21 +72,14 @@ class FederatedSchemaValidatorRequiresDirectiveTest {
     @ParameterizedTest(name = "{0}")
     @MethodSource("requiresDirectiveValidations")
     @Suppress("UnusedPrivateMember")
-    fun `validate @requires directive`(testCase: String, targetQueryClass: KClass<*>, federatedClass: KClass<*>, expectedError: String?) {
-        // TODO: This is failing because createType drops annonation information
-        val queries = listOf(TopLevelObject(targetQueryClass))
-        val schema = schemaGenerator.generate(queries)
-        val validatedType = schema.getType(federatedClass.simpleName) as? GraphQLObjectType
-        assertNotNull(validatedType)
-        assertEquals(targetQueryClass.simpleName, validatedType.name)
-
+    fun `validate @requires directive`(testCase: String, targetClass: KClass<*>, expectedError: String?) {
         if (expectedError != null) {
             val exception = assertFailsWith(InvalidFederatedSchema::class) {
-                validator.validateGraphQLType(validatedType)
+                schemaGenerator.graphQLTypeOf(targetClass.starProjectedType)
             }
             assertEquals(expectedError, exception.message)
         } else {
-            validator.validateGraphQLType(validatedType)
+            val validatedType = GraphQLTypeUtil.unwrapNonNull(schemaGenerator.graphQLTypeOf(targetClass.starProjectedType)) as GraphQLObjectType
             assertNotNull(validatedType.getDirective("key"))
             val weightField = validatedType.getFieldDefinition("weight")
             assertNotNull(weightField)
@@ -117,10 +109,6 @@ class FederatedSchemaValidatorRequiresDirectiveTest {
         fun shippingCost(): String = "$${weight * 9.99}"
     }
 
-    class SimpleRequiresQuery {
-        fun simpleRequires() = SimpleRequires("1", "foo")
-    }
-
     /*
     type RequiresLocalField @extends @key(fields : "id") {
       description: String!
@@ -137,10 +125,6 @@ class FederatedSchemaValidatorRequiresDirectiveTest {
 
         @RequiresDirective(FieldSet("weight"))
         fun shippingCost(): String = "$${weight * 9.99}"
-    }
-
-    class RequiresLocalFieldQuery {
-        fun requiresLocalField() = RequiresLocalField("1", "foo")
     }
 
     /*
@@ -162,10 +146,6 @@ class FederatedSchemaValidatorRequiresDirectiveTest {
         fun shippingCost(): String = "$${weight * 9.99}"
     }
 
-    class RequiresNonExistentFieldQuery {
-        fun requiresNonExistentField() = RequiresNonExistentField("1", "foo")
-    }
-
     /*
     type RequiresOnLocalType @key(fields : "id") {
       description: String!
@@ -180,9 +160,5 @@ class FederatedSchemaValidatorRequiresDirectiveTest {
 
         @RequiresDirective(FieldSet("weight"))
         fun shippingCost(): String = "$${weight * 9.99}"
-    }
-
-    class RequiresOnLocalTypeQuery {
-        fun requiresOnLocalType() = RequiresOnLocalType("1", "foo")
     }
 }

--- a/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/validation/FederatedSchemaValidatorRequiresDirectiveTest.kt
+++ b/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/validation/FederatedSchemaValidatorRequiresDirectiveTest.kt
@@ -36,6 +36,7 @@ import org.junit.jupiter.params.provider.MethodSource
 import java.util.stream.Stream
 import kotlin.properties.Delegates
 import kotlin.reflect.KClass
+import kotlin.reflect.full.createType
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
@@ -73,7 +74,8 @@ class FederatedSchemaValidatorRequiresDirectiveTest {
     @MethodSource("requiresDirectiveValidations")
     @Suppress("UnusedPrivateMember")
     fun `validate @requires directive`(testCase: String, targetClass: KClass<*>, expectedError: String?) {
-        val validatedType = schemaGenerator.objectType(targetClass) as? GraphQLObjectType
+        // TODO: This is failing because createType drops annonation information
+        val validatedType = schemaGenerator.graphQLTypeOf(targetClass.createType()) as? GraphQLObjectType
         assertNotNull(validatedType)
         assertEquals(targetClass.simpleName, validatedType.name)
 

--- a/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/validation/key/FederatedSchemaValidatorKeyDirectiveTest.kt
+++ b/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/validation/key/FederatedSchemaValidatorKeyDirectiveTest.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.expediagroup.graphql.federation.validation
+package com.expediagroup.graphql.federation.validation.key
 
 import com.expediagroup.graphql.federation.FederatedSchemaGenerator
 import com.expediagroup.graphql.federation.FederatedSchemaGeneratorConfig
@@ -81,7 +81,7 @@ class FederatedSchemaValidatorKeyDirectiveTest {
     @BeforeEach
     fun beforeTest() {
         val config = FederatedSchemaGeneratorConfig(
-            supportedPackages = listOf("com.expediagroup"),
+            supportedPackages = listOf("com.expediagroup.graphql.federation.validation.key"),
             hooks = FederatedSchemaGeneratorHooks(mockk())
         )
         schemaGenerator = FederatedSchemaGenerator(config)

--- a/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/validation/provides/FederatedSchemaValidatorProvidesDirectiveTest.kt
+++ b/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/validation/provides/FederatedSchemaValidatorProvidesDirectiveTest.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 @file:Suppress("MethodOverloading")
 /*
  * Copyright 2019 Expedia, Inc
@@ -15,7 +31,7 @@
  * limitations under the License.
  */
 
-package com.expediagroup.graphql.federation.validation
+package com.expediagroup.graphql.federation.validation.provides
 
 import com.expediagroup.graphql.federation.FederatedSchemaGenerator
 import com.expediagroup.graphql.federation.FederatedSchemaGeneratorConfig
@@ -39,7 +55,6 @@ import org.junit.jupiter.params.provider.MethodSource
 import java.util.stream.Stream
 import kotlin.reflect.KClass
 import kotlin.reflect.full.createType
-import kotlin.reflect.full.starProjectedType
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
@@ -72,7 +87,7 @@ class FederatedSchemaValidatorProvidesDirectiveTest {
     @BeforeEach
     fun beforeTest() {
         val config = FederatedSchemaGeneratorConfig(
-            supportedPackages = listOf("com.expediagroup"),
+            supportedPackages = listOf("com.expediagroup.graphql.federation.validation.provides"),
             hooks = FederatedSchemaGeneratorHooks(mockk())
         )
         schemaGenerator = FederatedSchemaGenerator(config)

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/SchemaGenerator.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/SchemaGenerator.kt
@@ -44,7 +44,6 @@ import graphql.schema.GraphQLTypeUtil
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
 
-@Suppress("LeakingThis")
 open class SchemaGenerator(val config: SchemaGeneratorConfig) {
 
     internal val state = SchemaGeneratorState(config.supportedPackages)

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/SchemaGenerator.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/SchemaGenerator.kt
@@ -53,8 +53,8 @@ open class SchemaGenerator(val config: SchemaGeneratorConfig) {
 
     open fun generate(
         queries: List<TopLevelObject>,
-        mutations: List<TopLevelObject>,
-        subscriptions: List<TopLevelObject>,
+        mutations: List<TopLevelObject> = emptyList(),
+        subscriptions: List<TopLevelObject> = emptyList(),
         builder: GraphQLSchema.Builder = GraphQLSchema.newSchema()
     ): GraphQLSchema {
         builder.query(generateQueries(this, queries))

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/SchemaGenerator.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/SchemaGenerator.kt
@@ -26,34 +26,22 @@ import com.expediagroup.graphql.generator.extensions.isUnion
 import com.expediagroup.graphql.generator.extensions.wrapInNonNull
 import com.expediagroup.graphql.generator.state.SchemaGeneratorState
 import com.expediagroup.graphql.generator.state.TypesCacheKey
-import com.expediagroup.graphql.generator.types.ArgumentBuilder
-import com.expediagroup.graphql.generator.types.DirectiveBuilder
-import com.expediagroup.graphql.generator.types.EnumBuilder
-import com.expediagroup.graphql.generator.types.FunctionBuilder
-import com.expediagroup.graphql.generator.types.InputObjectBuilder
-import com.expediagroup.graphql.generator.types.InputPropertyBuilder
-import com.expediagroup.graphql.generator.types.InterfaceBuilder
-import com.expediagroup.graphql.generator.types.ListBuilder
-import com.expediagroup.graphql.generator.types.MutationBuilder
-import com.expediagroup.graphql.generator.types.ObjectBuilder
-import com.expediagroup.graphql.generator.types.PropertyBuilder
-import com.expediagroup.graphql.generator.types.QueryBuilder
-import com.expediagroup.graphql.generator.types.ScalarBuilder
-import com.expediagroup.graphql.generator.types.SubscriptionBuilder
-import com.expediagroup.graphql.generator.types.UnionBuilder
-import graphql.schema.GraphQLArgument
+import com.expediagroup.graphql.generator.types.generateEnum
+import com.expediagroup.graphql.generator.types.generateInputObject
+import com.expediagroup.graphql.generator.types.generateInterface
+import com.expediagroup.graphql.generator.types.generateList
+import com.expediagroup.graphql.generator.types.generateMutations
+import com.expediagroup.graphql.generator.types.generateObject
+import com.expediagroup.graphql.generator.types.generateQueries
+import com.expediagroup.graphql.generator.types.generateScalar
+import com.expediagroup.graphql.generator.types.generateSubscriptions
+import com.expediagroup.graphql.generator.types.generateUnion
 import graphql.schema.GraphQLCodeRegistry
-import graphql.schema.GraphQLDirective
 import graphql.schema.GraphQLSchema
 import graphql.schema.GraphQLType
 import graphql.schema.GraphQLTypeReference
 import graphql.schema.GraphQLTypeUtil
-import java.lang.reflect.Field
-import kotlin.reflect.KAnnotatedElement
 import kotlin.reflect.KClass
-import kotlin.reflect.KFunction
-import kotlin.reflect.KParameter
-import kotlin.reflect.KProperty
 import kotlin.reflect.KType
 
 @Suppress("LeakingThis")
@@ -63,31 +51,15 @@ open class SchemaGenerator(val config: SchemaGeneratorConfig) {
     internal val subTypeMapper = SubTypeMapper(config.supportedPackages)
     internal val codeRegistry = GraphQLCodeRegistry.newCodeRegistry()
 
-    private val queryBuilder = QueryBuilder(this)
-    private val mutationBuilder = MutationBuilder(this)
-    private val subscriptionBuilder = SubscriptionBuilder(this)
-    private val objectTypeBuilder = ObjectBuilder(this)
-    private val unionTypeBuilder = UnionBuilder(this)
-    private val interfaceTypeBuilder = InterfaceBuilder(this)
-    private val propertyTypeBuilder = PropertyBuilder(this)
-    private val inputObjectTypeBuilder = InputObjectBuilder(this)
-    private val inputPropertyBuilder = InputPropertyBuilder(this)
-    private val listTypeBuilder = ListBuilder(this)
-    private val functionTypeBuilder = FunctionBuilder(this)
-    private val enumTypeBuilder = EnumBuilder(this)
-    private val scalarTypeBuilder = ScalarBuilder(this)
-    private val directiveTypeBuilder = DirectiveBuilder(this)
-    private val argumentBuilder = ArgumentBuilder(this)
-
     open fun generate(
         queries: List<TopLevelObject>,
         mutations: List<TopLevelObject>,
         subscriptions: List<TopLevelObject>,
         builder: GraphQLSchema.Builder = GraphQLSchema.newSchema()
     ): GraphQLSchema {
-        builder.query(queryBuilder.getQueryObject(queries))
-        builder.mutation(mutationBuilder.getMutationObject(mutations))
-        builder.subscription(subscriptionBuilder.getSubscriptionObject(subscriptions))
+        builder.query(generateQueries(this, queries))
+        builder.mutation(generateMutations(this, mutations))
+        builder.subscription(generateSubscriptions(this, subscriptions))
 
         // add unreferenced interface implementations
         state.additionalTypes.forEach {
@@ -108,7 +80,7 @@ open class SchemaGenerator(val config: SchemaGeneratorConfig) {
     open fun graphQLTypeOf(type: KType, inputType: Boolean = false, annotatedAsID: Boolean = false): GraphQLType {
         val hookGraphQLType = config.hooks.willGenerateGraphQLType(type)
         val graphQLType = hookGraphQLType
-            ?: scalarType(type, annotatedAsID)
+            ?: generateScalar(this, type, annotatedAsID)
             ?: objectFromReflection(type, inputType)
 
         // Do not call the hook on GraphQLTypeReference as we have not generated the type yet
@@ -136,50 +108,11 @@ open class SchemaGenerator(val config: SchemaGeneratorConfig) {
     }
 
     private fun getGraphQLType(kClass: KClass<*>, inputType: Boolean, type: KType): GraphQLType = when {
-        kClass.isEnum() -> @Suppress("UNCHECKED_CAST") (enumType(kClass as KClass<Enum<*>>))
-        kClass.isListType() -> listType(type, inputType)
-        kClass.isUnion() -> unionType(kClass)
-        kClass.isInterface() -> interfaceType(kClass)
-        inputType -> inputObjectType(kClass)
-        else -> objectType(kClass)
+        kClass.isEnum() -> @Suppress("UNCHECKED_CAST") (generateEnum(this, kClass as KClass<Enum<*>>))
+        kClass.isListType() -> generateList(this, type, inputType)
+        kClass.isUnion() -> generateUnion(this, kClass)
+        kClass.isInterface() -> generateInterface(this, kClass)
+        inputType -> generateInputObject(this, kClass)
+        else -> generateObject(this, kClass)
     }
-
-    open fun function(fn: KFunction<*>, parentName: String, target: Any? = null, abstract: Boolean = false) =
-        functionTypeBuilder.function(fn, parentName, target, abstract)
-
-    open fun property(prop: KProperty<*>, parentClass: KClass<*>) =
-        propertyTypeBuilder.property(prop, parentClass)
-
-    open fun listType(type: KType, inputType: Boolean) =
-        listTypeBuilder.listType(type, inputType)
-
-    open fun objectType(kClass: KClass<*>) =
-        objectTypeBuilder.objectType(kClass)
-
-    open fun inputObjectType(kClass: KClass<*>) =
-        inputObjectTypeBuilder.inputObjectType(kClass)
-
-    open fun inputProperty(prop: KProperty<*>, parentClass: KClass<*>) =
-        inputPropertyBuilder.inputProperty(prop, parentClass)
-
-    open fun interfaceType(kClass: KClass<*>) =
-        interfaceTypeBuilder.interfaceType(kClass)
-
-    open fun unionType(kClass: KClass<*>) =
-        unionTypeBuilder.unionType(kClass)
-
-    open fun enumType(kClass: KClass<out Enum<*>>) =
-        enumTypeBuilder.enumType(kClass)
-
-    open fun scalarType(type: KType, annotatedAsID: Boolean) =
-        scalarTypeBuilder.scalarType(type, annotatedAsID)
-
-    open fun directives(element: KAnnotatedElement, parentClass: KClass<*>? = null): List<GraphQLDirective> =
-        directiveTypeBuilder.directives(element, parentClass)
-
-    open fun fieldDirectives(field: Field): List<GraphQLDirective> =
-        directiveTypeBuilder.fieldDirectives(field)
-
-    open fun argument(parameter: KParameter): GraphQLArgument =
-        argumentBuilder.argument(parameter)
 }

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/InputObjectBuilder.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/InputObjectBuilder.kt
@@ -24,22 +24,20 @@ import com.expediagroup.graphql.generator.extensions.safeCast
 import graphql.schema.GraphQLInputObjectType
 import kotlin.reflect.KClass
 
-internal class InputObjectBuilder(private val generator: SchemaGenerator) {
-    internal fun inputObjectType(kClass: KClass<*>): GraphQLInputObjectType {
-        val builder = GraphQLInputObjectType.newInputObject()
+internal fun generateInputObject(generator: SchemaGenerator, kClass: KClass<*>): GraphQLInputObjectType {
+    val builder = GraphQLInputObjectType.newInputObject()
 
-        builder.name(kClass.getSimpleName(isInputClass = true))
-        builder.description(kClass.getGraphQLDescription())
+    builder.name(kClass.getSimpleName(isInputClass = true))
+    builder.description(kClass.getGraphQLDescription())
 
-        generator.directives(kClass).forEach {
-            builder.withDirective(it)
-        }
-
-        // It does not make sense to run functions against the input types so we only process the properties
-        kClass.getValidProperties(generator.config.hooks).forEach {
-            builder.field(generator.inputProperty(it, kClass))
-        }
-
-        return generator.config.hooks.onRewireGraphQLType(builder.build()).safeCast()
+    generateDirectives(generator, kClass).forEach {
+        builder.withDirective(it)
     }
+
+    // It does not make sense to run functions against the input types so we only process the properties
+    kClass.getValidProperties(generator.config.hooks).forEach {
+        builder.field(generateInputProperty(generator, it, kClass))
+    }
+
+    return generator.config.hooks.onRewireGraphQLType(builder.build()).safeCast()
 }

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/InputPropertyBuilder.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/InputPropertyBuilder.kt
@@ -26,20 +26,17 @@ import graphql.schema.GraphQLInputType
 import kotlin.reflect.KClass
 import kotlin.reflect.KProperty
 
-internal class InputPropertyBuilder(private val generator: SchemaGenerator) {
+internal fun generateInputProperty(generator: SchemaGenerator, prop: KProperty<*>, parentClass: KClass<*>): GraphQLInputObjectField {
+    val builder = GraphQLInputObjectField.newInputObjectField()
+    val graphQLInputType = generator.graphQLTypeOf(prop.returnType, true, prop.isPropertyGraphQLID(parentClass)).safeCast<GraphQLInputType>()
 
-    internal fun inputProperty(prop: KProperty<*>, parentClass: KClass<*>): GraphQLInputObjectField {
-        val builder = GraphQLInputObjectField.newInputObjectField()
-        val graphQLInputType = generator.graphQLTypeOf(prop.returnType, true, prop.isPropertyGraphQLID(parentClass)).safeCast<GraphQLInputType>()
+    builder.description(prop.getPropertyDescription(parentClass))
+    builder.name(prop.getPropertyName(parentClass))
+    builder.type(graphQLInputType)
 
-        builder.description(prop.getPropertyDescription(parentClass))
-        builder.name(prop.getPropertyName(parentClass))
-        builder.type(graphQLInputType)
-
-        generator.directives(prop, parentClass).forEach {
-            builder.withDirective(it)
-        }
-
-        return generator.config.hooks.onRewireGraphQLType(builder.build()).safeCast()
+    generateDirectives(generator, prop, parentClass).forEach {
+        builder.withDirective(it)
     }
+
+    return generator.config.hooks.onRewireGraphQLType(builder.build()).safeCast()
 }

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/ListBuilder.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/ListBuilder.kt
@@ -21,9 +21,7 @@ import com.expediagroup.graphql.generator.extensions.getWrappedType
 import graphql.schema.GraphQLList
 import kotlin.reflect.KType
 
-internal class ListBuilder(private val generator: SchemaGenerator) {
-    internal fun listType(type: KType, inputType: Boolean): GraphQLList {
-        val wrappedType = generator.graphQLTypeOf(type.getWrappedType(), inputType)
-        return GraphQLList.list(wrappedType)
-    }
+internal fun generateList(generator: SchemaGenerator, type: KType, inputType: Boolean): GraphQLList {
+    val wrappedType = generator.graphQLTypeOf(type.getWrappedType(), inputType)
+    return GraphQLList.list(wrappedType)
 }

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/MutationBuilder.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/MutationBuilder.kt
@@ -23,34 +23,31 @@ import com.expediagroup.graphql.generator.extensions.getValidFunctions
 import com.expediagroup.graphql.generator.extensions.isNotPublic
 import graphql.schema.GraphQLObjectType
 
-internal class MutationBuilder(private val generator: SchemaGenerator) {
+fun generateMutations(generator: SchemaGenerator, mutations: List<TopLevelObject>): GraphQLObjectType? {
 
-    fun getMutationObject(mutations: List<TopLevelObject>): GraphQLObjectType? {
-
-        if (mutations.isEmpty()) {
-            return null
-        }
-
-        val mutationBuilder = GraphQLObjectType.Builder()
-        mutationBuilder.name(generator.config.topLevelNames.mutation)
-
-        for (mutation in mutations) {
-            if (mutation.kClass.isNotPublic()) {
-                throw InvalidMutationTypeException(mutation.kClass)
-            }
-
-            generator.directives(mutation.kClass).forEach {
-                mutationBuilder.withDirective(it)
-            }
-
-            mutation.kClass.getValidFunctions(generator.config.hooks)
-                .forEach {
-                    val function = generator.function(it, generator.config.topLevelNames.mutation, mutation.obj)
-                    val functionFromHook = generator.config.hooks.didGenerateMutationType(mutation.kClass, it, function)
-                    mutationBuilder.field(functionFromHook)
-                }
-        }
-
-        return mutationBuilder.build()
+    if (mutations.isEmpty()) {
+        return null
     }
+
+    val mutationBuilder = GraphQLObjectType.Builder()
+    mutationBuilder.name(generator.config.topLevelNames.mutation)
+
+    for (mutation in mutations) {
+        if (mutation.kClass.isNotPublic()) {
+            throw InvalidMutationTypeException(mutation.kClass)
+        }
+
+        generateDirectives(generator, mutation.kClass).forEach {
+            mutationBuilder.withDirective(it)
+        }
+
+        mutation.kClass.getValidFunctions(generator.config.hooks)
+            .forEach {
+                val function = generateFunction(generator, it, generator.config.topLevelNames.mutation, mutation.obj)
+                val functionFromHook = generator.config.hooks.didGenerateMutationType(mutation.kClass, it, function)
+                mutationBuilder.field(functionFromHook)
+            }
+    }
+
+    return mutationBuilder.build()
 }

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/ScalarBuilder.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/ScalarBuilder.kt
@@ -30,11 +30,11 @@ import kotlin.reflect.full.isSubclassOf
 
 internal fun generateScalar(generator: SchemaGenerator, type: KType, annotatedAsID: Boolean): GraphQLScalarType? {
     val kClass = type.getKClass()
-
     val scalar = when {
         annotatedAsID -> getId(kClass)
-        else -> ScalarMap.defaultScalarsMap[kClass]
+        else -> defaultScalarsMap[kClass]
     }
+
     return scalar?.let {
         generator.config.hooks.onRewireGraphQLType(it).safeCast()
     }
@@ -49,17 +49,16 @@ private fun getId(kClass: KClass<*>): GraphQLScalarType? {
     }
 }
 
-private object ScalarMap {
-    val defaultScalarsMap = mapOf(
-        Int::class to Scalars.GraphQLInt,
-        Long::class to Scalars.GraphQLLong,
-        Short::class to Scalars.GraphQLShort,
-        Float::class to Scalars.GraphQLFloat,
-        Double::class to Scalars.GraphQLFloat,
-        BigDecimal::class to Scalars.GraphQLBigDecimal,
-        BigInteger::class to Scalars.GraphQLBigInteger,
-        Char::class to Scalars.GraphQLChar,
-        String::class to Scalars.GraphQLString,
-        Boolean::class to Scalars.GraphQLBoolean
-    )
-}
+private val defaultScalarsMap = mapOf(
+    Int::class to Scalars.GraphQLInt,
+    Long::class to Scalars.GraphQLLong,
+    Short::class to Scalars.GraphQLShort,
+    Float::class to Scalars.GraphQLFloat,
+    Double::class to Scalars.GraphQLFloat,
+    BigDecimal::class to Scalars.GraphQLBigDecimal,
+    BigInteger::class to Scalars.GraphQLBigInteger,
+    Char::class to Scalars.GraphQLChar,
+    String::class to Scalars.GraphQLString,
+    Boolean::class to Scalars.GraphQLBoolean
+)
+

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/ScalarBuilder.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/ScalarBuilder.kt
@@ -61,4 +61,3 @@ private val defaultScalarsMap = mapOf(
     String::class to Scalars.GraphQLString,
     Boolean::class to Scalars.GraphQLBoolean
 )
-

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/ScalarBuilder.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/ScalarBuilder.kt
@@ -28,41 +28,38 @@ import kotlin.reflect.KClass
 import kotlin.reflect.KType
 import kotlin.reflect.full.isSubclassOf
 
-internal class ScalarBuilder(private val generator: SchemaGenerator) {
+internal fun generateScalar(generator: SchemaGenerator, type: KType, annotatedAsID: Boolean): GraphQLScalarType? {
+    val kClass = type.getKClass()
 
-    internal fun scalarType(type: KType, annotatedAsID: Boolean): GraphQLScalarType? {
-        val kClass = type.getKClass()
-
-        val scalar = when {
-            annotatedAsID -> getId(kClass)
-            else -> defaultScalarsMap[kClass]
-        }
-        return scalar?.let {
-            generator.config.hooks.onRewireGraphQLType(it).safeCast()
-        }
+    val scalar = when {
+        annotatedAsID -> getId(kClass)
+        else -> ScalarMap.defaultScalarsMap[kClass]
     }
-
-    @Throws(InvalidIdTypeException::class)
-    private fun getId(kClass: KClass<*>): GraphQLScalarType? {
-        return if (kClass.isSubclassOf(String::class)) {
-            Scalars.GraphQLID
-        } else {
-            throw InvalidIdTypeException(kClass)
-        }
+    return scalar?.let {
+        generator.config.hooks.onRewireGraphQLType(it).safeCast()
     }
+}
 
-    private companion object {
-        private val defaultScalarsMap = mapOf(
-            Int::class to Scalars.GraphQLInt,
-            Long::class to Scalars.GraphQLLong,
-            Short::class to Scalars.GraphQLShort,
-            Float::class to Scalars.GraphQLFloat,
-            Double::class to Scalars.GraphQLFloat,
-            BigDecimal::class to Scalars.GraphQLBigDecimal,
-            BigInteger::class to Scalars.GraphQLBigInteger,
-            Char::class to Scalars.GraphQLChar,
-            String::class to Scalars.GraphQLString,
-            Boolean::class to Scalars.GraphQLBoolean
-        )
+@Throws(InvalidIdTypeException::class)
+private fun getId(kClass: KClass<*>): GraphQLScalarType? {
+    return if (kClass.isSubclassOf(String::class)) {
+        Scalars.GraphQLID
+    } else {
+        throw InvalidIdTypeException(kClass)
     }
+}
+
+private object ScalarMap {
+    val defaultScalarsMap = mapOf(
+        Int::class to Scalars.GraphQLInt,
+        Long::class to Scalars.GraphQLLong,
+        Short::class to Scalars.GraphQLShort,
+        Float::class to Scalars.GraphQLFloat,
+        Double::class to Scalars.GraphQLFloat,
+        BigDecimal::class to Scalars.GraphQLBigDecimal,
+        BigInteger::class to Scalars.GraphQLBigInteger,
+        Char::class to Scalars.GraphQLChar,
+        String::class to Scalars.GraphQLString,
+        Boolean::class to Scalars.GraphQLBoolean
+    )
 }

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/ArgumentBuilderTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/ArgumentBuilderTest.kt
@@ -31,12 +31,6 @@ import kotlin.test.assertNotNull
 
 internal class ArgumentBuilderTest : TypeTestHelper() {
 
-    private lateinit var builder: ArgumentBuilder
-
-    override fun beforeTest() {
-        builder = ArgumentBuilder(generator)
-    }
-
     internal interface MyInterface {
         val id: String
     }
@@ -57,7 +51,7 @@ internal class ArgumentBuilderTest : TypeTestHelper() {
     fun `Description is set on arguments`() {
         val kParameter = ArgumentTestClass::description.findParameterByName("input")
         assertNotNull(kParameter)
-        val result = builder.argument(kParameter)
+        val result = generateArgument(generator, kParameter)
 
         assertEquals("String", (result.type as? GraphQLNonNull)?.wrappedType?.name)
         assertEquals("Argument description", result.description)
@@ -67,7 +61,7 @@ internal class ArgumentBuilderTest : TypeTestHelper() {
     fun `Directives are included on arguments`() {
         val kParameter = ArgumentTestClass::directive.findParameterByName("input")
         assertNotNull(kParameter)
-        val result = builder.argument(kParameter)
+        val result = generateArgument(generator, kParameter)
 
         assertEquals("String", (result.type as? GraphQLNonNull)?.wrappedType?.name)
         assertEquals(1, result.directives.size)
@@ -78,7 +72,7 @@ internal class ArgumentBuilderTest : TypeTestHelper() {
     fun `Argument names can be changed with @GraphQLName`() {
         val kParameter = ArgumentTestClass::changeName.findParameterByName("input")
         assertNotNull(kParameter)
-        val result = builder.argument(kParameter)
+        val result = generateArgument(generator, kParameter)
 
         assertEquals("String", (result.type as? GraphQLNonNull)?.wrappedType?.name)
         assertEquals("newName", result.name)
@@ -88,7 +82,7 @@ internal class ArgumentBuilderTest : TypeTestHelper() {
     fun `ID argument type is valid`() {
         val kParameter = ArgumentTestClass::id.findParameterByName("idArg")
         assertNotNull(kParameter)
-        val result = builder.argument(kParameter)
+        val result = generateArgument(generator, kParameter)
 
         assertEquals(expected = "idArg", actual = result.name)
         assertEquals(Scalars.GraphQLID, (result.type as? GraphQLNonNull)?.wrappedType)
@@ -100,7 +94,7 @@ internal class ArgumentBuilderTest : TypeTestHelper() {
         assertNotNull(kParameter)
 
         assertFailsWith(InvalidInputFieldTypeException::class) {
-            builder.argument(kParameter)
+            generateArgument(generator, kParameter)
         }
     }
 }

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/DirectiveBuilderTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/DirectiveBuilderTest.kt
@@ -88,32 +88,32 @@ internal class DirectiveBuilderTest {
 
     @Test
     fun `no annotation`() {
-        assertTrue(basicGenerator.directives(MyClass::noAnnotation).isEmpty().isTrue())
+        assertTrue(generateDirectives(basicGenerator, MyClass::noAnnotation).isEmpty().isTrue())
     }
 
     @Test
     fun `no directive`() {
-        assertTrue(basicGenerator.directives(MyClass::noDirective).isEmpty().isTrue())
+        assertTrue(generateDirectives(basicGenerator, MyClass::noDirective).isEmpty().isTrue())
     }
 
     @Test
     fun `has directive`() {
-        assertEquals(expected = 1, actual = basicGenerator.directives(MyClass::simpleDirective).size)
+        assertEquals(expected = 1, actual = generateDirectives(basicGenerator, MyClass::simpleDirective).size)
     }
 
     @Test
     fun `has directive with string`() {
-        assertEquals(expected = 1, actual = basicGenerator.directives(MyClass::directiveWithString).size)
+        assertEquals(expected = 1, actual = generateDirectives(basicGenerator, MyClass::directiveWithString).size)
     }
 
     @Test
     fun `has directive with enum`() {
-        assertEquals(expected = 1, actual = basicGenerator.directives(MyClass::directiveWithEnum).size)
+        assertEquals(expected = 1, actual = generateDirectives(basicGenerator, MyClass::directiveWithEnum).size)
     }
 
     @Test
     fun `has directive with class`() {
-        assertEquals(expected = 1, actual = basicGenerator.directives(MyClass::directiveWithClass).size)
+        assertEquals(expected = 1, actual = generateDirectives(basicGenerator, MyClass::directiveWithClass).size)
     }
 
     @Test
@@ -123,9 +123,9 @@ internal class DirectiveBuilderTest {
         assertTrue(basicGenerator.state.directives.containsKey(Directives.SkipDirective.name))
         assertTrue(basicGenerator.state.directives.containsKey(DeprecatedDirective.name))
 
-        val firstInvocation = basicGenerator.directives(MyClass::simpleDirective)
+        val firstInvocation = generateDirectives(basicGenerator, MyClass::simpleDirective)
         assertEquals(1, firstInvocation.size)
-        val secondInvocation = basicGenerator.directives(MyClass::simpleDirective)
+        val secondInvocation = generateDirectives(basicGenerator, MyClass::simpleDirective)
         assertEquals(1, secondInvocation.size)
         assertEquals(firstInvocation.first(), secondInvocation.first())
         assertEquals(initialCount + 1, basicGenerator.state.directives.size)
@@ -135,7 +135,7 @@ internal class DirectiveBuilderTest {
     fun `directives are valid on fields (enum values)`() {
         val field = Type::class.java.getField("ONE")
 
-        val directives = basicGenerator.fieldDirectives(field)
+        val directives = generateFieldDirectives(basicGenerator, field)
 
         assertEquals(2, directives.size)
         assertEquals("directiveWithString", directives.first().name)
@@ -146,7 +146,7 @@ internal class DirectiveBuilderTest {
     fun `directives are empty on an enum with no valid annotations`() {
         val field = Type::class.java.getField("TWO")
 
-        val directives = basicGenerator.fieldDirectives(field)
+        val directives = generateFieldDirectives(basicGenerator, field)
 
         assertEquals(0, directives.size)
     }
@@ -154,8 +154,8 @@ internal class DirectiveBuilderTest {
     @Test
     fun `directives are created per each declaration`() {
         val initialCount = basicGenerator.state.directives.size
-        val directivesOnFirstField = basicGenerator.directives(MyClass::directiveWithString)
-        val directivesOnSecondField = basicGenerator.directives(MyClass::directiveWithAnotherString)
+        val directivesOnFirstField = generateDirectives(basicGenerator, MyClass::directiveWithString)
+        val directivesOnSecondField = generateDirectives(basicGenerator, MyClass::directiveWithAnotherString)
         assertEquals(expected = 1, actual = directivesOnFirstField.size)
         assertEquals(expected = 1, actual = directivesOnSecondField.size)
 
@@ -171,21 +171,21 @@ internal class DirectiveBuilderTest {
 
     @Test
     fun `directives on constructor arguments can be used with or without annotation prefix`() {
-        val noDirectiveResult = basicGenerator.directives(MyClassWithConstructorArgs::noDirective)
+        val noDirectiveResult = generateDirectives(basicGenerator, MyClassWithConstructorArgs::noDirective)
         assertEquals(expected = 0, actual = noDirectiveResult.size)
 
-        val propertyPrefixResult = basicGenerator.directives(MyClassWithConstructorArgs::propertyPrefix)
+        val propertyPrefixResult = generateDirectives(basicGenerator, MyClassWithConstructorArgs::propertyPrefix)
         assertEquals(expected = 1, actual = propertyPrefixResult.size)
         assertEquals(expected = "simpleDirective", actual = propertyPrefixResult.first().name)
 
-        val noPrefixResult = basicGenerator.directives(MyClassWithConstructorArgs::noPrefix, MyClassWithConstructorArgs::class)
+        val noPrefixResult = generateDirectives(basicGenerator, MyClassWithConstructorArgs::noPrefix, MyClassWithConstructorArgs::class)
         assertEquals(expected = 1, actual = noPrefixResult.size)
         assertEquals(expected = "simpleDirective", actual = noPrefixResult.first().name)
     }
 
     @Test
     fun `directives on constructor arguments only works with parent class`() {
-        val noPrefixResult = basicGenerator.directives(MyClassWithConstructorArgs::noPrefix, null)
+        val noPrefixResult = generateDirectives(basicGenerator, MyClassWithConstructorArgs::noPrefix, null)
         assertEquals(expected = 0, actual = noPrefixResult.size)
     }
 }

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/EnumBuilderTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/EnumBuilderTest.kt
@@ -51,16 +51,9 @@ internal class EnumBuilderTest : TypeTestHelper() {
     @GraphQLName("MyTestEnumRenamed")
     private enum class MyTestEnumCustomName
 
-    lateinit var builder: EnumBuilder
-
-    override fun beforeTest() {
-        super.beforeTest()
-        builder = EnumBuilder(generator)
-    }
-
     @Test
     fun enumType() {
-        val actual = builder.enumType(MyTestEnum::class)
+        val actual = generateEnum(generator, MyTestEnum::class)
         assertEquals(expected = 3, actual = actual.values.size)
         assertEquals(expected = "MyTestEnum", actual = actual.name)
         assertEquals(expected = "ONE", actual = actual.values[0].value)
@@ -70,13 +63,13 @@ internal class EnumBuilderTest : TypeTestHelper() {
 
     @Test
     fun `Custom name on enum class`() {
-        val gqlEnum = assertNotNull(builder.enumType(MyTestEnumCustomName::class))
+        val gqlEnum = assertNotNull(generateEnum(generator, MyTestEnumCustomName::class))
         assertEquals("MyTestEnumRenamed", gqlEnum.name)
     }
 
     @Test
     fun `Description on enum class and values`() {
-        val gqlEnum = assertNotNull(builder.enumType(MyTestEnum::class))
+        val gqlEnum = assertNotNull(generateEnum(generator, MyTestEnum::class))
         assertEquals("MyTestEnum description", gqlEnum.description)
 
         assertEquals("enum 'ONE' description", assertNotNull(gqlEnum.getValue("ONE")).description)
@@ -86,7 +79,7 @@ internal class EnumBuilderTest : TypeTestHelper() {
 
     @Test
     fun `Deprecation on enum values`() {
-        val gqlEnum = assertNotNull(builder.enumType(MyTestEnum::class))
+        val gqlEnum = assertNotNull(generateEnum(generator, MyTestEnum::class))
 
         val one = assertNotNull(gqlEnum.getValue("ONE"))
         assertFalse(one.isDeprecated)
@@ -103,14 +96,14 @@ internal class EnumBuilderTest : TypeTestHelper() {
 
     @Test
     fun `Enum classes can have directives`() {
-        val gqlEnum = assertNotNull(builder.enumType(MyTestEnum::class))
+        val gqlEnum = assertNotNull(generateEnum(generator, MyTestEnum::class))
         assertEquals(1, gqlEnum.directives.size)
         assertEquals("simpleDirective", gqlEnum.directives.first().name)
     }
 
     @Test
     fun `Enum values can have directives`() {
-        val gqlEnum = assertNotNull(builder.enumType(MyTestEnum::class))
+        val gqlEnum = assertNotNull(generateEnum(generator, MyTestEnum::class))
 
         val enumValuesDirectives = gqlEnum.values.last().directives
         assertEquals(3, enumValuesDirectives.size)
@@ -121,7 +114,7 @@ internal class EnumBuilderTest : TypeTestHelper() {
 
     @Test
     fun `Enum values can have a multiple directives`() {
-        val gqlEnum = assertNotNull(builder.enumType(MyTestEnum::class))
+        val gqlEnum = assertNotNull(generateEnum(generator, MyTestEnum::class))
         assertEquals(1, gqlEnum.values.first().directives.size)
         assertEquals("simpleDirective", gqlEnum.values.first().directives.first().name)
     }

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/FunctionBuilderTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/FunctionBuilderTest.kt
@@ -46,12 +46,6 @@ import kotlin.test.assertTrue
 @Suppress("Detekt.UnusedPrivateClass")
 internal class FunctionBuilderTest : TypeTestHelper() {
 
-    private lateinit var builder: FunctionBuilder
-
-    override fun beforeTest() {
-        builder = FunctionBuilder(generator)
-    }
-
     internal interface MyInterface {
         fun printMessage(message: String): String
         fun nestedReturnType(): MyImplementation
@@ -112,21 +106,21 @@ internal class FunctionBuilderTest : TypeTestHelper() {
     @Test
     fun `Function description can be set`() {
         val kFunction = Happy::littleTrees
-        val result = builder.function(kFunction, "Query", target = null, abstract = false)
+        val result = generateFunction(generator, kFunction, "Query", target = null, abstract = false)
         assertEquals("By bob", result.description)
     }
 
     @Test
     fun `Function names can be changed`() {
         val kFunction = Happy::originalName
-        val result = builder.function(kFunction, "Query", target = null, abstract = false)
+        val result = generateFunction(generator, kFunction, "Query", target = null, abstract = false)
         assertEquals("renamedFunction", result.name)
     }
 
     @Test
     fun `Functions can be deprecated`() {
         val kFunction = Happy::sketch
-        val result = builder.function(kFunction, "Query", target = null, abstract = false)
+        val result = generateFunction(generator, kFunction, "Query", target = null, abstract = false)
         assertTrue(result.isDeprecated)
         assertEquals("Should paint instead, replace with paint", result.deprecationReason)
 
@@ -138,7 +132,7 @@ internal class FunctionBuilderTest : TypeTestHelper() {
     @Test
     fun `test custom directive on function`() {
         val kFunction = Happy::littleTrees
-        val result = builder.function(kFunction, "Query", target = null, abstract = false)
+        val result = generateFunction(generator, kFunction, "Query", target = null, abstract = false)
 
         assertEquals(1, result.directives.size)
         val directive = result.directives[0]
@@ -155,7 +149,7 @@ internal class FunctionBuilderTest : TypeTestHelper() {
     @Test
     fun `test context on argument`() {
         val kFunction = Happy::context
-        val result = builder.function(kFunction, "Query", target = null, abstract = false)
+        val result = generateFunction(generator, kFunction, "Query", target = null, abstract = false)
 
         assertTrue(result.directives.isEmpty())
         assertEquals(expected = 1, actual = result.arguments.size)
@@ -166,7 +160,7 @@ internal class FunctionBuilderTest : TypeTestHelper() {
     @Test
     fun `test ignored parameter`() {
         val kFunction = Happy::ignoredParameter
-        val result = builder.function(kFunction, "Query", target = null, abstract = false)
+        val result = generateFunction(generator, kFunction, "Query", target = null, abstract = false)
 
         assertTrue(result.directives.isEmpty())
         assertEquals(expected = 1, actual = result.arguments.size)
@@ -177,7 +171,7 @@ internal class FunctionBuilderTest : TypeTestHelper() {
     @Test
     fun `non-abstract function`() {
         val kFunction = MyInterface::printMessage
-        val result = builder.function(fn = kFunction, parentName = "Query", target = null, abstract = false)
+        val result = generateFunction(generator, fn = kFunction, parentName = "Query", target = null, abstract = false)
 
         assertEquals(expected = 1, actual = result.arguments.size)
         assertTrue(generator.codeRegistry.getDataFetcher(FieldCoordinates.coordinates("Query", kFunction.name), result) is FunctionDataFetcher)
@@ -186,7 +180,7 @@ internal class FunctionBuilderTest : TypeTestHelper() {
     @Test
     fun `abstract function`() {
         val kFunction = MyInterface::printMessage
-        val result = builder.function(fn = kFunction, parentName = "Query", target = null, abstract = true)
+        val result = generateFunction(generator, fn = kFunction, parentName = "Query", target = null, abstract = true)
 
         assertEquals(expected = 1, actual = result.arguments.size)
     }
@@ -194,7 +188,7 @@ internal class FunctionBuilderTest : TypeTestHelper() {
     @Test
     fun `abstract function with target`() {
         val kFunction = MyInterface::printMessage
-        val result = builder.function(fn = kFunction, parentName = "Query", target = MyImplementation(), abstract = true)
+        val result = generateFunction(generator, fn = kFunction, parentName = "Query", target = MyImplementation(), abstract = true)
 
         assertEquals(expected = 1, actual = result.arguments.size)
     }
@@ -202,7 +196,7 @@ internal class FunctionBuilderTest : TypeTestHelper() {
     @Test
     fun `publisher return type is valid`() {
         val kFunction = Happy::publisher
-        val result = builder.function(fn = kFunction, parentName = "Query", target = null, abstract = false)
+        val result = generateFunction(generator, fn = kFunction, parentName = "Query", target = null, abstract = false)
 
         assertEquals(expected = 1, actual = result.arguments.size)
         assertEquals("Int", (result.type as? GraphQLNonNull)?.wrappedType?.name)
@@ -211,7 +205,7 @@ internal class FunctionBuilderTest : TypeTestHelper() {
     @Test
     fun `a return type that implements Publisher is valid`() {
         val kFunction = Happy::flowable
-        val result = builder.function(fn = kFunction, parentName = "Query", target = null, abstract = false)
+        val result = generateFunction(generator, fn = kFunction, parentName = "Query", target = null, abstract = false)
 
         assertEquals(expected = 1, actual = result.arguments.size)
         assertEquals("Int", (result.type as? GraphQLNonNull)?.wrappedType?.name)
@@ -220,7 +214,7 @@ internal class FunctionBuilderTest : TypeTestHelper() {
     @Test
     fun `completable future return type is valid`() {
         val kFunction = Happy::completableFuture
-        val result = builder.function(fn = kFunction, parentName = "Query", target = null, abstract = false)
+        val result = generateFunction(generator, fn = kFunction, parentName = "Query", target = null, abstract = false)
 
         assertEquals(expected = 1, actual = result.arguments.size)
         assertEquals("Int", (result.type as? GraphQLNonNull)?.wrappedType?.name)
@@ -229,7 +223,7 @@ internal class FunctionBuilderTest : TypeTestHelper() {
     @Test
     fun `DataFetchingEnvironment argument type is ignored`() {
         val kFunction = Happy::dataFetchingEnvironment
-        val result = builder.function(fn = kFunction, parentName = "Query", target = null, abstract = false)
+        val result = generateFunction(generator, fn = kFunction, parentName = "Query", target = null, abstract = false)
 
         assertEquals(expected = 0, actual = result.arguments.size)
         assertEquals("String", (result.type as? GraphQLNonNull)?.wrappedType?.name)
@@ -238,7 +232,7 @@ internal class FunctionBuilderTest : TypeTestHelper() {
     @Test
     fun `DataFetcherResult return type is valid and unwrapped in the schema`() {
         val kFunction = Happy::dataFetcherResult
-        val result = builder.function(fn = kFunction, parentName = "Query", target = null, abstract = false)
+        val result = generateFunction(generator, fn = kFunction, parentName = "Query", target = null, abstract = false)
 
         assertEquals("String", (result.type as? GraphQLNonNull)?.wrappedType?.name)
     }
@@ -246,7 +240,7 @@ internal class FunctionBuilderTest : TypeTestHelper() {
     @Test
     fun `DataFetcherResult of a List is valid and unwrapped in the schema`() {
         val kFunction = Happy::listDataFetcherResult
-        val result = builder.function(fn = kFunction, parentName = "Query", target = null, abstract = false)
+        val result = generateFunction(generator, fn = kFunction, parentName = "Query", target = null, abstract = false)
 
         assertTrue(result.type is GraphQLNonNull)
         val listType = GraphQLTypeUtil.unwrapNonNull(result.type)
@@ -258,7 +252,7 @@ internal class FunctionBuilderTest : TypeTestHelper() {
     @Test
     fun `DataFetcherResult of a nullable List is valid and unwrapped in the schema`() {
         val kFunction = Happy::nullalbeListDataFetcherResult
-        val result = builder.function(fn = kFunction, parentName = "Query", target = null, abstract = false)
+        val result = generateFunction(generator, fn = kFunction, parentName = "Query", target = null, abstract = false)
 
         val listType = result.type
         assertTrue(listType is GraphQLList)
@@ -271,14 +265,14 @@ internal class FunctionBuilderTest : TypeTestHelper() {
         val kFunction = Happy::dataFetcherCompletableFutureResult
 
         assertFailsWith(TypeNotSupportedException::class) {
-            builder.function(fn = kFunction, parentName = "Query", target = null, abstract = false)
+            generateFunction(generator, fn = kFunction, parentName = "Query", target = null, abstract = false)
         }
     }
 
     @Test
     fun `CompletableFuture of a DataFetcherResult is valid and unwrapped in the schema`() {
         val kFunction = Happy::completableFutureDataFetcherResult
-        val result = builder.function(fn = kFunction, parentName = "Query", target = null, abstract = false)
+        val result = generateFunction(generator, fn = kFunction, parentName = "Query", target = null, abstract = false)
 
         assertTrue(result.type is GraphQLNonNull)
         val stringType = GraphQLTypeUtil.unwrapNonNull(result.type)
@@ -288,9 +282,9 @@ internal class FunctionBuilderTest : TypeTestHelper() {
     @Test
     fun `Nested Self referencing object returns non null`() {
         val kInterfaceFunction = MyInterface::nestedReturnType
-        val kInterfaceResult = builder.function(fn = kInterfaceFunction, parentName = "Query", target = null, abstract = false)
+        val kInterfaceResult = generateFunction(generator, fn = kInterfaceFunction, parentName = "Query", target = null, abstract = false)
         val kImplFunction = MyImplementation::nestedReturnType
-        val implResult = builder.function(fn = kImplFunction, parentName = "Query", target = null, abstract = false)
+        val implResult = generateFunction(generator, fn = kImplFunction, parentName = "Query", target = null, abstract = false)
 
         assertTrue(implResult.type is GraphQLNonNull)
         assertEquals(kInterfaceResult.type, implResult.type)

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/InputObjectBuilderTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/InputObjectBuilderTest.kt
@@ -24,12 +24,6 @@ import kotlin.test.assertEquals
 
 internal class InputObjectBuilderTest : TypeTestHelper() {
 
-    private lateinit var builder: InputObjectBuilder
-
-    override fun beforeTest() {
-        builder = InputObjectBuilder(generator)
-    }
-
     @Suppress("Detekt.UnusedPrivateClass")
     @GraphQLDescription("The truth")
     @SimpleDirective
@@ -47,39 +41,39 @@ internal class InputObjectBuilderTest : TypeTestHelper() {
 
     @Test
     fun `Test naming`() {
-        val result = builder.inputObjectType(InputClass::class)
+        val result = generateInputObject(generator, InputClass::class)
         assertEquals("InputClassInput", result.name)
     }
 
     @Test
     fun `Test custom naming on classes`() {
-        val result = builder.inputObjectType(InputClassCustomName::class)
+        val result = generateInputObject(generator, InputClassCustomName::class)
         assertEquals("InputClassRenamedInput", result.name)
     }
 
     @Test
     fun `Test custom naming on arguments`() {
-        val result = builder.inputObjectType(InputClassCustomName::class)
+        val result = generateInputObject(generator, InputClassCustomName::class)
         assertEquals(expected = 1, actual = result.fields.size)
         assertEquals("myFieldRenamed", result.fields.first().name)
     }
 
     @Test
     fun `Test description`() {
-        val result = builder.inputObjectType(InputClass::class)
+        val result = generateInputObject(generator, InputClass::class)
         assertEquals("The truth", result.description)
     }
 
     @Test
     fun `directives should be on input objects`() {
-        val result = builder.inputObjectType(InputClass::class)
+        val result = generateInputObject(generator, InputClass::class)
         assertEquals(1, result.directives.size)
         assertEquals("simpleDirective", result.directives.first().name)
     }
 
     @Test
     fun `directives should be on input object fields`() {
-        val result = builder.inputObjectType(InputClass::class)
+        val result = generateInputObject(generator, InputClass::class)
         assertEquals(1, result.fields.first().directives.size)
         assertEquals("simpleDirective", result.fields.first().directives.first().name)
     }

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/InputPropertyBuilderTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/InputPropertyBuilderTest.kt
@@ -24,12 +24,6 @@ import kotlin.test.assertEquals
 
 internal class InputPropertyBuilderTest : TypeTestHelper() {
 
-    private lateinit var builder: InputPropertyBuilder
-
-    override fun beforeTest() {
-        builder = InputPropertyBuilder(generator)
-    }
-
     private data class InputPropertyTestClass(
         @GraphQLDescription("Custom description")
         val description: String,
@@ -46,23 +40,23 @@ internal class InputPropertyBuilderTest : TypeTestHelper() {
 
     @Test
     fun `Input property can have a description`() {
-        val result = builder.inputProperty(InputPropertyTestClass::description, InputPropertyTestClass::class)
+        val result = generateInputProperty(generator, InputPropertyTestClass::description, InputPropertyTestClass::class)
         assertEquals("Custom description", result.description)
     }
 
     @Test
     fun `Input property names can change`() {
-        val result = builder.inputProperty(InputPropertyTestClass::changeMe, InputPropertyTestClass::class)
+        val result = generateInputProperty(generator, InputPropertyTestClass::changeMe, InputPropertyTestClass::class)
         assertEquals("newName", result.name)
     }
 
     @Test
     fun `Input property can have directives`() {
-        val resultWithNoPrefix = builder.inputProperty(InputPropertyTestClass::directiveWithNoPrefix, InputPropertyTestClass::class)
+        val resultWithNoPrefix = generateInputProperty(generator, InputPropertyTestClass::directiveWithNoPrefix, InputPropertyTestClass::class)
         assertEquals(1, resultWithNoPrefix.directives.size)
         assertEquals("simpleDirective", resultWithNoPrefix.directives.first().name)
 
-        val resultWithPrefix = builder.inputProperty(InputPropertyTestClass::directiveWithPrefix, InputPropertyTestClass::class)
+        val resultWithPrefix = generateInputProperty(generator, InputPropertyTestClass::directiveWithPrefix, InputPropertyTestClass::class)
         assertEquals(1, resultWithPrefix.directives.size)
         assertEquals("simpleDirective", resultWithPrefix.directives.first().name)
     }

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/InterfaceBuilderTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/InterfaceBuilderTest.kt
@@ -25,12 +25,6 @@ import kotlin.test.assertEquals
 
 internal class InterfaceBuilderTest : TypeTestHelper() {
 
-    private lateinit var builder: InterfaceBuilder
-
-    override fun beforeTest() {
-        builder = InterfaceBuilder(generator)
-    }
-
     @Suppress("Detekt.UnusedPrivateClass")
     @GraphQLDescription("The truth")
     @SimpleDirective
@@ -42,25 +36,25 @@ internal class InterfaceBuilderTest : TypeTestHelper() {
 
     @Test
     fun `Test naming`() {
-        val result = builder.interfaceType(HappyInterface::class) as? GraphQLInterfaceType
+        val result = generateInterface(generator, HappyInterface::class) as? GraphQLInterfaceType
         assertEquals("HappyInterface", result?.name)
     }
 
     @Test
     fun `Test custom naming`() {
-        val result = builder.interfaceType(HappyInterfaceCustomName::class) as? GraphQLInterfaceType
+        val result = generateInterface(generator, HappyInterfaceCustomName::class) as? GraphQLInterfaceType
         assertEquals("HappyInterfaceRenamed", result?.name)
     }
 
     @Test
     fun `Test description`() {
-        val result = builder.interfaceType(HappyInterface::class) as? GraphQLInterfaceType
+        val result = generateInterface(generator, HappyInterface::class) as? GraphQLInterfaceType
         assertEquals("The truth", result?.description)
     }
 
     @Test
     fun `Interfaces can have directives`() {
-        val result = builder.interfaceType(HappyInterface::class) as? GraphQLInterfaceType
+        val result = generateInterface(generator, HappyInterface::class) as? GraphQLInterfaceType
         assertEquals(1, result?.directives?.size)
         assertEquals("simpleDirective", result?.directives?.first()?.name)
     }

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/ListBuilderTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/ListBuilderTest.kt
@@ -32,17 +32,11 @@ internal class ListBuilderTest : TypeTestHelper() {
         val primitiveArray = booleanArrayOf(true)
     }
 
-    private lateinit var builder: ListBuilder
-
-    override fun beforeTest() {
-        builder = ListBuilder(generator)
-    }
-
     @Test
     fun `test list of primitive`() {
         val listProp = ClassWithListAndArray::testList
 
-        val result = builder.listType(listProp.returnType, false)
+        val result = generateList(generator, listProp.returnType, false)
         assertEquals(Int::class.simpleName, (result.wrappedType as? GraphQLNonNull)?.wrappedType?.name)
     }
 
@@ -50,7 +44,7 @@ internal class ListBuilderTest : TypeTestHelper() {
     fun `test list of class`() {
         val listProp = ClassWithListAndArray::testListOfClass
 
-        val result = builder.listType(listProp.returnType, false)
+        val result = generateList(generator, listProp.returnType, false)
         assertEquals(MyDataClass::class.simpleName, (result.wrappedType as? GraphQLNonNull)?.wrappedType?.name)
     }
 
@@ -58,7 +52,7 @@ internal class ListBuilderTest : TypeTestHelper() {
     fun `test array`() {
         val arrayProp = ClassWithListAndArray::testArray
 
-        val result = builder.listType(arrayProp.returnType, false)
+        val result = generateList(generator, arrayProp.returnType, false)
         assertEquals(String::class.simpleName, (result.wrappedType as? GraphQLNonNull)?.wrappedType?.name)
     }
 
@@ -66,7 +60,7 @@ internal class ListBuilderTest : TypeTestHelper() {
     fun `test array of primitives`() {
         val primitiveArray = ClassWithListAndArray::primitiveArray
 
-        val result = builder.listType(primitiveArray.returnType, false)
+        val result = generateList(generator, primitiveArray.returnType, false)
         assertEquals(Boolean::class.simpleName, (result.wrappedType as? GraphQLNonNull)?.wrappedType?.name)
     }
 }

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/MutationBuilderTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/MutationBuilderTest.kt
@@ -59,32 +59,26 @@ internal class MutationBuilderTest : TypeTestHelper() {
         fun echo(msg: String) = msg
     }
 
-    private lateinit var builder: MutationBuilder
-
     override fun beforeSetup() {
         hooks = SimpleHooks()
     }
 
-    override fun beforeTest() {
-        builder = MutationBuilder(generator)
-    }
-
     @Test
     fun `empty list`() {
-        assertNull(builder.getMutationObject(emptyList()))
+        assertNull(generateMutations(generator, emptyList()))
     }
 
     @Test
     fun `verify builder fails if non public mutation is specified`() {
         assertFailsWith(exceptionClass = InvalidMutationTypeException::class) {
-            builder.getMutationObject(listOf(TopLevelObject(PrivateMutation())))
+            generateMutations(generator, listOf(TopLevelObject(PrivateMutation())))
         }
     }
 
     @Test
     fun `mutation with no valid functions`() {
         val mutations = listOf(TopLevelObject(NoFunctions()))
-        val result = builder.getMutationObject(mutations)
+        val result = generateMutations(generator, mutations)
         assertEquals(expected = "TestTopLevelMutation", actual = result?.name)
         assertTrue(result?.fieldDefinitions?.isEmpty().isTrue())
     }
@@ -92,7 +86,7 @@ internal class MutationBuilderTest : TypeTestHelper() {
     @Test
     fun `mutation with valid functions`() {
         val mutations = listOf(TopLevelObject(MutationObject()))
-        val result = builder.getMutationObject(mutations)
+        val result = generateMutations(generator, mutations)
         assertEquals(expected = "TestTopLevelMutation", actual = result?.name)
         assertEquals(expected = 1, actual = result?.fieldDefinitions?.size)
         assertEquals(expected = "mutation", actual = result?.fieldDefinitions?.firstOrNull()?.name)
@@ -101,14 +95,14 @@ internal class MutationBuilderTest : TypeTestHelper() {
     @Test
     fun `verify hooks are called`() {
         assertFalse((hooks as? SimpleHooks)?.calledHook.isTrue())
-        builder.getMutationObject(listOf(TopLevelObject(MutationObject())))
+        generateMutations(generator, listOf(TopLevelObject(MutationObject())))
         assertTrue((hooks as? SimpleHooks)?.calledHook.isTrue())
     }
 
     @Test
     fun `mutation objects can have directives`() {
         val mutations = listOf(TopLevelObject(MutationObject()))
-        val result = builder.getMutationObject(mutations)
+        val result = generateMutations(generator, mutations)
         assertEquals(expected = 1, actual = result?.directives?.size)
         assertEquals(expected = "simpleDirective", actual = result?.directives?.first()?.name)
     }

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/ObjectBuilderTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/ObjectBuilderTest.kt
@@ -30,12 +30,6 @@ import kotlin.test.assertNotNull
 @Suppress("Detekt.UnusedPrivateClass")
 internal class ObjectBuilderTest : TypeTestHelper() {
 
-    private lateinit var builder: ObjectBuilder
-
-    override fun beforeTest() {
-        builder = ObjectBuilder(generator)
-    }
-
     @GraphQLDirective(locations = [Introspection.DirectiveLocation.OBJECT])
     internal annotation class ObjectDirective(val arg: String)
 
@@ -48,28 +42,28 @@ internal class ObjectBuilderTest : TypeTestHelper() {
 
     @Test
     fun `Test naming`() {
-        val result = builder.objectType(BeHappy::class) as? GraphQLObjectType
+        val result = generateObject(generator, BeHappy::class) as? GraphQLObjectType
         assertNotNull(result)
         assertEquals("BeHappy", result.name)
     }
 
     @Test
     fun `Test custom naming`() {
-        val result = builder.objectType(BeHappyCustomName::class) as? GraphQLObjectType
+        val result = generateObject(generator, BeHappyCustomName::class) as? GraphQLObjectType
         assertNotNull(result)
         assertEquals("BeHappyRenamed", result.name)
     }
 
     @Test
     fun `Test description`() {
-        val result = builder.objectType(BeHappy::class) as? GraphQLObjectType
+        val result = generateObject(generator, BeHappy::class) as? GraphQLObjectType
         assertNotNull(result)
         assertEquals("The truth", result.description)
     }
 
     @Test
     fun `Test custom directive`() {
-        val result = builder.objectType(BeHappy::class) as? GraphQLObjectType
+        val result = generateObject(generator, BeHappy::class) as? GraphQLObjectType
         assertNotNull(result)
         assertEquals(1, result.directives.size)
 

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/PropertyBuilderTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/PropertyBuilderTest.kt
@@ -77,16 +77,10 @@ internal class PropertyBuilderTest : TypeTestHelper() {
         val directiveWithPrefix: String
     )
 
-    private lateinit var builder: PropertyBuilder
-
-    override fun beforeTest() {
-        builder = PropertyBuilder(generator)
-    }
-
     @Test
     fun `Test naming`() {
         val prop = ClassWithProperties::cake
-        val result = builder.property(prop, ClassWithProperties::class)
+        val result = generateProperty(generator, prop, ClassWithProperties::class)
 
         assertEquals("cake", result.name)
     }
@@ -94,7 +88,7 @@ internal class PropertyBuilderTest : TypeTestHelper() {
     @Test
     fun `Test deprecation`() {
         val prop = ClassWithProperties::dessert
-        val result = builder.property(prop, ClassWithProperties::class)
+        val result = generateProperty(generator, prop, ClassWithProperties::class)
 
         assertTrue(result.isDeprecated)
         assertEquals("Only cake", result.deprecationReason)
@@ -103,7 +97,7 @@ internal class PropertyBuilderTest : TypeTestHelper() {
     @Test
     fun `Test deprecation with replacement`() {
         val prop = ClassWithProperties::healthyFood
-        val result = builder.property(prop, ClassWithProperties::class)
+        val result = generateProperty(generator, prop, ClassWithProperties::class)
 
         assertTrue(result.isDeprecated)
         assertEquals("Healthy food is deprecated, replace with cake", result.deprecationReason)
@@ -112,7 +106,7 @@ internal class PropertyBuilderTest : TypeTestHelper() {
     @Test
     fun `Test description`() {
         val prop = ClassWithProperties::cake
-        val result = builder.property(prop, ClassWithProperties::class)
+        val result = generateProperty(generator, prop, ClassWithProperties::class)
 
         assertEquals("It's not a lie", result.description)
     }
@@ -120,7 +114,7 @@ internal class PropertyBuilderTest : TypeTestHelper() {
     @Test
     fun `Test description on data class`() {
         val prop = DataClassWithProperties::fooBar
-        val result = builder.property(prop, DataClassWithProperties::class)
+        val result = generateProperty(generator, prop, DataClassWithProperties::class)
 
         assertEquals("A great description", result.description)
     }
@@ -128,7 +122,7 @@ internal class PropertyBuilderTest : TypeTestHelper() {
     @Test
     fun `Test graphql id on data class`() {
         val prop = DataClassWithProperties::myId
-        val result = builder.property(prop, DataClassWithProperties::class)
+        val result = generateProperty(generator, prop, DataClassWithProperties::class)
 
         assertEquals("ID", (result.type as? GraphQLNonNull)?.wrappedType?.name)
     }
@@ -136,7 +130,7 @@ internal class PropertyBuilderTest : TypeTestHelper() {
     @Test
     fun `Test custom directive`() {
         val prop = ClassWithProperties::cake
-        val result = builder.property(prop, ClassWithProperties::class)
+        val result = generateProperty(generator, prop, ClassWithProperties::class)
 
         assertEquals(1, result.directives.size)
         val directive = result.directives[0]
@@ -152,17 +146,17 @@ internal class PropertyBuilderTest : TypeTestHelper() {
 
     @Test
     fun `Properties with no directives are not set`() {
-        val resultWithPrefix = builder.property(DataClassWithProperties::myId, DataClassWithProperties::class)
+        val resultWithPrefix = generateProperty(generator, DataClassWithProperties::myId, DataClassWithProperties::class)
         assertEquals(0, resultWithPrefix.directives.size)
     }
 
     @Test
     fun `Properties can have directives on the constructor args`() {
-        val resultWithPrefix = builder.property(DataClassWithProperties::directiveWithPrefix, DataClassWithProperties::class)
+        val resultWithPrefix = generateProperty(generator, DataClassWithProperties::directiveWithPrefix, DataClassWithProperties::class)
         assertEquals(1, resultWithPrefix.directives.size)
         assertEquals("simpleDirective", resultWithPrefix.directives.first().name)
 
-        val resultWithNoPrefix = builder.property(DataClassWithProperties::directiveWithNoPrefix, DataClassWithProperties::class)
+        val resultWithNoPrefix = generateProperty(generator, DataClassWithProperties::directiveWithNoPrefix, DataClassWithProperties::class)
         assertEquals(1, resultWithNoPrefix.directives.size)
         assertEquals("simpleDirective", resultWithNoPrefix.directives.first().name)
     }
@@ -170,7 +164,7 @@ internal class PropertyBuilderTest : TypeTestHelper() {
     @Test
     fun `Test nullable property`() {
         val prop = ClassWithProperties::nullableCake
-        val result = builder.property(prop, ClassWithProperties::class)
+        val result = generateProperty(generator, prop, ClassWithProperties::class)
 
         assertNull(result.description)
         assertTrue(result.type !is GraphQLNonNull)
@@ -202,10 +196,9 @@ internal class PropertyBuilderTest : TypeTestHelper() {
             dataFetcherFactoryProvider = mockDataFetcherFactoryProvider
         )
         val localGenerator = SchemaGenerator(localConfig)
-        val localBuilder = PropertyBuilder(localGenerator)
 
         val prop = ClassWithProperties::cake
-        val result = localBuilder.property(prop, ClassWithProperties::class)
+        val result = generateProperty(localGenerator, prop, ClassWithProperties::class)
 
         val parentType = ClassWithProperties::class.getSimpleName()
         val coordinates = FieldCoordinates.coordinates(parentType, prop.name)

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/QueryBuilderTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/QueryBuilderTest.kt
@@ -58,27 +58,21 @@ internal class QueryBuilderTest : TypeTestHelper() {
         fun hidden(value: Int) = value
     }
 
-    private lateinit var builder: QueryBuilder
-
     override fun beforeSetup() {
         hooks = SimpleHooks()
-    }
-
-    override fun beforeTest() {
-        builder = QueryBuilder(generator)
     }
 
     @Test
     fun `verify builder fails if non public query is specified`() {
         assertFailsWith(exceptionClass = InvalidQueryTypeException::class) {
-            builder.getQueryObject(listOf(TopLevelObject(PrivateQuery())))
+            generateQueries(generator, listOf(TopLevelObject(PrivateQuery())))
         }
     }
 
     @Test
     fun `query with no valid functions`() {
         val queries = listOf(TopLevelObject(NoFunctions()))
-        val result = builder.getQueryObject(queries)
+        val result = generateQueries(generator, queries)
         assertEquals(expected = "TestTopLevelQuery", actual = result.name)
         assertTrue(result.fieldDefinitions.isEmpty())
     }
@@ -86,7 +80,7 @@ internal class QueryBuilderTest : TypeTestHelper() {
     @Test
     fun `query with valid functions`() {
         val queries = listOf(TopLevelObject(QueryObject()))
-        val result = builder.getQueryObject(queries)
+        val result = generateQueries(generator, queries)
         assertEquals(expected = "TestTopLevelQuery", actual = result.name)
         assertEquals(expected = 1, actual = result.fieldDefinitions.size)
         assertEquals(expected = "query", actual = result.fieldDefinitions.first().name)
@@ -95,14 +89,14 @@ internal class QueryBuilderTest : TypeTestHelper() {
     @Test
     fun `verify hooks are called`() {
         assertFalse((hooks as? SimpleHooks)?.calledHook.isTrue())
-        builder.getQueryObject(listOf(TopLevelObject(QueryObject())))
+        generateQueries(generator, listOf(TopLevelObject(QueryObject())))
         assertTrue((hooks as? SimpleHooks)?.calledHook.isTrue())
     }
 
     @Test
     fun `query objects can have directives`() {
         val queries = listOf(TopLevelObject(QueryObject()))
-        val result = builder.getQueryObject(queries)
+        val result = generateQueries(generator, queries)
         assertEquals(expected = 1, actual = result.directives.size)
         assertEquals(expected = "simpleDirective", actual = result.directives.first().name)
     }

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/ScalarBuilderTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/ScalarBuilderTest.kt
@@ -30,12 +30,6 @@ import kotlin.test.assertFailsWith
 
 internal class ScalarBuilderTest : TypeTestHelper() {
 
-    private lateinit var builder: ScalarBuilder
-
-    override fun beforeTest() {
-        builder = ScalarBuilder(generator)
-    }
-
     internal class Ids {
         internal val stringID: String = "abc"
         internal val intID: Int = 1
@@ -85,7 +79,7 @@ internal class ScalarBuilderTest : TypeTestHelper() {
     }
 
     private fun verify(kType: KType, expected: GraphQLScalarType?, annotatedAsID: Boolean = false) {
-        val actual = builder.scalarType(kType, annotatedAsID)
+        val actual = generateScalar(generator, kType, annotatedAsID)
         assertEquals(expected = expected, actual = actual)
     }
 }

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/SubscriptionBuilderTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/SubscriptionBuilderTest.kt
@@ -36,48 +36,42 @@ internal class SubscriptionBuilderTest : TypeTestHelper() {
 
     @Test
     fun `given an empty list, it should not return a field`() {
-        val builder = SubscriptionBuilder(generator)
-        val result = builder.getSubscriptionObject(emptyList())
+        val result = generateSubscriptions(generator, emptyList())
         assertNull(result)
     }
 
     @Test
     fun `give a valid subscription class, it should properly set the top level name`() {
-        val builder = SubscriptionBuilder(generator)
         val subscriptions = listOf(TopLevelObject(MyPublicTestSubscription()))
         every { config.topLevelNames } returns TopLevelNames(subscription = "FooBar")
-        val result = builder.getSubscriptionObject(subscriptions)
+        val result = generateSubscriptions(generator, subscriptions)
 
         assertEquals(expected = "FooBar", actual = result?.name)
     }
 
     @Test
     fun `given a private class, it should throw an exception`() {
-        val builder = SubscriptionBuilder(generator)
         val subscriptions = listOf(TopLevelObject(MyPrivateTestSubscription()))
 
         assertFailsWith(InvalidSubscriptionTypeException::class) {
-            builder.getSubscriptionObject(subscriptions)
+            generateSubscriptions(generator, subscriptions)
         }
     }
 
     @Test
     fun `given a class with a function that does not return Publisher, it should throw an exception`() {
-        val builder = SubscriptionBuilder(generator)
         val subscriptions = listOf(TopLevelObject(MyInvalidSubscriptionClass()))
 
         assertFailsWith(InvalidSubscriptionTypeException::class) {
-            builder.getSubscriptionObject(subscriptions)
+            generateSubscriptions(generator, subscriptions)
         }
     }
 
     @Test
     fun `given a function that returns a Publisher, it should add it to the schema`() {
-
-        val builder = SubscriptionBuilder(generator)
         val subscriptions = listOf(TopLevelObject(MyPublicTestSubscription()))
 
-        val result = builder.getSubscriptionObject(subscriptions)
+        val result = generateSubscriptions(generator, subscriptions)
 
         assertEquals(3, result?.fieldDefinitions?.size)
         assertNotNull(result?.fieldDefinitions?.find { it.name == "counter" })
@@ -87,7 +81,6 @@ internal class SubscriptionBuilderTest : TypeTestHelper() {
 
     @Test
     fun `given custom hooks that filter functions, it should not generate those functions`() {
-        val builder = SubscriptionBuilder(generator)
         val subscriptions = listOf(TopLevelObject(MyPublicTestSubscription()))
 
         class CustomHooks : SchemaGeneratorHooks {
@@ -96,7 +89,7 @@ internal class SubscriptionBuilderTest : TypeTestHelper() {
 
         every { config.hooks } returns CustomHooks()
 
-        val result = builder.getSubscriptionObject(subscriptions)
+        val result = generateSubscriptions(generator, subscriptions)
 
         assertEquals(2, result?.fieldDefinitions?.size)
         assertNotNull(result?.fieldDefinitions?.find { it.name == "counter" })
@@ -104,7 +97,6 @@ internal class SubscriptionBuilderTest : TypeTestHelper() {
 
     @Test
     fun `given custom hooks that change the field after generation, it should use the new fields`() {
-        val builder = SubscriptionBuilder(generator)
         val subscriptions = listOf(TopLevelObject(MyPublicTestSubscription()))
 
         class CustomHooks : SchemaGeneratorHooks {
@@ -117,7 +109,7 @@ internal class SubscriptionBuilderTest : TypeTestHelper() {
 
         every { config.hooks } returns CustomHooks()
 
-        val result = builder.getSubscriptionObject(subscriptions)
+        val result = generateSubscriptions(generator, subscriptions)
 
         assertEquals(3, result?.fieldDefinitions?.size)
         assertNotNull(result?.fieldDefinitions?.find { it.name == "changedField" })

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/TypeTestHelper.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/TypeTestHelper.kt
@@ -33,13 +33,6 @@ import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.TestInstance.Lifecycle
-import java.lang.reflect.Field
-import kotlin.reflect.KAnnotatedElement
-import kotlin.reflect.KClass
-import kotlin.reflect.KFunction
-import kotlin.reflect.KParameter
-import kotlin.reflect.KProperty
-import kotlin.reflect.KType
 
 @Suppress(
     "Detekt.UnsafeCast",
@@ -50,34 +43,21 @@ import kotlin.reflect.KType
 internal open class TypeTestHelper {
     private val supportedPackages = listOf("com.expediagroup.graphql")
     private val subTypeMapper = SubTypeMapper(supportedPackages)
+    private val dataFetcherFactory: KotlinDataFetcherFactoryProvider = SimpleKotlinDataFetcherFactoryProvider()
     private val topLevelNames = TopLevelNames(
         query = "TestTopLevelQuery",
         mutation = "TestTopLevelMutation",
         subscription = "TestTopLevelSubscription"
     )
-
-    var state = spyk(SchemaGeneratorState(supportedPackages))
-    var cache = spyk(TypesCache(supportedPackages))
+    private val state = spyk(SchemaGeneratorState(supportedPackages))
+    private val cache = spyk(TypesCache(supportedPackages))
     val spyWiringFactory = spyk(KotlinDirectiveWiringFactory())
     var hooks: SchemaGeneratorHooks = object : SchemaGeneratorHooks {
         override val wiringFactory: KotlinDirectiveWiringFactory
             get() = spyWiringFactory
     }
-    var dataFetcherFactory: KotlinDataFetcherFactoryProvider = SimpleKotlinDataFetcherFactoryProvider()
-    var config = spyk(SchemaGeneratorConfig(supportedPackages, topLevelNames, hooks, dataFetcherFactory))
-    var generator = spyk(SchemaGenerator(config))
-
-    private var scalarBuilder: ScalarBuilder? = null
-    private var objectBuilder: ObjectBuilder? = null
-    private var listBuilder: ListBuilder? = null
-    private var interfaceBuilder: InterfaceBuilder? = null
-    private var directiveBuilder: DirectiveBuilder? = null
-    private var functionBuilder: FunctionBuilder? = null
-    private var propertyBuilder: PropertyBuilder? = null
-    private var inputPropertyBuilder: InputPropertyBuilder? = null
-    private var unionBuilder: UnionBuilder? = null
-    private var argumentBuilder: ArgumentBuilder? = null
-    private var inputObjectBuilder: InputObjectBuilder? = null
+    val config = spyk(SchemaGeneratorConfig(supportedPackages, topLevelNames, hooks, dataFetcherFactory))
+    val generator = spyk(SchemaGenerator(config))
 
     @BeforeEach
     fun setup() {
@@ -93,72 +73,6 @@ internal open class TypeTestHelper {
             mutation = "TestTopLevelMutation",
             subscription = "TestTopLevelSubscription"
         )
-
-        functionBuilder = spyk(FunctionBuilder(generator))
-        every { generator.function(any(), any(), any(), any()) } answers {
-            functionBuilder!!.function(it.invocation.args[0] as KFunction<*>, it.invocation.args[1] as String, it.invocation.args[2], it.invocation.args[3] as Boolean)
-        }
-
-        propertyBuilder = spyk(PropertyBuilder(generator))
-        every { generator.property(any(), any()) } answers {
-            propertyBuilder!!.property(it.invocation.args[0] as KProperty<*>, it.invocation.args[1] as KClass<*>)
-        }
-
-        inputPropertyBuilder = spyk(InputPropertyBuilder(generator))
-        every { generator.inputProperty(any(), any()) } answers {
-            inputPropertyBuilder!!.inputProperty(it.invocation.args[0] as KProperty<*>, it.invocation.args[1] as KClass<*>)
-        }
-
-        scalarBuilder = spyk(ScalarBuilder(generator))
-        every { generator.scalarType(any(), any()) } answers {
-            scalarBuilder!!.scalarType(it.invocation.args[0] as KType, it.invocation.args[1] as Boolean)
-        }
-
-        objectBuilder = spyk(ObjectBuilder(generator))
-        every { generator.objectType(any()) } answers {
-            objectBuilder!!.objectType(it.invocation.args[0] as KClass<*>)
-        }
-
-        inputObjectBuilder = spyk(InputObjectBuilder(generator))
-        every { generator.inputObjectType(any()) } answers {
-            inputObjectBuilder!!.inputObjectType(it.invocation.args[0] as KClass<*>)
-        }
-
-        listBuilder = spyk(ListBuilder(generator))
-        every { generator.listType(any(), any()) } answers {
-            listBuilder!!.listType(it.invocation.args[0] as KType, it.invocation.args[1] as Boolean)
-        }
-
-        interfaceBuilder = spyk(InterfaceBuilder(generator))
-        every { generator.interfaceType(any()) } answers {
-            interfaceBuilder!!.interfaceType(it.invocation.args[0] as KClass<*>)
-        }
-
-        unionBuilder = spyk(UnionBuilder(generator))
-        every { generator.unionType(any()) } answers {
-            unionBuilder!!.unionType(it.invocation.args[0] as KClass<*>)
-        }
-
-        argumentBuilder = spyk(ArgumentBuilder(generator))
-        every { generator.argument(any()) } answers {
-            argumentBuilder!!.argument(it.invocation.args[0] as KParameter)
-        }
-
-        directiveBuilder = spyk(DirectiveBuilder(generator))
-        every { generator.directives(any(), any()) } answers {
-            val directives = directiveBuilder!!.directives(it.invocation.args[0] as KAnnotatedElement, it.invocation.args[1] as? KClass<*>)
-            for (directive in directives) {
-                state.directives[directive.name] = directive
-            }
-            directives
-        }
-        every { generator.fieldDirectives(any()) } answers {
-            val directives = directiveBuilder!!.fieldDirectives(it.invocation.args[0] as Field)
-            for (directive in directives) {
-                state.directives[directive.name] = directive
-            }
-            directives
-        }
 
         beforeTest()
     }

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/UnionBuilderTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/UnionBuilderTest.kt
@@ -30,12 +30,6 @@ import kotlin.test.assertTrue
 @Suppress("Detekt.UnusedPrivateClass")
 internal class UnionBuilderTest : TypeTestHelper() {
 
-    private lateinit var builder: UnionBuilder
-
-    override fun beforeTest() {
-        builder = UnionBuilder(generator)
-    }
-
     @GraphQLDescription("The truth")
     @SimpleDirective
     private interface Cake
@@ -60,7 +54,7 @@ internal class UnionBuilderTest : TypeTestHelper() {
 
     @Test
     fun `Test naming`() {
-        val result = builder.unionType(Cake::class) as? GraphQLUnionType
+        val result = generateUnion(generator, Cake::class) as? GraphQLUnionType
         assertNotNull(result)
 
         assertEquals(Cake::class.java.simpleName, result.name)
@@ -70,7 +64,7 @@ internal class UnionBuilderTest : TypeTestHelper() {
 
     @Test
     fun `Test custom naming`() {
-        val result = builder.unionType(CakeCustomName::class) as? GraphQLUnionType
+        val result = generateUnion(generator, CakeCustomName::class) as? GraphQLUnionType
         assertNotNull(result)
 
         assertEquals("CakeRenamed", result.name)
@@ -80,7 +74,7 @@ internal class UnionBuilderTest : TypeTestHelper() {
 
     @Test
     fun `Test description`() {
-        val result = builder.unionType(Cake::class) as? GraphQLUnionType
+        val result = generateUnion(generator, Cake::class) as? GraphQLUnionType
         assertNotNull(result)
 
         assertEquals("The truth", result.description)
@@ -90,7 +84,7 @@ internal class UnionBuilderTest : TypeTestHelper() {
 
     @Test
     fun `Unions can have directives`() {
-        val result = builder.unionType(Cake::class) as? GraphQLUnionType
+        val result = generateUnion(generator, Cake::class) as? GraphQLUnionType
 
         assertNotNull(result)
         assertEquals(1, result.directives.size)
@@ -102,7 +96,7 @@ internal class UnionBuilderTest : TypeTestHelper() {
         val cache = generator.state.cache
         assertTrue(cache.doesNotContain(NestedUnionA::class))
 
-        val unionType = builder.unionType(NestedUnionA::class) as? GraphQLUnionType
+        val unionType = generateUnion(generator, NestedUnionA::class) as? GraphQLUnionType
         assertNotNull(unionType)
         assertFalse(cache.doesNotContain(NestedUnionA::class))
     }


### PR DESCRIPTION
### :pencil: Description
To remove the cyclic structure of the TypeBuilder and SchemaGenerator, I moved all the individual type builder to be pure functions that accept the schema generator as an argument. This means we can remove the methods on the schema generator that allow us to call the different type builders

### :link: Related Issues
Please merge this first: https://github.com/ExpediaGroup/graphql-kotlin/pull/531
Related to old issue: https://github.com/ExpediaGroup/graphql-kotlin/issues/84