### PR TITLE
Add example stress query

### DIFF
--- a/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/directives/TrackTimesInvoked.kt
+++ b/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/directives/TrackTimesInvoked.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.examples.directives
+
+import com.expediagroup.graphql.annotations.GraphQLDirective
+
+/**
+ * Used to verify the performance overhead of instrumentation on fields.
+ * Marker directive only, does not have DirectiveWiring.
+ */
+@GraphQLDirective(
+    name = TRACK_TIMES_INVOKED_DIRECTIVE_NAME,
+    description = "If the field is marked with this directive, " +
+        "we keep track of how many times this field was invoked per exection " +
+        "and log the result server side through graphql-java Instrumentation"
+)
+annotation class TrackTimesInvoked
+
+const val TRACK_TIMES_INVOKED_DIRECTIVE_NAME = "trackTimesInvoked"

--- a/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/instrumentation/TrackTimesInvokedInstrumentation.kt
+++ b/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/instrumentation/TrackTimesInvokedInstrumentation.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.examples.instrumentation
+
+import com.expediagroup.graphql.examples.directives.TRACK_TIMES_INVOKED_DIRECTIVE_NAME
+import graphql.ExecutionResult
+import graphql.execution.instrumentation.InstrumentationContext
+import graphql.execution.instrumentation.InstrumentationState
+import graphql.execution.instrumentation.SimpleInstrumentation
+import graphql.execution.instrumentation.SimpleInstrumentationContext
+import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters
+import graphql.execution.instrumentation.parameters.InstrumentationFieldFetchParameters
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Adds field count tracking in the instrumentation layer if [com.expediagroup.graphql.examples.directives.TrackTimesInvoked] is present.
+ */
+@Component
+class TrackTimesInvokedInstrumentation : SimpleInstrumentation() {
+
+    private val logger = LoggerFactory.getLogger(TrackTimesInvokedInstrumentation::class.java)
+
+    override fun createState(): InstrumentationState = TrackTimesInvokedInstrumenationState()
+
+    override fun beginFieldFetch(parameters: InstrumentationFieldFetchParameters): InstrumentationContext<Any> {
+        if (parameters.field.getDirective(TRACK_TIMES_INVOKED_DIRECTIVE_NAME) != null) {
+            (parameters.getInstrumentationState() as? TrackTimesInvokedInstrumenationState)?.incrementCount(parameters.field.name)
+        }
+
+        return SimpleInstrumentationContext<Any>()
+    }
+
+    override fun instrumentExecutionResult(executionResult: ExecutionResult, parameters: InstrumentationExecutionParameters): CompletableFuture<ExecutionResult> {
+        val count = (parameters.getInstrumentationState() as? TrackTimesInvokedInstrumenationState)?.getCount()
+        logger.info("LoggingInstrumentation fields invoked: $count")
+        return super.instrumentExecutionResult(executionResult, parameters)
+    }
+}
+
+class TrackTimesInvokedInstrumenationState : InstrumentationState {
+
+    private val fieldCount = ConcurrentHashMap<String, Int>()
+
+    fun incrementCount(fieldName: String) {
+        val currentCount = fieldCount.getOrDefault(fieldName, 0)
+        fieldCount[fieldName] = currentCount.plus(1)
+    }
+
+    fun getCount() = fieldCount.toString()
+}

--- a/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/instrumentation/TrackTimesInvokedInstrumentation.kt
+++ b/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/instrumentation/TrackTimesInvokedInstrumentation.kt
@@ -49,7 +49,7 @@ class TrackTimesInvokedInstrumentation : SimpleInstrumentation() {
 
     override fun instrumentExecutionResult(executionResult: ExecutionResult, parameters: InstrumentationExecutionParameters): CompletableFuture<ExecutionResult> {
         val count = (parameters.getInstrumentationState() as? TrackTimesInvokedInstrumenationState)?.getCount()
-        logger.info("LoggingInstrumentation fields invoked: $count")
+        logger.info("TrackTimesInvokedInstrumentation fields invoked: $count")
         return super.instrumentExecutionResult(executionResult, parameters)
     }
 }

--- a/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/instrumentation/TrackTimesInvokedInstrumentation.kt
+++ b/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/instrumentation/TrackTimesInvokedInstrumentation.kt
@@ -52,16 +52,19 @@ class TrackTimesInvokedInstrumentation : SimpleInstrumentation() {
         logger.info("TrackTimesInvokedInstrumentation fields invoked: $count")
         return super.instrumentExecutionResult(executionResult, parameters)
     }
-}
 
