### PR TITLE
Remove actions/cache from release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,26 +5,22 @@ on:
     types: [published]
 
 jobs:
-  build:
+  release:
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2
       - uses: gradle/wrapper-validation-action@v1
+
       - name: Set up Java 1.8
         uses: actions/setup-java@v1
         # dokka doesn't support Java 11
         with:
           java-version: 1.8
-      - name: Set up Gradle cache
-        uses: actions/cache@v1
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle.kts') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
+
       - name: Build library with Gradle
         run: ./gradlew clean build
+
       - name: Publish library with Gradle
         run: |
           NEW_VERSION=$(echo "${GITHUB_REF}" | cut -d "/" -f3)
@@ -35,4 +31,3 @@ jobs:
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           GPG_SECRET: ${{ secrets.GPG_SECRET }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-


### PR DESCRIPTION
### :pencil: Description

The step actions/cache does not support the release event.

See: https://github.com/actions/cache/blob/b45d91cc4bac5c58ff24b19cd3b6711b2c5eca8f/src/utils/actionUtils.ts#L98

And our logs: https://github.com/ExpediaGroup/graphql-kotlin/runs/408004612\?check_suite_focus\=true\#step:5:10
