### PR TITLE
[build] apply nexus-publish plugin to explicitly create sonatype staging

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,8 @@
 
+import de.marcphilipp.gradle.nexus.NexusPublishExtension
 import io.gitlab.arturbosch.detekt.detekt
 import org.jetbrains.dokka.gradle.DokkaTask
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-import java.net.URI
 import java.time.Instant
 
 description = "Libraries for running a GraphQL server in Kotlin"
@@ -16,6 +16,7 @@ plugins {
     jacoco
     signing
     `maven-publish`
+    id("de.marcphilipp.nexus-publish") apply false
     id("io.codearte.nexus-staging")
 }
 
@@ -53,7 +54,17 @@ subprojects {
     apply(plugin = "java-library")
     apply(plugin = "org.jetbrains.dokka")
     apply(plugin = "maven-publish")
+    apply(plugin = "de.marcphilipp.nexus-publish")
     apply(plugin = "signing")
+
+    configure<NexusPublishExtension> {
+        repositories {
+            sonatype {
+                username.set(System.getenv("SONATYPE_USERNAME"))
+                password.set(System.getenv("SONATYPE_PASSWORD"))
+            }
+        }
+    }
 
     tasks.withType<KotlinCompile> {
         kotlinOptions {
@@ -106,16 +117,6 @@ subprojects {
             dependsOn(dokka.path)
         }
         publishing {
-            repositories {
-                maven {
-                    name = "ossrh"
-                    url = URI.create("https://oss.sonatype.org/service/local/staging/deploy/maven2/")
-                    credentials {
-                        username = System.getenv("SONATYPE_USERNAME")
-                        password = System.getenv("SONATYPE_PASSWORD")
-                    }
-                }
-            }
             publications {
                 create<MavenPublication>("mavenJava") {
                     pom {

--- a/docs/contributors/release-proc.md
+++ b/docs/contributors/release-proc.md
@@ -2,14 +2,16 @@
 id: release-proc
 title: Releasing a new version
 ---
-1. The `pom.xml` should already be `${currentVersion}-SNAPSHOT`
 
-2. Draft a new release and tag the commit (usually just `master`) you want to release as `${currentVersion}` or
-   increment to a new major/minor version https://github.com/ExpediaDotCom/graphql-kotlin/releases
-    - When drafting a new release, look at the commit history and comment any new features that were made
-    - Travis will automatically build on a new tag, change the pom to remove `-SNAPSHOT`, and push the library to Maven
-      Central
-    - Travis will create a new branch that bumps the version in both the library and example to
-      `${nextVersion}-SNAPSHOT`
+In order to [release a new version](https://github.com/ExpediaDotCom/graphql-kotlin/releases) we simply need to draft a new release
+and tag the commit. Releases are following [semantic versioning](https://semver.org/) and specify major, minor and patch version.
 
-3. Create a new PR for the Travis branch for the snapshot updates
+Once release is published it will trigger corresponding [Github Action](https://github.com/ExpediaGroup/graphql-kotlin/blob/master/.github/workflows/release.yml)
+based on the published release event. Release workflow will then proceed to build and publish all library artifacts to [Maven Central](https://central.sonatype.org/).
+
+### Release requirements
+
+* tag should specify newly released library version that is following [semantic versioning](https://semver.org/)
+* tag and release name should match
+* release should contain the information about all the change sets that were included in the given release. We are using `release-drafter` to help automatically
+collect this information and generate automatic release notes.

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,4 +26,5 @@ dokkaVersion = 0.10.0
 jacocoVersion = 0.8.5
 ktlintVersion = 0.35.0
 ktlintPluginVersion = 9.1.1
+nexusPublishPluginVersion = 0.3.0
 stagingPluginVersion = 0.21.2

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,6 +3,7 @@ pluginManagement {
     val dokkaVersion: String by settings
     val kotlinVersion: String by settings
     val ktlintPluginVersion: String by settings
+    val nexusPublishPluginVersion: String by settings
     val springBootVersion: String by settings
     val stagingPluginVersion: String by settings
 
@@ -15,6 +16,7 @@ pluginManagement {
         id("org.jetbrains.dokka") version dokkaVersion
         id("org.springframework.boot") version springBootVersion
         id("io.codearte.nexus-staging") version stagingPluginVersion
+        id("de.marcphilipp.nexus-publish") version nexusPublishPluginVersion
     }
 }
 


### PR DESCRIPTION
### :pencil: Description

Currently Gradle publish task is not using staging repository ID when publishing to Sonatype Maven Central (see: https://github.com/gradle/gradle/issues/5711). Furthermore, Gradle publish does not automatically release artifacts from Sonatype staging directory and requires manual step to finalize the release (i.e. log in to Sonatype repository and release uploaded staged artifacts).

As a workaround, in order to automatically publish to Maven Central we need to apply:
* `nexus-publish-plugin` - to explicitly create Sonatype staging ID prior to publishing artifacts (needed by `nexus-staging-plugin` to work reliably)
* `nexus-staging-plugin` - to explicitly close and release libs triggering the automatic Maven Central release

NOTE: It appears that shortcomings of Gradle `maven-publish` plugin are due to their preference of JCenter repository. Based on the documentation it should be possible to configure JCenter to automatically publish staged artifacts and subsequently sync them with Maven Central. If we ever update to publish to JCenter instead we should be able to simplify the build and remove those additional plugins.

### :link: Related Issues