-class TrackTimesInvokedInstrumenationState : InstrumentationState {
+    /**
+     * The state per execution for this Instrumentation
+     */
+    private class TrackTimesInvokedInstrumenationState : InstrumentationState {
 
-    private val fieldCount = ConcurrentHashMap<String, Int>()
+        private val fieldCount = ConcurrentHashMap<String, Int>()
 
-    fun incrementCount(fieldName: String) {
-        val currentCount = fieldCount.getOrDefault(fieldName, 0)
-        fieldCount[fieldName] = currentCount.plus(1)
+        fun incrementCount(fieldName: String) {
+            val currentCount = fieldCount.getOrDefault(fieldName, 0)
+            fieldCount[fieldName] = currentCount.plus(1)
+        }
+
+        fun getCount() = fieldCount.toString()
     }
-
-    fun getCount() = fieldCount.toString()
 }

--- a/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/query/StressQuery.kt
+++ b/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/query/StressQuery.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2020 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.examples.query
+
+import com.expediagroup.graphql.annotations.GraphQLIgnore
+import com.expediagroup.graphql.spring.operations.Query
+import io.netty.util.internal.ThreadLocalRandom
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+@Component
+class StressQuery : Query {
+
+    fun lazyStressQuery(traceId: String?, count: Int?): List<LazyStressNode> {
+        val id = generateId(traceId)
+        return (1..(count ?: 1)).map { LazyStressNode(id) }
+    }
+
+    fun eagerStressQuery(traceId: String?, count: Int?): List<EagerStressNode> {
+        val id = generateId(traceId)
+        return (1..(count ?: 1)).map { EagerStressNode(id) }
+    }
+
+    @GraphQLIgnore
+    fun generateId(traceId: String?): String {
+        if (traceId == null) {
+            val random = ThreadLocalRandom.current()
+            return UUID(random.nextLong(), random.nextLong()).toString()
+        }
+        return traceId
+    }
+}
+
+@Suppress("MemberVisibilityCanBePrivate")
+class LazyStressNode(val traceId: String) {
+
+    fun functionId(): String {
+        val random = ThreadLocalRandom.current()
+        return UUID(random.nextLong(), random.nextLong()).toString()
+    }
+
+    fun ignoredId(): String {
+        val random = ThreadLocalRandom.current()
+        return UUID(random.nextLong(), random.nextLong()).toString()
+    }
+
+    suspend fun suspendId(): String {
+        val random = ThreadLocalRandom.current()
+        return UUID(random.nextLong(), random.nextLong()).toString()
+    }
+
+    suspend fun suspendIgnoredId(): String {
+        val random = ThreadLocalRandom.current()
+        return UUID(random.nextLong(), random.nextLong()).toString()
+    }
+
+    fun stressNode(count: Int?): List<LazyStressNode> {
+        return (1..(count ?: 1)).map { LazyStressNode(traceId) }
+    }
+}
+
+@Suppress("MemberVisibilityCanBePrivate")
+class EagerStressNode(val traceId: String) {
+
+    val valueId: String
+
+    init {
+        val random = ThreadLocalRandom.current()
+        valueId = UUID(random.nextLong(), random.nextLong()).toString()
+    }
+
+    fun stressNode(count: Int?): List<EagerStressNode> {
+        return (1..(count ?: 1)).map { EagerStressNode(traceId) }
+    }
+}

--- a/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/query/StressQuery.kt
+++ b/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/query/StressQuery.kt
@@ -14,76 +14,45 @@
  * limitations under the License.
  */
 
+@file:Suppress("unused")
+
 package com.expediagroup.graphql.examples.query
 
-import com.expediagroup.graphql.annotations.GraphQLIgnore
 import com.expediagroup.graphql.spring.operations.Query
 import io.netty.util.internal.ThreadLocalRandom
 import org.springframework.stereotype.Component
 import java.util.UUID
 
+/**
+ * Used to stress test the performance of running many data fetchers.
+ * Tests properties vs functions vs suspend functions.
+ */
 @Component
 class StressQuery : Query {
 
-    fun lazyStressQuery(traceId: String?, count: Int?): List<LazyStressNode> {
-        val id = generateId(traceId)
-        return (1..(count ?: 1)).map { LazyStressNode(id) }
-    }
-
-    fun eagerStressQuery(traceId: String?, count: Int?): List<EagerStressNode> {
-        val id = generateId(traceId)
-        return (1..(count ?: 1)).map { EagerStressNode(id) }
-    }
-
-    @GraphQLIgnore
-    fun generateId(traceId: String?): String {
-        if (traceId == null) {
-            val random = ThreadLocalRandom.current()
-            return UUID(random.nextLong(), random.nextLong()).toString()
-        }
-        return traceId
+    fun stressNode(traceId: String?, count: Int?): List<StressNode> {
+        val id = traceId ?: getRandomStringFromThread()
+        return getStressNodeLIst(id, count)
     }
 }
 
-@Suppress("MemberVisibilityCanBePrivate")
-class LazyStressNode(val traceId: String) {
+@Suppress("MemberVisibilityCanBePrivate", "RedundantSuspendModifier")
+class StressNode(val traceId: String) {
 
-    fun functionId(): String {
-        val random = ThreadLocalRandom.current()
-        return UUID(random.nextLong(), random.nextLong()).toString()
-    }
+    val valueId: String = getRandomStringFromThread()
 
-    fun ignoredId(): String {
-        val random = ThreadLocalRandom.current()
-        return UUID(random.nextLong(), random.nextLong()).toString()
-    }
+    fun functionId(): String = getRandomStringFromThread()
 
-    suspend fun suspendId(): String {
-        val random = ThreadLocalRandom.current()
-        return UUID(random.nextLong(), random.nextLong()).toString()
-    }
+    suspend fun suspendId(): String = getRandomStringFromThread()
 
-    suspend fun suspendIgnoredId(): String {
-        val random = ThreadLocalRandom.current()
-        return UUID(random.nextLong(), random.nextLong()).toString()
-    }
+    fun stressNode(count: Int?): List<StressNode> = getStressNodeLIst(traceId, count)
 
-    fun stressNode(count: Int?): List<LazyStressNode> {
-        return (1..(count ?: 1)).map { LazyStressNode(traceId) }
-    }
+    suspend fun suspendStressNode(count: Int?): List<StressNode> = getStressNodeLIst(traceId, count)
 }
 
-@Suppress("MemberVisibilityCanBePrivate")
-class EagerStressNode(val traceId: String) {
+private fun getStressNodeLIst(traceId: String, count: Int?): List<StressNode> = (1..(count ?: 1)).map { StressNode(traceId) }
 
-    val valueId: String
-
-    init {
-        val random = ThreadLocalRandom.current()
-        valueId = UUID(random.nextLong(), random.nextLong()).toString()
-    }
-
-    fun stressNode(count: Int?): List<EagerStressNode> {
-        return (1..(count ?: 1)).map { EagerStressNode(traceId) }
-    }
+private fun getRandomStringFromThread(): String {
+    val random = ThreadLocalRandom.current()
+    return UUID(random.nextLong(), random.nextLong()).toString()
 }

--- a/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/query/StressQuery.kt
+++ b/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/query/StressQuery.kt
@@ -18,6 +18,7 @@
 
 package com.expediagroup.graphql.examples.query
 
+import com.expediagroup.graphql.examples.directives.TrackTimesInvoked
 import com.expediagroup.graphql.spring.operations.Query
 import io.netty.util.internal.ThreadLocalRandom
 import org.springframework.stereotype.Component
@@ -32,7 +33,7 @@ class StressQuery : Query {
 
     fun stressNode(traceId: String?, count: Int?): List<StressNode> {
         val id = traceId ?: getRandomStringFromThread()
-        return getStressNodeLIst(id, count)
+        return (1..(count ?: 1)).map { StressNode(id) }
     }
 }
 
@@ -45,12 +46,12 @@ class StressNode(val traceId: String) {
 
     suspend fun suspendId(): String = getRandomStringFromThread()
 
-    fun stressNode(count: Int?): List<StressNode> = getStressNodeLIst(traceId, count)
+    @TrackTimesInvoked
+    fun loggingFunctionId(): String = getRandomStringFromThread()
 
-    suspend fun suspendStressNode(count: Int?): List<StressNode> = getStressNodeLIst(traceId, count)
+    @TrackTimesInvoked
+    suspend fun suspendLoggingFunctionId(): String = getRandomStringFromThread()
 }
-
-private fun getStressNodeLIst(traceId: String, count: Int?): List<StressNode> = (1..(count ?: 1)).map { StressNode(traceId) }
 
 private fun getRandomStringFromThread(): String {
     val random = ThreadLocalRandom.current()


### PR DESCRIPTION
## :pencil: Description
Add a `StressQuery` that will create a lot of nodes so we can stress test data fetchers with a single query instead of lots of requests. 

This will help us debug performance overhead around `PropertyDataFetcher` vs `FunctionDataFetcher` vs `suspend FunctionDataFetcher`

## Test Results

I used YourKit locally to get a snapshot of each query. The files are too big to upload but I am looking at the results right now

### Property
```graphql
query stress {
  stressNode(count:100000) {
    valueId
  }
}
```

### Functions
```graphql
query stress {
  stressNode(count:100000) {
    functionId
  }
}
```

### Suspend Functions
```graphql
query stress {
  stressNode(count:100000) {
    suspendId
  }
}
```