### PR TITLE
Allow updating custom additional types

### DIFF
--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/SchemaGenerator.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/SchemaGenerator.kt
@@ -82,5 +82,10 @@ open class SchemaGenerator(internal val config: SchemaGeneratorConfig) {
         }
     }
 
-    protected fun generateAdditionalTypes(additionalTypes: Set<KType>): Set<GraphQLType> = additionalTypes.map { generateGraphQLType(this, it) }.toSet()
+    /**
+     * Generate the GraphQL type for all the `additionalTypes`. They are generated as non-inputs and not as IDs.
+     * If you need to provide more custom additional types that were not picked up from reflection of the schema objects,
+     * you can modify the set of `additionalTypes` before you call this method.
+     */
+    protected open fun generateAdditionalTypes(additionalTypes: Set<KType>): Set<GraphQLType> = additionalTypes.map { generateGraphQLType(this, it) }.toSet()
 }

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/SchemaGenerator.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/SchemaGenerator.kt
@@ -82,5 +82,5 @@ open class SchemaGenerator(internal val config: SchemaGeneratorConfig) {
         }
     }
 
-    private fun generateAdditionalTypes(additionalTypes: Set<KType>): Set<GraphQLType> = additionalTypes.map { generateGraphQLType(this, it) }.toSet()
+    protected fun generateAdditionalTypes(additionalTypes: Set<KType>): Set<GraphQLType> = additionalTypes.map { generateGraphQLType(this, it) }.toSet()
 }

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/SchemaGeneratorTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/SchemaGeneratorTest.kt
@@ -17,8 +17,11 @@
 package com.expediagroup.graphql.generator
 
 import com.expediagroup.graphql.SchemaGeneratorConfig
+import com.expediagroup.graphql.extensions.deepName
 import org.junit.jupiter.api.Test
 import kotlin.reflect.KClass
+import kotlin.reflect.KType
+import kotlin.reflect.full.createType
 import kotlin.test.assertEquals
 
 class SchemaGeneratorTest {
@@ -38,8 +41,22 @@ class SchemaGeneratorTest {
         assertEquals(1, generator.additionalTypes.size)
     }
 
+    @Test
+    fun generateAdditionalTypes() {
+        val config = SchemaGeneratorConfig(listOf("com.expediagroup.graphql.generator"))
+        val generator = CustomSchemaGenerator(config)
+        val types = setOf(SomeObjectWithAnnotaiton::class.createType())
+
+        val result = generator.generateCustomAdditionalTypes(types)
+
+        assertEquals(1, result.size)
+        assertEquals("SomeObjectWithAnnotaiton!", result.first().deepName)
+    }
+
     class CustomSchemaGenerator(config: SchemaGeneratorConfig) : SchemaGenerator(config) {
         internal fun addTypes(annotation: KClass<*>) = addAdditionalTypesWithAnnotation(annotation)
+
+        internal fun generateCustomAdditionalTypes(types: Set<KType>) = generateAdditionalTypes(types)
     }
 
     annotation class MyCustomAnnotation


### PR DESCRIPTION
### :pencil: Description
As discussed in other PRs #587 and #585 we can allow developers to have more customization of the schema by allowing them to add additional types of their own without having to add it to the schema directly. What they do with this feature will be up to them, but from a library perspective it is not bad feature to support.

### :link: Related Issues
See my comment here for more details: https://github.com/ExpediaGroup/graphql-kotlin/pull/585#discussion_r374316867