### PR TITLE
Upgrade to graphql-java 14

### DIFF
--- a/examples/spring/src/test/kotlin/com/expediagroup/graphql/examples/query/PolymorphicQueryIT.kt
+++ b/examples/spring/src/test/kotlin/com/expediagroup/graphql/examples/query/PolymorphicQueryIT.kt
@@ -82,7 +82,8 @@ class PolymorphicQueryIT(@Autowired private val testClient: WebTestClient) {
             .exchange()
             .expectStatus().isOk
             .verifyError("Validation error of type WrongType: " +
-                "argument 'type' with value 'EnumValue{name='$unknownType'}' is not a valid 'AnimalType' @ 'animal'")
+                "argument 'type' with value 'EnumValue{name='$unknownType'}' is not a valid 'AnimalType' - " +
+                "Expected enum literal value not in allowable values -  'EnumValue{name='HELLO'}'. @ 'animal'")
     }
 
     @Test

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ org.gradle.parallel=true
 kotlinVersion = 1.3.50
 kotlinCoroutinesVersion = 1.3.2
 
-graphQLJavaVersion = 13.0
+graphQLJavaVersion = 14.0
 jacksonVersion = 2.10.1
 springBootVersion = 2.2.1.RELEASE
 classGraphVersion = 4.8.53

