### PR TITLE
Fixed URL to Subscription example

### DIFF
--- a/docs/spring-server/subscriptions.md
+++ b/docs/spring-server/subscriptions.md
@@ -14,7 +14,7 @@ You can see more details in the file [ApolloSubscriptionProtocolHandler](https:/
 If you would like to implement your own subscription handler, you can provide a primary spring bean for `HandlerMapping` that overrides the [default one](https://github.com/ExpediaGroup/graphql-kotlin/blob/master/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/SubscriptionAutoConfiguration.kt) which sets the url for subscriptions to the Apollo subscription handler.
 
 ## Example
-You can see an example implementation of a `Subscription` in the [example app](https://github.com/ExpediaGroup/graphql-kotlin/blob/master/examples/spring/src/main/kotlin/com/expediagroup/graphql/sample/subscriptions/SimpleSubscription.kt).
+You can see an example implementation of a `Subscription` in the [example app](https://github.com/ExpediaGroup/graphql-kotlin/blob/master/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/subscriptions/SimpleSubscription.kt).
 
 
 


### PR DESCRIPTION
### :pencil: Description
Fixed link to example code: `.../sample/...` -> `.../examples/...`

