### PR TITLE
Allow additional types to be added with custom SchemaGenerator

### DIFF
--- a/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/validation/validateProvidesDirective.kt
+++ b/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/validation/validateProvidesDirective.kt
@@ -16,12 +16,12 @@
 
 package com.expediagroup.graphql.federation.validation
 
+import com.expediagroup.graphql.extensions.unwrapType
 import com.expediagroup.graphql.federation.directives.PROVIDES_DIRECTIVE_NAME
 import com.expediagroup.graphql.federation.extensions.isExtendedType
 import graphql.schema.GraphQLFieldDefinition
 import graphql.schema.GraphQLObjectType
 import graphql.schema.GraphQLTypeReference
-import graphql.schema.GraphQLTypeUtil
 
 // [OK]    @provides on base type references valid @external fields on @extend object
 // [ERROR] @provides on base type references local object fields
@@ -30,7 +30,7 @@ import graphql.schema.GraphQLTypeUtil
 // [OK]    @provides references list of valid @extend objects
 // [ERROR] @provides references @external list field
 // [ERROR] @provides references @external interface field
-internal fun validateProvidesDirective(federatedType: String, field: GraphQLFieldDefinition): List<String> = when (val returnType = GraphQLTypeUtil.unwrapType(field.type).last()) {
+internal fun validateProvidesDirective(federatedType: String, field: GraphQLFieldDefinition): List<String> = when (val returnType = field.type.unwrapType()) {
     is GraphQLObjectType -> {
         if (!returnType.isExtendedType()) {
             listOf("@provides directive is specified on a $federatedType.${field.name} field references local object")

--- a/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/types/EntityTest.kt
+++ b/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/types/EntityTest.kt
@@ -16,7 +16,7 @@
 
 package com.expediagroup.graphql.federation.types
 
-import graphql.schema.GraphQLTypeUtil
+import com.expediagroup.graphql.extensions.unwrapType
 import graphql.schema.GraphQLUnionType
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
@@ -41,7 +41,7 @@ internal class EntityTest {
         assertFalse(result.description.isNullOrEmpty())
         assertEquals(expected = 1, actual = result.arguments.size)
 
-        val graphQLUnionType = GraphQLTypeUtil.unwrapType(result.type).last() as? GraphQLUnionType
+        val graphQLUnionType = result.type.unwrapType() as? GraphQLUnionType
 
         assertNotNull(graphQLUnionType)
         assertEquals(expected = "_Entity", actual = graphQLUnionType.name)
@@ -52,7 +52,7 @@ internal class EntityTest {
     @Test
     fun `generateEntityFieldDefinition should return a valid type on a multiple values`() {
         val result = generateEntityFieldDefinition(setOf("MyType", "MySecondType"))
-        val graphQLUnionType = GraphQLTypeUtil.unwrapType(result.type).last() as? GraphQLUnionType
+        val graphQLUnionType = result.type.unwrapType() as? GraphQLUnionType
 
         assertNotNull(graphQLUnionType)
         assertEquals(expected = 2, actual = graphQLUnionType.types.size)

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/extensions/graphqlTypeExtensions.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/extensions/graphqlTypeExtensions.kt
@@ -28,3 +28,10 @@ import graphql.schema.GraphQLTypeUtil
  */
 val GraphQLType.deepName: String
     get() = GraphQLTypeUtil.simplePrint(this)
+
+/**
+ * Unwrap the type of all layers and return the last element.
+ * This includes GraphQLNonNull and GraphQLList.
+ * If the type is not wrapped, it will just be returned.
+ */
+fun GraphQLType.unwrapType(): GraphQLType = GraphQLTypeUtil.unwrapType(this).last()

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/SchemaGenerator.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/SchemaGenerator.kt
@@ -19,7 +19,6 @@ package com.expediagroup.graphql.generator
 import com.expediagroup.graphql.SchemaGeneratorConfig
 import com.expediagroup.graphql.TopLevelObject
 import com.expediagroup.graphql.directives.DeprecatedDirective
-import com.expediagroup.graphql.extensions.unwrapType
 import com.expediagroup.graphql.generator.state.ClassScanner
 import com.expediagroup.graphql.generator.state.TypesCache
 import com.expediagroup.graphql.generator.types.generateGraphQLType
@@ -31,7 +30,6 @@ import graphql.schema.GraphQLCodeRegistry
 import graphql.schema.GraphQLDirective
 import graphql.schema.GraphQLSchema
 import graphql.schema.GraphQLType
-import graphql.schema.GraphQLTypeReference
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
@@ -98,15 +96,10 @@ open class SchemaGenerator(internal val config: SchemaGeneratorConfig) {
         }
     }
 
-    private fun generateAdditionalTypes(additionalTypes: Set<KType>): Set<GraphQLType> = additionalTypes.mapNotNull {
-        val graphQLType = generateGraphQLType(this, it, inputType = false, annotatedAsID = false)
-
-        // Do not add objects currently under construction to the additional types
-        val unwrappedType = graphQLType.unwrapType()
-        if (unwrappedType !is GraphQLTypeReference) {
-            graphQLType
-        } else {
-            null
-        }
-    }.toSet()
+    /**
+     * Gererate the GraphQL type for all the additional types. They are generated as non-inputs and not as IDs.
+     * If you need to provide more custom additional types that were not picked up from reflection of the schema objects,
+     * you modify the set before you call this method.
+     */
+    protected fun generateAdditionalTypes(additionalTypes: Set<KType>): Set<GraphQLType> = additionalTypes.map { generateGraphQLType(this, it) }.toSet()
 }

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/SchemaGenerator.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/SchemaGenerator.kt
@@ -96,10 +96,5 @@ open class SchemaGenerator(internal val config: SchemaGeneratorConfig) {
         }
     }
 
-    /**
-     * Gererate the GraphQL type for all the additional types. They are generated as non-inputs and not as IDs.
-     * If you need to provide more custom additional types that were not picked up from reflection of the schema objects,
-     * you modify the set before you call this method.
-     */
-    protected fun generateAdditionalTypes(additionalTypes: Set<KType>): Set<GraphQLType> = additionalTypes.map { generateGraphQLType(this, it) }.toSet()
+    private fun generateAdditionalTypes(additionalTypes: Set<KType>): Set<GraphQLType> = additionalTypes.map { generateGraphQLType(this, it) }.toSet()
 }

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/generateInterface.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/generateInterface.kt
@@ -26,8 +26,6 @@ import com.expediagroup.graphql.generator.extensions.getValidSuperclasses
 import com.expediagroup.graphql.generator.extensions.safeCast
 import graphql.TypeResolutionEnvironment
 import graphql.schema.GraphQLInterfaceType
-import graphql.schema.GraphQLTypeReference
-import graphql.schema.GraphQLTypeUtil
 import kotlin.reflect.KClass
 import kotlin.reflect.full.createType
 
@@ -53,14 +51,7 @@ internal fun generateInterface(generator: SchemaGenerator, kClass: KClass<*>): G
         .forEach { builder.field(generateFunction(generator, it, kClass.getSimpleName(), null, abstract = true)) }
 
     generator.classScanner.getSubTypesOf(kClass)
-        .map { generateGraphQLType(generator, it.createType()) }
-        .forEach {
-            // Do not add objects currently under construction to the additional types
-            val unwrappedType = GraphQLTypeUtil.unwrapType(it).last()
-            if (unwrappedType !is GraphQLTypeReference) {
-                generator.additionalTypes.add(it)
-            }
-        }
+        .forEach { generator.additionalTypes.add(it.createType()) }
 
     val interfaceType = builder.build()
     generator.codeRegistry.typeResolver(interfaceType) { env: TypeResolutionEnvironment -> env.schema.getObjectType(env.getObject<Any>().javaClass.kotlin.getSimpleName()) }

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/generateObject.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/generateObject.kt
@@ -16,6 +16,7 @@
 
 package com.expediagroup.graphql.generator.types
 
+import com.expediagroup.graphql.extensions.unwrapType
 import com.expediagroup.graphql.generator.SchemaGenerator
 import com.expediagroup.graphql.generator.extensions.getGraphQLDescription
 import com.expediagroup.graphql.generator.extensions.getSimpleName
@@ -26,7 +27,6 @@ import com.expediagroup.graphql.generator.extensions.safeCast
 import graphql.schema.GraphQLInterfaceType
 import graphql.schema.GraphQLObjectType
 import graphql.schema.GraphQLTypeReference
-import graphql.schema.GraphQLTypeUtil
 import kotlin.reflect.KClass
 import kotlin.reflect.full.createType
 
@@ -44,7 +44,7 @@ internal fun generateObject(generator: SchemaGenerator, kClass: KClass<*>): Grap
     kClass.getValidSuperclasses(generator.config.hooks)
         .map { generateGraphQLType(generator, it.createType()) }
         .forEach {
-            when (val unwrappedType = GraphQLTypeUtil.unwrapType(it).last()) {
+            when (val unwrappedType = it.unwrapType()) {
                 is GraphQLTypeReference -> builder.withInterface(unwrappedType)
                 is GraphQLInterfaceType -> builder.withInterface(unwrappedType)
             }

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/generateUnion.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/generateUnion.kt
@@ -16,6 +16,7 @@
 
 package com.expediagroup.graphql.generator.types
 
+import com.expediagroup.graphql.extensions.unwrapType
 import com.expediagroup.graphql.generator.SchemaGenerator
 import com.expediagroup.graphql.generator.extensions.getGraphQLDescription
 import com.expediagroup.graphql.generator.extensions.getSimpleName
@@ -23,7 +24,6 @@ import com.expediagroup.graphql.generator.extensions.safeCast
 import graphql.TypeResolutionEnvironment
 import graphql.schema.GraphQLObjectType
 import graphql.schema.GraphQLTypeReference
-import graphql.schema.GraphQLTypeUtil
 import graphql.schema.GraphQLUnionType
 import kotlin.reflect.KClass
 import kotlin.reflect.full.createType
@@ -40,7 +40,7 @@ internal fun generateUnion(generator: SchemaGenerator, kClass: KClass<*>): Graph
     generator.classScanner.getSubTypesOf(kClass)
         .map { generateGraphQLType(generator, it.createType()) }
         .forEach {
-            when (val unwrappedType = GraphQLTypeUtil.unwrapType(it).last()) {
+            when (val unwrappedType = it.unwrapType()) {
                 is GraphQLTypeReference -> builder.possibleType(unwrappedType)
                 is GraphQLObjectType -> builder.possibleType(unwrappedType)
             }

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/execution/FunctionDataFetcherTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/execution/FunctionDataFetcherTest.kt
@@ -51,8 +51,8 @@ internal class FunctionDataFetcherTest {
 
         fun throwException() { throw GraphQLException("Test Exception") }
 
-        suspend fun suspendThrow(value: String?): String = coroutineScope {
-            value ?: throw GraphQLException("Suspended Exception")
+        suspend fun suspendThrow(): String = coroutineScope<String> {
+            throw GraphQLException("Suspended Exception")
         }
 
         @GraphQLName("myCustomField")
@@ -155,7 +155,6 @@ internal class FunctionDataFetcherTest {
     fun `suspendThrow throws exception when resolved`() {
         val dataFetcher = FunctionDataFetcher(target = MyClass(), fn = MyClass::suspendThrow)
         val mockEnvironmet: DataFetchingEnvironment = mockk()
-        every { mockEnvironmet.arguments } returns mapOf("value" to null)
 
         try {
             val result = dataFetcher.get(mockEnvironmet)

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/extensions/GraphqlTypeExtensionsKtTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/extensions/GraphqlTypeExtensionsKtTest.kt
@@ -24,7 +24,7 @@ import io.mockk.mockk
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
-internal class DeepNameKtTest {
+internal class GraphqlTypeExtensionsKtTest {
 
     private val basicType = mockk<GraphQLNamedType> {
         every { name } returns "BasicType"
@@ -51,5 +51,28 @@ internal class DeepNameKtTest {
     fun `deepname of non null list of non nulls`() {
         val complicated = GraphQLNonNull(GraphQLList(GraphQLNonNull(basicType)))
         assertEquals(expected = "[BasicType!]!", actual = complicated.deepName)
+    }
+
+    @Test
+    fun `unwrapType works on basic types that are not wrapped`() {
+        assertEquals("BasicType", basicType.unwrapType().deepName)
+    }
+
+    @Test
+    fun `unwrapType works on non null`() {
+        val nonNull = GraphQLNonNull.nonNull(basicType)
+        assertEquals("BasicType", nonNull.unwrapType().deepName)
+    }
+
+    @Test
+    fun `unwrapType works on lists`() {
+        val graphQLList = GraphQLList.list(basicType)
+        assertEquals("BasicType", graphQLList.unwrapType().deepName)
+    }
+
+    @Test
+    fun `unwrapType works on multiple layers`() {
+        val graphQLList = GraphQLNonNull.nonNull(GraphQLList.list(GraphQLNonNull.nonNull(basicType)))
+        assertEquals("BasicType", graphQLList.unwrapType().deepName)
     }
 }

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/SchemaGeneratorTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/SchemaGeneratorTest.kt
@@ -17,8 +17,11 @@
 package com.expediagroup.graphql.generator
 
 import com.expediagroup.graphql.SchemaGeneratorConfig
+import com.expediagroup.graphql.extensions.deepName
 import org.junit.jupiter.api.Test
 import kotlin.reflect.KClass
+import kotlin.reflect.KType
+import kotlin.reflect.full.createType
 import kotlin.test.assertEquals
 
 class SchemaGeneratorTest {
@@ -38,8 +41,22 @@ class SchemaGeneratorTest {
         assertEquals(1, generator.additionalTypes.size)
     }
 
+    @Test
+    fun generateAdditionalTypes() {
+        val config = SchemaGeneratorConfig(listOf("com.expediagroup.graphql.generator"))
+        val generator = CustomSchemaGenerator(config)
+        val types = setOf(SomeObjectWithAnnotaiton::class.createType())
+
+        val result = generator.generateCustomAdditionalTypes(types)
+
+        assertEquals(1, result.size)
+        assertEquals("SomeObjectWithAnnotaiton!", result.first().deepName)
+    }
+
     class CustomSchemaGenerator(config: SchemaGeneratorConfig) : SchemaGenerator(config) {
         internal fun addTypes(annotation: KClass<*>) = addAdditionalTypesWithAnnotation(annotation)
+
+        internal fun generateCustomAdditionalTypes(types: Set<KType>) = generateAdditionalTypes(types)
     }
 
     annotation class MyCustomAnnotation

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/SchemaGeneratorTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/SchemaGeneratorTest.kt
@@ -17,11 +17,8 @@
 package com.expediagroup.graphql.generator
 
 import com.expediagroup.graphql.SchemaGeneratorConfig
-import com.expediagroup.graphql.extensions.deepName
 import org.junit.jupiter.api.Test
 import kotlin.reflect.KClass
-import kotlin.reflect.KType
-import kotlin.reflect.full.createType
 import kotlin.test.assertEquals
 
 class SchemaGeneratorTest {
@@ -41,22 +38,8 @@ class SchemaGeneratorTest {
         assertEquals(1, generator.additionalTypes.size)
     }
 
-    @Test
-    fun generateAdditionalTypes() {
-        val config = SchemaGeneratorConfig(listOf("com.expediagroup.graphql.generator"))
-        val generator = CustomSchemaGenerator(config)
-        val types = setOf(SomeObjectWithAnnotaiton::class.createType())
-
-        val result = generator.generateCustomAdditionalTypes(types)
-
-        assertEquals(1, result.size)
-        assertEquals("SomeObjectWithAnnotaiton!", result.first().deepName)
-    }
-
     class CustomSchemaGenerator(config: SchemaGeneratorConfig) : SchemaGenerator(config) {
         internal fun addTypes(annotation: KClass<*>) = addAdditionalTypesWithAnnotation(annotation)
-
-        internal fun generateCustomAdditionalTypes(types: Set<KType>) = generateAdditionalTypes(types)
     }
 
     annotation class MyCustomAnnotation

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/filters/SuperclassFiltersKtTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/filters/SuperclassFiltersKtTest.kt
@@ -16,6 +16,7 @@
 
 package com.expediagroup.graphql.generator.filters
 
+import com.expediagroup.graphql.annotations.GraphQLIgnore
 import org.junit.jupiter.api.Test
 import kotlin.reflect.KClass
 import kotlin.test.assertFalse
@@ -35,12 +36,18 @@ class SuperclassFiltersKtTest {
         fun internal(): String
     }
 
+    @GraphQLIgnore
+    interface IgnoredInterface {
+        fun public(): String
+    }
+
     @Test
     fun superclassFilters() {
         assertTrue(isValidSuperclass(Interface::class))
         assertFalse(isValidSuperclass(Union::class))
         assertFalse(isValidSuperclass(NonPublic::class))
         assertFalse(isValidSuperclass(Class::class))
+        assertFalse(isValidSuperclass(IgnoredInterface::class))
     }
 
     private fun isValidSuperclass(kClass: KClass<*>): Boolean = superclassFilters.all { it(kClass) }


### PR DESCRIPTION
### :pencil: Description
This is a patch change to allow additional types to more easily be extended in later PRs. As a side-effect of this change we actually simplify where types are all generated and the main generateSchema function becomes just a little more straight forward.

### :link: Related Issues
This will make https://github.com/ExpediaGroup/graphql-kotlin/pull/585 a little eaiser to implement