### PR TITLE
Polymorphic ignore 2.x

### DIFF
--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/extensions/kClassExtensions.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/extensions/kClassExtensions.kt
@@ -55,7 +55,7 @@ internal fun KClass<*>.getValidSuperclasses(hooks: SchemaGeneratorHooks): List<K
             this.superclasses.flatMap { it.getValidSuperclasses(hooks) }
         }
 
-internal fun KClass<*>.findConstructorParamter(name: String): KParameter? =
+internal fun KClass<*>.findConstructorParameter(name: String): KParameter? =
     this.primaryConstructor?.findParameterByName(name)
 
 internal fun KClass<*>.isInterface(): Boolean = this.java.isInterface || this.isAbstract

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/extensions/kPropertyExtensions.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/extensions/kPropertyExtensions.kt
@@ -48,4 +48,4 @@ internal fun KProperty<*>.getPropertyName(parentClass: KClass<*>): String? =
 internal fun KProperty<*>.getPropertyAnnotations(parentClass: KClass<*>): List<Annotation> =
     this.annotations.union(getConstructorParameter(parentClass)?.annotations.orEmpty()).toList()
 
-private fun KProperty<*>.getConstructorParameter(parentClass: KClass<*>) = parentClass.findConstructorParamter(this.name)
+private fun KProperty<*>.getConstructorParameter(parentClass: KClass<*>) = parentClass.findConstructorParameter(this.name)

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/filters/propertyFilters.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/filters/propertyFilters.kt
@@ -43,8 +43,7 @@ private val isNotIgnoredFromSuperClass: PropertyFilter = { prop, parentClass ->
 
     superPropsIgnored.none { superProp ->
         superProp.name == prop.name &&
-            superProp.returnType == prop.returnType &&
-            superProp.visibility == prop.visibility
+            superProp.returnType == prop.returnType
     }
 }
 

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/filters/propertyFilters.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/filters/propertyFilters.kt
@@ -16,11 +16,14 @@
 
 package com.expediagroup.graphql.generator.filters
 
+import com.expediagroup.graphql.generator.extensions.isGraphQLIgnored
 import com.expediagroup.graphql.generator.extensions.isPropertyGraphQLIgnored
 import com.expediagroup.graphql.generator.extensions.isPublic
 import com.expediagroup.graphql.generator.extensions.qualifiedName
 import kotlin.reflect.KClass
 import kotlin.reflect.KProperty
+import kotlin.reflect.full.memberProperties
+import kotlin.reflect.jvm.jvmErasure
 
 private typealias PropertyFilter = (KProperty<*>, KClass<*>) -> Boolean
 
@@ -30,4 +33,20 @@ private val isPropertyPublic: PropertyFilter = { prop, _ -> prop.isPublic() }
 private val isPropertyNotGraphQLIgnored: PropertyFilter = { prop, parentClass -> prop.isPropertyGraphQLIgnored(parentClass).not() }
 private val isNotBlacklistedType: PropertyFilter = { prop, _ -> blacklistTypes.contains(prop.returnType.qualifiedName).not() }
 
-internal val propertyFilters: List<PropertyFilter> = listOf(isPropertyPublic, isNotBlacklistedType, isPropertyNotGraphQLIgnored)
+private val isNotIgnoredFromSuperClass: PropertyFilter = { prop, parentClass ->
+    val superPropsIgnored = parentClass.supertypes
+        .flatMap { superType ->
+            superType.jvmErasure.memberProperties
+                .filter { superProp -> basicPropertyFilters.all { it.invoke(superProp, superType::class) } }
+                .filter { it.isGraphQLIgnored() }
+        }
+
+    superPropsIgnored.none { superProp ->
+        superProp.name == prop.name &&
+            superProp.returnType == prop.returnType &&
+            superProp.visibility == prop.visibility
+    }
+}
+
+private val basicPropertyFilters = listOf(isPropertyPublic, isNotBlacklistedType)
+internal val propertyFilters: List<PropertyFilter> = basicPropertyFilters + isPropertyNotGraphQLIgnored + isNotIgnoredFromSuperClass

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/generateInterface.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/generateInterface.kt
@@ -23,6 +23,7 @@ import com.expediagroup.graphql.generator.extensions.getSimpleName
 import com.expediagroup.graphql.generator.extensions.getValidFunctions
 import com.expediagroup.graphql.generator.extensions.getValidProperties
 import com.expediagroup.graphql.generator.extensions.getValidSuperclasses
+import com.expediagroup.graphql.generator.extensions.isGraphQLIgnored
 import com.expediagroup.graphql.generator.extensions.safeCast
 import graphql.TypeResolutionEnvironment
 import graphql.schema.GraphQLInterfaceType
@@ -51,6 +52,7 @@ internal fun generateInterface(generator: SchemaGenerator, kClass: KClass<*>): G
         .forEach { builder.field(generateFunction(generator, it, kClass.getSimpleName(), null, abstract = true)) }
 
     generator.classScanner.getSubTypesOf(kClass)
+        .filter { it.isGraphQLIgnored().not() }
         .forEach { generator.additionalTypes.add(it.createType()) }
 
     val interfaceType = builder.build()

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/PolymorphicTests.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/PolymorphicTests.kt
@@ -17,6 +17,7 @@
 package com.expediagroup.graphql.generator
 
 import com.expediagroup.graphql.TopLevelObject
