### PR TITLE
Set gradle prop to fix release process

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,6 +5,9 @@ version = 2.0.0-SNAPSHOT
 org.gradle.caching=true
 org.gradle.parallel=true
 
+# See https://github.com/gradle/gradle/issues/11308
+systemProp.org.gradle.internal.publish.checksums.insecure=true
+
 # dependencies
 kotlinVersion = 1.3.60
 kotlinCoroutinesVersion = 1.3.3

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.0.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
### :pencil: Description
There is a bug with Gradle 6 and Nexus 2 currently that we can fix by setting a systemProp. 

### :link: Related Issues
See here for more info: https://github.com/gradle/gradle/issues/11308