### PR TITLE
Update completable future mapping for coroutines

### DIFF
--- a/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/execution/EntityResolver.kt
+++ b/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/execution/EntityResolver.kt
@@ -23,7 +23,7 @@ import graphql.schema.DataFetchingEnvironment
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
-import kotlinx.coroutines.future.asCompletableFuture
+import kotlinx.coroutines.future.future
 import java.util.concurrent.CompletableFuture
 
 /**
@@ -45,7 +45,7 @@ open class EntityResolver(private val federatedTypeRegistry: FederatedTypeRegist
         val representations: List<Map<String, Any>> = env.getArgument("representations")
 
         val indexedBatchRequestsByType = representations.withIndex().groupBy { it.value["__typename"].toString() }
-        return GlobalScope.async {
+        return GlobalScope.future {
             val data = mutableListOf<Any?>()
             val errors = mutableListOf<GraphQLError>()
             indexedBatchRequestsByType.map { (typeName, indexedRequests) ->
@@ -68,6 +68,6 @@ open class EntityResolver(private val federatedTypeRegistry: FederatedTypeRegist
                 .data(data)
                 .errors(errors)
                 .build()
-        }.asCompletableFuture()
+        }
     }
 }


### PR DESCRIPTION
### :pencil: Description
Use the handy method on coroutine GlobalScope to execute as a CompletableFuture instead of mapping the result. This shouldn't really change much but does make the code a little easier to read

### :link: Related Issues
N\A