### PR TITLE
Add additionalTypes to generateSchema

### DIFF
--- a/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/FederatedSchemaGenerator.kt
+++ b/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/FederatedSchemaGenerator.kt
@@ -20,6 +20,7 @@ import com.expediagroup.graphql.TopLevelObject
 import com.expediagroup.graphql.federation.directives.ExtendsDirective
 import com.expediagroup.graphql.generator.SchemaGenerator
 import graphql.schema.GraphQLSchema
+import kotlin.reflect.KType
 
 /**
  * Generates federated GraphQL schemas based on the specified configuration.
@@ -30,8 +31,13 @@ open class FederatedSchemaGenerator(generatorConfig: FederatedSchemaGeneratorCon
      * Scans specified packages for all the federated (extended) types and adds them to the schema additional types,
      * then it generates the schema as usual using the [FederatedSchemaGeneratorConfig].
      */
-    override fun generateSchema(queries: List<TopLevelObject>, mutations: List<TopLevelObject>, subscriptions: List<TopLevelObject>): GraphQLSchema {
+    override fun generateSchema(
+        queries: List<TopLevelObject>,
+        mutations: List<TopLevelObject>,
+        subscriptions: List<TopLevelObject>,
+        additionalTypes: Set<KType>
+    ): GraphQLSchema {
         addAdditionalTypesWithAnnotation(ExtendsDirective::class)
-        return super.generateSchema(queries, mutations, subscriptions)
+        return super.generateSchema(queries, mutations, subscriptions, additionalTypes)
     }
 }

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/SchemaGenerator.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/SchemaGenerator.kt
@@ -42,7 +42,6 @@ import kotlin.reflect.full.createType
 open class SchemaGenerator(internal val config: SchemaGeneratorConfig) {
 
     val additionalTypes = mutableSetOf<KType>()
-    
     internal val classScanner = ClassScanner(config.supportedPackages)
     internal val cache = TypesCache(config.supportedPackages)
     internal val codeRegistry = GraphQLCodeRegistry.newCodeRegistry()

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/SchemaGenerator.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/SchemaGenerator.kt
@@ -56,7 +56,7 @@ open class SchemaGenerator(internal val config: SchemaGeneratorConfig) {
         subscriptions: List<TopLevelObject> = emptyList(),
         additionalTypes: Set<KType> = emptySet()
     ): GraphQLSchema {
-        
+
         this.additionalTypes.addAll(additionalTypes)
         val builder = GraphQLSchema.newSchema()
         builder.query(generateQueries(this, queries))
@@ -65,7 +65,6 @@ open class SchemaGenerator(internal val config: SchemaGeneratorConfig) {
         builder.additionalTypes(generateAdditionalTypes())
         builder.additionalDirectives(directives.values.toSet())
         builder.codeRegistry(codeRegistry.build())
-        
         val schema = config.hooks.willBuildSchema(builder).build()
 
         classScanner.close()

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/SchemaGenerator.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/SchemaGenerator.kt
@@ -41,7 +41,7 @@ import kotlin.reflect.full.createType
  */
 open class SchemaGenerator(internal val config: SchemaGeneratorConfig) {
 
-    val additionalTypes = mutableSetOf<KType>()
+    internal val additionalTypes = mutableSetOf<KType>()
     internal val classScanner = ClassScanner(config.supportedPackages)
     internal val cache = TypesCache(config.supportedPackages)
     internal val codeRegistry = GraphQLCodeRegistry.newCodeRegistry()

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/SchemaGenerator.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/SchemaGenerator.kt
@@ -53,9 +53,11 @@ open class SchemaGenerator(internal val config: SchemaGeneratorConfig) {
     open fun generateSchema(
         queries: List<TopLevelObject>,
         mutations: List<TopLevelObject> = emptyList(),
-        subscriptions: List<TopLevelObject> = emptyList()
+        subscriptions: List<TopLevelObject> = emptyList(),
+        additionalTypes: Set<KType> = emptySet()
     ): GraphQLSchema {
-
+        
+        this.additionalTypes.addAll(additionalTypes)
         val builder = GraphQLSchema.newSchema()
         builder.query(generateQueries(this, queries))
         builder.mutation(generateMutations(this, mutations))
@@ -63,7 +65,7 @@ open class SchemaGenerator(internal val config: SchemaGeneratorConfig) {
         builder.additionalTypes(generateAdditionalTypes())
         builder.additionalDirectives(directives.values.toSet())
         builder.codeRegistry(codeRegistry.build())
-
+        
         val schema = config.hooks.willBuildSchema(builder).build()
 
         classScanner.close()
@@ -85,11 +87,11 @@ open class SchemaGenerator(internal val config: SchemaGeneratorConfig) {
     /**
      * Generate the GraphQL type for all the `additionalTypes`. They are generated as non-inputs and not as IDs.
      * If you need to provide more custom additional types that were not picked up from reflection of the schema objects,
-     * you can modify the set of `additionalTypes` before you call this method.
+     * you can provide more types to be added through [generateSchema].
      *
-     * This function is recursive because while generating the additionalTypes it is possible to create additional types that need to be processed.
+     * This function loops because while generating the additionalTypes it is possible to create more additional types that need to be processed.
      */
-    protected open fun generateAdditionalTypes(): Set<GraphQLType> {
+    protected fun generateAdditionalTypes(): Set<GraphQLType> {
         val graphqlTypes = mutableSetOf<GraphQLType>()
         while (this.additionalTypes.isNotEmpty()) {
             val currentlyProcessedTypes = LinkedHashSet(this.additionalTypes)

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/SchemaGenerator.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/SchemaGenerator.kt
@@ -41,10 +41,11 @@ import kotlin.reflect.full.createType
  */
 open class SchemaGenerator(internal val config: SchemaGeneratorConfig) {
 
+    val additionalTypes = mutableSetOf<KType>()
+    
     internal val classScanner = ClassScanner(config.supportedPackages)
     internal val cache = TypesCache(config.supportedPackages)
     internal val codeRegistry = GraphQLCodeRegistry.newCodeRegistry()
-    internal val additionalTypes = mutableSetOf<KType>()
     internal val directives = ConcurrentHashMap<String, GraphQLDirective>()
 
     /**


### PR DESCRIPTION
### :pencil: Description
Additional types cannot be edited, but comments suggest that is the appropriate way to add additional types before generateAdditionalTypes() is called:

```
    /**
     * Generate the GraphQL type for all the `additionalTypes`. They are generated as non-inputs and not as IDs.
     * If you need to provide more custom additional types that were not picked up from reflection of the schema objects,
     * you can modify the set of `additionalTypes` before you call this method.
     *
     * This function is recursive because while generating the additionalTypes it is possible to create additional types that need to be processed.
     */
```

### :link: Related Issues
#615