### PR TITLE
Update dependency versions and docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ Or you can navigate to each module to build them individually.
 
 We are using [mockk](http://mockk.io), [JUnit](https://junit.org/junit5/), and [jacoco](https://www.eclemma.org/jacoco/) for our main testing libraries. This ensures we have good code coverage and can easily test all cases of schema generation.
 
-To run tests use Maven
+To run tests:
 
 ```shell script
 ./gradlew check
@@ -41,7 +41,7 @@ To run tests use Maven
 You can also view the code coverage reports published to Codecov. This validates that our coverage levels are maintained. Links are in the README.
 
 ### Linting
-We are also [ktlint](https://ktlint.github.io/) and [detekt](https://arturbosch.github.io/detekt/) for code style checking and linting. These can be run with the following Maven commands
+We are also [ktlint](https://ktlint.github.io/) and [detekt](https://arturbosch.github.io/detekt/) for code style checking and linting.
 
 **Note**:
 These will be run as part of the `validate` phase of a full build but if you want to run them manually you will have to navigate to each module directory and run the command

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -14,8 +14,13 @@ in this documentation should be available in the sample app.
 
 In order to run it you can run
 [Application.kt](https://github.com/ExpediaGroup/graphql-kotlin/blob/master/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/Application.kt)
-directly from your IDE. Alternatively you can also use the Spring Boot maven plugin by running `mvn spring-boot:run`
-from the command line. Once the app has started you can explore the example schema by opening Playground endpoint at
+directly from your IDE. Alternatively you can also use the Spring Boot plugin from the command line.
+
+```shell script
+./gradlew bootRun
+```
+
+Once the app has started you can explore the example schema by opening Playground endpoint at
 [http://localhost:8080/playground](http://localhost:8080/playground).
 
 ## Federation Example

--- a/examples/federation/README.md
+++ b/examples/federation/README.md
@@ -13,13 +13,17 @@ You can make queries against the spring apps directly or combined queries from t
 Build the spring applications by running the following commands in the `/federation` directory
 
 ```shell script
-mvn clean install
-``` 
+./gradlew clean build
+```
 
 Start the servers:
 
 * Run each `Application.kt` directly from your IDE
-* Alternatively you can also use the spring boot maven plugin by running `mvn spring-boot:run` from the command line.
+* Alternatively you can also use the spring boot plugin from the command line.
+
+```shell script
+./gradlew bootRun
+```
 
 
 Once the app has started you can explore the example schema by opening Playground endpoint

--- a/examples/federation/base-app/README.md
+++ b/examples/federation/base-app/README.md
@@ -18,7 +18,11 @@ Build the application by running the following from examples root directory:
 Start the server:
 
 * Run `Application.kt` directly from your IDE
-* Alternatively you can also use the spring boot maven plugin by running `./gradlew ::federation-example:base-app:bootRun` from the command line in the root examples directory.
+* Alternatively you can also use the spring boot plugin from the command line in the root examples directory.
+
+```shell script
+./gradlew ::federation-example:base-app:bootRun
+```
 
 
 Once the app has started you can explore the example schema by opening Playground endpoint at http://localhost:8080/playground.

--- a/examples/federation/extend-app/README.md
+++ b/examples/federation/extend-app/README.md
@@ -18,7 +18,11 @@ Build the application by running the following from examples root directory:
 Start the server:
 
 * Run `Application.kt` directly from your IDE
-* Alternatively you can also use the spring boot maven plugin by running `./gradlew :federation-example:extend-app:bootRun` from the command line in the root examples directory.
+* Alternatively you can also use the spring boot plugin from the command line in the root examples directory.
+
+```shell script
+./gradlew :federation-example:extend-app:bootRun
+```
 
 
 Once the app has started you can explore the example schema by opening Playground endpoint at http://localhost:8080/playground.

--- a/examples/spring/README.md
+++ b/examples/spring/README.md
@@ -21,6 +21,10 @@ From the root examples directory you can run the following:
 Then to start the server:
 
 * Run `Application.kt` directly from your IDE
-* Alternatively you can also use the spring boot maven plugin by running `./gradlew :spring-example:bootRun` from the command line in the root examples directory.
+* Alternatively you can also use the spring boot plugin from the command line in the root examples directory.
+
+```shell script
+./gradlew :spring-example:bootRun
+```
 
 Once the app has started you can explore the example schema by opening the GraphQL Playground endpoint at http://localhost:8080/playground.

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,25 +6,25 @@ org.gradle.caching=true
 org.gradle.parallel=true
 
 # dependencies
-kotlinVersion = 1.3.50
-kotlinCoroutinesVersion = 1.3.2
+kotlinVersion = 1.3.60
+kotlinCoroutinesVersion = 1.3.3
 
 graphQLJavaVersion = 14.0
-jacksonVersion = 2.10.1
-springBootVersion = 2.2.1.RELEASE
-classGraphVersion = 4.8.53
-reactorVersion = 3.3.0.RELEASE
-reactorExtensionsVersion = 1.0.0.RELEASE
+jacksonVersion = 2.10.2
+springBootVersion = 2.2.4.RELEASE
+classGraphVersion = 4.8.60
+reactorVersion = 3.3.2.RELEASE
+reactorExtensionsVersion = 1.0.2.RELEASE
 
 # test dependency versions
-junitVersion = 5.5.2
+junitVersion = 5.6.0
 mockkVersion = 1.9.3
 
 # plugin versions
-detektVersion = 1.1.1
+detektVersion = 1.4.0
 dokkaVersion = 0.10.0
 jacocoVersion = 0.8.5
-ktlintVersion = 0.35.0
+ktlintVersion = 0.36.0
 ktlintPluginVersion = 9.1.1
 nexusPublishPluginVersion = 0.3.0
 stagingPluginVersion = 0.21.2

--- a/graphql-kotlin-schema-generator/build.gradle.kts
+++ b/graphql-kotlin-schema-generator/build.gradle.kts
@@ -5,6 +5,7 @@ val graphQLJavaVersion: String by project
 val jacksonVersion: String by project
 val kotlinVersion: String by project
 val kotlinCoroutinesVersion: String by project
+val rxjavaVersion = "2.2.17"
 
 dependencies {
     api("com.graphql-java:graphql-java:$graphQLJavaVersion")
@@ -13,7 +14,7 @@ dependencies {
     api("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
     api("io.github.classgraph:classgraph:$classGraphVersion")
     api("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion")
-    testImplementation("io.reactivex.rxjava2:rxjava:2.2.14")
+    testImplementation("io.reactivex.rxjava2:rxjava:$rxjavaVersion")
 }
 
 tasks {


### PR DESCRIPTION
### :pencil: Description
Update various dependencies. The only minor version update is for JUnit, detekt, and ktlint so there shouldn't be any library code we need to update to take advantage of new features. At the same time, I cleaned up a couple docs and README files that reference maven still.

### :link: Related Issues
Fixes https://github.com/ExpediaGroup/graphql-kotlin/issues/566

### 🔢 Dependency Release notes
* Kotlin: https://blog.jetbrains.com/kotlin/2019/11/kotlin-1-3-60-released/
* Kotlin coroutines: https://github.com/Kotlin/kotlinx.coroutines/releases/tag/1.3.3
* Jackson: https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.10.2
* Spring Boot: https://spring.io/blog/2020/01/20/spring-boot-2-2-4-released
* Classgraph: https://github.com/classgraph/classgraph/releases/tag/classgraph-4.8.60
* Reactor: https://github.com/reactor/reactor-core/releases/tag/v3.3.2.RELEASE
* Reactor Extensions: https://github.com/reactor/reactor-kotlin-extensions/releases/tag/v1.0.2.RELEASE
* JUnit: https://junit.org/junit5/docs/current/release-notes/index.html#release-notes-5.6.0
* detekt: https://github.com/arturbosch/detekt/releases/tag/1.4.0
* ktlint: https://github.com/pinterest/ktlint/releases/tag/0.36.0