### PR TITLE
Publish the build directory in the website

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -39,6 +39,6 @@ jobs:
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./build
+        publish_dir: ./website/build
         user_name: eg-oss-ci
         user_email: oss@expediagroup.com


### PR DESCRIPTION
### :pencil: Description
As seen in this publish step the path is relative to the project.

https://github.com/ExpediaGroup/graphql-kotlin/runs/469008143?check_suite_focus=true#step:6:123

```
Error: ENOENT: no such file or directory, scandir '/home/runner/work/graphql-kotlin/graphql-kotlin/build'
```

### :link: Related Issues
#616 
#614 