### PR TITLE
[docs] Fix the NPM/Github security report issue

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -6298,9 +6298,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://artylab.expedia.biz/api/npm/public-npm-virtual/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "version": "1.2.5",
+      "resolved": "https://artylab.expedia.biz/api/npm/public-npm-virtual/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha1-Z9ZgFLZqaoqqDAg8X9WN9OTpdgI=",
       "dev": true
     },
     "mixin-deep": {

--- a/website/package.json
+++ b/website/package.json
@@ -15,8 +15,12 @@
     "rename-version": "docusaurus-rename-version",
     "clean": "rimraf build i18n"
   },
+  "@comment devDependencies": {
+    "minimist": "This is only includes for security reasons. This can be removed once docusaurus updates"
+  },
   "devDependencies": {
     "docusaurus": "1.14.4",
-    "rimraf": "3.0.2"
+    "rimraf": "3.0.2",
+    "minimist": "1.2.5"
   }
 }


### PR DESCRIPTION
### :pencil: Description
Github warned us about an issue in one of docusaurus' dependencies. This forces the new fixed version. This is only in our docs code.

### :link: Related Issues
Resolved the Github security report: https://github.com/ExpediaGroup/graphql-kotlin/network/alert/website/package-lock.json/minimist/open