### PR TITLE
Add new hooks for mapping the function returned value

### DIFF
--- a/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/extension/CustomSchemaGeneratorHooks.kt
+++ b/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/extension/CustomSchemaGeneratorHooks.kt
@@ -22,6 +22,7 @@ import graphql.language.StringValue
 import graphql.schema.Coercing
 import graphql.schema.GraphQLScalarType
 import graphql.schema.GraphQLType
+import reactor.core.publisher.Mono
 import java.util.UUID
 import kotlin.reflect.KType
 
@@ -36,6 +37,16 @@ class CustomSchemaGeneratorHooks(override val wiringFactory: KotlinDirectiveWiri
     override fun willGenerateGraphQLType(type: KType): GraphQLType? = when (type.classifier) {
         UUID::class -> graphqlUUIDType
         else -> null
+    }
+
+    override fun willResolveFunctionType(type: KType): KType = when (type.classifier) {
+        Mono::class -> type.arguments.first().type!!
+        else -> type
+    }
+
+    override fun willReturnFunctionResult(result: Any?): Any? = when (result) {
+        is Mono<*> -> result.toFuture()
+        else -> result
     }
 }
 

--- a/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/query/MonadQuery.kt
+++ b/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/query/MonadQuery.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.examples.query
+
+import com.expediagroup.graphql.annotations.GraphQLDescription
+import com.expediagroup.graphql.spring.operations.Query
+import org.springframework.stereotype.Component
+import reactor.core.publisher.Mono
+import java.util.concurrent.CompletableFuture
+
+@Component
+class MonadQuery : Query {
+    fun monads() = MonadFunctionContainer()
+}
+
+class MonadFunctionContainer {
+
+    @GraphQLDescription("Return the passed in message but wrapped in a Mono")
+    fun reactorEcho(msg: String): Mono<String> = Mono.just(msg)
+
+    @GraphQLDescription("Return the passed in message but wrapped in a CompletableFuture")
+    fun completableFutureEcho(msg: String): CompletableFuture<String> = CompletableFuture.completedFuture(msg)
+}

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/execution/KotlinDataFetcherFactoryProvider.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/execution/KotlinDataFetcherFactoryProvider.kt
@@ -16,6 +16,7 @@
 
 package com.expediagroup.graphql.execution
 
