### PR TITLE
[federation] Move vals and functions to internal scope

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ pom.xml.versionsBackup
 # gradle ignore
 .gradle
 build/
+out/
 
 # Ignore Gradle GUI config
 gradle-app.setting

--- a/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/FederatedSchemaGeneratorHooks.kt
+++ b/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/FederatedSchemaGeneratorHooks.kt
@@ -28,6 +28,7 @@ import com.expediagroup.graphql.federation.types.FIELD_SET_SCALAR_TYPE
 import com.expediagroup.graphql.federation.types.SERVICE_FIELD_DEFINITION
 import com.expediagroup.graphql.federation.types._Service
 import com.expediagroup.graphql.federation.types.generateEntityFieldDefinition
+import com.expediagroup.graphql.federation.validation.FederatedSchemaValidator
 import com.expediagroup.graphql.hooks.SchemaGeneratorHooks
 import graphql.TypeResolutionEnvironment
 import graphql.schema.DataFetcher

--- a/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/types/_Any.kt
+++ b/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/types/_Any.kt
@@ -34,7 +34,7 @@ import java.util.stream.Collectors
  * The _Any scalar is used to pass representations of entities from external services into the root _entities field for execution.
  * Validation of the _Any scalar is done by matching the __typename and @external fields defined in the schema.
  */
-val ANY_SCALAR_TYPE: GraphQLScalarType = GraphQLScalarType.newScalar()
+internal val ANY_SCALAR_TYPE: GraphQLScalarType = GraphQLScalarType.newScalar()
     .name("_Any")
     .description("Federation scalar type used to represent any external entities passed to _entities query.")
     .coercing(AnyCoercing)

--- a/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/types/_Entity.kt
+++ b/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/types/_Entity.kt
@@ -27,7 +27,7 @@ import graphql.schema.GraphQLUnionType
  * Generates union of all types that use the  @key directive, including both types native to the schema and extended types.
  */
 @Suppress("SpreadOperator")
-fun generateEntityFieldDefinition(federatedTypes: Set<String>): GraphQLFieldDefinition {
+internal fun generateEntityFieldDefinition(federatedTypes: Set<String>): GraphQLFieldDefinition {
     val possibleTypes = federatedTypes
         .map { GraphQLTypeReference(it) }
         .toTypedArray()

--- a/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/types/_FieldSet.kt
+++ b/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/types/_FieldSet.kt
@@ -29,7 +29,7 @@ import graphql.schema.GraphQLScalarType
  * This means it can represent a single field "upc", multiple fields "id countryCode", and even nested selection sets
  * "id organization { id }".
  */
-val FIELD_SET_SCALAR_TYPE: GraphQLScalarType = GraphQLScalarType.newScalar(Scalars.GraphQLString)
+internal val FIELD_SET_SCALAR_TYPE: GraphQLScalarType = GraphQLScalarType.newScalar(Scalars.GraphQLString)
     .name("_FieldSet")
     .description("Federation type representing set of fields")
     .coercing(FieldSetCoercing)

--- a/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/types/_Service.kt
+++ b/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/types/_Service.kt
@@ -33,10 +33,10 @@ private val SERVICE_OBJECT_TYPE = GraphQLObjectType.newObject()
             .build())
     .build()
 
-val SERVICE_FIELD_DEFINITION: GraphQLFieldDefinition = GraphQLFieldDefinition.newFieldDefinition()
+internal val SERVICE_FIELD_DEFINITION: GraphQLFieldDefinition = GraphQLFieldDefinition.newFieldDefinition()
     .name("_service")
     .type(SERVICE_OBJECT_TYPE)
     .build()
 
-@Suppress("ClassNaming")
-data class _Service(val sdl: String)
+@Suppress("ClassNaming", "ClassName")
+internal data class _Service(val sdl: String)

--- a/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/validation/FederatedSchemaValidator.kt
+++ b/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/validation/FederatedSchemaValidator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Expedia, Inc
+ * Copyright 2020 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.expediagroup.graphql.federation
+package com.expediagroup.graphql.federation.validation
 
 import com.expediagroup.graphql.federation.directives.EXTENDS_DIRECTIVE_NAME
 import com.expediagroup.graphql.federation.directives.EXTERNAL_DIRECTIVE_NAME
@@ -23,9 +23,6 @@ import com.expediagroup.graphql.federation.directives.PROVIDES_DIRECTIVE_NAME
 import com.expediagroup.graphql.federation.directives.REQUIRES_DIRECTIVE_NAME
 import com.expediagroup.graphql.federation.exception.InvalidFederatedSchema
 import com.expediagroup.graphql.federation.extensions.isFederatedType
-import com.expediagroup.graphql.federation.validation.validateDirective
-import com.expediagroup.graphql.federation.validation.validateProvidesDirective
-import com.expediagroup.graphql.federation.validation.validateRequiresDirective
 import graphql.schema.GraphQLDirective
 import graphql.schema.GraphQLFieldDefinition
 import graphql.schema.GraphQLInterfaceType
@@ -36,7 +33,7 @@ import graphql.schema.GraphQLTypeUtil
 /**
  * Validates generated federated objects.
  */
-class FederatedSchemaValidator {
+internal class FederatedSchemaValidator {
 
     /**
      * Validates target GraphQLType whether it is a valid federated object.
@@ -48,7 +45,7 @@ class FederatedSchemaValidator {
      * - @requires directive is only applicable on extended types and references @external fields
      * - @provides directive references valid @external fields
      */
-    fun validateGraphQLType(type: GraphQLType) {
+    internal fun validateGraphQLType(type: GraphQLType) {
         val unwrappedType = GraphQLTypeUtil.unwrapAll(type)
         if (unwrappedType is GraphQLObjectType && unwrappedType.isFederatedType()) {
             validate(unwrappedType.name, unwrappedType.fieldDefinitions, unwrappedType.directivesByName)

--- a/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/validation/FederatedSchemaValidatorTest.kt
+++ b/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/validation/FederatedSchemaValidatorTest.kt
@@ -14,13 +14,15 @@
  * limitations under the License.
  */
 
-package com.expediagroup.graphql.federation
+package com.expediagroup.graphql.federation.validation
 
 import com.expediagroup.graphql.federation.directives.KEY_DIRECTIVE_NAME
 import com.expediagroup.graphql.federation.directives.PROVIDES_DIRECTIVE_NAME
 import com.expediagroup.graphql.federation.directives.REQUIRES_DIRECTIVE_NAME
 import com.expediagroup.graphql.federation.directives.extendsDirectiveType
 import com.expediagroup.graphql.federation.exception.InvalidFederatedSchema
+import com.expediagroup.graphql.federation.externalDirective
+import com.expediagroup.graphql.federation.getKeyDirective
 import graphql.Scalars.GraphQLString
 import graphql.schema.GraphQLDirective
 import graphql.schema.GraphQLFieldDefinition


### PR DESCRIPTION
### :pencil: Description
To cleanup our public class, function, and value exposure, I moved some of the federation objects to internal scope since they do not need to be exposed as public
