### PR TITLE
[build] Update nexus publish timeout

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -187,9 +187,11 @@ tasks {
     nexusStaging {
         username = System.getenv("SONATYPE_USERNAME")
         password = System.getenv("SONATYPE_PASSWORD")
-
         packageGroup = rootProject.group.toString()
+        numberOfRetries = 60
+        delayBetweenRetriesInMillis = 5000
     }
+
     val publish by getting
     publish.dependsOn(":initializeSonatypeStagingRepository")
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,5 +26,5 @@ dokkaVersion = 0.10.0
 jacocoVersion = 0.8.5
 ktlintVersion = 0.36.0
 ktlintPluginVersion = 9.1.1
-nexusPublishPluginVersion = 0.3.0
+nexusPublishPluginVersion = 0.4.0
 stagingPluginVersion = 0.21.2


### PR DESCRIPTION
### :pencil: Description
Increase the default timeout of publish to 5 minutes (60 attempts at 5 seconds)


### :link: Related Issues
Failed publish: https://github.com/ExpediaGroup/graphql-kotlin/commit/f4cd12841d8b85df8dbe5c9294322d59e9ff6e9f/checks?check_suite_id=416873727