### PR TITLE
Polymorphic ignore

### DIFF
--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/extensions/kClassExtensions.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/extensions/kClassExtensions.kt
@@ -55,7 +55,7 @@ internal fun KClass<*>.getValidSuperclasses(hooks: SchemaGeneratorHooks): List<K
             this.superclasses.flatMap { it.getValidSuperclasses(hooks) }
         }
 
-internal fun KClass<*>.findConstructorParamter(name: String): KParameter? =
+internal fun KClass<*>.findConstructorParameter(name: String): KParameter? =
     this.primaryConstructor?.findParameterByName(name)
 
 internal fun KClass<*>.isInterface(): Boolean = this.java.isInterface || this.isAbstract

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/extensions/kPropertyExtensions.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/extensions/kPropertyExtensions.kt
@@ -48,4 +48,4 @@ internal fun KProperty<*>.getPropertyName(parentClass: KClass<*>): String? =
 internal fun KProperty<*>.getPropertyAnnotations(parentClass: KClass<*>): List<Annotation> =
     this.annotations.union(getConstructorParameter(parentClass)?.annotations.orEmpty()).toList()
 
-private fun KProperty<*>.getConstructorParameter(parentClass: KClass<*>) = parentClass.findConstructorParamter(this.name)
+private fun KProperty<*>.getConstructorParameter(parentClass: KClass<*>) = parentClass.findConstructorParameter(this.name)

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/filters/propertyFilters.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/filters/propertyFilters.kt
@@ -16,11 +16,14 @@
 
 package com.expediagroup.graphql.generator.filters
 
+import com.expediagroup.graphql.generator.extensions.isGraphQLIgnored
 import com.expediagroup.graphql.generator.extensions.isPropertyGraphQLIgnored
 import com.expediagroup.graphql.generator.extensions.isPublic
 import com.expediagroup.graphql.generator.extensions.qualifiedName
 import kotlin.reflect.KClass
 import kotlin.reflect.KProperty
+import kotlin.reflect.full.memberProperties
+import kotlin.reflect.jvm.jvmErasure
 
 private typealias PropertyFilter = (KProperty<*>, KClass<*>) -> Boolean
 
@@ -29,5 +32,20 @@ private val blacklistTypes: List<String> = listOf("kotlin.reflect.KClass")
 private val isPropertyPublic: PropertyFilter = { prop, _ -> prop.isPublic() }
 private val isPropertyNotGraphQLIgnored: PropertyFilter = { prop, parentClass -> prop.isPropertyGraphQLIgnored(parentClass).not() }
 private val isNotBlacklistedType: PropertyFilter = { prop, _ -> blacklistTypes.contains(prop.returnType.qualifiedName).not() }
+private val isNotIgnoredFromSuperClass: PropertyFilter = { prop, parentClass ->
+    val superPropsIgnored = parentClass.supertypes
+        .flatMap { superType ->
+            superType.jvmErasure.memberProperties
+                .filter { superProp -> basicPropertyFilters.all { it.invoke(superProp, superType::class) } }
+                .filter { it.isGraphQLIgnored() }
+        }
 
-internal val propertyFilters: List<PropertyFilter> = listOf(isPropertyPublic, isNotBlacklistedType, isPropertyNotGraphQLIgnored)
+    superPropsIgnored.none { superProp ->
+        superProp.name == prop.name &&
+        superProp.returnType == prop.returnType &&
+        superProp.visibility == prop.visibility
+    }
+}
+
+private val basicPropertyFilters = listOf(isPropertyPublic, isNotBlacklistedType)
+internal val propertyFilters: List<PropertyFilter> = basicPropertyFilters + isPropertyNotGraphQLIgnored + isNotIgnoredFromSuperClass

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/InterfaceBuilder.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/InterfaceBuilder.kt
@@ -24,6 +24,7 @@ import com.expediagroup.graphql.generator.extensions.getSimpleName
 import com.expediagroup.graphql.generator.extensions.getValidFunctions
 import com.expediagroup.graphql.generator.extensions.getValidProperties
 import com.expediagroup.graphql.generator.extensions.getValidSuperclasses
+import com.expediagroup.graphql.generator.extensions.isGraphQLIgnored
 import com.expediagroup.graphql.generator.extensions.safeCast
 import graphql.TypeResolutionEnvironment
 import graphql.schema.GraphQLInterfaceType
@@ -58,6 +59,7 @@ internal class InterfaceBuilder(generator: SchemaGenerator) : TypeBuilder(genera
                 .forEach { builder.field(generator.function(it, kClass.getSimpleName(), abstract = true)) }
 
             subTypeMapper.getSubTypesOf(kClass)
+                .filter { it.isGraphQLIgnored().not() }
                 .map { graphQLTypeOf(it.createType()) }
                 .forEach {
                     // Do not add objects currently under construction to the additional types

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/extensions/KClassExtensionsTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/extensions/KClassExtensionsTest.kt
@@ -234,10 +234,10 @@ open class KClassExtensionsTest {
 
     @Test
     fun `test findConstructorParamter`() {
-        assertNotNull(MyTestClass::class.findConstructorParamter("publicProperty"))
-        assertNull(MyTestClass::class.findConstructorParamter("foobar"))
-        assertNull(EmptyConstructorClass::class.findConstructorParamter("id"))
-        assertNull(TestInterface::class.findConstructorParamter("foobar"))
+        assertNotNull(MyTestClass::class.findConstructorParameter("publicProperty"))
+        assertNull(MyTestClass::class.findConstructorParameter("foobar"))
+        assertNull(EmptyConstructorClass::class.findConstructorParameter("id"))
+        assertNull(TestInterface::class.findConstructorParameter("foobar"))
     }
 
     @Test


### PR DESCRIPTION
### :pencil: Description

Fixes transitive properties of `@GraphQLIgnore` when applied on polymorphic types.

### :link: Related Issues
Fixes #631 and #632