### PR TITLE
Increase Gradle wrapper memory

### DIFF
--- a/examples/gradle.properties
+++ b/examples/gradle.properties
@@ -4,7 +4,6 @@ version = 1.0-SNAPSHOT
 # build config
 org.gradle.caching=true
 org.gradle.parallel=true
-org.gradle.configureondemand=true
 
 # Increase the memory to run on GH Actions
 # See: https://github.com/gradle/gradle/issues/8139

--- a/examples/gradle.properties
+++ b/examples/gradle.properties
@@ -4,3 +4,8 @@ version = 1.0-SNAPSHOT
 # build config
 org.gradle.caching=true
 org.gradle.parallel=true
+org.gradle.configureondemand=true
+
+# Increase the memory to run on GH Actions
+# See: https://github.com/gradle/gradle/issues/8139
+org.gradle.jvmargs=-Xmx2g -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,6 @@ version = 2.0.0-SNAPSHOT
 # build config
 org.gradle.caching=true
 org.gradle.parallel=true
-org.gradle.configureondemand=true
 
 # See https://github.com/gradle/gradle/issues/11308
 systemProp.org.gradle.internal.publish.checksums.insecure=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,9 +4,14 @@ version = 2.0.0-SNAPSHOT
 # build config
 org.gradle.caching=true
 org.gradle.parallel=true
+org.gradle.configureondemand=true
 
 # See https://github.com/gradle/gradle/issues/11308
 systemProp.org.gradle.internal.publish.checksums.insecure=true
+
+# Increase the memory to run on GH Actions
+# See: https://github.com/gradle/gradle/issues/8139
+org.gradle.jvmargs=-Xmx2g -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError
 
 # dependencies
 kotlinVersion = 1.3.61

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
### :pencil: Description
Increase the gradle jvm max memory as we are seeing intermittent OutOfMemory errors on GitHub Actions

See: https://github.com/gradle/gradle/issues/8139

### :link: Related Issues
N\A