### PR TITLE
BREAKING CHANGE: Make the KotlinDataFetcherFactoryProvider nullable

### DIFF
--- a/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/execution/CustomDataFetcherFactoryProvider.kt
+++ b/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/execution/CustomDataFetcherFactoryProvider.kt
@@ -31,14 +31,14 @@ class CustomDataFetcherFactoryProvider(
     private val objectMapper: ObjectMapper
 ) : SimpleKotlinDataFetcherFactoryProvider(objectMapper) {
 
-    override fun functionDataFetcherFactory(target: Any?, kFunction: KFunction<*>): DataFetcherFactory<Any> = DataFetcherFactory<Any> {
+    override fun functionDataFetcherFactory(target: Any?, kFunction: KFunction<*>) = DataFetcherFactory {
         CustomFunctionDataFetcher(
             target = target,
             fn = kFunction,
             objectMapper = objectMapper)
     }
 
-    override fun propertyDataFetcherFactory(kClass: KClass<*>, kProperty: KProperty<*>): DataFetcherFactory<Any> =
+    override fun propertyDataFetcherFactory(kClass: KClass<*>, kProperty: KProperty<*>): DataFetcherFactory<Any?> =
         if (kProperty.isLateinit) {
             springDataFetcherFactory
         } else {

--- a/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/execution/SpringDataFetcherFactory.kt
+++ b/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/execution/SpringDataFetcherFactory.kt
@@ -25,7 +25,7 @@ import org.springframework.beans.factory.BeanFactoryAware
 import org.springframework.stereotype.Component
 
 @Component
-class SpringDataFetcherFactory : DataFetcherFactory<Any>, BeanFactoryAware {
+class SpringDataFetcherFactory : DataFetcherFactory<Any?>, BeanFactoryAware {
     private lateinit var beanFactory: BeanFactory
 
     override fun setBeanFactory(beanFactory: BeanFactory) {
@@ -33,10 +33,10 @@ class SpringDataFetcherFactory : DataFetcherFactory<Any>, BeanFactoryAware {
     }
 
     @Suppress("UNCHECKED_CAST")
-    override fun get(environment: DataFetcherFactoryEnvironment?): DataFetcher<Any> {
+    override fun get(environment: DataFetcherFactoryEnvironment?): DataFetcher<Any?> {
 
         // Strip out possible `Input` and `!` suffixes added to by the SchemaGenerator
         val targetedTypeName = environment?.fieldDefinition?.type?.deepName?.removeSuffix("!")?.removeSuffix("Input")
-        return beanFactory.getBean("${targetedTypeName}DataFetcher") as DataFetcher<Any>
+        return beanFactory.getBean("${targetedTypeName}DataFetcher") as DataFetcher<Any?>
     }
 }

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/execution/KotlinDataFetcherFactoryProvider.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/execution/KotlinDataFetcherFactoryProvider.kt
@@ -37,7 +37,7 @@ interface KotlinDataFetcherFactoryProvider {
      * retrieved during data fetcher execution from [graphql.schema.DataFetchingEnvironment]
      * @param kFunction Kotlin function being invoked
      */
-    fun functionDataFetcherFactory(target: Any?, kFunction: KFunction<*>): DataFetcherFactory<Any>
+    fun functionDataFetcherFactory(target: Any?, kFunction: KFunction<*>): DataFetcherFactory<Any?>
 
     /**
      * Retrieve an instance of [DataFetcherFactory] that will be used to resolve target property.
@@ -45,7 +45,7 @@ interface KotlinDataFetcherFactoryProvider {
      * @param kClass parent class that contains this property
      * @param kProperty Kotlin property that should be resolved
      */
-    fun propertyDataFetcherFactory(kClass: KClass<*>, kProperty: KProperty<*>): DataFetcherFactory<Any>
+    fun propertyDataFetcherFactory(kClass: KClass<*>, kProperty: KProperty<*>): DataFetcherFactory<Any?>
 }
 
 /**
@@ -56,14 +56,14 @@ open class SimpleKotlinDataFetcherFactoryProvider(
     private val objectMapper: ObjectMapper = jacksonObjectMapper()
 ) : KotlinDataFetcherFactoryProvider {
 
-    override fun functionDataFetcherFactory(target: Any?, kFunction: KFunction<*>): DataFetcherFactory<Any> = DataFetcherFactory<Any> {
+    override fun functionDataFetcherFactory(target: Any?, kFunction: KFunction<*>) = DataFetcherFactory {
         FunctionDataFetcher(
             target = target,
             fn = kFunction,
             objectMapper = objectMapper)
     }
 
-    override fun propertyDataFetcherFactory(kClass: KClass<*>, kProperty: KProperty<*>): DataFetcherFactory<Any> = DataFetcherFactory<Any> {
+    override fun propertyDataFetcherFactory(kClass: KClass<*>, kProperty: KProperty<*>) = DataFetcherFactory<Any?> {
         PropertyDataFetcher(kProperty.name)
     }
 }

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/execution/CustomDataFetcherTests.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/execution/CustomDataFetcherTests.kt
@@ -67,7 +67,7 @@ data class AnimalDetails(val specialId: Int)
 
 class CustomDataFetcherFactoryProvider : SimpleKotlinDataFetcherFactoryProvider() {
 
-    override fun propertyDataFetcherFactory(kClass: KClass<*>, kProperty: KProperty<*>): DataFetcherFactory<Any> =
+    override fun propertyDataFetcherFactory(kClass: KClass<*>, kProperty: KProperty<*>): DataFetcherFactory<Any?> =
         if (kProperty.isLateinit) {
             DataFetcherFactories.useDataFetcher(AnimalDetailsDataFetcher())
         } else {
@@ -75,7 +75,7 @@ class CustomDataFetcherFactoryProvider : SimpleKotlinDataFetcherFactoryProvider(
         }
 }
 
-class AnimalDetailsDataFetcher : DataFetcher<Any> {
+class AnimalDetailsDataFetcher : DataFetcher<Any?> {
 
     override fun get(environment: DataFetchingEnvironment?): AnimalDetails {
         val animal = environment?.getSource<Animal>()

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/GeneratePropertyTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/GeneratePropertyTest.kt
@@ -185,8 +185,8 @@ internal class GeneratePropertyTest : TypeTestHelper() {
                     every { getSchemaDirectiveWiring(any()) } returns object : KotlinSchemaDirectiveWiring {}
                 }
         }
-        val mockDataFetcher: DataFetcher<Any> = mockk()
-        val mockFactory: DataFetcherFactory<Any> = mockk()
+        val mockDataFetcher: DataFetcher<Any?> = mockk()
+        val mockFactory: DataFetcherFactory<Any?> = mockk()
         val mockDataFetcherFactoryProvider: KotlinDataFetcherFactoryProvider = mockk()
 
         every { mockDataFetcherFactoryProvider.propertyDataFetcherFactory(any(), any()) } returns mockFactory


### PR DESCRIPTION
### :pencil: Description
We made the `FunctionDataFetcher` return nullable in this change https://github.com/ExpediaGroup/graphql-kotlin/pull/613. That is a good change but I only realized after integrating into our internal SDK that this also impacts the `KotlinDataFetcherFactoryProvider`. 

`KotlinDataFetcherFactoryProvider` returns a `DataFetcherFactory`, and in graphql-java those are supposed to implement the same types that the `DataFetcher` returns. So this change fixed that to match the same types in graphql-java.

This is a breaking change as the interface signature has now been changed.

### :link: Related Issues
Data Fetcher returns nullable here: https://github.com/ExpediaGroup/graphql-kotlin/pull/613