### PR TITLE
BREAKING CHANGE: empty complex types should fail schema generation

### DIFF
--- a/detekt.yml
+++ b/detekt.yml
@@ -13,11 +13,11 @@ complexity:
     threshold: 10
     active: true
   TooManyFunctions:
-    thresholdInInterfaces: 15
+    thresholdInInterfaces: 20
     thresholdInClasses: 15
     thresholdInFiles: 15
   ComplexInterface:
-    threshold: 15
+    threshold: 20
 
 naming:
   FunctionMaxLength:

--- a/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/FederatedSchemaGeneratorHooks.kt
+++ b/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/FederatedSchemaGeneratorHooks.kt
@@ -110,7 +110,7 @@ open class FederatedSchemaGeneratorHooks(private val federatedTypeRegistry: Fede
     }
 
     // skip validation for empty query type - federation will add _service query
-    override fun didGenerateQueryObjectType(type: GraphQLObjectType): GraphQLObjectType = type
+    override fun didGenerateQueryObject(type: GraphQLObjectType): GraphQLObjectType = type
 }
 
 private fun TypeResolutionEnvironment.getObjectName(): String? {

--- a/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/FederatedSchemaGeneratorHooks.kt
+++ b/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/FederatedSchemaGeneratorHooks.kt
@@ -108,6 +108,9 @@ open class FederatedSchemaGeneratorHooks(private val federatedTypeRegistry: Fede
         return federatedSchema.query(federatedQuery.build())
             .codeRegistry(federatedCodeRegistry.build())
     }
+
+    // skip validation for empty query type - federation will add _service query
+    override fun didGenerateQueryObjectType(type: GraphQLObjectType): GraphQLObjectType = type
 }
 
 private fun TypeResolutionEnvironment.getObjectName(): String? {

--- a/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/toFederatedSchema.kt
+++ b/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/toFederatedSchema.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Expedia, Inc
+ * Copyright 2020 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import graphql.schema.GraphQLSchema
  * Entry point to generate federated graphql schema using reflection on the passed objects.
  *
  * @param config federated schema generation configuration
- * @param queries optional list of [TopLevelObject] to use for GraphQL queries
+ * @param queries list of [TopLevelObject] to use for GraphQL queries
  * @param mutations optional list of [TopLevelObject] to use for GraphQL mutations
  * @param subscriptions optional list of [TopLevelObject] to use for GraphQL subscriptions
  *
@@ -33,7 +33,7 @@ import graphql.schema.GraphQLSchema
 @Throws(GraphQLKotlinException::class)
 fun toFederatedSchema(
     config: FederatedSchemaGeneratorConfig,
-    queries: List<TopLevelObject> = emptyList(),
+    queries: List<TopLevelObject>,
     mutations: List<TopLevelObject> = emptyList(),
     subscriptions: List<TopLevelObject> = emptyList()
 ): GraphQLSchema {

--- a/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/toFederatedSchema.kt
+++ b/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/toFederatedSchema.kt
@@ -24,7 +24,7 @@ import graphql.schema.GraphQLSchema
  * Entry point to generate federated graphql schema using reflection on the passed objects.
  *
  * @param config federated schema generation configuration
- * @param queries list of [TopLevelObject] to use for GraphQL queries
+ * @param queries optional list of [TopLevelObject] to use for GraphQL queries
  * @param mutations optional list of [TopLevelObject] to use for GraphQL mutations
  * @param subscriptions optional list of [TopLevelObject] to use for GraphQL subscriptions
  *
@@ -33,7 +33,7 @@ import graphql.schema.GraphQLSchema
 @Throws(GraphQLKotlinException::class)
 fun toFederatedSchema(
     config: FederatedSchemaGeneratorConfig,
-    queries: List<TopLevelObject>,
+    queries: List<TopLevelObject> = emptyList(),
     mutations: List<TopLevelObject> = emptyList(),
     subscriptions: List<TopLevelObject> = emptyList()
 ): GraphQLSchema {

--- a/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/FederatedSchemaGeneratorTest.kt
+++ b/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/FederatedSchemaGeneratorTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Expedia, Inc
+ * Copyright 2020 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -67,6 +67,7 @@ type Query @extends {
   #Union of all types that use the @key directive, including both types native to the schema and extended types
   _entities(representations: [_Any!]!): [_Entity]!
   _service: _Service
+  hello(name: String!): String!
 }
 
 type Review {
@@ -108,7 +109,7 @@ class FederatedSchemaGeneratorTest {
             hooks = FederatedSchemaGeneratorHooks(FederatedTypeRegistry())
         )
 
-        val schema = toFederatedSchema(config)
+        val schema = toFederatedSchema(config = config, queries = listOf(TopLevelObject(SimpleQuery())))
         assertEquals(FEDERATED_SDL, schema.print().trim())
         val productType = schema.getObjectType("Book")
         assertNotNull(productType)

--- a/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/FederatedSchemaGeneratorTest.kt
+++ b/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/FederatedSchemaGeneratorTest.kt
@@ -67,7 +67,6 @@ type Query @extends {
   #Union of all types that use the @key directive, including both types native to the schema and extended types
   _entities(representations: [_Any!]!): [_Entity]!
   _service: _Service
-  hello(name: String!): String!
 }
 
 type Review {
@@ -109,7 +108,7 @@ class FederatedSchemaGeneratorTest {
             hooks = FederatedSchemaGeneratorHooks(FederatedTypeRegistry())
         )
 
-        val schema = toFederatedSchema(config = config, queries = listOf(TopLevelObject(SimpleQuery())))
+        val schema = toFederatedSchema(config = config)
         assertEquals(FEDERATED_SDL, schema.print().trim())
         val productType = schema.getObjectType("Book")
         assertNotNull(productType)

--- a/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/data/TestSchema.kt
+++ b/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/data/TestSchema.kt
@@ -25,7 +25,7 @@ import com.expediagroup.graphql.federation.toFederatedSchema
 import graphql.schema.GraphQLSchema
 
 internal fun federatedTestSchema(
-    queries: List<TopLevelObject> = listOf(),
+    queries: List<TopLevelObject> = emptyList(),
     federatedTypeResolvers: Map<String, FederatedTypeResolver<*>> = emptyMap()
 ): GraphQLSchema {
     val config = FederatedSchemaGeneratorConfig(

--- a/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/data/TestSchema.kt
+++ b/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/data/TestSchema.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Expedia, Inc
+ * Copyright 2020 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package com.expediagroup.graphql.federation.data
 
+import com.expediagroup.graphql.TopLevelObject
 import com.expediagroup.graphql.federation.FederatedSchemaGeneratorConfig
 import com.expediagroup.graphql.federation.FederatedSchemaGeneratorHooks
 import com.expediagroup.graphql.federation.execution.FederatedTypeRegistry
@@ -23,11 +24,13 @@ import com.expediagroup.graphql.federation.execution.FederatedTypeResolver
 import com.expediagroup.graphql.federation.toFederatedSchema
 import graphql.schema.GraphQLSchema
 
-internal fun federatedTestSchema(federatedTypeResolvers: Map<String, FederatedTypeResolver<*>> = emptyMap()): GraphQLSchema {
+internal fun federatedTestSchema(
+    queries: List<TopLevelObject> = listOf(),
+    federatedTypeResolvers: Map<String, FederatedTypeResolver<*>> = emptyMap()
+): GraphQLSchema {
     val config = FederatedSchemaGeneratorConfig(
         supportedPackages = listOf("com.expediagroup.graphql.federation.data.queries.federated"),
         hooks = FederatedSchemaGeneratorHooks(FederatedTypeRegistry(federatedTypeResolvers))
     )
-
-    return toFederatedSchema(config)
+    return toFederatedSchema(config = config, queries = queries)
 }

--- a/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/execution/FederatedQueryResolverTest.kt
+++ b/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/execution/FederatedQueryResolverTest.kt
@@ -16,7 +16,6 @@
 
 package com.expediagroup.graphql.federation.execution
 
-import com.expediagroup.graphql.TopLevelObject
 import com.expediagroup.graphql.federation.data.BookResolver
 import com.expediagroup.graphql.federation.data.UserResolver
 import com.expediagroup.graphql.federation.data.federatedTestSchema
@@ -49,7 +48,6 @@ class FederatedQueryResolverTest {
     @Test
     fun `verify can resolve federated entities`() {
         val schema = federatedTestSchema(
-            queries = listOf(TopLevelObject(ResolverTestQuery())),
             federatedTypeResolvers = mapOf("Book" to BookResolver(), "User" to UserResolver())
         )
         val userRepresentation = mapOf<String, Any>("__typename" to "User", "userId" to 123, "name" to "testName")
@@ -101,12 +99,5 @@ class FederatedQueryResolverTest {
                 assertEquals("Unable to resolve federated type, representation={id=124}", error["message"])
             }
         }
-    }
-
-    // GraphQL spec requires at least single query to be present as Query type is needed to run introspection queries
-    // see: https://github.com/graphql/graphql-spec/issues/490 and https://github.com/graphql/graphql-spec/issues/568
-    class ResolverTestQuery {
-        @Suppress("Detekt.FunctionOnlyReturningConstant")
-        fun query(): String = "hello"
     }
 }

--- a/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/execution/FederatedQueryResolverTest.kt
+++ b/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/execution/FederatedQueryResolverTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Expedia, Inc
+ * Copyright 2020 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,13 @@
 
 package com.expediagroup.graphql.federation.execution
 
-import graphql.ExecutionInput
-import graphql.GraphQL
-import org.junit.jupiter.api.Test
+import com.expediagroup.graphql.TopLevelObject
 import com.expediagroup.graphql.federation.data.BookResolver
 import com.expediagroup.graphql.federation.data.UserResolver
 import com.expediagroup.graphql.federation.data.federatedTestSchema
+import graphql.ExecutionInput
+import graphql.GraphQL
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
@@ -47,7 +48,10 @@ class FederatedQueryResolverTest {
 
     @Test
     fun `verify can resolve federated entities`() {
-        val schema = federatedTestSchema(mapOf("Book" to BookResolver(), "User" to UserResolver()))
+        val schema = federatedTestSchema(
+            queries = listOf(TopLevelObject(ResolverTestQuery())),
+            federatedTypeResolvers = mapOf("Book" to BookResolver(), "User" to UserResolver())
+        )
         val userRepresentation = mapOf<String, Any>("__typename" to "User", "userId" to 123, "name" to "testName")
         val book1Representation = mapOf<String, Any>("__typename" to "Book", "id" to 987, "weight" to 2.0)
         val book2Representation = mapOf<String, Any>("__typename" to "Book", "id" to 988, "weight" to 1.0)
@@ -97,5 +101,12 @@ class FederatedQueryResolverTest {
                 assertEquals("Unable to resolve federated type, representation={id=124}", error["message"])
             }
         }
+    }
+
+    // GraphQL spec requires at least single query to be present as Query type is needed to run introspection queries
+    // see: https://github.com/graphql/graphql-spec/issues/490 and https://github.com/graphql/graphql-spec/issues/568
+    class ResolverTestQuery {
+        @Suppress("Detekt.FunctionOnlyReturningConstant")
+        fun query(): String = "hello"
     }
 }

--- a/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/execution/ServiceQueryResolverTest.kt
+++ b/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/execution/ServiceQueryResolverTest.kt
@@ -43,10 +43,6 @@ type Book implements Product @extends @key(fields : "id") {
   weight: Float! @external
 }
 
-type Query {
-  hello(name: String!): String!
-}
-
 type Review {
   body: String!
   content: String @deprecated(reason : "no longer supported, replace with use Review.body instead")
@@ -80,7 +76,7 @@ class ServiceQueryResolverTest {
             hooks = FederatedSchemaGeneratorHooks(FederatedTypeRegistry())
         )
 
-        val schema = toFederatedSchema(config = config, queries = listOf(TopLevelObject(SimpleQuery())))
+        val schema = toFederatedSchema(config = config)
         val query = """
             query sdlQuery {
               _service {

--- a/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/execution/ServiceQueryResolverTest.kt
+++ b/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/execution/ServiceQueryResolverTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Expedia, Inc
+ * Copyright 2020 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,12 +19,12 @@ package com.expediagroup.graphql.federation.execution
 import com.expediagroup.graphql.TopLevelObject
 import com.expediagroup.graphql.federation.FederatedSchemaGeneratorConfig
 import com.expediagroup.graphql.federation.FederatedSchemaGeneratorHooks
+import com.expediagroup.graphql.federation.data.queries.simple.NestedQuery
+import com.expediagroup.graphql.federation.data.queries.simple.SimpleQuery
 import com.expediagroup.graphql.federation.toFederatedSchema
 import graphql.ExecutionInput
 import graphql.GraphQL
 import org.junit.jupiter.api.Test
-import com.expediagroup.graphql.federation.data.queries.simple.NestedQuery
-import com.expediagroup.graphql.federation.data.queries.simple.SimpleQuery
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 
@@ -41,6 +41,10 @@ type Book implements Product @extends @key(fields : "id") {
   reviews: [Review!]!
   shippingCost: String! @requires(fields : "weight")
   weight: Float! @external
+}
+
+type Query {
+  hello(name: String!): String!
 }
 
 type Review {
@@ -76,7 +80,7 @@ class ServiceQueryResolverTest {
             hooks = FederatedSchemaGeneratorHooks(FederatedTypeRegistry())
         )
 
-        val schema = toFederatedSchema(config)
+        val schema = toFederatedSchema(config = config, queries = listOf(TopLevelObject(SimpleQuery())))
         val query = """
             query sdlQuery {
               _service {

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/exceptions/EmptyInputObjectTypeException.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/exceptions/EmptyInputObjectTypeException.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.exceptions
+
+import com.expediagroup.graphql.generator.extensions.getSimpleName
+import kotlin.reflect.KType
+
+/**
+ * Thrown when schema input object type does not expose any fields. Since GraphQL always requires you to explicitly specify all the fields down to scalar values, using an input object type without
+ * any defined fields would result in a field that is impossible to query without producing an error.
+ *
+ * @see [Issue 568](https://github.com/graphql/graphql-spec/issues/568)
+ */
+class EmptyInputObjectTypeException(ktype: KType) : GraphQLKotlinException("Invalid ${ktype.getSimpleName(isInputType = true)} input object type - input object does not expose any fields.")

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/exceptions/EmptyInterfaceTypeException.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/exceptions/EmptyInterfaceTypeException.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.exceptions
+
+import com.expediagroup.graphql.generator.extensions.getSimpleName
+import kotlin.reflect.KType
+
+/**
+ * Thrown when interface type does not expose any fields - this should never happen unless we explicitly exclude fields from interface either through
+ * annotating fields with @GraphQLIgnore or by custom hooks that filter out available functions. Since GraphQL always requires you to select fields down
+ * to scalar values, an object type without any defined fields cannot be accessed in any way in a query.
+ *
+ * @see [Issue 568](https://github.com/graphql/graphql-spec/issues/568)
+ */
+class EmptyInterfaceTypeException(ktype: KType) : GraphQLKotlinException("Invalid ${ktype.getSimpleName()} interface type - interface does not expose any fields.")

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/exceptions/EmptyMutationTypeException.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/exceptions/EmptyMutationTypeException.kt
@@ -16,12 +16,9 @@
 
 package com.expediagroup.graphql.exceptions
 
-import kotlin.reflect.KClass
-
 /**
- * Thrown when an interface implements another interface or abstract class that is not excluded from the schema.
+ * Thrown when generated GraphQL Mutation type does not expose any fields.
  *
- * This is an invalid schema until the GraphQL spec is updated
- * https://github.com/ExpediaGroup/graphql-kotlin/issues/419
+ * @see [Issue 568](https://github.com/graphql/graphql-spec/issues/568)
  */
-class InvalidInterfaceException(klazz: KClass<*>) : GraphQLKotlinException("Invalid ${klazz.simpleName} interface - interfaces can not have any superclasses.")
+object EmptyMutationTypeException : GraphQLKotlinException("Invalid mutation object type - no valid mutations are available.")

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/exceptions/EmptyObjectTypeException.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/exceptions/EmptyObjectTypeException.kt
@@ -16,12 +16,13 @@
 
 package com.expediagroup.graphql.exceptions
 
-import kotlin.reflect.KClass
+import com.expediagroup.graphql.generator.extensions.getSimpleName
+import kotlin.reflect.KType
 
 /**
- * Thrown when an interface implements another interface or abstract class that is not excluded from the schema.
+ * Thrown when schema object type does not expose any fields. Since GraphQL always requires you to select fields down to scalar values, an object type without any defined fields cannot be accessed
+ * in any way in a query.
  *
- * This is an invalid schema until the GraphQL spec is updated
- * https://github.com/ExpediaGroup/graphql-kotlin/issues/419
+ * @see [Issue 568](https://github.com/graphql/graphql-spec/issues/568)
  */
-class InvalidInterfaceException(klazz: KClass<*>) : GraphQLKotlinException("Invalid ${klazz.simpleName} interface - interfaces can not have any superclasses.")
+class EmptyObjectTypeException(ktype: KType) : GraphQLKotlinException("Invalid ${ktype.getSimpleName()} object type - object does not expose any fields.")

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/exceptions/EmptyQueryTypeException.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/exceptions/EmptyQueryTypeException.kt
@@ -16,12 +16,9 @@
 
 package com.expediagroup.graphql.exceptions
 
-import kotlin.reflect.KClass
-
 /**
- * Thrown when an interface implements another interface or abstract class that is not excluded from the schema.
+ * Thrown when generated GraphQL Query type does not expose any fields.
  *
- * This is an invalid schema until the GraphQL spec is updated
- * https://github.com/ExpediaGroup/graphql-kotlin/issues/419
+ * @see [Issue 568](https://github.com/graphql/graphql-spec/issues/568)
  */
-class InvalidInterfaceException(klazz: KClass<*>) : GraphQLKotlinException("Invalid ${klazz.simpleName} interface - interfaces can not have any superclasses.")
+object EmptyQueryTypeException : GraphQLKotlinException("Invalid query object type - no valid queries are available.")

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/exceptions/EmptySubscriptionTypeException.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/exceptions/EmptySubscriptionTypeException.kt
@@ -16,12 +16,9 @@
 
 package com.expediagroup.graphql.exceptions
 
-import kotlin.reflect.KClass
-
 /**
- * Thrown when an interface implements another interface or abstract class that is not excluded from the schema.
+ * Thrown when generated GraphQL Subscription type does not expose any fields.
  *
- * This is an invalid schema until the GraphQL spec is updated
- * https://github.com/ExpediaGroup/graphql-kotlin/issues/419
+ * @see [Issue 568](https://github.com/graphql/graphql-spec/issues/568)
  */
-class InvalidInterfaceException(klazz: KClass<*>) : GraphQLKotlinException("Invalid ${klazz.simpleName} interface - interfaces can not have any superclasses.")
+object EmptySubscriptionTypeException : GraphQLKotlinException("Invalid subscription object type - no valid subscriptions are available.")

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/InterfaceBuilder.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/InterfaceBuilder.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Expedia, Inc
+ * Copyright 2020 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ import kotlin.reflect.full.createType
 internal fun generateInterface(generator: SchemaGenerator, kClass: KClass<*>): GraphQLInterfaceType {
     // Interfaces can not implement another interface in GraphQL
     if (kClass.getValidSuperclasses(generator.config.hooks).isNotEmpty()) {
-        throw InvalidInterfaceException()
+        throw InvalidInterfaceException(klazz = kClass)
     }
 
     val builder = GraphQLInterfaceType.newInterface()

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/MutationBuilder.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/MutationBuilder.kt
@@ -43,10 +43,10 @@ fun generateMutations(generator: SchemaGenerator, mutations: List<TopLevelObject
         mutation.kClass.getValidFunctions(generator.config.hooks)
             .forEach {
                 val function = generateFunction(generator, it, generator.config.topLevelNames.mutation, mutation.obj)
-                val functionFromHook = generator.config.hooks.didGenerateMutationFieldType(mutation.kClass, it, function)
+                val functionFromHook = generator.config.hooks.didGenerateMutationField(mutation.kClass, it, function)
                 mutationBuilder.field(functionFromHook)
             }
     }
 
-    return generator.config.hooks.didGenerateMutationObjectType(mutationBuilder.build())
+    return generator.config.hooks.didGenerateMutationObject(mutationBuilder.build())
 }

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/MutationBuilder.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/MutationBuilder.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Expedia, Inc
+ * Copyright 2020 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,6 @@ import com.expediagroup.graphql.generator.extensions.isNotPublic
 import graphql.schema.GraphQLObjectType
 
 fun generateMutations(generator: SchemaGenerator, mutations: List<TopLevelObject>): GraphQLObjectType? {
-
     if (mutations.isEmpty()) {
         return null
     }
@@ -44,10 +43,10 @@ fun generateMutations(generator: SchemaGenerator, mutations: List<TopLevelObject
         mutation.kClass.getValidFunctions(generator.config.hooks)
             .forEach {
                 val function = generateFunction(generator, it, generator.config.topLevelNames.mutation, mutation.obj)
-                val functionFromHook = generator.config.hooks.didGenerateMutationType(mutation.kClass, it, function)
+                val functionFromHook = generator.config.hooks.didGenerateMutationFieldType(mutation.kClass, it, function)
                 mutationBuilder.field(functionFromHook)
             }
     }
 
-    return mutationBuilder.build()
+    return generator.config.hooks.didGenerateMutationObjectType(mutationBuilder.build())
 }

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/QueryBuilder.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/QueryBuilder.kt
@@ -39,10 +39,10 @@ fun generateQueries(generator: SchemaGenerator, queries: List<TopLevelObject>): 
         query.kClass.getValidFunctions(generator.config.hooks)
             .forEach {
                 val function = generateFunction(generator, it, generator.config.topLevelNames.query, query.obj)
-                val functionFromHook = generator.config.hooks.didGenerateQueryFieldType(query.kClass, it, function)
+                val functionFromHook = generator.config.hooks.didGenerateQueryField(query.kClass, it, function)
                 queryBuilder.field(functionFromHook)
             }
     }
 
-    return generator.config.hooks.didGenerateQueryObjectType(queryBuilder.build())
+    return generator.config.hooks.didGenerateQueryObject(queryBuilder.build())
 }

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/QueryBuilder.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/QueryBuilder.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Expedia, Inc
+ * Copyright 2020 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package com.expediagroup.graphql.generator.types
 
 import com.expediagroup.graphql.TopLevelObject
+import com.expediagroup.graphql.exceptions.EmptyQueryTypeException
 import com.expediagroup.graphql.exceptions.InvalidQueryTypeException
 import com.expediagroup.graphql.generator.SchemaGenerator
 import com.expediagroup.graphql.generator.extensions.getValidFunctions
@@ -24,6 +25,10 @@ import com.expediagroup.graphql.generator.extensions.isNotPublic
 import graphql.schema.GraphQLObjectType
 
 fun generateQueries(generator: SchemaGenerator, queries: List<TopLevelObject>): GraphQLObjectType {
+    if (queries.isEmpty()) {
+        throw EmptyQueryTypeException
+    }
+
     val queryBuilder = GraphQLObjectType.Builder()
     queryBuilder.name(generator.config.topLevelNames.query)
 
@@ -39,10 +44,10 @@ fun generateQueries(generator: SchemaGenerator, queries: List<TopLevelObject>): 
         query.kClass.getValidFunctions(generator.config.hooks)
             .forEach {
                 val function = generateFunction(generator, it, generator.config.topLevelNames.query, query.obj)
-                val functionFromHook = generator.config.hooks.didGenerateQueryType(query.kClass, it, function)
+                val functionFromHook = generator.config.hooks.didGenerateQueryFieldType(query.kClass, it, function)
                 queryBuilder.field(functionFromHook)
             }
     }
 
-    return queryBuilder.build()
+    return generator.config.hooks.didGenerateQueryObjectType(queryBuilder.build())
 }

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/QueryBuilder.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/QueryBuilder.kt
@@ -17,7 +17,6 @@
 package com.expediagroup.graphql.generator.types
 
 import com.expediagroup.graphql.TopLevelObject
-import com.expediagroup.graphql.exceptions.EmptyQueryTypeException
 import com.expediagroup.graphql.exceptions.InvalidQueryTypeException
 import com.expediagroup.graphql.generator.SchemaGenerator
 import com.expediagroup.graphql.generator.extensions.getValidFunctions
@@ -25,10 +24,6 @@ import com.expediagroup.graphql.generator.extensions.isNotPublic
 import graphql.schema.GraphQLObjectType
 
 fun generateQueries(generator: SchemaGenerator, queries: List<TopLevelObject>): GraphQLObjectType {
-    if (queries.isEmpty()) {
-        throw EmptyQueryTypeException
-    }
-
     val queryBuilder = GraphQLObjectType.Builder()
     queryBuilder.name(generator.config.topLevelNames.query)
 

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/SubscriptionBuilder.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/SubscriptionBuilder.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Expedia, Inc
+ * Copyright 2020 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,6 @@ import graphql.schema.GraphQLObjectType
 import org.reactivestreams.Publisher
 
 internal fun generateSubscriptions(generator: SchemaGenerator, subscriptions: List<TopLevelObject>): GraphQLObjectType? {
-
     if (subscriptions.isEmpty()) {
         return null
     }
@@ -46,10 +45,10 @@ internal fun generateSubscriptions(generator: SchemaGenerator, subscriptions: Li
                 }
 
                 val function = generateFunction(generator, it, generator.config.topLevelNames.subscription, subscription.obj)
-                val functionFromHook = generator.config.hooks.didGenerateSubscriptionType(subscription.kClass, it, function)
+                val functionFromHook = generator.config.hooks.didGenerateSubscriptionFieldType(subscription.kClass, it, function)
                 subscriptionBuilder.field(functionFromHook)
             }
     }
 
-    return subscriptionBuilder.build()
+    return generator.config.hooks.didGenerateSubscriptionObjectType(subscriptionBuilder.build())
 }

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/SubscriptionBuilder.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/SubscriptionBuilder.kt
@@ -45,10 +45,10 @@ internal fun generateSubscriptions(generator: SchemaGenerator, subscriptions: Li
                 }
 
                 val function = generateFunction(generator, it, generator.config.topLevelNames.subscription, subscription.obj)
-                val functionFromHook = generator.config.hooks.didGenerateSubscriptionFieldType(subscription.kClass, it, function)
+                val functionFromHook = generator.config.hooks.didGenerateSubscriptionField(subscription.kClass, it, function)
                 subscriptionBuilder.field(functionFromHook)
             }
     }
 
-    return generator.config.hooks.didGenerateSubscriptionObjectType(subscriptionBuilder.build())
+    return generator.config.hooks.didGenerateSubscriptionObject(subscriptionBuilder.build())
 }

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/hooks/SchemaGeneratorHooks.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/hooks/SchemaGeneratorHooks.kt
@@ -112,42 +112,42 @@ interface SchemaGeneratorHooks {
     }
 
     /**
-     * Called after converting the function to a field definition but before adding to the schema to allow customization
+     * Called after converting the function to a field definition but before adding to the query object to allow customization
      */
-    fun didGenerateQueryFieldType(kClass: KClass<*>, function: KFunction<*>, fieldDefinition: GraphQLFieldDefinition): GraphQLFieldDefinition = fieldDefinition
+    fun didGenerateQueryField(kClass: KClass<*>, function: KFunction<*>, fieldDefinition: GraphQLFieldDefinition): GraphQLFieldDefinition = fieldDefinition
 
     /**
-     * Called after converting the function to a field definition but before adding to the schema to allow customization
+     * Called after converting the function to a field definition but before adding to the mutation object to allow customization
      */
-    fun didGenerateMutationFieldType(kClass: KClass<*>, function: KFunction<*>, fieldDefinition: GraphQLFieldDefinition): GraphQLFieldDefinition = fieldDefinition
+    fun didGenerateMutationField(kClass: KClass<*>, function: KFunction<*>, fieldDefinition: GraphQLFieldDefinition): GraphQLFieldDefinition = fieldDefinition
 
     /**
-     * Called after converting the function to a field definition but before adding to the schema to allow customization
+     * Called after converting the function to a field definition but before adding to the subscription object to allow customization
      */
-    fun didGenerateSubscriptionFieldType(kClass: KClass<*>, function: KFunction<*>, fieldDefinition: GraphQLFieldDefinition): GraphQLFieldDefinition = fieldDefinition
+    fun didGenerateSubscriptionField(kClass: KClass<*>, function: KFunction<*>, fieldDefinition: GraphQLFieldDefinition): GraphQLFieldDefinition = fieldDefinition
 
     /**
-     * Called after generating the Query object type but before adding it to the schema.
+     * Called after generating the Query object but before adding it to the schema.
      */
-    fun didGenerateQueryObjectType(type: GraphQLObjectType): GraphQLObjectType = if (type.fieldDefinitions.isEmpty()) {
+    fun didGenerateQueryObject(type: GraphQLObjectType): GraphQLObjectType = if (type.fieldDefinitions.isEmpty()) {
         throw EmptyQueryTypeException
     } else {
         type
     }
 
     /**
-     * Called after generating the Mutation object type but before adding it to the schema.
+     * Called after generating the Mutation object but before adding it to the schema.
      */
-    fun didGenerateMutationObjectType(type: GraphQLObjectType): GraphQLObjectType = if (type.fieldDefinitions.isEmpty()) {
+    fun didGenerateMutationObject(type: GraphQLObjectType): GraphQLObjectType = if (type.fieldDefinitions.isEmpty()) {
         throw EmptyMutationTypeException
     } else {
         type
     }
 
     /**
-     * Called after generating the Subscription object type but before adding it to the schema.
+     * Called after generating the Subscription object but before adding it to the schema.
      */
-    fun didGenerateSubscriptionObjectType(type: GraphQLObjectType): GraphQLObjectType = if (type.fieldDefinitions.isEmpty()) {
+    fun didGenerateSubscriptionObject(type: GraphQLObjectType): GraphQLObjectType = if (type.fieldDefinitions.isEmpty()) {
         throw EmptySubscriptionTypeException
     } else {
         type

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/hooks/SchemaGeneratorHooks.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/hooks/SchemaGeneratorHooks.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Expedia, Inc
+ * Copyright 2020 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,11 +17,21 @@
 package com.expediagroup.graphql.hooks
 
 import com.expediagroup.graphql.directives.KotlinDirectiveWiringFactory
+import com.expediagroup.graphql.exceptions.EmptyInputObjectTypeException
+import com.expediagroup.graphql.exceptions.EmptyInterfaceTypeException
+import com.expediagroup.graphql.exceptions.EmptyMutationTypeException
+import com.expediagroup.graphql.exceptions.EmptyObjectTypeException
+import com.expediagroup.graphql.exceptions.EmptyQueryTypeException
+import com.expediagroup.graphql.exceptions.EmptySubscriptionTypeException
 import graphql.schema.FieldCoordinates
 import graphql.schema.GraphQLCodeRegistry
 import graphql.schema.GraphQLFieldDefinition
+import graphql.schema.GraphQLInputObjectType
+import graphql.schema.GraphQLInterfaceType
+import graphql.schema.GraphQLObjectType
 import graphql.schema.GraphQLSchema
 import graphql.schema.GraphQLType
+import graphql.schema.GraphQLTypeUtil
 import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
 import kotlin.reflect.KProperty
@@ -90,22 +100,58 @@ interface SchemaGeneratorHooks {
     /**
      * Called after wrapping the type based on nullity but before adding the generated type to the schema
      */
-    fun didGenerateGraphQLType(type: KType, generatedType: GraphQLType) = generatedType
+    @Suppress("Detekt.ThrowsCount")
+    fun didGenerateGraphQLType(type: KType, generatedType: GraphQLType): GraphQLType {
+        val unwrapped = GraphQLTypeUtil.unwrapNonNull(generatedType)
+        return when {
+            unwrapped is GraphQLInterfaceType && unwrapped.fieldDefinitions.isEmpty() -> throw EmptyInterfaceTypeException(ktype = type)
+            unwrapped is GraphQLObjectType && unwrapped.fieldDefinitions.isEmpty() -> throw EmptyObjectTypeException(ktype = type)
+            unwrapped is GraphQLInputObjectType && unwrapped.fieldDefinitions.isEmpty() -> throw EmptyInputObjectTypeException(ktype = type)
+            else -> generatedType
+        }
+    }
 
     /**
      * Called after converting the function to a field definition but before adding to the schema to allow customization
      */
-    fun didGenerateQueryType(kClass: KClass<*>, function: KFunction<*>, fieldDefinition: GraphQLFieldDefinition): GraphQLFieldDefinition = fieldDefinition
+    fun didGenerateQueryFieldType(kClass: KClass<*>, function: KFunction<*>, fieldDefinition: GraphQLFieldDefinition): GraphQLFieldDefinition = fieldDefinition
 
     /**
      * Called after converting the function to a field definition but before adding to the schema to allow customization
      */
-    fun didGenerateMutationType(kClass: KClass<*>, function: KFunction<*>, fieldDefinition: GraphQLFieldDefinition): GraphQLFieldDefinition = fieldDefinition
+    fun didGenerateMutationFieldType(kClass: KClass<*>, function: KFunction<*>, fieldDefinition: GraphQLFieldDefinition): GraphQLFieldDefinition = fieldDefinition
 
     /**
      * Called after converting the function to a field definition but before adding to the schema to allow customization
      */
-    fun didGenerateSubscriptionType(kClass: KClass<*>, function: KFunction<*>, fieldDefinition: GraphQLFieldDefinition): GraphQLFieldDefinition = fieldDefinition
+    fun didGenerateSubscriptionFieldType(kClass: KClass<*>, function: KFunction<*>, fieldDefinition: GraphQLFieldDefinition): GraphQLFieldDefinition = fieldDefinition
+
+    /**
+     * Called after generating the Query object type but before adding it to the schema.
+     */
+    fun didGenerateQueryObjectType(type: GraphQLObjectType): GraphQLObjectType = if (type.fieldDefinitions.isEmpty()) {
+        throw EmptyQueryTypeException
+    } else {
+        type
+    }
+
+    /**
+     * Called after generating the Mutation object type but before adding it to the schema.
+     */
+    fun didGenerateMutationObjectType(type: GraphQLObjectType): GraphQLObjectType = if (type.fieldDefinitions.isEmpty()) {
+        throw EmptyMutationTypeException
+    } else {
+        type
+    }
+
+    /**
+     * Called after generating the Subscription object type but before adding it to the schema.
+     */
+    fun didGenerateSubscriptionObjectType(type: GraphQLObjectType): GraphQLObjectType = if (type.fieldDefinitions.isEmpty()) {
+        throw EmptySubscriptionTypeException
+    } else {
+        type
+    }
 
     val wiringFactory: KotlinDirectiveWiringFactory
         get() = KotlinDirectiveWiringFactory()

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/PolymorphicTests.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/PolymorphicTests.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Expedia, Inc
+ * Copyright 2020 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -269,4 +269,7 @@ class Cheesecake : Cake {
 
 interface Dessert
 
-class IceCream : Dessert
+@Suppress("Detekt.FunctionOnlyReturningConstant")
+class IceCream : Dessert {
+    fun flavor(): String = "chocolate"
+}

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/MutationBuilderTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/MutationBuilderTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Expedia, Inc
+ * Copyright 2020 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,12 +19,14 @@ package com.expediagroup.graphql.generator.types
 import com.expediagroup.graphql.TopLevelObject
 import com.expediagroup.graphql.annotations.GraphQLDescription
 import com.expediagroup.graphql.annotations.GraphQLIgnore
+import com.expediagroup.graphql.exceptions.EmptyMutationTypeException
 import com.expediagroup.graphql.exceptions.InvalidMutationTypeException
 import com.expediagroup.graphql.generator.extensions.isTrue
 import com.expediagroup.graphql.hooks.SchemaGeneratorHooks
 import com.expediagroup.graphql.test.utils.SimpleDirective
 import graphql.schema.GraphQLFieldDefinition
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
 import kotlin.test.assertEquals
@@ -38,9 +40,9 @@ internal class MutationBuilderTest : TypeTestHelper() {
 
     internal class SimpleHooks : SchemaGeneratorHooks {
         var calledHook = false
-        override fun didGenerateMutationType(kClass: KClass<*>, function: KFunction<*>, fieldDefinition: GraphQLFieldDefinition): GraphQLFieldDefinition {
+        override fun didGenerateMutationFieldType(kClass: KClass<*>, function: KFunction<*>, fieldDefinition: GraphQLFieldDefinition): GraphQLFieldDefinition {
             calledHook = true
-            return super.didGenerateMutationType(kClass, function, fieldDefinition)
+            return super.didGenerateMutationFieldType(kClass, function, fieldDefinition)
         }
     }
 
@@ -78,9 +80,9 @@ internal class MutationBuilderTest : TypeTestHelper() {
     @Test
     fun `mutation with no valid functions`() {
         val mutations = listOf(TopLevelObject(NoFunctions()))
-        val result = generateMutations(generator, mutations)
-        assertEquals(expected = "TestTopLevelMutation", actual = result?.name)
-        assertTrue(result?.fieldDefinitions?.isEmpty().isTrue())
+        assertThrows<EmptyMutationTypeException> {
+            generateMutations(generator, mutations)
+        }
     }
 
     @Test

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/MutationBuilderTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/MutationBuilderTest.kt
@@ -40,9 +40,9 @@ internal class MutationBuilderTest : TypeTestHelper() {
 
     internal class SimpleHooks : SchemaGeneratorHooks {
         var calledHook = false
-        override fun didGenerateMutationFieldType(kClass: KClass<*>, function: KFunction<*>, fieldDefinition: GraphQLFieldDefinition): GraphQLFieldDefinition {
+        override fun didGenerateMutationField(kClass: KClass<*>, function: KFunction<*>, fieldDefinition: GraphQLFieldDefinition): GraphQLFieldDefinition {
             calledHook = true
-            return super.didGenerateMutationFieldType(kClass, function, fieldDefinition)
+            return super.didGenerateMutationField(kClass, function, fieldDefinition)
         }
     }
 

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/QueryBuilderTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/QueryBuilderTest.kt
@@ -39,9 +39,9 @@ internal class QueryBuilderTest : TypeTestHelper() {
 
     internal class SimpleHooks : SchemaGeneratorHooks {
         var calledHook = false
-        override fun didGenerateQueryFieldType(kClass: KClass<*>, function: KFunction<*>, fieldDefinition: GraphQLFieldDefinition): GraphQLFieldDefinition {
+        override fun didGenerateQueryField(kClass: KClass<*>, function: KFunction<*>, fieldDefinition: GraphQLFieldDefinition): GraphQLFieldDefinition {
             calledHook = true
-            return super.didGenerateQueryFieldType(kClass, function, fieldDefinition)
+            return super.didGenerateQueryField(kClass, function, fieldDefinition)
         }
     }
 

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/SubscriptionBuilderTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/SubscriptionBuilderTest.kt
@@ -109,7 +109,7 @@ internal class SubscriptionBuilderTest : TypeTestHelper() {
         val subscriptions = listOf(TopLevelObject(MyPublicTestSubscription()))
 
         class CustomHooks : SchemaGeneratorHooks {
-            override fun didGenerateSubscriptionFieldType(kClass: KClass<*>, function: KFunction<*>, fieldDefinition: GraphQLFieldDefinition): GraphQLFieldDefinition {
+            override fun didGenerateSubscriptionField(kClass: KClass<*>, function: KFunction<*>, fieldDefinition: GraphQLFieldDefinition): GraphQLFieldDefinition {
                 return if (fieldDefinition.name == "filterMe") {
                     fieldDefinition.transform { fieldBuilder -> fieldBuilder.name("changedField") }
                 } else fieldDefinition

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/SubscriptionBuilderTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/SubscriptionBuilderTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Expedia, Inc
+ * Copyright 2020 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,12 +18,14 @@ package com.expediagroup.graphql.generator.types
 
 import com.expediagroup.graphql.TopLevelNames
 import com.expediagroup.graphql.TopLevelObject
+import com.expediagroup.graphql.exceptions.EmptySubscriptionTypeException
 import com.expediagroup.graphql.exceptions.InvalidSubscriptionTypeException
 import com.expediagroup.graphql.hooks.SchemaGeneratorHooks
 import graphql.schema.GraphQLFieldDefinition
 import io.mockk.every
 import io.reactivex.Flowable
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.reactivestreams.Publisher
 import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
@@ -38,6 +40,13 @@ internal class SubscriptionBuilderTest : TypeTestHelper() {
     fun `given an empty list, it should not return a field`() {
         val result = generateSubscriptions(generator, emptyList())
         assertNull(result)
+    }
+
+    @Test
+    fun `given subscription without fields should throw exception`() {
+        assertThrows<EmptySubscriptionTypeException> {
+            generateSubscriptions(generator, listOf(TopLevelObject(MyEmptyTestSubscription())))
+        }
     }
 
     @Test
@@ -100,7 +109,7 @@ internal class SubscriptionBuilderTest : TypeTestHelper() {
         val subscriptions = listOf(TopLevelObject(MyPublicTestSubscription()))
 
         class CustomHooks : SchemaGeneratorHooks {
-            override fun didGenerateSubscriptionType(kClass: KClass<*>, function: KFunction<*>, fieldDefinition: GraphQLFieldDefinition): GraphQLFieldDefinition {
+            override fun didGenerateSubscriptionFieldType(kClass: KClass<*>, function: KFunction<*>, fieldDefinition: GraphQLFieldDefinition): GraphQLFieldDefinition {
                 return if (fieldDefinition.name == "filterMe") {
                     fieldDefinition.transform { fieldBuilder -> fieldBuilder.name("changedField") }
                 } else fieldDefinition
@@ -132,3 +141,5 @@ class MyInvalidSubscriptionClass {
 private class MyPrivateTestSubscription {
     fun counter(): Publisher<Int> = Flowable.just(3)
 }
+
+class MyEmptyTestSubscription

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/UnionBuilderTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/UnionBuilderTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Expedia, Inc
+ * Copyright 2020 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,14 +34,20 @@ internal class UnionBuilderTest : TypeTestHelper() {
     @SimpleDirective
     private interface Cake
 
+    @Suppress("Detekt.FunctionOnlyReturningConstant")
     @GraphQLDescription("so red")
-    private class StrawBerryCake : Cake
+    private class StrawBerryCake : Cake {
+        fun recipe(): String = "google it"
+    }
 
     @GraphQLName("CakeRenamed")
     private interface CakeCustomName
 
+    @Suppress("Detekt.FunctionOnlyReturningConstant")
     @GraphQLName("StrawBerryCakeRenamed")
-    private class StrawBerryCakeCustomName : CakeCustomName
+    private class StrawBerryCakeCustomName : CakeCustomName {
+        fun recipe(): String = "bing it"
+    }
 
     private interface NestedUnionA
 

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/hooks/SchemaGeneratorHooksTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/hooks/SchemaGeneratorHooksTest.kt
@@ -103,7 +103,7 @@ class SchemaGeneratorHooksTest {
             override fun didGenerateGraphQLType(type: KType, generatedType: GraphQLType): GraphQLType = generatedType
 
             // skip validation
-            override fun didGenerateQueryObjectType(type: GraphQLObjectType): GraphQLObjectType = type
+            override fun didGenerateQueryObject(type: GraphQLObjectType): GraphQLObjectType = type
         }
 
         val hooks = MockSchemaGeneratorHooks()
@@ -197,7 +197,7 @@ class SchemaGeneratorHooksTest {
     @Test
     fun `calls hook before adding query field to schema`() {
         class MockSchemaGeneratorHooks : SchemaGeneratorHooks {
-            override fun didGenerateQueryFieldType(
+            override fun didGenerateQueryField(
                 kClass: KClass<*>,
                 function: KFunction<*>,
                 fieldDefinition: GraphQLFieldDefinition
@@ -221,7 +221,7 @@ class SchemaGeneratorHooksTest {
     @Test
     fun `calls hook before adding mutation field to schema`() {
         class MockSchemaGeneratorHooks : SchemaGeneratorHooks {
-            override fun didGenerateMutationFieldType(
+            override fun didGenerateMutationField(
                 kClass: KClass<*>,
                 function: KFunction<*>,
                 fieldDefinition: GraphQLFieldDefinition

--- a/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/SubscriptionConfigurationTest.kt
+++ b/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/SubscriptionConfigurationTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Expedia, Inc
+ * Copyright 2020 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package com.expediagroup.graphql.spring
 import com.expediagroup.graphql.SchemaGeneratorConfig
 import com.expediagroup.graphql.spring.execution.QueryHandler
 import com.expediagroup.graphql.spring.execution.SubscriptionHandler
+import com.expediagroup.graphql.spring.operations.Query
 import com.expediagroup.graphql.spring.operations.Subscription
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
@@ -103,6 +104,9 @@ class SubscriptionConfigurationTest {
         fun objectMapper(): ObjectMapper = jacksonObjectMapper()
 
         @Bean
+        fun query(): Query = SimpleQuery()
+
+        @Bean
         fun subscription(): Subscription = SimpleSubscription()
     }
 
@@ -114,6 +118,9 @@ class SubscriptionConfigurationTest {
         fun objectMapper(): ObjectMapper = jacksonObjectMapper()
 
         @Bean
+        fun query(): Query = SimpleQuery()
+
+        @Bean
         fun subscription(): Subscription = SimpleSubscription()
 
         @Bean
@@ -123,6 +130,13 @@ class SubscriptionConfigurationTest {
 
         @Bean
         fun webSocketHandlerAdapter(): WebSocketHandlerAdapter = mockk()
+    }
+
+    // GraphQL spec requires at least single query to be present as Query type is needed to run introspection queries
+    // see: https://github.com/graphql/graphql-spec/issues/490 and https://github.com/graphql/graphql-spec/issues/568
+    class SimpleQuery : Query {
+        @Suppress("Detekt.FunctionOnlyReturningConstant")
+        fun query(): String = "hello!"
     }
 
     class SimpleSubscription : Subscription {

--- a/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/execution/SubscriptionHandlerTest.kt
+++ b/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/execution/SubscriptionHandlerTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Expedia, Inc
+ * Copyright 2020 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ class SubscriptionHandlerTest {
 
     private val testSchema: GraphQLSchema = toSchema(
         config = SchemaGeneratorConfig(supportedPackages = listOf("com.expediagroup.graphql.spring.execution")),
-        queries = listOf(),
+        queries = listOf(TopLevelObject(BasicQuery())),
         subscriptions = listOf(TopLevelObject(BasicSubscription()))
     )
     private val testGraphQL: GraphQL = GraphQL.newGraphQL(testSchema).build()
@@ -103,6 +103,13 @@ class SubscriptionHandlerTest {
             }
             .expectComplete()
             .verify()
+    }
+
+    // GraphQL spec requires at least single query to be present as Query type is needed to run introspection queries
+    // see: https://github.com/graphql/graphql-spec/issues/490 and https://github.com/graphql/graphql-spec/issues/568
+    class BasicQuery {
+        @Suppress("Detekt.FunctionOnlyReturningConstant")
+        fun query(): String = "hello"
     }
 
     class BasicSubscription {

--- a/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/execution/SubscriptionWebSocketHandlerIT.kt
+++ b/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/execution/SubscriptionWebSocketHandlerIT.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Expedia, Inc
+ * Copyright 2020 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import com.expediagroup.graphql.spring.model.GraphQLRequest
 import com.expediagroup.graphql.spring.model.SubscriptionOperationMessage
 import com.expediagroup.graphql.spring.model.SubscriptionOperationMessage.ClientMessages.GQL_CONNECTION_INIT
 import com.expediagroup.graphql.spring.model.SubscriptionOperationMessage.ClientMessages.GQL_START
+import com.expediagroup.graphql.spring.operations.Query
 import com.expediagroup.graphql.spring.operations.Subscription
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
@@ -161,6 +162,10 @@ class SubscriptionWebSocketHandlerIT(@LocalServerPort private var port: Int) {
 
     @Configuration
     class TestConfiguration {
+
+        @Bean
+        fun query(): Query = SimpleQuery()
+
         @Bean
         fun subscription(): Subscription = SimpleSubscription()
 
@@ -170,6 +175,13 @@ class SubscriptionWebSocketHandlerIT(@LocalServerPort private var port: Int) {
                 value = request.headers.getFirst("X-Custom-Header") ?: "default"
             )
         }
+    }
+
+    // GraphQL spec requires at least single query to be present as Query type is needed to run introspection queries
+    // see: https://github.com/graphql/graphql-spec/issues/490 and https://github.com/graphql/graphql-spec/issues/568
+    class SimpleQuery : Query {
+        @Suppress("Detekt.FunctionOnlyReturningConstant")
+        fun query(): String = "hello!"
     }
 
     class SimpleSubscription : Subscription {


### PR DESCRIPTION
### :pencil: Description

GraphQL specification requires Query type to be present as it is required to run introspection query. Per specification it also shouldn't be possible to generate empty complex types (objects, input objects or interfaces) and they should expose at least a single field. Since root Query type is a special GraphQLObjectType it also has to expose at least a single field.

Breaking changes:
* at least single Query is required when generating the schema
* split `didGenerateQueryType` hook (and corresponding `Mutation` and `Subscription` hooks) into `didGenerateQueryFieldType` (previous functionality) and `didGenerateQueryObjectType` hooks to allow more granular control when generating the schema
* default `SchemaGeneratorHooks` now performs validation of generated object types (including special query, mutation and subscription types), input object types and interfaces to ensure we don't generate empty complex object types

see: https://github.com/graphql/graphql-spec/issues/490 and https://github.com/graphql/graphql-spec/issues/568

### :link: Related Issues
None