### PR TITLE
[docs] example usage of Reactor Mono

### DIFF
--- a/docs/execution/async-models.md
+++ b/docs/execution/async-models.md
@@ -64,29 +64,57 @@ will result in the exactly the same schema as in the coroutine example above.
 
 ## RxJava/Reactor
 
-If you use a different monad type, like `Single` from [RxJava](https://github.com/ReactiveX/RxJava) or `Mono` from
-[Project Reactor](https://projectreactor.io/), you just have to provide the logic in
-`SchemaGeneratorHooks.willResolveMonad` to unwrap it and return the inner class.
+If you want to use a different monad type, like `Single` from [RxJava](https://github.com/ReactiveX/RxJava) or `Mono` from
+[Project Reactor](https://projectreactor.io/), you have to:
+
+1. Create custom `SchemaGeneratorHook` that implements `willResolveMonad` to provide the necessary logic
+to correctly unwrap the monad and return the inner class to generate valid schema
 
 ```kotlin
-class RxJava2Query {
-    fun asynchronouslyDo(): Observable<Int> = Observable.just(1)
-
-    fun asynchronouslyDoSingle(): Single<Int> = Single.just(1)
-
-    fun maybe(): Maybe<Int> = Maybe.empty()
-}
-
-private class MonadHooks : SchemaGeneratorHooks {
+class MonadHooks : SchemaGeneratorHooks {
     override fun willResolveMonad(type: KType): KType = when (type.classifier) {
-        Observable::class, Single::class, Maybe::class -> type.arguments.firstOrNull()?.type
+        Mono::class -> type.arguments.firstOrNull()?.type
         else -> type
     } ?: type
 }
+```
 
-val configWithRxJavaMonads = getConfig(hooks = MonadHooks())
+2. Provide custom data fetcher that will properly process those monad types.
 
-toSchema(queries = listOf(TopLevelObject(RxJava2Query())), config = configWithRxJavaMonads)
+```kotlin
+class CustomFunctionDataFetcher(target: Any?, fn: KFunction<*>, objectMapper: ObjectMapper) : FunctionDataFetcher(target, fn, objectMapper) {
+  override fun get(environment: DataFetchingEnvironment): Any? = when (val result = super.get(environment)) {
+    is Mono<*> -> result.toFuture()
+    else -> result
+  }
+}
+
+class CustomDataFetcherFactoryProvider(
+    private val objectMapper: ObjectMapper
+) : SimpleKotlinDataFetcherFactoryProvider(objectMapper) {
+
+  override fun functionDataFetcherFactory(target: Any?, kFunction: KFunction<*>): DataFetcherFactory<Any> = DataFetcherFactory<Any> {
+    CustomFunctionDataFetcher(
+      target = target,
+      fn = kFunction,
+      objectMapper = objectMapper)
+  }
+}
+```
+
+With the above you can then create your schema as follows:
+
+```kotlin
+class ReactorQuery {
+    fun asynchronouslyDo(): Mono<Int> = Mono.just(1)
+}
+
+val configWithReactorMonoMonad = SchemaGeneratorConfig(
+  supportedPackages = listOf("myPackage"),
+  hooks = MonadHooks(),
+  dataFetcherFactoryProvider = CustomDataFetcherFactoryProvider())
+
+toSchema(queries = listOf(TopLevelObject(ReactorQuery())), config = configWithReactorMonoMonad)
 ```
 
 This will produce
@@ -94,10 +122,9 @@ This will produce
 ```graphql
 type Query {
   asynchronouslyDo(): Int
-  asynchronouslyDoSingle(): Int
-  maybe: Int
 }
 ```
 
 You can find additional example on how to configure the hooks in our [unit
-tests](https://github.com/ExpediaGroup/graphql-kotlin/blob/master/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/SchemaGeneratorAsyncTests.kt).
+tests](https://github.com/ExpediaGroup/graphql-kotlin/blob/master/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/SchemaGeneratorAsyncTests.kt)
+and [example app](https://github.com/ExpediaGroup/graphql-kotlin/blob/master/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/query/AsyncQuery.kt).

--- a/examples/federation/base-app/src/main/kotlin/com/expediagroup/graphql/examples/Application.kt
+++ b/examples/federation/base-app/src/main/kotlin/com/expediagroup/graphql/examples/Application.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Expedia, Inc
+ * Copyright 2020 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package com.expediagroup.graphql.examples
 
-import com.expediagroup.graphql.examples.extension.CustomFederationSchemaGeneratorHooks
+import com.expediagroup.graphql.examples.hooks.CustomFederationSchemaGeneratorHooks
 import com.expediagroup.graphql.federation.execution.FederatedTypeRegistry
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication

--- a/examples/federation/base-app/src/main/kotlin/com/expediagroup/graphql/examples/hooks/CustomFederationSchemaGeneratorHooks.kt
+++ b/examples/federation/base-app/src/main/kotlin/com/expediagroup/graphql/examples/hooks/CustomFederationSchemaGeneratorHooks.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Expedia, Inc
+ * Copyright 2020 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-package com.expediagroup.graphql.examples.extension
+package com.expediagroup.graphql.examples.hooks
 
-import com.expediagroup.graphql.directives.KotlinDirectiveWiringFactory
-import com.expediagroup.graphql.hooks.SchemaGeneratorHooks
+import com.expediagroup.graphql.federation.FederatedSchemaGeneratorHooks
+import com.expediagroup.graphql.federation.execution.FederatedTypeRegistry
 import graphql.language.StringValue
 import graphql.schema.Coercing
 import graphql.schema.GraphQLScalarType
@@ -28,14 +28,14 @@ import kotlin.reflect.KType
 /**
  * Schema generator hook that adds additional scalar types.
  */
-class CustomSchemaGeneratorHooks(override val wiringFactory: KotlinDirectiveWiringFactory) : SchemaGeneratorHooks {
+class CustomFederationSchemaGeneratorHooks(federatedTypeRegistry: FederatedTypeRegistry) : FederatedSchemaGeneratorHooks(federatedTypeRegistry) {
 
     /**
      * Register additional GraphQL scalar types.
      */
     override fun willGenerateGraphQLType(type: KType): GraphQLType? = when (type.classifier) {
         UUID::class -> graphqlUUIDType
-        else -> null
+        else -> super.willGenerateGraphQLType(type)
     }
 }
 

--- a/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/Application.kt
+++ b/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/Application.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Expedia, Inc
+ * Copyright 2020 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,12 +17,12 @@
 package com.expediagroup.graphql.examples
 
 import com.expediagroup.graphql.directives.KotlinDirectiveWiringFactory
-import com.expediagroup.graphql.examples.datafetchers.CustomDataFetcherFactoryProvider
-import com.expediagroup.graphql.examples.datafetchers.SpringDataFetcherFactory
 import com.expediagroup.graphql.examples.directives.CustomDirectiveWiringFactory
 import com.expediagroup.graphql.examples.exceptions.CustomDataFetcherExceptionHandler
+import com.expediagroup.graphql.examples.execution.CustomDataFetcherFactoryProvider
 import com.expediagroup.graphql.examples.execution.MySubscriptionHooks
-import com.expediagroup.graphql.examples.extension.CustomSchemaGeneratorHooks
+import com.expediagroup.graphql.examples.execution.SpringDataFetcherFactory
+import com.expediagroup.graphql.examples.hooks.CustomSchemaGeneratorHooks
 import com.expediagroup.graphql.spring.execution.ApolloSubscriptionHooks
 import com.fasterxml.jackson.databind.ObjectMapper
 import graphql.execution.DataFetcherExceptionHandler

--- a/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/execution/CustomDataFetcherFactoryProvider.kt
+++ b/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/execution/CustomDataFetcherFactoryProvider.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Expedia, Inc
+ * Copyright 2020 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-package com.expediagroup.graphql.examples.datafetchers
+package com.expediagroup.graphql.examples.execution
 
 import com.expediagroup.graphql.execution.SimpleKotlinDataFetcherFactoryProvider
 import com.fasterxml.jackson.databind.ObjectMapper
 import graphql.schema.DataFetcherFactory
 import kotlin.reflect.KClass
+import kotlin.reflect.KFunction
 import kotlin.reflect.KProperty
 
 /**
@@ -27,8 +28,15 @@ import kotlin.reflect.KProperty
  */
 class CustomDataFetcherFactoryProvider(
     private val springDataFetcherFactory: SpringDataFetcherFactory,
-    objectMapper: ObjectMapper
+    private val objectMapper: ObjectMapper
 ) : SimpleKotlinDataFetcherFactoryProvider(objectMapper) {
+
+    override fun functionDataFetcherFactory(target: Any?, kFunction: KFunction<*>): DataFetcherFactory<Any> = DataFetcherFactory<Any> {
+        CustomFunctionDataFetcher(
+            target = target,
+            fn = kFunction,
+            objectMapper = objectMapper)
+    }
 
     override fun propertyDataFetcherFactory(kClass: KClass<*>, kProperty: KProperty<*>): DataFetcherFactory<Any> =
         if (kProperty.isLateinit) {

--- a/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/execution/CustomFunctionDataFetcher.kt
+++ b/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/execution/CustomFunctionDataFetcher.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.examples.execution
+
+import com.expediagroup.graphql.execution.FunctionDataFetcher
+import com.fasterxml.jackson.databind.ObjectMapper
+import graphql.schema.DataFetchingEnvironment
+import reactor.core.publisher.Mono
+import kotlin.reflect.KFunction
+
+/**
+ * Custom function data fetcher that adds support for Reactor Mono.
+ */
+class CustomFunctionDataFetcher(target: Any?, fn: KFunction<*>, objectMapper: ObjectMapper) : FunctionDataFetcher(target, fn, objectMapper) {
+
+    override fun get(environment: DataFetchingEnvironment): Any? = when (val result = super.get(environment)) {
+        is Mono<*> -> result.toFuture()
+        else -> result
+    }
+}

--- a/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/execution/SpringDataFetcherFactory.kt
+++ b/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/execution/SpringDataFetcherFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Expedia, Inc
+ * Copyright 2020 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.expediagroup.graphql.examples.datafetchers
+package com.expediagroup.graphql.examples.execution
 
 import com.expediagroup.graphql.extensions.deepName
 import graphql.schema.DataFetcher

--- a/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/query/AsyncQuery.kt
+++ b/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/query/AsyncQuery.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Expedia, Inc
+ * Copyright 2020 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,11 @@ package com.expediagroup.graphql.examples.query
 
 import com.expediagroup.graphql.annotations.GraphQLDescription
 import com.expediagroup.graphql.spring.operations.Query
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.time.delay
 import org.springframework.stereotype.Component
+import reactor.core.publisher.Mono
+import java.time.Duration
 import java.util.concurrent.CompletableFuture
 
 /**
@@ -27,15 +31,25 @@ import java.util.concurrent.CompletableFuture
 @Component
 class AsyncQuery : Query {
 
-    @GraphQLDescription("Delays for given amount and then echos the string back." +
+    @GraphQLDescription("Delays for given amount of time using CompletableFuture and then echoes the string back." +
             " The default async executor will work with CompletableFuture." +
             " To use other rx frameworks you'll need to install a custom one to handle the types correctly.")
-    fun delayedEchoUsingCompletableFuture(msg: String, delaySeconds: Int): CompletableFuture<String> {
+    fun delayedEchoUsingCompletableFuture(msg: String, delayMilliseconds: Int): CompletableFuture<String> {
         val future = CompletableFuture<String>()
         Thread {
-            Thread.sleep(delaySeconds * 1000L)
+            Thread.sleep(delayMilliseconds.toLong())
             future.complete(msg)
         }.start()
         return future
+    }
+
+    @GraphQLDescription("Delays for given amount of time using Reactor Mono and then echoes the string back.")
+    fun delayedEchoUsingReactorMono(msg: String, delayMilliseconds: Int): Mono<String> =
+        Mono.just(msg).delayElement(Duration.ofMillis(delayMilliseconds.toLong()))
+
+    @GraphQLDescription("Delays for given amount of time using Coroutine and then echoes the string back.")
+    suspend fun delayedEchoUsingCoroutine(msg: String, delayMilliseconds: Int): String = coroutineScope {
+        delay(Duration.ofMillis(delayMilliseconds.toLong()))
+        msg
     }
 }

--- a/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/subscriptions/SimpleSubscription.kt
+++ b/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/subscriptions/SimpleSubscription.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Expedia, Inc
+ * Copyright 2020 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,6 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 import reactor.core.publisher.Flux
-import reactor.core.publisher.Mono
 import java.time.Duration
 import kotlin.random.Random
 
@@ -37,7 +36,7 @@ class SimpleSubscription : Subscription {
     val logger: Logger = LoggerFactory.getLogger(SimpleSubscription::class.java)
 
     @GraphQLDescription("Returns a single value")
-    fun singleValueSubscription(): Mono<Int> = Mono.just(1)
+    fun singleValueSubscription(): Flux<Int> = Flux.just(1)
 
     @GraphQLDescription("Returns a random number every second")
     fun counter(): Flux<Int> = Flux.interval(Duration.ofSeconds(1)).map {

--- a/examples/spring/src/test/kotlin/com/expediagroup/graphql/examples/query/AsyncQueryIT.kt
+++ b/examples/spring/src/test/kotlin/com/expediagroup/graphql/examples/query/AsyncQueryIT.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Expedia, Inc
+ * Copyright 2020 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,13 +36,41 @@ class AsyncQueryIT(@Autowired private val testClient: WebTestClient) {
     @Test
     fun `verify delayedEchoUsingCompletableFuture query`() {
         val query = "delayedEchoUsingCompletableFuture"
-        val data = "hello"
+        val data = "helloUsingCompletableFuture"
 
         testClient.post()
             .uri(GRAPHQL_ENDPOINT)
             .accept(APPLICATION_JSON)
             .contentType(GRAPHQL_MEDIA_TYPE)
-            .bodyValue("query { $query(msg: \"$data\", delaySeconds: 1) }")
+            .bodyValue("query { $query(msg: \"$data\", delayMilliseconds: 200) }")
+            .exchange()
+            .verifyData(query, data)
+    }
+
+    @Test
+    fun `verify delayedEchoUsingReactorMono query`() {
+        val query = "delayedEchoUsingReactorMono"
+        val data = "helloUsingMono"
+
+        testClient.post()
+            .uri(GRAPHQL_ENDPOINT)
+            .accept(APPLICATION_JSON)
+            .contentType(GRAPHQL_MEDIA_TYPE)
+            .bodyValue("query { $query(msg: \"$data\", delayMilliseconds: 200) }")
+            .exchange()
+            .verifyData(query, data)
+    }
+
+    @Test
+    fun `verify delayedEchoUsingCoroutine query`() {
+        val query = "delayedEchoUsingCoroutine"
+        val data = "helloUsingCoroutine"
+
+        testClient.post()
+            .uri(GRAPHQL_ENDPOINT)
+            .accept(APPLICATION_JSON)
+            .contentType(GRAPHQL_MEDIA_TYPE)
+            .bodyValue("query { $query(msg: \"$data\", delayMilliseconds: 200) }")
             .exchange()
             .verifyData(query, data)
     }


### PR DESCRIPTION
### :pencil: Description

With the removal of evaluation predicates from the `FunctionDataFetcher` we no longer have an option to automatically handle Reactor/RxJava monads. In order to enable monad support we need to configure custom `SchemaGeneratorHook` to generate valid schema as well as custom `FunctionDataFetcher` so it can correctly process monads at runtime. Ideally this sort of additional runtime logic should be handled by hooks/instrumentation but with the current implementation relying on `graphql-java` it is the simplest workaround to get it working.

### :link: Related Issues
https://github.com/ExpediaGroup/graphql-kotlin/issues/596
https://github.com/ExpediaGroup/graphql-kotlin/pull/597