--- a/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/FederatedSchemaGeneratorHooks.kt
+++ b/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/FederatedSchemaGeneratorHooks.kt
@@ -51,8 +51,8 @@ import kotlin.reflect.full.findAnnotation
  * Hooks for generating federated GraphQL schema.
  */
 open class FederatedSchemaGeneratorHooks(private val federatedTypeRegistry: FederatedTypeRegistry) : SchemaGeneratorHooks {
-    private val directiveDefinitionRegex = "(^#.+$[\\r\\n])?^directive @\\w+.+$[\\r\\n]*".toRegex(setOf(RegexOption.MULTILINE, RegexOption.IGNORE_CASE))
-    private val scalarDefinitionRegex = "(^#.+$[\\r\\n])?^scalar (_FieldSet|_Any)$[\\r\\n]*".toRegex(setOf(RegexOption.MULTILINE, RegexOption.IGNORE_CASE))
+    private val directiveDefinitionRegex = "(^\".+\"$[\\r\\n])?^directive @\\w+.+\$[\\r\\n]*".toRegex(setOf(RegexOption.MULTILINE, RegexOption.IGNORE_CASE))
+    private val scalarDefinitionRegex = "(^\".+\"$[\\r\\n])?^scalar (_FieldSet|_Any)$[\\r\\n]*".toRegex(setOf(RegexOption.MULTILINE, RegexOption.IGNORE_CASE))
     private val emptyQueryRegex = "^type Query \\{$\\s+^\\}$\\s+".toRegex(setOf(RegexOption.MULTILINE, RegexOption.IGNORE_CASE))
     private val validator = FederatedSchemaValidator()
 

--- a/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/FederatedSchemaGeneratorHooks.kt
+++ b/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/FederatedSchemaGeneratorHooks.kt
@@ -17,9 +17,14 @@
 package com.expediagroup.graphql.federation
 
 import com.expediagroup.graphql.annotations.GraphQLName
+import com.expediagroup.graphql.directives.DEPRECATED_DIRECTIVE_NAME
 import com.expediagroup.graphql.extensions.print
+import com.expediagroup.graphql.federation.directives.EXTENDS_DIRECTIVE_NAME
+import com.expediagroup.graphql.federation.directives.EXTERNAL_DIRECTIVE_NAME
 import com.expediagroup.graphql.federation.directives.FieldSet
 import com.expediagroup.graphql.federation.directives.KEY_DIRECTIVE_NAME
+import com.expediagroup.graphql.federation.directives.PROVIDES_DIRECTIVE_NAME
+import com.expediagroup.graphql.federation.directives.REQUIRES_DIRECTIVE_NAME
 import com.expediagroup.graphql.federation.directives.extendsDirectiveType
 import com.expediagroup.graphql.federation.execution.EntityResolver
 import com.expediagroup.graphql.federation.execution.FederatedTypeRegistry
@@ -34,9 +39,11 @@ import graphql.TypeResolutionEnvironment
 import graphql.schema.DataFetcher
 import graphql.schema.FieldCoordinates
 import graphql.schema.GraphQLCodeRegistry
+import graphql.schema.GraphQLDirective
 import graphql.schema.GraphQLObjectType
 import graphql.schema.GraphQLSchema
 import graphql.schema.GraphQLType
+import java.util.function.Predicate
 import kotlin.reflect.KType
 import kotlin.reflect.full.findAnnotation
 
@@ -45,11 +52,12 @@ import kotlin.reflect.full.findAnnotation
  */
 open class FederatedSchemaGeneratorHooks(private val federatedTypeRegistry: FederatedTypeRegistry) : SchemaGeneratorHooks {
     private val directiveDefinitionRegex = "(^#.+$[\\r\\n])?^directive @\\w+.+$[\\r\\n]*".toRegex(setOf(RegexOption.MULTILINE, RegexOption.IGNORE_CASE))
-    private val customDirectivesRegex = "\\s*@(?!extends)(?!external)(?!key)(?!provides)(?!requires)(?!deprecated)\\w+(?:\\(.*(?=\\))\\))?".toRegex(
-        setOf(RegexOption.MULTILINE, RegexOption.IGNORE_CASE))
     private val scalarDefinitionRegex = "(^#.+$[\\r\\n])?^scalar (_FieldSet|_Any)$[\\r\\n]*".toRegex(setOf(RegexOption.MULTILINE, RegexOption.IGNORE_CASE))
     private val emptyQueryRegex = "^type Query \\{$\\s+^\\}$\\s+".toRegex(setOf(RegexOption.MULTILINE, RegexOption.IGNORE_CASE))
     private val validator = FederatedSchemaValidator()
+
+    private val directivesToInclude = listOf(EXTENDS_DIRECTIVE_NAME, EXTERNAL_DIRECTIVE_NAME, KEY_DIRECTIVE_NAME, PROVIDES_DIRECTIVE_NAME, REQUIRES_DIRECTIVE_NAME, DEPRECATED_DIRECTIVE_NAME)
+    private val customDirectivePredicate: Predicate<GraphQLDirective> = Predicate { directivesToInclude.contains(it.name) }
 
     override fun willGenerateGraphQLType(type: KType): GraphQLType? = when (type.classifier) {
         FieldSet::class -> FIELD_SET_SCALAR_TYPE
@@ -79,14 +87,13 @@ open class FederatedSchemaGeneratorHooks(private val federatedTypeRegistry: Fede
          * - any custom directives
          * - new federated scalars
          */
-        val sdl = originalSchema.print(includeDefaultSchemaDefinition = false)
+        val sdl = originalSchema.print(includeDefaultSchemaDefinition = false, includeDirectivesFilter = customDirectivePredicate)
             /**
-             * TODO: this can be simplified once this is solved: apollographql/apollo-server#3334
+             * TODO: this can be simplified once this is solved: https://github.com/apollographql/apollo-server/issues/3334
              */
             .replace(directiveDefinitionRegex, "")
             .replace(scalarDefinitionRegex, "")
             .replace(emptyQueryRegex, "")
-            .replace(customDirectivesRegex, "")
             .trim()
         federatedCodeRegistry.dataFetcher(FieldCoordinates.coordinates(originalQuery.name, SERVICE_FIELD_DEFINITION.name), DataFetcher { _Service(sdl) })
 

--- a/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/FederatedSchemaGeneratorTest.kt
+++ b/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/FederatedSchemaGeneratorTest.kt
@@ -32,21 +32,36 @@ private const val FEDERATED_SDL = """schema {
   query: Query
 }
 
-#Marks target field as external meaning it will be resolved by federated schema
+"Directs the executor to include this field or fragment only when the `if` argument is true"
+directive @include(
+    "Included when true."
+    if: Boolean!
+  ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+"Directs the executor to skip this field or fragment when the `if`'argument is true."
+directive @skip(
+    "Skipped when true."
+    if: Boolean!
+  ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+"Marks target field as external meaning it will be resolved by federated schema"
 directive @external on FIELD_DEFINITION
 
-#Marks target object as extending part of the federated schema
+"Marks target object as extending part of the federated schema"
 directive @extends on OBJECT | INTERFACE
 
-#Specifies the base type field set that will be selectable by the gateway
+"Specifies the base type field set that will be selectable by the gateway"
 directive @provides(fields: _FieldSet!) on FIELD_DEFINITION
+
+"Marks the target field/enum value as deprecated"
+directive @deprecated(reason: String = "No longer supported") on FIELD_DEFINITION | ENUM_VALUE
 
 directive @custom on SCHEMA | SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
-#Space separated list of primary keys needed to access federated object
+"Space separated list of primary keys needed to access federated object"
 directive @key(fields: _FieldSet!) on OBJECT | INTERFACE
 
-#Specifies required input field set from the base type for a resolver
+"Specifies required input field set from the base type for a resolver"
 directive @requires(fields: _FieldSet!) on FIELD_DEFINITION
 
 interface Product @extends @key(fields : "id") {
@@ -65,7 +80,7 @@ type Book implements Product @extends @key(fields : "id") {
 }
 
 type Query @extends {
-  #Union of all types that use the @key directive, including both types native to the schema and extended types
+  "Union of all types that use the @key directive, including both types native to the schema and extended types"
   _entities(representations: [_Any!]!): [_Entity]!
   _service: _Service
 }
@@ -85,20 +100,11 @@ type _Service {
   sdl: String!
 }
 
-#Federation scalar type used to represent any external entities passed to _entities query.
+"Federation scalar type used to represent any external entities passed to _entities query."
 scalar _Any
 
-#Federation type representing set of fields
-scalar _FieldSet
-
-#Directs the executor to include this field or fragment only when the `if` argument is true
-directive @include(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
-
-#Directs the executor to skip this field or fragment when the `if`'argument is true.
-directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
-
-#Marks the target field/enum value as deprecated
-directive @deprecated(reason: String = "No longer supported") on FIELD_DEFINITION | ENUM_VALUE"""
+"Federation type representing set of fields"
+scalar _FieldSet"""
 
 class FederatedSchemaGeneratorTest {
 

--- a/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/FederatedSchemaGeneratorTest.kt
+++ b/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/FederatedSchemaGeneratorTest.kt
@@ -79,6 +79,10 @@ type Book implements Product @extends @key(fields : "id") {
   weight: Float! @external
 }
 
+type CustomScalar {
+  value: String!
+}
+
 type Query @extends {
   "Union of all types that use the @key directive, including both types native to the schema and extended types"
   _entities(representations: [_Any!]!): [_Entity]!
@@ -88,6 +92,7 @@ type Query @extends {
 type Review {
   body: String! @custom
   content: String @deprecated(reason : "no longer supported, replace with use Review.body instead")
+  customScalar: CustomScalar!
   id: String!
 }
 

--- a/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/data/queries/federated/Product.kt
+++ b/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/data/queries/federated/Product.kt
@@ -16,6 +16,7 @@
 
 package com.expediagroup.graphql.federation.data.queries.federated
 
+import com.expediagroup.graphql.annotations.GraphQLDescription
 import com.expediagroup.graphql.annotations.GraphQLDirective
 import com.expediagroup.graphql.annotations.GraphQLIgnore
 import com.expediagroup.graphql.federation.directives.ExtendsDirective
@@ -59,7 +60,7 @@ class Book(
     @ExternalDirective
     var weight: Double by Delegates.notNull()
 
-    override fun reviews(): List<Review> = listOf(Review("parent-$id", "Dummy Review $id"))
+    override fun reviews(): List<Review> = listOf(Review(id = "parent-$id", body = "Dummy Review $id", content = null, customScalar = CustomScalar("foo")))
 
     @RequiresDirective(FieldSet("weight"))
     fun shippingCost(): String = "$${weight * 9.99}"
@@ -98,7 +99,8 @@ type Review {
 data class Review(
     val id: String,
     @CustomDirective val body: String,
-    @Deprecated(message = "no longer supported", replaceWith = ReplaceWith("use Review.body instead")) val content: String? = null
+    @Deprecated(message = "no longer supported", replaceWith = ReplaceWith("use Review.body instead")) val content: String? = null,
+    val customScalar: CustomScalar
 )
 
 /*
@@ -115,4 +117,11 @@ data class User(
 )
 
 @GraphQLDirective(name = "custom")
+@GraphQLDescription("""
+    This is a multi-line comment on a custom directive.
+    This should still work multiline and double quotes (") in the description.
+    Line 3.
+""")
 annotation class CustomDirective
+
+class CustomScalar(val value: String)

--- a/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/types/ServiceTest.kt
+++ b/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/types/ServiceTest.kt
@@ -16,6 +16,7 @@
 
 package com.expediagroup.graphql.federation.types
 
+import graphql.Scalars.GraphQLString
 import graphql.schema.GraphQLNonNull
 import graphql.schema.GraphQLObjectType
 import org.junit.jupiter.api.Test
@@ -40,6 +41,6 @@ internal class ServiceTest {
 
         val fieldType = serviceObject.fieldDefinitions.first().type as? GraphQLNonNull
         assertNotNull(fieldType)
-        assertEquals(expected = "String", actual = fieldType.wrappedType.name)
+        assertEquals(expected = GraphQLString, actual = fieldType.wrappedType)
     }
 }

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/directives/KotlinDirectiveWiringFactory.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/directives/KotlinDirectiveWiringFactory.kt
@@ -23,7 +23,7 @@ import graphql.schema.GraphQLCodeRegistry
 import graphql.schema.GraphQLDirective
 import graphql.schema.GraphQLDirectiveContainer
 import graphql.schema.GraphQLFieldDefinition
-import graphql.schema.GraphQLType
+import graphql.schema.GraphQLSchemaElement
 
 /**
  * Wiring factory that is used to provide the directives.
@@ -35,10 +35,10 @@ open class KotlinDirectiveWiringFactory(
     /**
      * Wire up the directive based on the GraphQL type.
      */
-    fun onWire(graphQLType: GraphQLType, coordinates: FieldCoordinates? = null, codeRegistry: GraphQLCodeRegistry.Builder? = null): GraphQLType {
-        if (graphQLType !is GraphQLDirectiveContainer) return graphQLType
+    fun onWire(graphQLSchemaElement: GraphQLSchemaElement, coordinates: FieldCoordinates? = null, codeRegistry: GraphQLCodeRegistry.Builder? = null): GraphQLSchemaElement {
+        if (graphQLSchemaElement !is GraphQLDirectiveContainer) return graphQLSchemaElement
 
-        return wireDirectives(graphQLType, coordinates, graphQLType.getAllDirectives(), codeRegistry)
+        return wireDirectives(graphQLSchemaElement, coordinates, graphQLSchemaElement.getAllDirectives(), codeRegistry)
     }
 
     /**

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/exceptions/CouldNotCastGraphQLSchemaElement.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/exceptions/CouldNotCastGraphQLSchemaElement.kt
@@ -16,11 +16,11 @@
 
 package com.expediagroup.graphql.exceptions
 
-import graphql.schema.GraphQLType
+import graphql.schema.GraphQLSchemaElement
 import kotlin.reflect.KClass
 
 /**
- * Thrown when the casting a GraphQLType to some parent type is invalid
+ * Thrown when the casting a [GraphQLSchemaElement] to some parent type is invalid
  */
-class CouldNotCastGraphQLType(type: GraphQLType, kClass: KClass<*>) :
-    GraphQLKotlinException("Could not cast GraphQLType $type to $kClass")
+class CouldNotCastGraphQLSchemaElement(graphQLSchemaElement: GraphQLSchemaElement, kClass: KClass<*>) :
+    GraphQLKotlinException("Could not cast GraphQLSchemaElement $graphQLSchemaElement to $kClass")

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/extensions/GraphQLSchemaExtensions.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/extensions/GraphQLSchemaExtensions.kt
@@ -16,13 +16,10 @@
 
 package com.expediagroup.graphql.extensions
 
-import com.expediagroup.graphql.directives.DeprecatedDirective
-import graphql.Directives
-import graphql.schema.GraphQLArgument
 import graphql.schema.GraphQLDirective
 import graphql.schema.GraphQLSchema
-import graphql.schema.GraphQLTypeUtil
 import graphql.schema.idl.SchemaPrinter
+import java.util.function.Predicate
 
 /**
  * Prints out SDL representation of a target schema.
@@ -34,46 +31,28 @@ import graphql.schema.idl.SchemaPrinter
  * @param includeDefaultSchemaDefinition boolean flag indicating whether SDL should include schema definition if using
  *   default root type names
  * @param includeDirectives boolean flag indicating whether SDL should include directive information
+ * @param includeDirectivesFilter Predicate to filter out specifc directives. Defaults to filter all directives by the value of [includeDirectives]
+ * @param descriptionsAsHashComments boolean flag indicating whether SDL print the description with # instead of ""
  */
 fun GraphQLSchema.print(
     includeIntrospectionTypes: Boolean = false,
     includeScalarTypes: Boolean = true,
     includeExtendedScalarTypes: Boolean = true,
     includeDefaultSchemaDefinition: Boolean = true,
-    includeDirectives: Boolean = true
+    includeDirectives: Boolean = true,
+    includeDirectivesFilter: Predicate<GraphQLDirective> = Predicate { includeDirectives },
+    descriptionsAsHashComments: Boolean = false
 ): String {
     val schemaPrinter = SchemaPrinter(
         SchemaPrinter.Options.defaultOptions()
             .includeIntrospectionTypes(includeIntrospectionTypes)
             .includeScalarTypes(includeScalarTypes || includeExtendedScalarTypes)
             .includeExtendedScalarTypes(includeExtendedScalarTypes)
-            .includeSchemaDefintion(includeDefaultSchemaDefinition)
+            .includeSchemaDefinition(includeDefaultSchemaDefinition)
             .includeDirectives(includeDirectives)
+            .includeDirectives(includeDirectivesFilter)
+            .descriptionsAsHashComments(descriptionsAsHashComments)
     )
 
-    var schemaString = schemaPrinter.print(this)
-    if (includeDirectives) {
-        // graphql-java SchemaPrinter filters out common directives, below is a workaround to print default built-in directives
-        val defaultDirectives = arrayOf(Directives.IncludeDirective, Directives.SkipDirective, DeprecatedDirective)
-        val directivesToString = defaultDirectives.joinToString("\n\n") { directive -> """
-                #${directive.description}
-                directive @${directive.name}${parseDirectiveArguments(directive)} on ${directive.validLocations().joinToString(" | ") { loc -> loc.name }}
-            """.trimIndent()
-        }
-        schemaString += "\n" + directivesToString
-    }
-    return schemaString
-}
-
-private fun parseDirectiveArguments(directive: GraphQLDirective) = if (directive.arguments.isNotEmpty()) {
-    """(${directive.arguments.joinToString(", ") { argument ->
-        "${argument.name}: ${GraphQLTypeUtil.simplePrint(argument.type)}${parseDirectiveArgumentValue(argument)}" }})"""
-} else {
-    ""
-}
-
-private fun parseDirectiveArgumentValue(argument: GraphQLArgument) = if (null != argument.defaultValue) {
-    " = \"${argument.defaultValue}\""
-} else {
-    ""
+    return schemaPrinter.print(this)
 }

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/extensions/GraphQLSchemaExtensions.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/extensions/GraphQLSchemaExtensions.kt
@@ -32,7 +32,6 @@ import java.util.function.Predicate
  *   default root type names
  * @param includeDirectives boolean flag indicating whether SDL should include directive information
  * @param includeDirectivesFilter Predicate to filter out specifc directives. Defaults to filter all directives by the value of [includeDirectives]
- * @param descriptionsAsHashComments boolean flag indicating whether SDL print the description with # instead of ""
  */
 fun GraphQLSchema.print(
     includeIntrospectionTypes: Boolean = false,
@@ -40,8 +39,7 @@ fun GraphQLSchema.print(
     includeExtendedScalarTypes: Boolean = true,
     includeDefaultSchemaDefinition: Boolean = true,
     includeDirectives: Boolean = true,
-    includeDirectivesFilter: Predicate<GraphQLDirective> = Predicate { includeDirectives },
-    descriptionsAsHashComments: Boolean = false
+    includeDirectivesFilter: Predicate<GraphQLDirective> = Predicate { includeDirectives }
 ): String {
     val schemaPrinter = SchemaPrinter(
         SchemaPrinter.Options.defaultOptions()
@@ -51,7 +49,6 @@ fun GraphQLSchema.print(
             .includeSchemaDefinition(includeDefaultSchemaDefinition)
             .includeDirectives(includeDirectives)
             .includeDirectives(includeDirectivesFilter)
-            .descriptionsAsHashComments(descriptionsAsHashComments)
     )
 
     return schemaPrinter.print(this)

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/extensions/graphQLExtensions.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/extensions/graphQLExtensions.kt
@@ -16,11 +16,12 @@
 
 package com.expediagroup.graphql.generator.extensions
 
-import com.expediagroup.graphql.exceptions.CouldNotCastGraphQLType
+import com.expediagroup.graphql.exceptions.CouldNotCastGraphQLSchemaElement
 import graphql.schema.GraphQLDirective
 import graphql.schema.GraphQLDirectiveContainer
 import graphql.schema.GraphQLFieldDefinition
 import graphql.schema.GraphQLNonNull
+import graphql.schema.GraphQLSchemaElement
 import graphql.schema.GraphQLType
 import kotlin.reflect.KType
 
@@ -34,9 +35,9 @@ internal fun GraphQLType.wrapInNonNull(type: KType): GraphQLType = when {
     else -> GraphQLNonNull.nonNull(this)
 }
 
-@Throws(CouldNotCastGraphQLType::class)
-internal inline fun <reified T : GraphQLType> GraphQLType.safeCast(): T {
-    if (this !is T) throw CouldNotCastGraphQLType(this, T::class)
+@Throws(CouldNotCastGraphQLSchemaElement::class)
+internal inline fun <reified T : GraphQLSchemaElement> GraphQLSchemaElement.safeCast(): T {
+    if (this !is T) throw CouldNotCastGraphQLSchemaElement(this, T::class)
     return this
 }
 

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/state/KGraphQLType.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/state/KGraphQLType.kt
@@ -16,10 +16,10 @@
 
 package com.expediagroup.graphql.generator.state
 
-import graphql.schema.GraphQLType
+import graphql.schema.GraphQLNamedType
 import kotlin.reflect.KClass
 
 /**
  * Container for the types cache information.
  */
-internal data class KGraphQLType(val kClass: KClass<*>, val graphQLType: GraphQLType)
+internal data class KGraphQLType(val kClass: KClass<*>, val graphQLType: GraphQLNamedType)

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/state/TypesCache.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/state/TypesCache.kt
@@ -22,6 +22,7 @@ import com.expediagroup.graphql.generator.extensions.getKClass
 import com.expediagroup.graphql.generator.extensions.getSimpleName
 import com.expediagroup.graphql.generator.extensions.isListType
 import com.expediagroup.graphql.generator.extensions.qualifiedName
+import graphql.schema.GraphQLNamedType
 import graphql.schema.GraphQLType
 import graphql.schema.GraphQLTypeReference
 import kotlin.reflect.KClass
@@ -35,7 +36,7 @@ internal class TypesCache(private val supportedPackages: List<String>) {
     private val typesUnderConstruction: MutableSet<TypesCacheKey> = mutableSetOf()
 
     @Throws(ConflictingTypesException::class)
-    internal fun get(cacheKey: TypesCacheKey): GraphQLType? {
+    internal fun get(cacheKey: TypesCacheKey): GraphQLNamedType? {
         val cacheKeyString = getCacheKeyString(cacheKey) ?: return null
         val cachedType = cache[cacheKeyString]
 
@@ -67,7 +68,7 @@ internal class TypesCache(private val supportedPackages: List<String>) {
      */
     internal fun clear() = cache.clear()
 
-    internal fun doesNotContainGraphQLType(graphQLType: GraphQLType) =
+    internal fun doesNotContainGraphQLType(graphQLType: GraphQLNamedType) =
         cache.none { (_, v) -> v.graphQLType.name == graphQLType.name }
 
     /**
@@ -101,7 +102,7 @@ internal class TypesCache(private val supportedPackages: List<String>) {
             else -> {
                 typesUnderConstruction.add(cacheKey)
                 val newType = build(kClass)
-                if (newType !is GraphQLTypeReference) {
+                if (newType !is GraphQLTypeReference && newType is GraphQLNamedType) {
                     put(cacheKey, KGraphQLType(kClass, newType))
                 }
                 typesUnderConstruction.remove(cacheKey)

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/hooks/SchemaGeneratorHooks.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/hooks/SchemaGeneratorHooks.kt
@@ -30,6 +30,7 @@ import graphql.schema.GraphQLInputObjectType
 import graphql.schema.GraphQLInterfaceType
 import graphql.schema.GraphQLObjectType
 import graphql.schema.GraphQLSchema
+import graphql.schema.GraphQLSchemaElement
 import graphql.schema.GraphQLType
 import graphql.schema.GraphQLTypeUtil
 import kotlin.reflect.KClass
@@ -94,7 +95,7 @@ interface SchemaGeneratorHooks {
      * Called after `willGenerateGraphQLType` and before `didGenerateGraphQLType`.
      * Enables you to change the wiring, e.g. apply directives to alter the target type.
      */
-    fun onRewireGraphQLType(generatedType: GraphQLType, coordinates: FieldCoordinates? = null, codeRegistry: GraphQLCodeRegistry.Builder? = null): GraphQLType =
+    fun onRewireGraphQLType(generatedType: GraphQLSchemaElement, coordinates: FieldCoordinates? = null, codeRegistry: GraphQLCodeRegistry.Builder? = null): GraphQLSchemaElement =
         wiringFactory.onWire(generatedType, coordinates, codeRegistry)
 
     /**

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/extensions/DeepNameKtTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/extensions/DeepNameKtTest.kt
@@ -17,24 +17,18 @@
 package com.expediagroup.graphql.extensions
 
 import graphql.schema.GraphQLList
+import graphql.schema.GraphQLNamedType
 import graphql.schema.GraphQLNonNull
-import graphql.schema.GraphQLType
-import graphql.schema.GraphQLTypeVisitor
-import graphql.util.TraversalControl
-import graphql.util.TraverserContext
+import io.mockk.every
+import io.mockk.mockk
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 internal class DeepNameKtTest {
 
-    private class BasicType : GraphQLType {
-        override fun getName() = "BasicType"
-
-        override fun accept(context: TraverserContext<GraphQLType>, visitor: GraphQLTypeVisitor): TraversalControl =
-            context.thisNode().accept(context, visitor)
+    private val basicType = mockk<GraphQLNamedType> {
+        every { name } returns "BasicType"
     }
-
-    private val basicType = BasicType()
 
     @Test
     fun `deepname of basic type`() {

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/extensions/GraphQLSchemaExtensionsTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/extensions/GraphQLSchemaExtensionsTest.kt
@@ -200,16 +200,16 @@ class GraphQLSchemaExtensionsTest {
 
         val sdl = schema.print(includeDefaultSchemaDefinition = false, includeDirectives = false).trim()
         val expected = """
-            #documented type
+            "documented type"
             type DocumentedType {
-              #documented property
+              "documented property"
               id: Int!
             }
 
             type Query {
-              #documented query
+              "documented query"
               documented(
-                #documented argument
+                "documented argument"
                 id: Int!
               ): DocumentedType!
             }
@@ -257,6 +257,21 @@ class GraphQLSchemaExtensionsTest {
 
         val sdl = schema.print(includeDefaultSchemaDefinition = false).trim()
         val expected = """
+            "Directs the executor to include this field or fragment only when the `if` argument is true"
+            directive @include(
+                "Included when true."
+                if: Boolean!
+              ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+            "Directs the executor to skip this field or fragment when the `if`'argument is true."
+            directive @skip(
+                "Skipped when true."
+                if: Boolean!
+              ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+            "Marks the target field/enum value as deprecated"
+            directive @deprecated(reason: String = "No longer supported") on FIELD_DEFINITION | ENUM_VALUE
+
             directive @customDirective on FIELD_DEFINITION
 
             type ClassWithDirective {
@@ -278,15 +293,6 @@ class GraphQLSchemaExtensionsTest {
               THREE @deprecated(reason : "deprecated enum value, replace with ONE")
               TWO @deprecated(reason : "deprecated enum value")
             }
-
-            #Directs the executor to include this field or fragment only when the `if` argument is true
-            directive @include(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
-
-            #Directs the executor to skip this field or fragment when the `if`'argument is true.
-            directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
-
-            #Marks the target field/enum value as deprecated
-            directive @deprecated(reason: String = "No longer supported") on FIELD_DEFINITION | ENUM_VALUE
         """.trimIndent()
         assertEquals(expected, sdl)
     }

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/SchemaGeneratorAsyncTests.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/SchemaGeneratorAsyncTests.kt
@@ -21,6 +21,7 @@ import com.expediagroup.graphql.getTestSchemaConfigWithHooks
 import com.expediagroup.graphql.hooks.SchemaGeneratorHooks
 import com.expediagroup.graphql.testSchemaConfig
 import com.expediagroup.graphql.toSchema
+import graphql.schema.GraphQLNamedType
 import graphql.schema.GraphQLNonNull
 import io.reactivex.Maybe
 import io.reactivex.Observable
@@ -29,6 +30,8 @@ import org.junit.jupiter.api.Test
 import java.util.concurrent.CompletableFuture
 import kotlin.reflect.KType
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 class SchemaGeneratorAsyncTests {
 
@@ -44,33 +47,41 @@ class SchemaGeneratorAsyncTests {
     @Test
     fun `SchemaGenerator strips type argument from CompletableFuture to support async servlet`() {
         val schema = toSchema(queries = listOf(TopLevelObject(AsyncQuery())), config = testSchemaConfig)
-        val returnTypeName =
-            (schema.getObjectType("Query").getFieldDefinition("asynchronouslyDo").type as? GraphQLNonNull)?.wrappedType?.name
-        assertEquals("Int", returnTypeName)
+        val returnType =
+            (schema.getObjectType("Query").getFieldDefinition("asynchronouslyDo").type as? GraphQLNonNull)?.wrappedType
+        assertNotNull(returnType)
+        assertTrue(returnType is GraphQLNamedType)
+        assertEquals("Int", returnType.name)
     }
 
     @Test
     fun `SchemaGenerator strips type argument from RxJava2 Observable`() {
         val schema = toSchema(queries = listOf(TopLevelObject(RxJava2Query())), config = configWithRxJavaMonads)
-        val returnTypeName =
-            (schema.getObjectType("Query").getFieldDefinition("asynchronouslyDo").type as? GraphQLNonNull)?.wrappedType?.name
-        assertEquals("Int", returnTypeName)
+        val returnType =
+            (schema.getObjectType("Query").getFieldDefinition("asynchronouslyDo").type as? GraphQLNonNull)?.wrappedType
+        assertNotNull(returnType)
+        assertTrue(returnType is GraphQLNamedType)
+        assertEquals("Int", returnType.name)
     }
 
     @Test
     fun `SchemaGenerator strips type argument from RxJava2 Single`() {
         val schema = toSchema(queries = listOf(TopLevelObject(RxJava2Query())), config = configWithRxJavaMonads)
-        val returnTypeName =
-            (schema.getObjectType("Query").getFieldDefinition("asynchronouslyDoSingle").type as? GraphQLNonNull)?.wrappedType?.name
-        assertEquals("Int", returnTypeName)
+        val returnType =
+            (schema.getObjectType("Query").getFieldDefinition("asynchronouslyDoSingle").type as? GraphQLNonNull)?.wrappedType
+        assertNotNull(returnType)
+        assertTrue(returnType is GraphQLNamedType)
+        assertEquals("Int", returnType.name)
     }
 
     @Test
     fun `SchemaGenerator strips type argument from RxJava2 Maybe`() {
         val schema = toSchema(queries = listOf(TopLevelObject(RxJava2Query())), config = configWithRxJavaMonads)
-        val returnTypeName =
-            (schema.getObjectType("Query").getFieldDefinition("maybe").type as? GraphQLNonNull)?.wrappedType?.name
-        assertEquals("Int", returnTypeName)
+        val returnType =
+            (schema.getObjectType("Query").getFieldDefinition("maybe").type as? GraphQLNonNull)?.wrappedType
+        assertNotNull(returnType)
+        assertTrue(returnType is GraphQLNamedType)
+        assertEquals("Int", returnType.name)
     }
 
     class AsyncQuery {

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/extensions/GraphQLExtensionsTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/extensions/GraphQLExtensionsTest.kt
@@ -16,18 +16,16 @@
 
 package com.expediagroup.graphql.generator.extensions
 
-import com.expediagroup.graphql.exceptions.CouldNotCastGraphQLType
+import com.expediagroup.graphql.exceptions.CouldNotCastGraphQLSchemaElement
 import graphql.schema.GraphQLArgument
 import graphql.schema.GraphQLDirective
 import graphql.schema.GraphQLDirectiveContainer
 import graphql.schema.GraphQLFieldDefinition
 import graphql.schema.GraphQLInterfaceType
+import graphql.schema.GraphQLNamedType
 import graphql.schema.GraphQLNonNull
 import graphql.schema.GraphQLObjectType
 import graphql.schema.GraphQLType
-import graphql.schema.GraphQLTypeVisitor
-import graphql.util.TraversalControl
-import graphql.util.TraverserContext
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.Test
@@ -40,14 +38,9 @@ import kotlin.test.assertTrue
 @Suppress("Detekt.LargeClass")
 internal class GraphQLExtensionsTest {
 
-    private class BasicType : GraphQLType {
-        override fun getName() = "BasicType"
-
-        override fun accept(context: TraverserContext<GraphQLType>, visitor: GraphQLTypeVisitor): TraversalControl =
-            context.thisNode().accept(context, visitor)
+    private val basicType = mockk<GraphQLNamedType> {
+        every { name } returns "BasicType"
     }
-
-    private val basicType = BasicType()
     private val mockDirective: GraphQLDirective = mockk()
 
     @Test
@@ -125,10 +118,10 @@ internal class GraphQLExtensionsTest {
 
     @Test
     fun `safeCast with GraphQLType passes`() {
-        val type: GraphQLType = mockk()
+        val type: GraphQLNamedType = mockk()
         every { type.name } returns "foo"
 
-        val castedType = type.safeCast<GraphQLType>()
+        val castedType = type.safeCast<GraphQLNamedType>()
         assertEquals("foo", castedType.name)
     }
 
@@ -144,7 +137,7 @@ internal class GraphQLExtensionsTest {
     fun `safeCast valid type to the wrong type fails`() {
         val type: GraphQLType = GraphQLObjectType.newObject().name("name").description("description").build()
 
-        assertFailsWith(CouldNotCastGraphQLType::class) {
+        assertFailsWith(CouldNotCastGraphQLSchemaElement::class) {
             type.safeCast<GraphQLInterfaceType>()
         }
     }

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/state/KGraphQLTypeTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/state/KGraphQLTypeTest.kt
@@ -16,10 +16,8 @@
 
 package com.expediagroup.graphql.generator.state
 
-import graphql.schema.GraphQLType
-import graphql.schema.GraphQLTypeVisitor
-import graphql.util.TraversalControl
-import graphql.util.TraverserContext
+import graphql.schema.GraphQLNamedType
+import io.mockk.mockk
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
@@ -27,11 +25,7 @@ internal class KGraphQLTypeTest {
 
     @Suppress("Detekt.UnusedPrivateClass")
     private data class MyType(val id: Int = 0)
-    private val graphQLType = object : GraphQLType {
-        override fun getName(): String = "MyType"
-
-        override fun accept(context: TraverserContext<GraphQLType>, visitor: GraphQLTypeVisitor): TraversalControl = context.thisNode().accept(context, visitor)
-    }
+    private val graphQLType: GraphQLNamedType = mockk()
 
     @Test
     fun `properties are set`() {

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/state/TypesCacheTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/state/TypesCacheTest.kt
@@ -16,10 +16,9 @@
 
 package com.expediagroup.graphql.generator.state
 
-import graphql.schema.GraphQLType
-import graphql.schema.GraphQLTypeVisitor
-import graphql.util.TraversalControl
-import graphql.util.TraverserContext
+import graphql.schema.GraphQLNamedType
+import io.mockk.every
+import io.mockk.mockk
 import org.junit.jupiter.api.Test
 import kotlin.reflect.full.findParameterByName
 import kotlin.reflect.full.starProjectedType
@@ -33,16 +32,12 @@ class TypesCacheTest {
 
     internal data class MyType(val id: Int = 0)
 
-    private val graphQLType: GraphQLType = object : GraphQLType {
-        override fun getName(): String = "MyType"
-
-        override fun accept(context: TraverserContext<GraphQLType>, visitor: GraphQLTypeVisitor): TraversalControl = context.thisNode().accept(context, visitor)
+    private val graphQLType: GraphQLNamedType = mockk {
+        every { name } returns "MyType"
     }
 
-    private val secondGraphQLType: GraphQLType = object : GraphQLType {
-        override fun getName(): String = "MySecondType"
-
-        override fun accept(context: TraverserContext<GraphQLType>, visitor: GraphQLTypeVisitor): TraversalControl = context.thisNode().accept(context, visitor)
+    private val secondGraphQLType: GraphQLNamedType = mockk {
+        every { name } returns "MySecondType"
     }
 
     internal class MyClass {

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/GenerateArgumentTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/GenerateArgumentTest.kt
@@ -22,6 +22,7 @@ import com.expediagroup.graphql.annotations.GraphQLName
 import com.expediagroup.graphql.exceptions.InvalidInputFieldTypeException
 import com.expediagroup.graphql.test.utils.SimpleDirective
 import graphql.Scalars
+import graphql.Scalars.GraphQLString
 import graphql.schema.GraphQLList
 import graphql.schema.GraphQLNonNull
 import graphql.schema.GraphQLTypeUtil
@@ -61,7 +62,7 @@ internal class GenerateArgumentTest : TypeTestHelper() {
         assertNotNull(kParameter)
         val result = generateArgument(generator, kParameter)
 
-        assertEquals("String", (result.type as? GraphQLNonNull)?.wrappedType?.name)
+        assertEquals(GraphQLString, (result.type as? GraphQLNonNull)?.wrappedType)
         assertEquals("Argument description", result.description)
     }
 
@@ -71,7 +72,7 @@ internal class GenerateArgumentTest : TypeTestHelper() {
         assertNotNull(kParameter)
         val result = generateArgument(generator, kParameter)
 
-        assertEquals("String", (result.type as? GraphQLNonNull)?.wrappedType?.name)
+        assertEquals(GraphQLString, (result.type as? GraphQLNonNull)?.wrappedType)
         assertEquals(1, result.directives.size)
         assertEquals("simpleDirective", result.directives.firstOrNull()?.name)
     }
@@ -82,7 +83,7 @@ internal class GenerateArgumentTest : TypeTestHelper() {
         assertNotNull(kParameter)
         val result = generateArgument(generator, kParameter)
 
-        assertEquals("String", (result.type as? GraphQLNonNull)?.wrappedType?.name)
+        assertEquals(GraphQLString, (result.type as? GraphQLNonNull)?.wrappedType)
         assertEquals("newName", result.name)
     }
 

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/GenerateFunctionTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/GenerateFunctionTest.kt
@@ -25,6 +25,8 @@ import com.expediagroup.graphql.exceptions.TypeNotSupportedException
 import com.expediagroup.graphql.execution.FunctionDataFetcher
 import graphql.ExceptionWhileDataFetching
 import graphql.Scalars
+import graphql.Scalars.GraphQLInt
+import graphql.Scalars.GraphQLString
 import graphql.execution.DataFetcherResult
 import graphql.execution.ExecutionPath
 import graphql.introspection.Introspection
@@ -199,7 +201,7 @@ internal class GenerateFunctionTest : TypeTestHelper() {
         val result = generateFunction(generator, fn = kFunction, parentName = "Query", target = null, abstract = false)
 
         assertEquals(expected = 1, actual = result.arguments.size)
-        assertEquals("Int", (result.type as? GraphQLNonNull)?.wrappedType?.name)
+        assertEquals(GraphQLInt, (result.type as? GraphQLNonNull)?.wrappedType)
     }
 
     @Test
@@ -208,7 +210,7 @@ internal class GenerateFunctionTest : TypeTestHelper() {
         val result = generateFunction(generator, fn = kFunction, parentName = "Query", target = null, abstract = false)
 
         assertEquals(expected = 1, actual = result.arguments.size)
-        assertEquals("Int", (result.type as? GraphQLNonNull)?.wrappedType?.name)
+        assertEquals(GraphQLInt, (result.type as? GraphQLNonNull)?.wrappedType)
     }
 
     @Test
@@ -217,7 +219,7 @@ internal class GenerateFunctionTest : TypeTestHelper() {
         val result = generateFunction(generator, fn = kFunction, parentName = "Query", target = null, abstract = false)
 
         assertEquals(expected = 1, actual = result.arguments.size)
-        assertEquals("Int", (result.type as? GraphQLNonNull)?.wrappedType?.name)
+        assertEquals(GraphQLInt, (result.type as? GraphQLNonNull)?.wrappedType)
     }
 
     @Test
@@ -226,7 +228,7 @@ internal class GenerateFunctionTest : TypeTestHelper() {
         val result = generateFunction(generator, fn = kFunction, parentName = "Query", target = null, abstract = false)
 
         assertEquals(expected = 0, actual = result.arguments.size)
-        assertEquals("String", (result.type as? GraphQLNonNull)?.wrappedType?.name)
+        assertEquals(GraphQLString, (result.type as? GraphQLNonNull)?.wrappedType)
     }
 
     @Test
@@ -234,7 +236,7 @@ internal class GenerateFunctionTest : TypeTestHelper() {
         val kFunction = Happy::dataFetcherResult
         val result = generateFunction(generator, fn = kFunction, parentName = "Query", target = null, abstract = false)
 
-        assertEquals("String", (result.type as? GraphQLNonNull)?.wrappedType?.name)
+        assertEquals(GraphQLString, (result.type as? GraphQLNonNull)?.wrappedType)
     }
 
     @Test
@@ -246,7 +248,7 @@ internal class GenerateFunctionTest : TypeTestHelper() {
         val listType = GraphQLTypeUtil.unwrapNonNull(result.type)
         assertTrue(listType is GraphQLList)
         val stringType = GraphQLTypeUtil.unwrapNonNull(GraphQLTypeUtil.unwrapOne(listType))
-        assertEquals("String", stringType.name)
+        assertEquals(GraphQLString, stringType)
     }
 
     @Test
@@ -257,7 +259,7 @@ internal class GenerateFunctionTest : TypeTestHelper() {
         val listType = result.type
         assertTrue(listType is GraphQLList)
         val stringType = listType.wrappedType
-        assertEquals("String", stringType.name)
+        assertEquals(GraphQLString, stringType)
     }
 
     @Test
@@ -276,7 +278,7 @@ internal class GenerateFunctionTest : TypeTestHelper() {
 
         assertTrue(result.type is GraphQLNonNull)
         val stringType = GraphQLTypeUtil.unwrapNonNull(result.type)
-        assertEquals("String", stringType.name)
+        assertEquals(GraphQLString, stringType)
     }
 
     @Test

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/GenerateListTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/GenerateListTest.kt
@@ -17,6 +17,7 @@
 package com.expediagroup.graphql.generator.types
 
 import graphql.schema.GraphQLList
+import graphql.schema.GraphQLNamedType
 import graphql.schema.GraphQLTypeUtil
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
@@ -96,5 +97,5 @@ internal class GenerateListTest : TypeTestHelper() {
         assertEquals("MyDataClassInput", getListTypeName(result))
     }
 
-    private fun getListTypeName(list: GraphQLList) = GraphQLTypeUtil.unwrapNonNull(list.wrappedType).name
+    private fun getListTypeName(list: GraphQLList) = (GraphQLTypeUtil.unwrapNonNull(list.wrappedType) as? GraphQLNamedType)?.name
 }

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/GeneratePropertyTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/GeneratePropertyTest.kt
@@ -32,7 +32,9 @@ import graphql.introspection.Introspection
 import graphql.schema.DataFetcher
 import graphql.schema.DataFetcherFactory
 import graphql.schema.FieldCoordinates
+import graphql.schema.GraphQLNamedType
 import graphql.schema.GraphQLNonNull
+import graphql.schema.GraphQLTypeUtil
 import graphql.schema.PropertyDataFetcher
 import io.mockk.every
 import io.mockk.mockk
@@ -124,7 +126,7 @@ internal class GeneratePropertyTest : TypeTestHelper() {
         val prop = DataClassWithProperties::myId
         val result = generateProperty(generator, prop, DataClassWithProperties::class)
 
-        assertEquals("ID", (result.type as? GraphQLNonNull)?.wrappedType?.name)
+        assertEquals("ID", (GraphQLTypeUtil.unwrapNonNull(result.type) as? GraphQLNamedType)?.name)
     }
 
     @Test

--- a/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/routes/RouteConfigurationIT.kt
+++ b/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/routes/RouteConfigurationIT.kt
@@ -63,23 +63,32 @@ class RouteConfigurationIT(@Autowired private val testClient: WebTestClient) {
 
     @Test
     fun `verify SDL route`() {
-        val expectedSchema = """schema {
-  query: Query
-}
+        val expectedSchema = """
+            schema {
+              query: Query
+            }
 
-type Query {
-  context: String!
-  hello(name: String!): String!
-}
+            "Directs the executor to include this field or fragment only when the `if` argument is true"
+            directive @include(
+                "Included when true."
+                if: Boolean!
+              ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
-#Directs the executor to include this field or fragment only when the `if` argument is true
-directive @include(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+            "Directs the executor to skip this field or fragment when the `if`'argument is true."
+            directive @skip(
+                "Skipped when true."
+                if: Boolean!
+              ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
-#Directs the executor to skip this field or fragment when the `if`'argument is true.
-directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+            "Marks the target field/enum value as deprecated"
+            directive @deprecated(reason: String = "No longer supported") on FIELD_DEFINITION | ENUM_VALUE
 
-#Marks the target field/enum value as deprecated
-directive @deprecated(reason: String = "No longer supported") on FIELD_DEFINITION | ENUM_VALUE"""
+            type Query {
+              context: String!
+              hello(name: String!): String!
+            }
+
+            """.trimIndent()
 
         testClient.get().uri("/sdl")
             .accept(MediaType.TEXT_PLAIN)


### PR DESCRIPTION
### :pencil: Description
Upgrading to graphql-java 14 requires some breaking changes: https://github.com/graphql-java/graphql-java/releases/tag/v14.0

The biggest change is that the SDL descriptions are now printed with `"Comments"` instead of `#Comment`. So we needed to update a few integration tests and our regex in federation that inspects the schema. This PR would make it a lot simpler, but it can be merged later: https://github.com/graphql-java/graphql-java/pull/1756

The other big change is in the underlying schema code and how a `GraphQLType` has been split up into `GraphQLType` and `GraphQLNamedType`, and how some elements of execution use the new type `GraphQLSchemaElement` instead of `GraphQLType`. We were able to hide most of this behind the generator but there are some breaking changes to our library users in the hooks.

### :link: Related Issues
* Fixes https://github.com/ExpediaGroup/graphql-kotlin/issues/565
* Fixes https://github.com/ExpediaGroup/graphql-kotlin/issues/533