### PR TITLE
[build] add missing credentials to nexus-staging plugin config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           NEW_VERSION=$(echo "${GITHUB_REF}" | cut -d "/" -f3)
           echo "New version: ${NEW_VERSION}"
-          ./gradlew publish -Pversion=${NEW_VERSION}
+          ./gradlew publish closeAndReleaseRepository -Pversion=${NEW_VERSION}
         env:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -181,7 +181,9 @@ tasks {
     jar {
         enabled = false
     }
-    val closeAndReleaseRepository by getting
-    val publish by getting
-    publish.finalizedBy(closeAndReleaseRepository)
+    nexusStaging {
+        serverUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        username = System.getenv("SONATYPE_USERNAME")
+        password = System.getenv("SONATYPE_PASSWORD")
+    }
 }


### PR DESCRIPTION
### :pencil: Description

Also changes release workflow to an explicit task invocation.

### :link: Related Issues
