### PR TITLE
Add release notes step in GH Actions

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -41,3 +41,11 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           yml: ./codecov.yml
+
+  release-notes:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Release Drafter
+        uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### :pencil: Description
Instead of using a Github App on the repo, we can move to use the new GH Action release-drafter so the release notes are updated on every merge to master

This runs in parallel with the gradle build so it does not block.

See https://github.com/release-drafter/release-drafter

### 🔗 Related Issues
The release-drafter team as plans on removing the GH App eventually: https://github.com/release-drafter/release-drafter/issues/335