### PR TITLE
Add 1.x.x branch to CI workflow

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - 1.x.x
     paths-ignore:
       - 'docs/**'
       - 'website/**'


### PR DESCRIPTION
### :pencil: Description
We should still build the 1.x.x branch on every checkin

### :link: Related Issues
N\A