### PR TITLE
Upgrade springboot to fix security issue

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,14 +14,15 @@ kotlinCoroutinesVersion = 1.3.3
 
 graphQLJavaVersion = 14.0
 jacksonVersion = 2.10.2
-springBootVersion = 2.2.4.RELEASE
+springBootVersion = 2.2.5.RELEASE
 classGraphVersion = 4.8.65
-reactorVersion = 3.3.2.RELEASE
+reactorVersion = 3.3.3.RELEASE
 reactorExtensionsVersion = 1.0.2.RELEASE
 
 # test dependency versions
 junitVersion = 5.6.0
 mockkVersion = 1.9.3
+rxjavaVersion = 3.0.0
 
 # plugin versions
 detektVersion = 1.5.1

--- a/graphql-kotlin-schema-generator/build.gradle.kts
+++ b/graphql-kotlin-schema-generator/build.gradle.kts
@@ -5,7 +5,7 @@ val graphQLJavaVersion: String by project
 val jacksonVersion: String by project
 val kotlinVersion: String by project
 val kotlinCoroutinesVersion: String by project
-val rxjavaVersion = "3.0.0"
+val rxjavaVersion: String by project
 
 dependencies {
     api("com.graphql-java:graphql-java:$graphQLJavaVersion")


### PR DESCRIPTION
### :pencil: Description
Spring Boot 2.2.5 was released which includes a fix for a security issue in netty. See: https://spring.io/blog/2020/02/27/spring-boot-2-2-5-released

### :link: Related Issues
Fixes https://github.com/ExpediaGroup/graphql-kotlin/issues/625