+import com.expediagroup.graphql.hooks.SchemaGeneratorHooks
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import graphql.schema.DataFetcherFactory
@@ -37,7 +38,7 @@ interface KotlinDataFetcherFactoryProvider {
      * retrieved during data fetcher execution from [graphql.schema.DataFetchingEnvironment]
      * @param kFunction Kotlin function being invoked
      */
-    fun functionDataFetcherFactory(target: Any?, kFunction: KFunction<*>): DataFetcherFactory<Any>
+    fun functionDataFetcherFactory(target: Any?, kFunction: KFunction<*>, hooks: SchemaGeneratorHooks): DataFetcherFactory<Any>
 
     /**
      * Retrieve an instance of [DataFetcherFactory] that will be used to resolve target property.
@@ -56,14 +57,16 @@ open class SimpleKotlinDataFetcherFactoryProvider(
     private val objectMapper: ObjectMapper = jacksonObjectMapper()
 ) : KotlinDataFetcherFactoryProvider {
 
-    override fun functionDataFetcherFactory(target: Any?, kFunction: KFunction<*>): DataFetcherFactory<Any> = DataFetcherFactory<Any> {
+    override fun functionDataFetcherFactory(target: Any?, kFunction: KFunction<*>, hooks: SchemaGeneratorHooks): DataFetcherFactory<Any> = DataFetcherFactory<Any> {
         FunctionDataFetcher(
             target = target,
             fn = kFunction,
-            objectMapper = objectMapper)
+            hooks = hooks,
+            objectMapper = objectMapper
+        )
     }
 
     override fun propertyDataFetcherFactory(kClass: KClass<*>, kProperty: KProperty<*>): DataFetcherFactory<Any> = DataFetcherFactory<Any> {
-        PropertyDataFetcher(kProperty.name)
+        PropertyDataFetcher<Any>(kProperty.name)
     }
 }

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/generateFunction.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/generateFunction.kt
@@ -48,14 +48,14 @@ internal fun generateFunction(generator: SchemaGenerator, fn: KFunction<*>, pare
         builder.argument(generateArgument(generator, it))
     }
 
-    val typeFromHooks = generator.config.hooks.willResolveMonad(fn.returnType)
+    val typeFromHooks = generator.config.hooks.willResolveFunctionType(fn.returnType)
     val returnType = getWrappedReturnType(typeFromHooks)
     val graphQLOutputType = generateGraphQLType(generator, returnType).safeCast<GraphQLOutputType>()
     val graphQLType = builder.type(graphQLOutputType).build()
     val coordinates = FieldCoordinates.coordinates(parentName, functionName)
 
     if (!abstract) {
-        val dataFetcherFactory = generator.config.dataFetcherFactoryProvider.functionDataFetcherFactory(target = target, kFunction = fn)
+        val dataFetcherFactory = generator.config.dataFetcherFactoryProvider.functionDataFetcherFactory(target = target, kFunction = fn, hooks = generator.config.hooks)
         generator.codeRegistry.dataFetcher(coordinates, dataFetcherFactory)
     }
 

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/hooks/SchemaGeneratorHooks.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/hooks/SchemaGeneratorHooks.kt
@@ -65,10 +65,28 @@ interface SchemaGeneratorHooks {
     fun willAddGraphQLTypeToSchema(type: KType, generatedType: GraphQLType): GraphQLType = generatedType
 
     /**
-     * Called before resolving a KType to the GraphQL type.
-     * This allows for a custom resolver on how to extract wrapped values, like in a CompletableFuture.
+     * Called after the using reflection to get the return type of a function,
+     * and before the GraphQLType is calculated. You can use this with other common asynchronous
+     * librarys that wrap the return type like Reactor or RxJava.
+     *
+     * If you convert the value to a [java.util.concurrent.CompletableFuture] with out fetching the
+     * result then graphql-java will natively handle fetching the value for you.
+     *
+     * This allows for a custom resolver on how to extract wrapped values information.
+     * You will most likely have to also provide hooks with [willReturnFunctionResult]
+     * to retrieve the value of the result when executing the data fetcher.
      */
-    fun willResolveMonad(type: KType): KType = type
+    fun willResolveFunctionType(type: KType): KType = type
+
+    /**
+     * Called after running the [com.expediagroup.graphql.execution.FunctionDataFetcher] and
+     * before the result is passed to the execution engine. You can use this with other common
+     * asynchronous librarys that wrap the return type like Reactor or RxJava.
+     *
+     * If you are using [willResolveFunctionType], you will most likely have to add logic here
+     * on how to retrieve the value from your wrapped type.
+     */
+    fun willReturnFunctionResult(result: Any?): Any? = result
 
     /**
      * Called when looking at the KClass superclasses to determine if it valid for adding to the generated schema.

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/SchemaGeneratorAsyncTests.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/SchemaGeneratorAsyncTests.kt
@@ -36,7 +36,7 @@ import kotlin.test.assertTrue
 class SchemaGeneratorAsyncTests {
 
     private class MonadHooks : SchemaGeneratorHooks {
-        override fun willResolveMonad(type: KType): KType = when (type.classifier) {
+        override fun willResolveFunctionType(type: KType): KType = when (type.classifier) {
             Observable::class, Single::class, Maybe::class -> type.arguments.firstOrNull()?.type
             else -> type
         } ?: type

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/hooks/SchemaGeneratorHooksTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/hooks/SchemaGeneratorHooksTest.kt
@@ -252,7 +252,7 @@ class SchemaGeneratorHooksTest {
         val hooks = NoopSchemaGeneratorHooks
         val type = TestQuery::query.returnType
 
-        assertEquals(expected = "SomeData", actual = hooks.willResolveMonad(type).getSimpleName())
+        assertEquals(expected = "SomeData", actual = hooks.willResolveFunctionType(type).getSimpleName())
     }
 
     @Test


### PR DESCRIPTION
### :pencil: Description
In the master branch it looks, like we actually don't have a way to resolve custom function wrapper types. The schema can be generated but the execution does not allow for custom behaviour. 

* Rename `willResolveMonad` to `willResolveFunctionType`
* Add new hook `willReturnFunctionResult` which allows developers to fetch the result of their custom function wrapper.

### :link: Related Issues
This is a first draft change related to #596