### PR TITLE
move generation of additional types to an iterative approach

### DIFF
--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/SchemaGenerator.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/SchemaGenerator.kt
@@ -90,14 +90,15 @@ open class SchemaGenerator(internal val config: SchemaGeneratorConfig) {
      * This function is recursive because while generating the additionalTypes it is possible to create additional types that need to be processed.
      */
     protected open fun generateAdditionalTypes(): Set<GraphQLType> {
-        val currentlyProcessedTypes = this.additionalTypes.toSet()
-        this.additionalTypes.clear()
-        val graphqlTypes = currentlyProcessedTypes.map { generateGraphQLType(this, it) }.toSet()
+        val currentlyProcessedTypes = mutableSetOf<KType>()
+        val graphqlTypes = mutableSetOf<GraphQLType>()
+        do {
+            currentlyProcessedTypes.addAll(this.additionalTypes)
+            this.additionalTypes.clear()
+            graphqlTypes.addAll(currentlyProcessedTypes.map { generateGraphQLType(this, it) })
+            currentlyProcessedTypes.clear()
+        } while (this.additionalTypes.isNotEmpty())
 
-        return if (this.additionalTypes.isNotEmpty()) {
-            graphqlTypes.plus(generateAdditionalTypes())
-        } else {
-            graphqlTypes
-        }
+        return graphqlTypes.toSet()
     }
 }

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/SchemaGeneratorTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/SchemaGeneratorTest.kt
@@ -48,7 +48,7 @@ class SchemaGeneratorTest {
         val result = generator.generateCustomAdditionalTypes()
 
         assertEquals(1, result.size)
-        assertEquals("SomeObjectWithAnnotaiton!", result.first().deepName)
+        assertEquals("SomeObjectWithAnnotation!", result.first().deepName)
     }
 
     class CustomSchemaGenerator(config: SchemaGeneratorConfig) : SchemaGenerator(config) {
@@ -61,5 +61,5 @@ class SchemaGeneratorTest {
     annotation class MyOtherCustomAnnotation
 
     @MyCustomAnnotation
-    data class SomeObjectWithAnnotaiton(val name: String)
+    data class SomeObjectWithAnnotation(val name: String)
 }


### PR DESCRIPTION
### :pencil: Description
Changed the current recursive approach of adding the additional types to iterative one.

This approach saves:
-  a bunch of `toSet()` calls which internally means creation of new LinkedHashSet
- `.plus()` calls which also creates a new LinkedHashSet and does an `addAll()` internally.