### PR TITLE
[build] configure nexus-staging plugin

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,10 +19,12 @@ where "my-new-feature" describes what you're working on.
 You can use Gradle to build all the modules from the root directory
 
 ```shell script
-gradle clean build
+./gradlew clean build
 ```
 
-Or you can navigate to each module to build them individually
+Or you can navigate to each module to build them individually.
+
+> NOTE: in order to ensure you use the right version of Gradle we highly recommend to use the provided wrapper scripts
 
 ## Add tests for any bug fixes or new functionality
 
@@ -33,7 +35,7 @@ We are using [mockk](http://mockk.io), [JUnit](https://junit.org/junit5/), and [
 To run tests use Maven
 
 ```shell script
-gradle check
+./gradlew check
 ```
 
 You can also view the code coverage reports published to Codecov. This validates that our coverage levels are maintained. Links are in the README.
@@ -45,10 +47,10 @@ We are also [ktlint](https://ktlint.github.io/) and [detekt](https://arturbosch.
 These will be run as part of the `validate` phase of a full build but if you want to run them manually you will have to navigate to each module directory and run the command
 
 ```shell script
-gradle ktlintCheck
+./gradlew ktlintCheck
 ```
 ```shell script
-gradle detekt
+./gradlew detekt
 ```
 
 ## Add documentation for new or updated functionality

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,6 +16,7 @@ plugins {
     jacoco
     signing
     `maven-publish`
+    id("io.codearte.nexus-staging")
 }
 
 allprojects {
@@ -180,4 +181,7 @@ tasks {
     jar {
         enabled = false
     }
+    val closeAndReleaseRepository by getting
+    val publish by getting
+    publish.finalizedBy(closeAndReleaseRepository)
 }

--- a/examples/federation/base-app/README.md
+++ b/examples/federation/base-app/README.md
@@ -3,16 +3,22 @@
 One way to run a GraphQL server is with [Spring Boot](https://github.com/spring-projects/spring-boot). This example app uses [Spring Webflux](https://docs.spring.io/spring/docs/current/spring-framework-reference/web-reactive.html) together with `graphql-kotlin` and [graphql-playground](https://github.com/prisma/graphql-playground).
 
 ### Running locally
-Build the application
+Build the application by running the following from examples root directory:
 
 ```bash
-gradle build
+# build all examples
+./gradlew build
+
+# only build federation extended app project
+./gradlew :federation-example:base-app
 ```
+
+> NOTE: in order to ensure you use the right version of Gradle we highly recommend to use the provided wrapper scripts
 
 Start the server:
 
 * Run `Application.kt` directly from your IDE
-* Alternatively you can also use the spring boot maven plugin by running `gradle bootRun` from the command line.
+* Alternatively you can also use the spring boot maven plugin by running `./gradlew ::federation-example:base-app:bootRun` from the command line in the root examples directory.
 
 
 Once the app has started you can explore the example schema by opening Playground endpoint at http://localhost:8080/playground.

--- a/examples/federation/extend-app/README.md
+++ b/examples/federation/extend-app/README.md
@@ -3,16 +3,22 @@
 One way to run a GraphQL server is with [Spring Boot](https://github.com/spring-projects/spring-boot). This example app uses [Spring Webflux](https://docs.spring.io/spring/docs/current/spring-framework-reference/web-reactive.html) together with `graphql-kotlin` and [graphql-playground](https://github.com/prisma/graphql-playground).
 
 ### Running locally
-Build the application
+Build the application by running the following from examples root directory:
 
 ```bash
-gradle build
+# build all examples
+./gradlew build
+
+# only build federation extended app project
+./gradlew :federation-example:extend-app
 ```
+
+> NOTE: in order to ensure you use the right version of Gradle we highly recommend to use the provided wrapper scripts
 
 Start the server:
 
 * Run `Application.kt` directly from your IDE
-* Alternatively you can also use the spring boot maven plugin by running `gradle bootRun` from the command line.
+* Alternatively you can also use the spring boot maven plugin by running `./gradlew :federation-example:extend-app:bootRun` from the command line in the root examples directory.
 
 
 Once the app has started you can explore the example schema by opening Playground endpoint at http://localhost:8080/playground.

--- a/examples/spring/README.md
+++ b/examples/spring/README.md
@@ -4,17 +4,23 @@ One way to run a GraphQL server is with [Spring Boot](https://github.com/spring-
 
 ### Running locally
 
-First you must build all the other modules since this is a multi-module project.
+First you must build all the other necessary modules since this is a multi-module project.
 
-From the root directory:
+From the root examples directory you can run the following:
 
 ```shell script
-gradle build
+# build all examples
+./gradlew build
+
+# only build spring-example project
+./gradlew :spring-example:build
 ```
+
+> NOTE: in order to ensure you use the right version of Gradle we highly recommend to use the provided wrapper scripts
 
 Then to start the server:
 
 * Run `Application.kt` directly from your IDE
-* Alternatively you can also use the spring boot maven plugin by running `gradle bootRun` from the command line in the spring example directory.
+* Alternatively you can also use the spring boot maven plugin by running `./gradlew :spring-example:bootRun` from the command line in the root examples directory.
 
 Once the app has started you can explore the example schema by opening the GraphQL Playground endpoint at http://localhost:8080/playground.

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,3 +26,4 @@ dokkaVersion = 0.10.0
 jacocoVersion = 0.8.5
 ktlintVersion = 0.35.0
 ktlintPluginVersion = 9.1.1
+stagingPluginVersion = 0.21.2

--- a/graphql-kotlin-spring-server/build.gradle.kts
+++ b/graphql-kotlin-spring-server/build.gradle.kts
@@ -2,7 +2,7 @@ description = "Spring Boot autoconfiguration library for creating reactive Graph
 
 plugins {
     id("org.jetbrains.kotlin.plugin.spring")
-    kotlin("kapt")
+    id("org.jetbrains.kotlin.kapt")
 }
 
 val kotlinCoroutinesVersion: String by project

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,14 +4,17 @@ pluginManagement {
     val kotlinVersion: String by settings
     val ktlintPluginVersion: String by settings
     val springBootVersion: String by settings
+    val stagingPluginVersion: String by settings
 
     plugins {
         id("org.jetbrains.kotlin.jvm") version kotlinVersion
+        id("org.jetbrains.kotlin.kapt") version kotlinVersion
         id("org.jetbrains.kotlin.plugin.spring") version kotlinVersion
         id("io.gitlab.arturbosch.detekt") version detektVersion
         id("org.jlleitschuh.gradle.ktlint") version ktlintPluginVersion
         id("org.jetbrains.dokka") version dokkaVersion
         id("org.springframework.boot") version springBootVersion
+        id("io.codearte.nexus-staging") version stagingPluginVersion
     }
 }
 


### PR DESCRIPTION
### :pencil: Description

`maven-publish` plugin only uploads to nexus staging but does not release the artifacts which means ithe release process requires an extra manual step (i.e. log into nexus web ui and release). `nexus-staging` plugin automates this proces by allowing you to automatically release published artifacts to nexus (i.e. similar to what maven `nexus-staging-maven-plugin`).

Updated build process so the `publish` task is finalized by `closeAndReleaseRepository` task.

### :link: Related Issues