+import com.expediagroup.graphql.annotations.GraphQLIgnore
 import com.expediagroup.graphql.annotations.GraphQLName
 import com.expediagroup.graphql.exceptions.InvalidInputFieldTypeException
 import com.expediagroup.graphql.testSchemaConfig
@@ -31,6 +32,7 @@ import org.junit.jupiter.api.Test
 import kotlin.random.Random
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 internal class PolymorphicTests {
@@ -144,6 +146,33 @@ internal class PolymorphicTests {
         val strawberryCakeResolver = dessertResolver.getType(mockTypeResolutionEnvironment(BerryCake(), schema))
         assertNotNull(strawberryCakeResolver)
         assertEquals("StrawberryCake", strawberryCakeResolver.name)
+    }
+
+    @Test
+    fun `Interface implementations are not computed when marked with GraphQLIgnore annotation`() {
+        val schema = toSchema(queries = listOf(TopLevelObject(QueryWithIgnoredInfo())), config = testSchemaConfig)
+        val service = schema.getType("Service") as? GraphQLInterfaceType
+        assertNotNull(service)
+
+        val webService = schema.getType("WebService") as? GraphQLObjectType
+        assertNotNull(webService)
+
+        val microService = schema.getType("MicroService") as? GraphQLObjectType
+        assertNull(microService)
+    }
+
+    @Test
+    fun `Ignored interface properties should not appear in the subtype`() {
+        val schema = toSchema(queries = listOf(TopLevelObject(QueryWithIgnoredInfo())), config = testSchemaConfig)
+        val service = schema.getType("Service") as? GraphQLInterfaceType
+        assertNotNull(service)
+        val interfaceIgnoredField = service.getFieldDefinition("shouldNotBeInTheSchema")
+        assertNull(interfaceIgnoredField)
+
+        val webService = schema.getType("WebService") as? GraphQLObjectType
+        assertNotNull(webService)
+        val subtypeIgnoredField = webService.getFieldDefinition("shouldNotBeInTheSchema")
+        assertNull(subtypeIgnoredField)
     }
 
     private fun mockTypeResolutionEnvironment(target: Any, schema: GraphQLSchema): TypeResolutionEnvironment =
@@ -273,3 +302,20 @@ interface Dessert
 class IceCream : Dessert {
     fun flavor(): String = "chocolate"
 }
+
+class QueryWithIgnoredInfo {
+    fun webservice(): Service = WebService("gql-kotlin-service")
+    fun microservice(): Service = MicroService("micro-gql-kotlin-service")
+}
+
+interface Service {
+    val name: String
+
+    @GraphQLIgnore
+    val shouldNotBeInTheSchema: Boolean
+}
+
+data class WebService(override val name: String, override val shouldNotBeInTheSchema: Boolean = false) : Service
+
+@GraphQLIgnore
+data class MicroService(override val name: String, override val shouldNotBeInTheSchema: Boolean = true) : Service

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/extensions/KClassExtensionsTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/extensions/KClassExtensionsTest.kt
@@ -234,10 +234,10 @@ open class KClassExtensionsTest {
 
     @Test
     fun `test findConstructorParamter`() {
-        assertNotNull(MyTestClass::class.findConstructorParamter("publicProperty"))
-        assertNull(MyTestClass::class.findConstructorParamter("foobar"))
-        assertNull(EmptyConstructorClass::class.findConstructorParamter("id"))
-        assertNull(TestInterface::class.findConstructorParamter("foobar"))
+        assertNotNull(MyTestClass::class.findConstructorParameter("publicProperty"))
+        assertNull(MyTestClass::class.findConstructorParameter("foobar"))
+        assertNull(EmptyConstructorClass::class.findConstructorParameter("id"))
+        assertNull(TestInterface::class.findConstructorParameter("foobar"))
     }
 
     @Test

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/filters/PropertyFiltersTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/filters/PropertyFiltersTest.kt
@@ -33,6 +33,8 @@ internal class PropertyFiltersTest {
         assertFalse(isValidProperty(MyClass::kClass, MyDataClass::class))
         assertTrue(isValidProperty(MyDataClass::id, MyDataClass::class))
         assertFalse(isValidProperty(MyDataClass::ignoredProperty, MyDataClass::class))
+        assertFalse(isValidProperty(MyDataClass::ignoredProperty, MyDataClass::class))
+        assertFalse(isValidProperty(MyClass::foo, MyClass::class))
     }
 
     internal data class MyDataClass(
@@ -42,7 +44,12 @@ internal class PropertyFiltersTest {
         internal val ignoredProperty: Int = 0
     )
 
-    internal class MyClass {
+    interface MyInterface {
+        @GraphQLIgnore
+        val foo: Int
+    }
+
+    internal class MyClass : MyInterface {
 
         val publicProperty: Int = 0
 
@@ -52,6 +59,7 @@ internal class PropertyFiltersTest {
 
         @GraphQLIgnore
         internal val ignoredProperty: Int = 0
+        override val foo: Int = 5
     }
 
     private fun isValidProperty(property: KProperty<*>, parentClass: KClass<*>): Boolean = propertyFilters.all { it(property, parentClass) }


### PR DESCRIPTION
### :pencil: Description

Fixes transitive properties of @GraphQLIgnore when applied on polymorphic types.
Apply the same changes as #633 for the 2.x / master branch

### :link: Related Issues
Fixes #631 and #632