### PR TITLE
Reuse schema generator for tests

### DIFF
--- a/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/toFederatedSchema.kt
+++ b/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/toFederatedSchema.kt
@@ -38,5 +38,7 @@ fun toFederatedSchema(
     subscriptions: List<TopLevelObject> = emptyList()
 ): GraphQLSchema {
     val generator = FederatedSchemaGenerator(config)
-    return generator.generateSchema(queries, mutations, subscriptions)
+    return generator.use {
+        it.generateSchema(queries, mutations, subscriptions)
+    }
 }

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/SchemaGenerator.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/SchemaGenerator.kt
@@ -67,7 +67,7 @@ open class SchemaGenerator(internal val config: SchemaGeneratorConfig) {
         builder.codeRegistry(codeRegistry.build())
         val schema = config.hooks.willBuildSchema(builder).build()
 
-        classScanner.close()
+        cleanUpResources()
 
         return schema
     }
@@ -99,5 +99,11 @@ open class SchemaGenerator(internal val config: SchemaGeneratorConfig) {
         }
 
         return graphqlTypes.toSet()
+    }
+
+    private fun cleanUpResources() {
+        additionalTypes.clear()
+        cache.clear()
+        directives.clear()
     }
 }

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/SchemaGenerator.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/SchemaGenerator.kt
@@ -28,6 +28,7 @@ import graphql.schema.GraphQLCodeRegistry
 import graphql.schema.GraphQLDirective
 import graphql.schema.GraphQLSchema
 import graphql.schema.GraphQLType
+import java.io.Closeable
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
@@ -39,7 +40,7 @@ import kotlin.reflect.full.createType
  * This class maintains the state of the schema while generation is taking place. It is passed into the internal functions
  * so they can use the cache and add additional types and directives into the schema as they parse the Kotlin code.
  */
-open class SchemaGenerator(internal val config: SchemaGeneratorConfig) {
+open class SchemaGenerator(internal val config: SchemaGeneratorConfig) : Closeable {
 
     internal val additionalTypes = mutableSetOf<KType>()
     internal val classScanner = ClassScanner(config.supportedPackages)
@@ -56,8 +57,8 @@ open class SchemaGenerator(internal val config: SchemaGeneratorConfig) {
         subscriptions: List<TopLevelObject> = emptyList(),
         additionalTypes: Set<KType> = emptySet()
     ): GraphQLSchema {
-
         this.additionalTypes.addAll(additionalTypes)
+
         val builder = GraphQLSchema.newSchema()
         builder.query(generateQueries(this, queries))
         builder.mutation(generateMutations(this, mutations))
@@ -65,11 +66,8 @@ open class SchemaGenerator(internal val config: SchemaGeneratorConfig) {
         builder.additionalTypes(generateAdditionalTypes())
         builder.additionalDirectives(directives.values.toSet())
         builder.codeRegistry(codeRegistry.build())
-        val schema = config.hooks.willBuildSchema(builder).build()
 
-        cleanUpResources()
-
-        return schema
+        return config.hooks.willBuildSchema(builder).build()
     }
 
     /**
@@ -101,9 +99,19 @@ open class SchemaGenerator(internal val config: SchemaGeneratorConfig) {
         return graphqlTypes.toSet()
     }
 
-    private fun cleanUpResources() {
-        additionalTypes.clear()
+    /**
+     * Clear the generator type cache, reflection scan, additional types,
+     * and the saved directives. You may want call this after you have
+     * called [generateSchema] and performed some other actions which is why
+     * we have a separate method to explicitly clear.
+     *
+     * If you use the built in [com.expediagroup.graphql.toSchema], we will handle
+     * clean up of resources for you.
+     */
+    override fun close() {
+        classScanner.close()
         cache.clear()
+        additionalTypes.clear()
         directives.clear()
     }
 }

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/state/ClassScanner.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/state/ClassScanner.kt
@@ -19,10 +19,11 @@ package com.expediagroup.graphql.generator.state
 import io.github.classgraph.ClassGraph
 import io.github.classgraph.ClassInfo
 import io.github.classgraph.ClassInfoList
+import java.io.Closeable
 import kotlin.reflect.KClass
 import kotlin.reflect.jvm.jvmName
 
-internal class ClassScanner(supportedPackages: List<String>) {
+internal class ClassScanner(supportedPackages: List<String>) : Closeable {
 
     @Suppress("Detekt.SpreadOperator")
     private val scanResult = ClassGraph()
@@ -38,6 +39,8 @@ internal class ClassScanner(supportedPackages: List<String>) {
             .map { it.loadClass().kotlin }
             .filterNot { it.isAbstract }
     }
+
+    override fun close() = scanResult.close()
 
     fun getClassesWithAnnotation(annotation: KClass<*>) = scanResult.getClassesWithAnnotation(annotation.jvmName).map { it.loadClass().kotlin }
 

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/state/ClassScanner.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/state/ClassScanner.kt
@@ -41,8 +41,6 @@ internal class ClassScanner(supportedPackages: List<String>) {
 
     fun getClassesWithAnnotation(annotation: KClass<*>) = scanResult.getClassesWithAnnotation(annotation.jvmName).map { it.loadClass().kotlin }
 
-    fun close() = scanResult.close()
-
     @Suppress("Detekt.SwallowedException")
     private fun getImplementingClasses(classInfo: ClassInfo) =
         try {

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/toSchema.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/toSchema.kt
@@ -38,5 +38,7 @@ fun toSchema(
     subscriptions: List<TopLevelObject> = emptyList()
 ): GraphQLSchema {
     val generator = SchemaGenerator(config)
-    return generator.generateSchema(queries, mutations, subscriptions)
+    return generator.use {
+        it.generateSchema(queries, mutations, subscriptions)
+    }
 }

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/directives/DirectiveTests.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/directives/DirectiveTests.kt
@@ -18,10 +18,10 @@ package com.expediagroup.graphql.directives
 
 import com.expediagroup.graphql.TopLevelObject
 import com.expediagroup.graphql.annotations.GraphQLDirective
+import com.expediagroup.graphql.generator.SchemaGenerator
 import com.expediagroup.graphql.getTestSchemaConfigWithHooks
 import com.expediagroup.graphql.hooks.SchemaGeneratorHooks
-import com.expediagroup.graphql.testSchemaConfig
-import com.expediagroup.graphql.toSchema
+import com.expediagroup.graphql.testGenerator
 import graphql.Scalars
 import graphql.schema.GraphQLNonNull
 import graphql.schema.GraphQLObjectType
@@ -34,7 +34,7 @@ class DirectiveTests {
 
     @Test
     fun `SchemaGenerator marks deprecated fields in the return objects`() {
-        val schema = toSchema(queries = listOf(TopLevelObject(QueryWithDeprecatedFields())), config = testSchemaConfig)
+        val schema = testGenerator.generateSchema(queries = listOf(TopLevelObject(QueryWithDeprecatedFields())))
         val topLevelQuery = schema.getObjectType("Query")
         val query = topLevelQuery.getFieldDefinition("deprecatedFieldQuery")
         val result = (query.type as? GraphQLNonNull)?.wrappedType as? GraphQLObjectType
@@ -46,7 +46,7 @@ class DirectiveTests {
 
     @Test
     fun `SchemaGenerator marks deprecated queries and documents replacement`() {
-        val schema = toSchema(queries = listOf(TopLevelObject(QueryWithDeprecatedFields())), config = testSchemaConfig)
+        val schema = testGenerator.generateSchema(queries = listOf(TopLevelObject(QueryWithDeprecatedFields())))
         val topLevelQuery = schema.getObjectType("Query")
         val query = topLevelQuery.getFieldDefinition("deprecatedQueryWithReplacement")
 
@@ -56,7 +56,7 @@ class DirectiveTests {
 
     @Test
     fun `SchemaGenerator marks deprecated queries`() {
-        val schema = toSchema(queries = listOf(TopLevelObject(QueryWithDeprecatedFields())), config = testSchemaConfig)
+        val schema = testGenerator.generateSchema(queries = listOf(TopLevelObject(QueryWithDeprecatedFields())))
         val topLevelQuery = schema.getObjectType("Query")
         val query = topLevelQuery.getFieldDefinition("deprecatedQuery")
         assertTrue(query.isDeprecated)
@@ -70,7 +70,8 @@ class DirectiveTests {
             override val wiringFactory: KotlinDirectiveWiringFactory
                 get() = KotlinDirectiveWiringFactory(manualWiring = mapOf("dummyDirective" to wiring, "RightNameDirective" to wiring))
         })
-        val schema = toSchema(queries = listOf(TopLevelObject(QueryObject())), config = config)
+        val generator = SchemaGenerator(config)
+        val schema = generator.generateSchema(queries = listOf(TopLevelObject(QueryObject())))
 
         val query = schema.queryType.getFieldDefinition("query")
         assertNotNull(query)
@@ -84,7 +85,8 @@ class DirectiveTests {
             override val wiringFactory: KotlinDirectiveWiringFactory
                 get() = KotlinDirectiveWiringFactory(manualWiring = mapOf("dummyDirective" to wiring, "RightNameDirective" to wiring))
         })
-        val schema = toSchema(queries = listOf(TopLevelObject(QueryObject())), config = config)
+        val generator = SchemaGenerator(config)
+        val schema = generator.generateSchema(queries = listOf(TopLevelObject(QueryObject())))
 
         val directive = assertNotNull(
                 (schema.getType("Location") as? GraphQLObjectType)

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/directives/DirectiveTests.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/directives/DirectiveTests.kt
@@ -97,50 +97,50 @@ class DirectiveTests {
         assertEquals("arg", directive.arguments[0].name)
         assertEquals(GraphQLNonNull(Scalars.GraphQLString), directive.arguments[0].type)
     }
+
+    @GraphQLDirective(name = "RightNameDirective")
+    annotation class WrongNameDirective(val arg: String)
+
+    @GraphQLDirective
+    annotation class DummyDirective
+
+    class Geography(
+        val id: Int?,
+        val type: GeoType,
+        val locations: List<Location>
+    ) {
+        @Suppress("Detekt.FunctionOnlyReturningConstant")
+        fun somethingCool(): String = "Something cool"
+    }
+
+    enum class GeoType {
+        CITY, STATE
+    }
+
+    @WrongNameDirective(arg = "arenaming")
+    data class Location(val lat: Double, val lon: Double)
+
+    class QueryObject {
+
+        @DummyDirective
+        fun query(value: Int): Geography = Geography(value, GeoType.CITY, listOf())
+    }
+
+    class QueryWithDeprecatedFields {
+        @Deprecated("this query is deprecated")
+        fun deprecatedQuery(something: String) = something
+
+        @Deprecated("this query is also deprecated", replaceWith = ReplaceWith("shinyNewQuery"))
+        fun deprecatedQueryWithReplacement(something: String) = something
+
+        fun deprecatedFieldQuery(something: String) = ClassWithDeprecatedField(something, something.reversed())
+
+        fun deprecatedArgumentQuery(input: ClassWithDeprecatedField) = input.something
+    }
+
+    data class ClassWithDeprecatedField(
+        val something: String,
+        @Deprecated("this field is deprecated")
+        val deprecatedField: String
+    )
 }
-
-@GraphQLDirective(name = "RightNameDirective")
-annotation class WrongNameDirective(val arg: String)
-
-@GraphQLDirective
-annotation class DummyDirective
-
-class Geography(
-    val id: Int?,
-    val type: GeoType,
-    val locations: List<Location>
-) {
-    @Suppress("Detekt.FunctionOnlyReturningConstant")
-    fun somethingCool(): String = "Something cool"
-}
-
-enum class GeoType {
-    CITY, STATE
-}
-
-@WrongNameDirective(arg = "arenaming")
-data class Location(val lat: Double, val lon: Double)
-
-class QueryObject {
-
-    @DummyDirective
-    fun query(value: Int): Geography = Geography(value, GeoType.CITY, listOf())
-}
-
-class QueryWithDeprecatedFields {
-    @Deprecated("this query is deprecated")
-    fun deprecatedQuery(something: String) = something
-
-    @Deprecated("this query is also deprecated", replaceWith = ReplaceWith("shinyNewQuery"))
-    fun deprecatedQueryWithReplacement(something: String) = something
-
-    fun deprecatedFieldQuery(something: String) = ClassWithDeprecatedField(something, something.reversed())
-
-    fun deprecatedArgumentQuery(input: ClassWithDeprecatedField) = input.something
-}
-
-data class ClassWithDeprecatedField(
-    val something: String,
-    @Deprecated("this field is deprecated")
-    val deprecatedField: String
-)

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/execution/CustomDataFetcherTests.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/execution/CustomDataFetcherTests.kt
@@ -50,37 +50,37 @@ class CustomDataFetcherTests {
         val details = data?.get("details") as? Map<*, *>
         assertEquals(11, details?.get("specialId"))
     }
-}
 
-class AnimalQuery {
-    fun findAnimal(): Animal = Animal(1, "cat")
-}
+    class AnimalQuery {
+        fun findAnimal(): Animal = Animal(1, "cat")
+    }
 
-@Suppress("DataClassShouldBeImmutable")
-data class Animal(
-    val id: Int,
-    val type: String
-) {
-    lateinit var details: AnimalDetails
-}
+    @Suppress("DataClassShouldBeImmutable")
+    data class Animal(
+        val id: Int,
+        val type: String
+    ) {
+        lateinit var details: AnimalDetails
+    }
 
-data class AnimalDetails(val specialId: Int)
+    data class AnimalDetails(val specialId: Int)
 
-class CustomDataFetcherFactoryProvider : SimpleKotlinDataFetcherFactoryProvider() {
+    class CustomDataFetcherFactoryProvider : SimpleKotlinDataFetcherFactoryProvider() {
 
-    override fun propertyDataFetcherFactory(kClass: KClass<*>, kProperty: KProperty<*>): DataFetcherFactory<Any?> =
-        if (kProperty.isLateinit) {
-            DataFetcherFactories.useDataFetcher(AnimalDetailsDataFetcher())
-        } else {
-            super.propertyDataFetcherFactory(kClass, kProperty)
+        override fun propertyDataFetcherFactory(kClass: KClass<*>, kProperty: KProperty<*>): DataFetcherFactory<Any?> =
+            if (kProperty.isLateinit) {
+                DataFetcherFactories.useDataFetcher(AnimalDetailsDataFetcher())
+            } else {
+                super.propertyDataFetcherFactory(kClass, kProperty)
+            }
+    }
+
+    class AnimalDetailsDataFetcher : DataFetcher<Any?> {
+
+        override fun get(environment: DataFetchingEnvironment?): AnimalDetails {
+            val animal = environment?.getSource<Animal>()
+            val specialId = animal?.id?.plus(10) ?: 0
+            return animal.let { AnimalDetails(specialId) }
         }
-}
-
-class AnimalDetailsDataFetcher : DataFetcher<Any?> {
-
-    override fun get(environment: DataFetchingEnvironment?): AnimalDetails {
-        val animal = environment?.getSource<Animal>()
-        val specialId = animal?.id?.plus(10) ?: 0
-        return animal.let { AnimalDetails(specialId) }
     }
 }

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/execution/CustomDataFetcherTests.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/execution/CustomDataFetcherTests.kt
@@ -19,7 +19,7 @@ package com.expediagroup.graphql.execution
 import com.expediagroup.graphql.SchemaGeneratorConfig
 import com.expediagroup.graphql.TopLevelObject
 import com.expediagroup.graphql.extensions.deepName
-import com.expediagroup.graphql.toSchema
+import com.expediagroup.graphql.generator.SchemaGenerator
 import graphql.GraphQL
 import graphql.schema.DataFetcher
 import graphql.schema.DataFetcherFactories
@@ -34,7 +34,8 @@ class CustomDataFetcherTests {
     @Test
     fun `Custom DataFetcher can be used on functions`() {
         val config = SchemaGeneratorConfig(supportedPackages = listOf("com.expediagroup"), dataFetcherFactoryProvider = CustomDataFetcherFactoryProvider())
-        val schema = toSchema(queries = listOf(TopLevelObject(AnimalQuery())), config = config)
+        val generator = SchemaGenerator(config)
+        val schema = generator.generateSchema(queries = listOf(TopLevelObject(AnimalQuery())))
 
         val animalType = schema.getObjectType("Animal")
         assertEquals("AnimalDetails!", animalType.getFieldDefinition("details").type.deepName)

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/extensions/GraphQLSchemaExtensionsTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/extensions/GraphQLSchemaExtensionsTest.kt
@@ -22,9 +22,9 @@ import com.expediagroup.graphql.annotations.GraphQLDirective
 import com.expediagroup.graphql.annotations.GraphQLID
 import com.expediagroup.graphql.annotations.GraphQLIgnore
 import com.expediagroup.graphql.annotations.GraphQLName
+import com.expediagroup.graphql.generator.SchemaGenerator
 import com.expediagroup.graphql.getTestSchemaConfigWithMockedDirectives
-import com.expediagroup.graphql.testSchemaConfig
-import com.expediagroup.graphql.toSchema
+import com.expediagroup.graphql.testGenerator
 import graphql.introspection.Introspection
 import graphql.schema.GraphQLSchema
 import org.junit.jupiter.api.Test
@@ -42,7 +42,7 @@ class GraphQLSchemaExtensionsTest {
 
     @Test
     fun `verify print result of a simple schema`() {
-        val schema: GraphQLSchema = toSchema(queries = listOf(TopLevelObject(SimpleQuery())), config = testSchemaConfig)
+        val schema: GraphQLSchema = testGenerator.generateSchema(queries = listOf(TopLevelObject(SimpleQuery())))
 
         val sdl = schema.print(includeDirectives = false).trim()
         val expected = """
@@ -60,7 +60,7 @@ class GraphQLSchemaExtensionsTest {
 
     @Test
     fun `verify print result of a simple schema with extended scalars`() {
-        val schema: GraphQLSchema = toSchema(queries = listOf(TopLevelObject(SimpleQuery())), config = testSchemaConfig)
+        val schema: GraphQLSchema = testGenerator.generateSchema(queries = listOf(TopLevelObject(SimpleQuery())))
 
         val sdl = schema.print(includeDirectives = false, includeScalarTypes = false, includeExtendedScalarTypes = true).trim()
         val expected = """
@@ -78,7 +78,7 @@ class GraphQLSchemaExtensionsTest {
 
     @Test
     fun `verify print result of a simple schema with no scalars`() {
-        val schema: GraphQLSchema = toSchema(queries = listOf(TopLevelObject(SimpleQuery())), config = testSchemaConfig)
+        val schema: GraphQLSchema = testGenerator.generateSchema(queries = listOf(TopLevelObject(SimpleQuery())))
 
         val sdl = schema.print(includeDirectives = false, includeScalarTypes = false, includeExtendedScalarTypes = false).trim()
         val expected = """
@@ -107,7 +107,7 @@ class GraphQLSchemaExtensionsTest {
 
     @Test
     fun `verify print result of a schema with renamed fields`() {
-        val schema: GraphQLSchema = toSchema(queries = listOf(TopLevelObject(RenamedQuery())), config = testSchemaConfig)
+        val schema: GraphQLSchema = testGenerator.generateSchema(queries = listOf(TopLevelObject(RenamedQuery())))
 
         val sdl = schema.print(includeDefaultSchemaDefinition = false, includeDirectives = false).trim()
         val expected = """
@@ -134,7 +134,7 @@ class GraphQLSchemaExtensionsTest {
 
     @Test
     fun `verify print result of a schema with GraphQL ID`() {
-        val schema: GraphQLSchema = toSchema(queries = listOf(TopLevelObject(QueryWithId())), config = testSchemaConfig)
+        val schema: GraphQLSchema = testGenerator.generateSchema(queries = listOf(TopLevelObject(QueryWithId())))
 
         val sdl = schema.print(includeDefaultSchemaDefinition = false, includeDirectives = false).trim()
         val expected = """
@@ -168,7 +168,7 @@ class GraphQLSchemaExtensionsTest {
 
     @Test
     fun `verify print result of a schema with ignored elements`() {
-        val schema: GraphQLSchema = toSchema(queries = listOf(TopLevelObject(QueryWithExcludedFields())), config = testSchemaConfig)
+        val schema: GraphQLSchema = testGenerator.generateSchema(queries = listOf(TopLevelObject(QueryWithExcludedFields())))
 
         val sdl = schema.print(includeDefaultSchemaDefinition = false, includeDirectives = false).trim()
         val expected = """
@@ -196,7 +196,7 @@ class GraphQLSchemaExtensionsTest {
 
     @Test
     fun `verify print result of a documented schema`() {
-        val schema: GraphQLSchema = toSchema(queries = listOf(TopLevelObject(DocumentedQuery())), config = testSchemaConfig)
+        val schema: GraphQLSchema = testGenerator.generateSchema(queries = listOf(TopLevelObject(DocumentedQuery())))
 
         val sdl = schema.print(includeDefaultSchemaDefinition = false, includeDirectives = false).trim()
         val expected = """
@@ -253,7 +253,8 @@ class GraphQLSchemaExtensionsTest {
 
     @Test
     fun `verify print result of a schema with directives`() {
-        val schema: GraphQLSchema = toSchema(queries = listOf(TopLevelObject(QueryWithDirectives())), config = getTestSchemaConfigWithMockedDirectives())
+        val generator = SchemaGenerator(getTestSchemaConfigWithMockedDirectives())
+        val schema: GraphQLSchema = generator.generateSchema(queries = listOf(TopLevelObject(QueryWithDirectives())))
 
         val sdl = schema.print(includeDefaultSchemaDefinition = false).trim()
         val expected = """

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/PolymorphicTests.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/PolymorphicTests.kt
@@ -21,7 +21,6 @@ import com.expediagroup.graphql.annotations.GraphQLIgnore
 import com.expediagroup.graphql.annotations.GraphQLName
 import com.expediagroup.graphql.createNewTestGenerator
 import com.expediagroup.graphql.exceptions.InvalidInputFieldTypeException
-import com.expediagroup.graphql.testGenerator
 import graphql.TypeResolutionEnvironment
 import graphql.schema.GraphQLInterfaceType
 import graphql.schema.GraphQLObjectType
@@ -39,7 +38,7 @@ class PolymorphicTests {
 
     @Test
     fun `Schema generator creates union types from marked up interface`() {
-        val schema = testGenerator.generateSchema(queries = listOf(TopLevelObject(QueryWithUnion())))
+        val schema = createNewTestGenerator().use { it.generateSchema(queries = listOf(TopLevelObject(QueryWithUnion()))) }
 
         val graphqlType = schema.getType("BodyPart") as? GraphQLUnionType
         assertNotNull(graphqlType)
@@ -56,7 +55,7 @@ class PolymorphicTests {
 
     @Test
     fun `SchemaGenerator can expose an interface and its implementations`() {
-        val schema = testGenerator.generateSchema(queries = listOf(TopLevelObject(QueryWithInterface())))
+        val schema = createNewTestGenerator().use { it.generateSchema(queries = listOf(TopLevelObject(QueryWithInterface()))) }
 
         val interfaceType = schema.getType("AnInterface") as? GraphQLInterfaceType
         assertNotNull(interfaceType)
@@ -70,20 +69,20 @@ class PolymorphicTests {
     @Test
     fun `Interfaces cannot be used as input field types`() {
         assertThrows(InvalidInputFieldTypeException::class.java) {
-            testGenerator.generateSchema(queries = listOf(TopLevelObject(QueryWithUnAuthorizedInterfaceArgument())))
+            createNewTestGenerator().use { it.generateSchema(queries = listOf(TopLevelObject(QueryWithUnAuthorizedInterfaceArgument()))) }
         }
     }
 
     @Test
     fun `Union cannot be used as input field types`() {
         assertThrows(InvalidInputFieldTypeException::class.java) {
-            testGenerator.generateSchema(queries = listOf(TopLevelObject(QueryWithUnAuthorizedUnionArgument())))
+            createNewTestGenerator().use { it.generateSchema(queries = listOf(TopLevelObject(QueryWithUnAuthorizedUnionArgument()))) }
         }
     }
 
     @Test
     fun `Object types implementing union and interfaces are only created once`() {
-        val schema = testGenerator.generateSchema(queries = listOf(TopLevelObject(QueryWithInterfaceAndUnion())))
+        val schema = createNewTestGenerator().use { it.generateSchema(queries = listOf(TopLevelObject(QueryWithInterfaceAndUnion()))) }
 
         val carType = schema.getType("Car") as? GraphQLObjectType
         assertNotNull(carType)
@@ -97,7 +96,7 @@ class PolymorphicTests {
 
     @Test
     fun `Interfaces can declare properties of their own type`() {
-        val schema = createNewTestGenerator().generateSchema(queries = listOf(TopLevelObject(QueryWithRecursiveType())))
+        val schema = createNewTestGenerator().use { it.generateSchema(queries = listOf(TopLevelObject(QueryWithRecursiveType()))) }
 
         val personType = schema.getType("Person")
         assertNotNull(personType)
@@ -105,7 +104,7 @@ class PolymorphicTests {
 
     @Test
     fun `Abstract classes should be converted to interfaces`() {
-        val schema = testGenerator.generateSchema(queries = listOf(TopLevelObject(QueryWithAbstract())))
+        val schema = createNewTestGenerator().use { it.generateSchema(queries = listOf(TopLevelObject(QueryWithAbstract()))) }
 
         val abstractInterface = schema.getType("MyAbstract") as? GraphQLInterfaceType
         assertNotNull(abstractInterface)
@@ -118,7 +117,7 @@ class PolymorphicTests {
 
     @Test
     fun `Interface types can be correctly resolved`() {
-        val schema = createNewTestGenerator().generateSchema(queries = listOf(TopLevelObject(QueryWithRenamedAbstracts())))
+        val schema = createNewTestGenerator().use { it.generateSchema(queries = listOf(TopLevelObject(QueryWithRenamedAbstracts()))) }
 
         val cakeInterface = schema.getType("Cake") as? GraphQLInterfaceType
         assertNotNull(cakeInterface)
@@ -134,7 +133,7 @@ class PolymorphicTests {
 
     @Test
     fun `Union types can be correctly resolved`() {
-        val schema = testGenerator.generateSchema(queries = listOf(TopLevelObject(QueryWithRenamedAbstracts())))
+        val schema = createNewTestGenerator().use { it.generateSchema(queries = listOf(TopLevelObject(QueryWithRenamedAbstracts()))) }
 
         val dessertUnion = schema.getType("Dessert") as? GraphQLUnionType
         assertNotNull(dessertUnion)
@@ -150,7 +149,7 @@ class PolymorphicTests {
 
     @Test
     fun `Interface implementations are not computed when marked with GraphQLIgnore annotation`() {
-        val schema = testGenerator.generateSchema(queries = listOf(TopLevelObject(QueryWithIgnoredInfo())))
+        val schema = createNewTestGenerator().use { it.generateSchema(queries = listOf(TopLevelObject(QueryWithIgnoredInfo()))) }
         val service = schema.getType("Service") as? GraphQLInterfaceType
         assertNotNull(service)
 
@@ -163,7 +162,7 @@ class PolymorphicTests {
 
     @Test
     fun `Ignored interface properties should not appear in the subtype`() {
-        val schema = createNewTestGenerator().generateSchema(queries = listOf(TopLevelObject(QueryWithIgnoredInfo())))
+        val schema = createNewTestGenerator().use { it.generateSchema(queries = listOf(TopLevelObject(QueryWithIgnoredInfo()))) }
         val service = schema.getType("Service") as? GraphQLInterfaceType
         assertNotNull(service)
         val interfaceIgnoredField = service.getFieldDefinition("shouldNotBeInTheSchema")

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/PolymorphicTests.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/PolymorphicTests.kt
@@ -20,8 +20,7 @@ import com.expediagroup.graphql.TopLevelObject
 import com.expediagroup.graphql.annotations.GraphQLIgnore
 import com.expediagroup.graphql.annotations.GraphQLName
 import com.expediagroup.graphql.exceptions.InvalidInputFieldTypeException
-import com.expediagroup.graphql.testSchemaConfig
-import com.expediagroup.graphql.toSchema
+import com.expediagroup.graphql.testGenerator
 import graphql.TypeResolutionEnvironment
 import graphql.schema.GraphQLInterfaceType
 import graphql.schema.GraphQLObjectType
@@ -35,11 +34,11 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
-internal class PolymorphicTests {
+class PolymorphicTests {
 
     @Test
     fun `Schema generator creates union types from marked up interface`() {
-        val schema = toSchema(queries = listOf(TopLevelObject(QueryWithUnion())), config = testSchemaConfig)
+        val schema = testGenerator.generateSchema(queries = listOf(TopLevelObject(QueryWithUnion())))
 
         val graphqlType = schema.getType("BodyPart") as? GraphQLUnionType
         assertNotNull(graphqlType)
@@ -56,7 +55,7 @@ internal class PolymorphicTests {
 
     @Test
     fun `SchemaGenerator can expose an interface and its implementations`() {
-        val schema = toSchema(queries = listOf(TopLevelObject(QueryWithInterface())), config = testSchemaConfig)
+        val schema = testGenerator.generateSchema(queries = listOf(TopLevelObject(QueryWithInterface())))
 
         val interfaceType = schema.getType("AnInterface") as? GraphQLInterfaceType
         assertNotNull(interfaceType)
@@ -70,20 +69,20 @@ internal class PolymorphicTests {
     @Test
     fun `Interfaces cannot be used as input field types`() {
         assertThrows(InvalidInputFieldTypeException::class.java) {
-            toSchema(queries = listOf(TopLevelObject(QueryWithUnAuthorizedInterfaceArgument())), config = testSchemaConfig)
+            testGenerator.generateSchema(queries = listOf(TopLevelObject(QueryWithUnAuthorizedInterfaceArgument())))
         }
     }
 
     @Test
     fun `Union cannot be used as input field types`() {
         assertThrows(InvalidInputFieldTypeException::class.java) {
-            toSchema(queries = listOf(TopLevelObject(QueryWithUnAuthorizedUnionArgument())), config = testSchemaConfig)
+            testGenerator.generateSchema(queries = listOf(TopLevelObject(QueryWithUnAuthorizedUnionArgument())))
         }
     }
 
     @Test
     fun `Object types implementing union and interfaces are only created once`() {
-        val schema = toSchema(queries = listOf(TopLevelObject(QueryWithInterfaceAndUnion())), config = testSchemaConfig)
+        val schema = testGenerator.generateSchema(queries = listOf(TopLevelObject(QueryWithInterfaceAndUnion())))
 
         val carType = schema.getType("Car") as? GraphQLObjectType
         assertNotNull(carType)
@@ -97,7 +96,7 @@ internal class PolymorphicTests {
 
     @Test
     fun `Interfaces can declare properties of their own type`() {
-        val schema = toSchema(queries = listOf(TopLevelObject(QueryWithRecursiveType())), config = testSchemaConfig)
+        val schema = testGenerator.generateSchema(queries = listOf(TopLevelObject(QueryWithRecursiveType())))
 
         val personType = schema.getType("Person")
         assertNotNull(personType)
@@ -105,7 +104,7 @@ internal class PolymorphicTests {
 
     @Test
     fun `Abstract classes should be converted to interfaces`() {
-        val schema = toSchema(queries = listOf(TopLevelObject(QueryWithAbstract())), config = testSchemaConfig)
+        val schema = testGenerator.generateSchema(queries = listOf(TopLevelObject(QueryWithAbstract())))
 
         val abstractInterface = schema.getType("MyAbstract") as? GraphQLInterfaceType
         assertNotNull(abstractInterface)
@@ -118,7 +117,7 @@ internal class PolymorphicTests {
 
     @Test
     fun `Interface types can be correctly resolved`() {
-        val schema = toSchema(queries = listOf(TopLevelObject(QueryWithRenamedAbstracts())), config = testSchemaConfig)
+        val schema = testGenerator.generateSchema(queries = listOf(TopLevelObject(QueryWithRenamedAbstracts())))
 
         val cakeInterface = schema.getType("Cake") as? GraphQLInterfaceType
         assertNotNull(cakeInterface)
@@ -134,7 +133,7 @@ internal class PolymorphicTests {
 
     @Test
     fun `Union types can be correctly resolved`() {
-        val schema = toSchema(queries = listOf(TopLevelObject(QueryWithRenamedAbstracts())), config = testSchemaConfig)
+        val schema = testGenerator.generateSchema(queries = listOf(TopLevelObject(QueryWithRenamedAbstracts())))
 
         val dessertUnion = schema.getType("Dessert") as? GraphQLUnionType
         assertNotNull(dessertUnion)
@@ -150,7 +149,7 @@ internal class PolymorphicTests {
 
     @Test
     fun `Interface implementations are not computed when marked with GraphQLIgnore annotation`() {
-        val schema = toSchema(queries = listOf(TopLevelObject(QueryWithIgnoredInfo())), config = testSchemaConfig)
+        val schema = testGenerator.generateSchema(queries = listOf(TopLevelObject(QueryWithIgnoredInfo())))
         val service = schema.getType("Service") as? GraphQLInterfaceType
         assertNotNull(service)
 
@@ -163,7 +162,7 @@ internal class PolymorphicTests {
 
     @Test
     fun `Ignored interface properties should not appear in the subtype`() {
-        val schema = toSchema(queries = listOf(TopLevelObject(QueryWithIgnoredInfo())), config = testSchemaConfig)
+        val schema = testGenerator.generateSchema(queries = listOf(TopLevelObject(QueryWithIgnoredInfo())))
         val service = schema.getType("Service") as? GraphQLInterfaceType
         assertNotNull(service)
         val interfaceIgnoredField = service.getFieldDefinition("shouldNotBeInTheSchema")

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/PolymorphicTests.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/PolymorphicTests.kt
@@ -19,8 +19,8 @@ package com.expediagroup.graphql.generator
 import com.expediagroup.graphql.TopLevelObject
 import com.expediagroup.graphql.annotations.GraphQLIgnore
 import com.expediagroup.graphql.annotations.GraphQLName
-import com.expediagroup.graphql.exceptions.InvalidInputFieldTypeException
 import com.expediagroup.graphql.createNewTestGenerator
+import com.expediagroup.graphql.exceptions.InvalidInputFieldTypeException
 import com.expediagroup.graphql.testGenerator
 import graphql.TypeResolutionEnvironment
 import graphql.schema.GraphQLInterfaceType
@@ -177,145 +177,145 @@ class PolymorphicTests {
 
     private fun mockTypeResolutionEnvironment(target: Any, schema: GraphQLSchema): TypeResolutionEnvironment =
         TypeResolutionEnvironment(target, emptyMap(), null, null, schema, null)
-}
 
-class QueryWithInterface {
-    fun fromUnion(): Union = AnImplementation()
-    fun query(): AnInterface = AnImplementation()
-    fun fromImplementation(): AnImplementation = AnImplementation()
-}
-
-class QueryWithUnAuthorizedInterfaceArgument {
-    fun notAllowed(arg: AnInterface): AnInterface = arg
-}
-
-class QueryWithUnAuthorizedUnionArgument {
-    fun notAllowed(body: BodyPart): BodyPart = body
-}
-
-interface Union
-
-interface AnInterface {
-    val property: String
-}
-
-data class AnImplementation(
-    override val property: String = "A value",
-    val implementationSpecific: String = "It's implementation specific"
-) : AnInterface, Union
-
-class QueryWithUnion {
-    fun query(whichHand: String): BodyPart = when (whichHand) {
-        "right" -> RightHand(12)
-        else -> LeftHand("hello world", Arm(true))
-    }
-}
-
-interface BodyPart
-
-data class LeftHand(
-    val field: String,
-    val associatedWith: BodyPart
-) : BodyPart
-
-data class RightHand(
-    val property: Int
-) : BodyPart
-
-data class Arm(
-    val value: Boolean
-) : BodyPart
-
-class QueryWithInterfaceAndUnion {
-    fun product(): Product = Car("DB9", "black")
-}
-
-interface Vehicle {
-    val color: String
-}
-
-interface Product
-
-data class Car(val model: String, override val color: String) : Vehicle, Product
-
-class QueryWithRecursiveType {
-    fun query(): Person = Father("knock knock", Child())
-}
-
-interface Person {
-    val child: Person?
-}
-
-data class Child(
-    override val child: Person? = null
-) : Person
-
-data class Father(
-    val dadJoke: String,
-    override val child: Person?
-) : Person
-
-class QueryWithAbstract {
-    fun query(): MyAbstract = MyClass(id = 1, name = "JUnit")
-
-    fun queryImplementation(): MyClass = MyClass(id = 1, name = "JUnit_2")
-}
-
-@Suppress("UnnecessaryAbstractClass")
-abstract class MyAbstract {
-    abstract val id: Int
-}
-
-data class MyClass(override val id: Int, val name: String) : MyAbstract()
-
-class QueryWithRenamedAbstracts {
-
-    fun randomCake(): Cake = if (Random.nextBoolean()) {
-        BerryCake()
-    } else {
-        Cheesecake()
+    class QueryWithInterface {
+        fun fromUnion(): Union = AnImplementation()
+        fun query(): AnInterface = AnImplementation()
+        fun fromImplementation(): AnImplementation = AnImplementation()
     }
 
-    fun randomDessert(): Dessert = if (Random.nextBoolean()) {
-        IceCream()
-    } else {
-        BerryCake()
+    class QueryWithUnAuthorizedInterfaceArgument {
+        fun notAllowed(arg: AnInterface): AnInterface = arg
     }
-}
 
-interface Cake {
-    fun recipe(): String
-}
+    class QueryWithUnAuthorizedUnionArgument {
+        fun notAllowed(body: BodyPart): BodyPart = body
+    }
 
-@GraphQLName("StrawberryCake")
-class BerryCake : Cake, Dessert {
-    override fun recipe(): String = "google it"
-}
+    interface Union
 
-class Cheesecake : Cake {
-    override fun recipe(): String = "use bing"
-}
+    interface AnInterface {
+        val property: String
+    }
 
-interface Dessert
+    data class AnImplementation(
+        override val property: String = "A value",
+        val implementationSpecific: String = "It's implementation specific"
+    ) : AnInterface, Union
 
-@Suppress("Detekt.FunctionOnlyReturningConstant")
-class IceCream : Dessert {
-    fun flavor(): String = "chocolate"
-}
+    class QueryWithUnion {
+        fun query(whichHand: String): BodyPart = when (whichHand) {
+            "right" -> RightHand(12)
+            else -> LeftHand("hello world", Arm(true))
+        }
+    }
 
-class QueryWithIgnoredInfo {
-    fun webservice(): Service = WebService("gql-kotlin-service")
-    fun microservice(): Service = MicroService("micro-gql-kotlin-service")
-}
+    interface BodyPart
 
-interface Service {
-    val name: String
+    data class LeftHand(
+        val field: String,
+        val associatedWith: BodyPart
+    ) : BodyPart
+
+    data class RightHand(
+        val property: Int
+    ) : BodyPart
+
+    data class Arm(
+        val value: Boolean
+    ) : BodyPart
+
+    class QueryWithInterfaceAndUnion {
+        fun product(): Product = Car("DB9", "black")
+    }
+
+    interface Vehicle {
+        val color: String
+    }
+
+    interface Product
+
+    data class Car(val model: String, override val color: String) : Vehicle, Product
+
+    class QueryWithRecursiveType {
+        fun query(): Person = Father("knock knock", Child())
+    }
+
+    interface Person {
+        val child: Person?
+    }
+
+    data class Child(
+        override val child: Person? = null
+    ) : Person
+
+    data class Father(
+        val dadJoke: String,
+        override val child: Person?
+    ) : Person
+
+    class QueryWithAbstract {
+        fun query(): MyAbstract = MyClass(id = 1, name = "JUnit")
+
+        fun queryImplementation(): MyClass = MyClass(id = 1, name = "JUnit_2")
+    }
+
+    @Suppress("UnnecessaryAbstractClass")
+    abstract class MyAbstract {
+        abstract val id: Int
+    }
+
+    data class MyClass(override val id: Int, val name: String) : MyAbstract()
+
+    class QueryWithRenamedAbstracts {
+
+        fun randomCake(): Cake = if (Random.nextBoolean()) {
+            BerryCake()
+        } else {
+            Cheesecake()
+        }
+
+        fun randomDessert(): Dessert = if (Random.nextBoolean()) {
+            IceCream()
+        } else {
+            BerryCake()
+        }
+    }
+
+    interface Cake {
+        fun recipe(): String
+    }
+
+    @GraphQLName("StrawberryCake")
+    class BerryCake : Cake, Dessert {
+        override fun recipe(): String = "google it"
+    }
+
+    class Cheesecake : Cake {
+        override fun recipe(): String = "use bing"
+    }
+
+    interface Dessert
+
+    @Suppress("Detekt.FunctionOnlyReturningConstant")
+    class IceCream : Dessert {
+        fun flavor(): String = "chocolate"
+    }
+
+    class QueryWithIgnoredInfo {
+        fun webservice(): Service = WebService("gql-kotlin-service")
+        fun microservice(): Service = MicroService("micro-gql-kotlin-service")
+    }
+
+    interface Service {
+        val name: String
+
+        @GraphQLIgnore
+        val shouldNotBeInTheSchema: Boolean
+    }
+
+    data class WebService(override val name: String, override val shouldNotBeInTheSchema: Boolean = false) : Service
 
     @GraphQLIgnore
-    val shouldNotBeInTheSchema: Boolean
+    data class MicroService(override val name: String, override val shouldNotBeInTheSchema: Boolean = true) : Service
 }
-
-data class WebService(override val name: String, override val shouldNotBeInTheSchema: Boolean = false) : Service
-
-@GraphQLIgnore
-data class MicroService(override val name: String, override val shouldNotBeInTheSchema: Boolean = true) : Service

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/PolymorphicTests.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/PolymorphicTests.kt
@@ -20,6 +20,7 @@ import com.expediagroup.graphql.TopLevelObject
 import com.expediagroup.graphql.annotations.GraphQLIgnore
 import com.expediagroup.graphql.annotations.GraphQLName
 import com.expediagroup.graphql.exceptions.InvalidInputFieldTypeException
+import com.expediagroup.graphql.createNewTestGenerator
 import com.expediagroup.graphql.testGenerator
 import graphql.TypeResolutionEnvironment
 import graphql.schema.GraphQLInterfaceType
@@ -96,7 +97,7 @@ class PolymorphicTests {
 
     @Test
     fun `Interfaces can declare properties of their own type`() {
-        val schema = testGenerator.generateSchema(queries = listOf(TopLevelObject(QueryWithRecursiveType())))
+        val schema = createNewTestGenerator().generateSchema(queries = listOf(TopLevelObject(QueryWithRecursiveType())))
 
         val personType = schema.getType("Person")
         assertNotNull(personType)
@@ -117,7 +118,7 @@ class PolymorphicTests {
 
     @Test
     fun `Interface types can be correctly resolved`() {
-        val schema = testGenerator.generateSchema(queries = listOf(TopLevelObject(QueryWithRenamedAbstracts())))
+        val schema = createNewTestGenerator().generateSchema(queries = listOf(TopLevelObject(QueryWithRenamedAbstracts())))
 
         val cakeInterface = schema.getType("Cake") as? GraphQLInterfaceType
         assertNotNull(cakeInterface)
@@ -162,7 +163,7 @@ class PolymorphicTests {
 
     @Test
     fun `Ignored interface properties should not appear in the subtype`() {
-        val schema = testGenerator.generateSchema(queries = listOf(TopLevelObject(QueryWithIgnoredInfo())))
+        val schema = createNewTestGenerator().generateSchema(queries = listOf(TopLevelObject(QueryWithIgnoredInfo())))
         val service = schema.getType("Service") as? GraphQLInterfaceType
         assertNotNull(service)
         val interfaceIgnoredField = service.getFieldDefinition("shouldNotBeInTheSchema")

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/SchemaGeneratorAsyncTests.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/SchemaGeneratorAsyncTests.kt
@@ -19,8 +19,7 @@ package com.expediagroup.graphql.generator
 import com.expediagroup.graphql.TopLevelObject
 import com.expediagroup.graphql.getTestSchemaConfigWithHooks
 import com.expediagroup.graphql.hooks.SchemaGeneratorHooks
-import com.expediagroup.graphql.testSchemaConfig
-import com.expediagroup.graphql.toSchema
+import com.expediagroup.graphql.testGenerator
 import graphql.schema.GraphQLNamedType
 import graphql.schema.GraphQLNonNull
 import io.reactivex.rxjava3.core.Maybe
@@ -46,7 +45,7 @@ class SchemaGeneratorAsyncTests {
 
     @Test
     fun `SchemaGenerator strips type argument from CompletableFuture to support async servlet`() {
-        val schema = toSchema(queries = listOf(TopLevelObject(AsyncQuery())), config = testSchemaConfig)
+        val schema = testGenerator.generateSchema(queries = listOf(TopLevelObject(AsyncQuery())))
         val returnType =
             (schema.getObjectType("Query").getFieldDefinition("asynchronouslyDo").type as? GraphQLNonNull)?.wrappedType
         assertNotNull(returnType)
@@ -56,7 +55,8 @@ class SchemaGeneratorAsyncTests {
 
     @Test
     fun `SchemaGenerator strips type argument from RxJava2 Observable`() {
-        val schema = toSchema(queries = listOf(TopLevelObject(RxJava2Query())), config = configWithRxJavaMonads)
+        val generator = SchemaGenerator(configWithRxJavaMonads)
+        val schema = generator.generateSchema(queries = listOf(TopLevelObject(RxJava2Query())))
         val returnType =
             (schema.getObjectType("Query").getFieldDefinition("asynchronouslyDo").type as? GraphQLNonNull)?.wrappedType
         assertNotNull(returnType)
@@ -66,7 +66,8 @@ class SchemaGeneratorAsyncTests {
 
     @Test
     fun `SchemaGenerator strips type argument from RxJava2 Single`() {
-        val schema = toSchema(queries = listOf(TopLevelObject(RxJava2Query())), config = configWithRxJavaMonads)
+        val generator = SchemaGenerator(configWithRxJavaMonads)
+        val schema = generator.generateSchema(queries = listOf(TopLevelObject(RxJava2Query())))
         val returnType =
             (schema.getObjectType("Query").getFieldDefinition("asynchronouslyDoSingle").type as? GraphQLNonNull)?.wrappedType
         assertNotNull(returnType)
@@ -76,7 +77,8 @@ class SchemaGeneratorAsyncTests {
 
     @Test
     fun `SchemaGenerator strips type argument from RxJava2 Maybe`() {
-        val schema = toSchema(queries = listOf(TopLevelObject(RxJava2Query())), config = configWithRxJavaMonads)
+        val generator = SchemaGenerator(configWithRxJavaMonads)
+        val schema = generator.generateSchema(queries = listOf(TopLevelObject(RxJava2Query())))
         val returnType =
             (schema.getObjectType("Query").getFieldDefinition("maybe").type as? GraphQLNonNull)?.wrappedType
         assertNotNull(returnType)

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/GenerateSubscriptionTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/GenerateSubscriptionTest.kt
@@ -123,23 +123,23 @@ internal class GenerateSubscriptionTest : TypeTestHelper() {
         assertEquals(3, result?.fieldDefinitions?.size)
         assertNotNull(result?.fieldDefinitions?.find { it.name == "changedField" })
     }
+
+    class MyPublicTestSubscription {
+        fun counter(): Publisher<Int> = Flowable.just(1)
+
+        fun flowabelCounter(): Flowable<Int> = Flowable.just(1)
+
+        fun filterMe(): Publisher<Int> = Flowable.just(2)
+    }
+
+    class MyInvalidSubscriptionClass {
+        @Suppress("Detekt.FunctionOnlyReturningConstant")
+        fun number(): Int = 1
+    }
+
+    private class MyPrivateTestSubscription {
+        fun counter(): Publisher<Int> = Flowable.just(3)
+    }
+
+    class MyEmptyTestSubscription
 }
-
-class MyPublicTestSubscription {
-    fun counter(): Publisher<Int> = Flowable.just(1)
-
-    fun flowabelCounter(): Flowable<Int> = Flowable.just(1)
-
-    fun filterMe(): Publisher<Int> = Flowable.just(2)
-}
-
-class MyInvalidSubscriptionClass {
-    @Suppress("Detekt.FunctionOnlyReturningConstant")
-    fun number(): Int = 1
-}
-
-private class MyPrivateTestSubscription {
-    fun counter(): Publisher<Int> = Flowable.just(3)
-}
-
-class MyEmptyTestSubscription

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/TypeTestHelper.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/TypeTestHelper.kt
@@ -27,7 +27,6 @@ import com.expediagroup.graphql.generator.state.ClassScanner
 import com.expediagroup.graphql.hooks.SchemaGeneratorHooks
 import io.mockk.every
 import io.mockk.spyk
-import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.TestInstance.Lifecycle
@@ -66,11 +65,6 @@ open class TypeTestHelper {
         every { spyWiringFactory.getSchemaDirectiveWiring(any()) } returns object : KotlinSchemaDirectiveWiring {}
 
         beforeTest()
-    }
-
-    @AfterAll
-    fun cleanup() {
-        classScanner.close()
     }
 
     open fun beforeTest() {}

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/TypeTestHelper.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/TypeTestHelper.kt
@@ -18,12 +18,12 @@ package com.expediagroup.graphql.generator.types
 
 import com.expediagroup.graphql.SchemaGeneratorConfig
 import com.expediagroup.graphql.TopLevelNames
+import com.expediagroup.graphql.defaultSupportedPackages
 import com.expediagroup.graphql.directives.KotlinDirectiveWiringFactory
 import com.expediagroup.graphql.directives.KotlinSchemaDirectiveWiring
 import com.expediagroup.graphql.execution.KotlinDataFetcherFactoryProvider
 import com.expediagroup.graphql.execution.SimpleKotlinDataFetcherFactoryProvider
 import com.expediagroup.graphql.generator.SchemaGenerator
-import com.expediagroup.graphql.generator.state.ClassScanner
 import com.expediagroup.graphql.hooks.SchemaGeneratorHooks
 import io.mockk.every
 import io.mockk.spyk
@@ -38,8 +38,6 @@ import org.junit.jupiter.api.TestInstance.Lifecycle
 )
 @TestInstance(Lifecycle.PER_CLASS)
 open class TypeTestHelper {
-    private val supportedPackages = listOf("com.expediagroup.graphql")
-    private val classScanner = ClassScanner(supportedPackages)
     private val dataFetcherFactory: KotlinDataFetcherFactoryProvider = SimpleKotlinDataFetcherFactoryProvider()
     private val topLevelNames = TopLevelNames(
         query = "TestTopLevelQuery",
@@ -52,7 +50,7 @@ open class TypeTestHelper {
         override val wiringFactory: KotlinDirectiveWiringFactory
             get() = spyWiringFactory
     }
-    val config = spyk(SchemaGeneratorConfig(supportedPackages, topLevelNames, hooks, dataFetcherFactory))
+    val config = spyk(SchemaGeneratorConfig(defaultSupportedPackages, topLevelNames, hooks, dataFetcherFactory))
     val generator = spyk(SchemaGenerator(config))
 
     @BeforeEach
@@ -60,6 +58,9 @@ open class TypeTestHelper {
         beforeSetup()
 
         generator.cache.clear()
+        generator.additionalTypes.clear()
+        generator.directives.clear()
+
         every { config.hooks } returns hooks
         every { config.dataFetcherFactoryProvider } returns dataFetcherFactory
         every { spyWiringFactory.getSchemaDirectiveWiring(any()) } returns object : KotlinSchemaDirectiveWiring {}

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/hooks/SchemaGeneratorHooksTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/hooks/SchemaGeneratorHooksTest.kt
@@ -21,11 +21,11 @@ import com.expediagroup.graphql.annotations.GraphQLIgnore
 import com.expediagroup.graphql.exceptions.EmptyInputObjectTypeException
 import com.expediagroup.graphql.exceptions.EmptyInterfaceTypeException
 import com.expediagroup.graphql.exceptions.EmptyObjectTypeException
+import com.expediagroup.graphql.generator.SchemaGenerator
 import com.expediagroup.graphql.generator.extensions.getSimpleName
 import com.expediagroup.graphql.getTestSchemaConfigWithHooks
 import com.expediagroup.graphql.test.utils.graphqlUUIDType
-import com.expediagroup.graphql.testSchemaConfig
-import com.expediagroup.graphql.toSchema
+import com.expediagroup.graphql.testGenerator
 import graphql.schema.GraphQLFieldDefinition
 import graphql.schema.GraphQLInterfaceType
 import graphql.schema.GraphQLObjectType
@@ -60,9 +60,9 @@ class SchemaGeneratorHooksTest {
         }
 
         val hooks = MockSchemaGeneratorHooks()
-        val schema = toSchema(
-            queries = listOf(TopLevelObject(TestQuery())),
-            config = getTestSchemaConfigWithHooks(hooks)
+        val generator = SchemaGenerator(getTestSchemaConfigWithHooks(hooks))
+        val schema = generator.generateSchema(
+            queries = listOf(TopLevelObject(TestQuery()))
         )
         assertTrue(hooks.willBuildSchemaCalled)
         assertNotNull(schema.getType("InjectedFromHook"))
@@ -83,9 +83,9 @@ class SchemaGeneratorHooksTest {
         }
 
         val hooks = MockSchemaGeneratorHooks()
-        val schema = toSchema(
-            queries = listOf(TopLevelObject(TestQuery())),
-            config = getTestSchemaConfigWithHooks(hooks)
+        val generator = SchemaGenerator(getTestSchemaConfigWithHooks(hooks))
+        val schema = generator.generateSchema(
+            queries = listOf(TopLevelObject(TestQuery()))
         )
         assertTrue(hooks.calledFilterFunction)
         assertFalse(schema.queryType.fieldDefinitions.isEmpty())
@@ -110,9 +110,9 @@ class SchemaGeneratorHooksTest {
         }
 
         val hooks = MockSchemaGeneratorHooks()
-        val schema = toSchema(
-            queries = listOf(TopLevelObject(TestQuery())),
-            config = getTestSchemaConfigWithHooks(hooks)
+        val generator = SchemaGenerator(getTestSchemaConfigWithHooks(hooks))
+        val schema = generator.generateSchema(
+            queries = listOf(TopLevelObject(TestQuery()))
         )
         assertTrue(hooks.calledFilterFunction)
         assertTrue(schema.queryType.fieldDefinitions.isEmpty())
@@ -129,9 +129,9 @@ class SchemaGeneratorHooksTest {
         }
 
         val hooks = MockSchemaGeneratorHooks()
-        toSchema(
-            queries = listOf(TopLevelObject(TestInterfaceQuery())),
-            config = getTestSchemaConfigWithHooks(hooks)
+        val generator = SchemaGenerator(getTestSchemaConfigWithHooks(hooks))
+        generator.generateSchema(
+            queries = listOf(TopLevelObject(TestInterfaceQuery()))
         )
         assertTrue(hooks.seenTypes.contains(RandomData::class.createType()))
         assertTrue(hooks.seenTypes.contains(SomeData::class.createType()))
@@ -141,27 +141,27 @@ class SchemaGeneratorHooksTest {
     @Test
     fun `empty object type will not be added to the schema`() {
         assertThrows<EmptyObjectTypeException> {
-            toSchema(
-                queries = listOf(TopLevelObject(TestWithEmptyObjectQuery())),
-                config = testSchemaConfig)
+            testGenerator.generateSchema(
+                queries = listOf(TopLevelObject(TestWithEmptyObjectQuery()))
+            )
         }
     }
 
     @Test
     fun `empty input object type will not be added to the schema`() {
         assertThrows<EmptyInputObjectTypeException> {
-            toSchema(
-                queries = listOf(TopLevelObject(TestWithEmptyInputObjectQuery())),
-                config = testSchemaConfig)
+            testGenerator.generateSchema(
+                queries = listOf(TopLevelObject(TestWithEmptyInputObjectQuery()))
+            )
         }
     }
 
     @Test
     fun `empty interface will not be added to the schema`() {
         assertThrows<EmptyInterfaceTypeException> {
-            toSchema(
-                queries = listOf(TopLevelObject(TestWithEmptyInterfaceQuery())),
-                config = testSchemaConfig)
+            testGenerator.generateSchema(
+                queries = listOf(TopLevelObject(TestWithEmptyInterfaceQuery()))
+            )
         }
     }
 
@@ -182,9 +182,9 @@ class SchemaGeneratorHooksTest {
         }
 
         val hooks = MockSchemaGeneratorHooks()
-        val schema = toSchema(
-            queries = listOf(TopLevelObject(TestQuery())),
-            config = getTestSchemaConfigWithHooks(hooks)
+        val generator = SchemaGenerator(getTestSchemaConfigWithHooks(hooks))
+        val schema = generator.generateSchema(
+            queries = listOf(TopLevelObject(TestQuery()))
         )
         assertTrue(hooks.hookCalled)
 
@@ -212,9 +212,9 @@ class SchemaGeneratorHooksTest {
         }
 
         val hooks = MockSchemaGeneratorHooks()
-        val schema = toSchema(
-            queries = listOf(TopLevelObject(TestQuery())),
-            config = getTestSchemaConfigWithHooks(hooks)
+        val generator = SchemaGenerator(getTestSchemaConfigWithHooks(hooks))
+        val schema = generator.generateSchema(
+            queries = listOf(TopLevelObject(TestQuery()))
         )
         val topLevelQuery = schema.getObjectType("Query")
         val query = topLevelQuery.getFieldDefinition("query")
@@ -236,10 +236,10 @@ class SchemaGeneratorHooksTest {
         }
 
         val hooks = MockSchemaGeneratorHooks()
-        val schema = toSchema(
+        val generator = SchemaGenerator(getTestSchemaConfigWithHooks(hooks))
+        val schema = generator.generateSchema(
             queries = listOf(TopLevelObject(TestQuery())),
-            mutations = listOf(TopLevelObject(TestQuery())),
-            config = getTestSchemaConfigWithHooks(hooks)
+            mutations = listOf(TopLevelObject(TestQuery()))
         )
         val topLevelQuery = schema.getObjectType("Mutation")
         val query = topLevelQuery.getFieldDefinition("query")
@@ -270,9 +270,9 @@ class SchemaGeneratorHooksTest {
         }
 
         val hooks = MockSchemaGeneratorHooks()
-        val schema = toSchema(
-            queries = listOf(TopLevelObject(CustomTypesQuery())),
-            config = getTestSchemaConfigWithHooks(hooks)
+        val generator = SchemaGenerator(getTestSchemaConfigWithHooks(hooks))
+        val schema = generator.generateSchema(
+            queries = listOf(TopLevelObject(CustomTypesQuery()))
         )
 
         assertTrue(hooks.hookCalled)

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/test/integration/ConcurrentAdditionalTypesTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/test/integration/ConcurrentAdditionalTypesTest.kt
@@ -17,8 +17,7 @@
 package com.expediagroup.graphql.test.integration
 
 import com.expediagroup.graphql.TopLevelObject
-import com.expediagroup.graphql.testSchemaConfig
-import com.expediagroup.graphql.toSchema
+import com.expediagroup.graphql.testGenerator
 import org.junit.jupiter.api.Test
 import kotlin.test.assertNotNull
 
@@ -27,7 +26,7 @@ class ConcurrentAdditionalTypesTest {
     @Test
     fun `verify a concurrent exception is not thrown if there are additionalTypes added when generating the additionalTypes`() {
         val queries = listOf(TopLevelObject(SimpleQuery()))
-        val schema = toSchema(testSchemaConfig, queries)
+        val schema = testGenerator.generateSchema(queries)
         assertNotNull(schema)
         assertNotNull(schema.getType("InterfaceOne"))
         assertNotNull(schema.getType("InterfaceTwo"))

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/test/integration/CustomScalarExecutionTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/test/integration/CustomScalarExecutionTest.kt
@@ -17,10 +17,10 @@
 package com.expediagroup.graphql.test.integration
 
 import com.expediagroup.graphql.TopLevelObject
+import com.expediagroup.graphql.generator.SchemaGenerator
 import com.expediagroup.graphql.getTestSchemaConfigWithHooks
 import com.expediagroup.graphql.hooks.SchemaGeneratorHooks
 import com.expediagroup.graphql.test.utils.graphqlUUIDType
-import com.expediagroup.graphql.toSchema
 import graphql.GraphQL
 import graphql.schema.GraphQLType
 import org.junit.jupiter.api.Test
@@ -33,10 +33,8 @@ import kotlin.test.assertNotNull
 
 class CustomScalarExecutionTest {
 
-    private val schema = toSchema(
-        queries = listOf(TopLevelObject(QueryObject())),
-        config = getTestSchemaConfigWithHooks(CustomScalarHooks())
-    )
+    private val generator = SchemaGenerator(getTestSchemaConfigWithHooks(CustomScalarHooks()))
+    private val schema = generator.generateSchema(listOf(TopLevelObject(QueryObject())))
     private val graphQL: GraphQL = GraphQL.newGraphQL(schema).build()
 
     @Test

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/test/integration/InterfaceOfInterfaceTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/test/integration/InterfaceOfInterfaceTest.kt
@@ -17,8 +17,8 @@
 package com.expediagroup.graphql.test.integration
 
 import com.expediagroup.graphql.TopLevelObject
+import com.expediagroup.graphql.createNewTestGenerator
 import com.expediagroup.graphql.exceptions.InvalidInterfaceException
-import com.expediagroup.graphql.testGenerator
 import org.junit.jupiter.api.Test
 import kotlin.test.assertFailsWith
 
@@ -29,7 +29,7 @@ class InterfaceOfInterfaceTest {
         val queries = listOf(TopLevelObject(InterfaceOfInterfaceQuery()))
 
         assertFailsWith(InvalidInterfaceException::class) {
-            testGenerator.generateSchema(queries = queries)
+            createNewTestGenerator().generateSchema(queries = queries)
         }
     }
 

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/test/integration/InterfaceOfInterfaceTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/test/integration/InterfaceOfInterfaceTest.kt
@@ -18,8 +18,7 @@ package com.expediagroup.graphql.test.integration
 
 import com.expediagroup.graphql.TopLevelObject
 import com.expediagroup.graphql.exceptions.InvalidInterfaceException
-import com.expediagroup.graphql.testSchemaConfig
-import com.expediagroup.graphql.toSchema
+import com.expediagroup.graphql.testGenerator
 import org.junit.jupiter.api.Test
 import kotlin.test.assertFailsWith
 
@@ -30,7 +29,7 @@ class InterfaceOfInterfaceTest {
         val queries = listOf(TopLevelObject(InterfaceOfInterfaceQuery()))
 
         assertFailsWith(InvalidInterfaceException::class) {
-            toSchema(queries = queries, config = testSchemaConfig)
+            testGenerator.generateSchema(queries = queries)
         }
     }
 

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/test/integration/NodeGraphTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/test/integration/NodeGraphTest.kt
@@ -41,31 +41,31 @@ class NodeGraphTest {
             assertFalse(it.type is GraphQLTypeReference, "Node.${it.name} is a GraphQLTypeReference")
         }
     }
-}
 
-/**
- * Represents a recursive type that references itself,
- * similar to a tree node structure.
- */
-data class Node(
-    val id: Int,
-    val value: String,
-    val parent: Node? = null,
-    val children: MutableList<Node> = mutableListOf()
-)
+    /**
+     * Represents a recursive type that references itself,
+     * similar to a tree node structure.
+     */
+    data class Node(
+        val id: Int,
+        val value: String,
+        val parent: Node? = null,
+        val children: MutableList<Node> = mutableListOf()
+    )
 
-class NodeQuery {
+    class NodeQuery {
 
-    private val root = Node(id = 0, value = "root")
-    private val nodeA = Node(id = 1, value = "A", parent = root)
-    private val nodeB = Node(id = 2, value = "B", parent = root)
-    private val nodeC = Node(id = 3, value = "C", parent = nodeB)
+        private val root = Node(id = 0, value = "root")
+        private val nodeA = Node(id = 1, value = "A", parent = root)
+        private val nodeB = Node(id = 2, value = "B", parent = root)
+        private val nodeC = Node(id = 3, value = "C", parent = nodeB)
 
-    init {
-        root.children.add(nodeA)
-        root.children.add(nodeB)
-        nodeB.children.add(nodeC)
+        init {
+            root.children.add(nodeA)
+            root.children.add(nodeB)
+            nodeB.children.add(nodeC)
+        }
+
+        fun nodeGraph() = root
     }
-
-    fun nodeGraph() = root
 }

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/test/integration/NodeGraphTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/test/integration/NodeGraphTest.kt
@@ -17,8 +17,7 @@
 package com.expediagroup.graphql.test.integration
 
 import com.expediagroup.graphql.TopLevelObject
-import com.expediagroup.graphql.testSchemaConfig
-import com.expediagroup.graphql.toSchema
+import com.expediagroup.graphql.testGenerator
 import graphql.schema.GraphQLObjectType
 import graphql.schema.GraphQLTypeReference
 import org.junit.jupiter.api.Test
@@ -31,7 +30,7 @@ class NodeGraphTest {
     fun nodeGraph() {
         val queries = listOf(TopLevelObject(NodeQuery()))
 
-        val schema = toSchema(queries = queries, config = testSchemaConfig)
+        val schema = testGenerator.generateSchema(queries = queries)
 
         assertEquals(expected = 1, actual = schema.queryType.fieldDefinitions.size)
         assertEquals(expected = "nodeGraph", actual = schema.queryType.fieldDefinitions.first().name)

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/test/integration/OptionalResultsTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/test/integration/OptionalResultsTest.kt
@@ -42,13 +42,13 @@ class OptionalResultsTest {
         assertEquals("req", optionalResults["required"])
         assertNull(optionalResults["optional"])
     }
-}
 
-data class HasOptionalData(
-    val required: String,
-    val optional: String?
-)
+    data class HasOptionalData(
+        val required: String,
+        val optional: String?
+    )
 
-class QueryObject {
-    fun optionalResults() = HasOptionalData("req", null)
+    class QueryObject {
+        fun optionalResults() = HasOptionalData("req", null)
+    }
 }

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/test/integration/OptionalResultsTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/test/integration/OptionalResultsTest.kt
@@ -17,8 +17,7 @@
 package com.expediagroup.graphql.test.integration
 
 import com.expediagroup.graphql.TopLevelObject
-import com.expediagroup.graphql.testSchemaConfig
-import com.expediagroup.graphql.toSchema
+import com.expediagroup.graphql.testGenerator
 import graphql.GraphQL
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
@@ -28,10 +27,9 @@ import kotlin.test.assertNull
 class OptionalResultsTest {
     @Test
     fun `SchemaGenerator generates a simple GraphQL schema`() {
-        val schema = toSchema(
+        val schema = testGenerator.generateSchema(
             queries = listOf(TopLevelObject(QueryObject())),
-            mutations = listOf(),
-            config = testSchemaConfig
+            mutations = listOf()
         )
         val graphQL = GraphQL.newGraphQL(schema).build()
 

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/test/integration/OutputTypeWithRecursiveInputTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/test/integration/OutputTypeWithRecursiveInputTest.kt
@@ -17,8 +17,7 @@
 package com.expediagroup.graphql.test.integration
 
 import com.expediagroup.graphql.TopLevelObject
-import com.expediagroup.graphql.testSchemaConfig
-import com.expediagroup.graphql.toSchema
+import com.expediagroup.graphql.testGenerator
 import org.junit.jupiter.api.Test
 import kotlin.test.assertNotNull
 
@@ -27,7 +26,7 @@ class OutputTypeWithRecursiveInputTest {
     @Test
     fun `An output type that gets generated first and then has fields with arguments of itself generates properly`() {
         val queries = listOf(TopLevelObject(Query()))
-        val schema = toSchema(testSchemaConfig, queries)
+        val schema = testGenerator.generateSchema(queries)
         assertNotNull(schema)
         assertNotNull(schema.getType("MyObject"))
         assertNotNull(schema.getType("MyObjectInput"))

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/test/integration/RecursiveInputTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/test/integration/RecursiveInputTest.kt
@@ -17,8 +17,7 @@
 package com.expediagroup.graphql.test.integration
 
 import com.expediagroup.graphql.TopLevelObject
-import com.expediagroup.graphql.testSchemaConfig
-import com.expediagroup.graphql.toSchema
+import com.expediagroup.graphql.testGenerator
 import org.junit.jupiter.api.Test
 import java.util.UUID
 import kotlin.test.assertNotNull
@@ -28,7 +27,7 @@ class RecursiveInputTest {
     @Test
     fun `Input type with a recursive argument should work`() {
         val queries = listOf(TopLevelObject(RecursiveInputQueries()))
-        val schema = toSchema(testSchemaConfig, queries)
+        val schema = testGenerator.generateSchema(queries)
         assertNotNull(schema)
         assertNotNull(schema.getType("RecursivePerson"))
         assertNotNull(schema.getType("RecursivePersonInput"))

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/test/integration/RecursiveInterfaceTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/test/integration/RecursiveInterfaceTest.kt
@@ -17,8 +17,7 @@
 package com.expediagroup.graphql.test.integration
 
 import com.expediagroup.graphql.TopLevelObject
-import com.expediagroup.graphql.testSchemaConfig
-import com.expediagroup.graphql.toSchema
+import com.expediagroup.graphql.testGenerator
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
@@ -27,7 +26,7 @@ class RecursiveInterfaceTest {
     @Test
     fun recursiveInterface() {
         val queries = listOf(TopLevelObject(RecursiveInterfaceQuery()))
-        val schema = toSchema(queries = queries, config = testSchemaConfig)
+        val schema = testGenerator.generateSchema(queries = queries)
         assertEquals(1, schema.queryType.fieldDefinitions.size)
         val field = schema.queryType.fieldDefinitions.first()
         assertEquals("getRoot", field.name)
@@ -36,7 +35,7 @@ class RecursiveInterfaceTest {
     @Test
     fun `interface with self field`() {
         val queries = listOf(TopLevelObject(InterfaceWithSelfFieldQuery()))
-        val schema = toSchema(queries = queries, config = testSchemaConfig)
+        val schema = testGenerator.generateSchema(queries = queries)
         assertEquals(1, schema.queryType.fieldDefinitions.size)
         val field = schema.queryType.fieldDefinitions.first()
         assertEquals("getInterface", field.name)

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/test/integration/RecursiveInterfaceTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/test/integration/RecursiveInterfaceTest.kt
@@ -40,38 +40,38 @@ class RecursiveInterfaceTest {
         val field = schema.queryType.fieldDefinitions.first()
         assertEquals("getInterface", field.name)
     }
-}
 
-class RecursiveInterfaceQuery {
-    fun getRoot() = RecursiveClassA()
-}
+    class RecursiveInterfaceQuery {
+        fun getRoot() = RecursiveClassA()
+    }
 
-class InterfaceWithSelfFieldQuery {
-    fun getInterface() = InterfaceWithSelfFieldB()
-}
+    class InterfaceWithSelfFieldQuery {
+        fun getInterface() = InterfaceWithSelfFieldB()
+    }
 
-interface SomeInterfaceWithId {
-    val id: String
-}
+    interface SomeInterfaceWithId {
+        val id: String
+    }
 
-interface InterfaceWithSelfField {
-    val parent: InterfaceWithSelfField?
-}
+    interface InterfaceWithSelfField {
+        val parent: InterfaceWithSelfField?
+    }
 
-class RecursiveClassA : SomeInterfaceWithId {
-    override val id = "A"
-    fun getB() = RecursiveClassB()
-}
+    class RecursiveClassA : SomeInterfaceWithId {
+        override val id = "A"
+        fun getB() = RecursiveClassB()
+    }
 
-class RecursiveClassB : SomeInterfaceWithId {
-    override val id = "B"
-    fun getA() = RecursiveClassA()
-}
+    class RecursiveClassB : SomeInterfaceWithId {
+        override val id = "B"
+        fun getA() = RecursiveClassA()
+    }
 
-class InterfaceWithSelfFieldA : InterfaceWithSelfField {
-    override val parent: InterfaceWithSelfField? = null
-}
+    class InterfaceWithSelfFieldA : InterfaceWithSelfField {
+        override val parent: InterfaceWithSelfField? = null
+    }
 
-class InterfaceWithSelfFieldB : InterfaceWithSelfField {
-    override val parent = InterfaceWithSelfFieldA()
+    class InterfaceWithSelfFieldB : InterfaceWithSelfField {
+        override val parent = InterfaceWithSelfFieldA()
+    }
 }

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/test/integration/RecursiveUnionTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/test/integration/RecursiveUnionTest.kt
@@ -31,18 +31,18 @@ class RecursiveUnionTest {
         val field = schema.queryType.fieldDefinitions.first()
         assertEquals("getRoot", field.name)
     }
-}
 
-class RecursiveUnionQuery {
-    fun getRoot() = RecursiveUnionA()
-}
+    class RecursiveUnionQuery {
+        fun getRoot() = RecursiveUnionA()
+    }
 
-interface SomeUnion
+    interface SomeUnion
 
-class RecursiveUnionA : SomeUnion {
-    fun getB() = RecursiveUnionB()
-}
+    class RecursiveUnionA : SomeUnion {
+        fun getB() = RecursiveUnionB()
+    }
 
-class RecursiveUnionB : SomeUnion {
-    fun getA() = RecursiveUnionA()
+    class RecursiveUnionB : SomeUnion {
+        fun getA() = RecursiveUnionA()
+    }
 }

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/test/integration/RecursiveUnionTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/test/integration/RecursiveUnionTest.kt
@@ -17,8 +17,7 @@
 package com.expediagroup.graphql.test.integration
 
 import com.expediagroup.graphql.TopLevelObject
-import com.expediagroup.graphql.testSchemaConfig
-import com.expediagroup.graphql.toSchema
+import com.expediagroup.graphql.testGenerator
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
@@ -27,7 +26,7 @@ class RecursiveUnionTest {
     @Test
     fun recursiveUnion() {
         val queries = listOf(TopLevelObject(RecursiveUnionQuery()))
-        val schema = toSchema(queries = queries, config = testSchemaConfig)
+        val schema = testGenerator.generateSchema(queries = queries)
         assertEquals(1, schema.queryType.fieldDefinitions.size)
         val field = schema.queryType.fieldDefinitions.first()
         assertEquals("getRoot", field.name)

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/testSchemaConfig.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/testSchemaConfig.kt
@@ -23,9 +23,11 @@ import com.expediagroup.graphql.hooks.SchemaGeneratorHooks
 import io.mockk.every
 import io.mockk.spyk
 
-val defaultSupportedPackages = listOf("com.expediagroup")
+val defaultSupportedPackages = listOf("com.expediagroup.graphql")
 val testSchemaConfig = SchemaGeneratorConfig(defaultSupportedPackages)
 val testGenerator = SchemaGenerator(testSchemaConfig)
+
+fun createNewTestGenerator() = SchemaGenerator(testSchemaConfig)
 
 fun getTestSchemaConfigWithHooks(hooks: SchemaGeneratorHooks) = SchemaGeneratorConfig(defaultSupportedPackages, hooks = hooks)
 

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/testSchemaConfig.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/testSchemaConfig.kt
@@ -18,12 +18,14 @@ package com.expediagroup.graphql
 
 import com.expediagroup.graphql.directives.KotlinDirectiveWiringFactory
 import com.expediagroup.graphql.directives.KotlinSchemaDirectiveWiring
+import com.expediagroup.graphql.generator.SchemaGenerator
 import com.expediagroup.graphql.hooks.SchemaGeneratorHooks
 import io.mockk.every
 import io.mockk.spyk
 
 val defaultSupportedPackages = listOf("com.expediagroup")
 val testSchemaConfig = SchemaGeneratorConfig(defaultSupportedPackages)
+val testGenerator = SchemaGenerator(testSchemaConfig)
 
 fun getTestSchemaConfigWithHooks(hooks: SchemaGeneratorHooks) = SchemaGeneratorConfig(defaultSupportedPackages, hooks = hooks)
 


### PR DESCRIPTION
### :pencil: Description
In an effort to save memory and build time, I made a common testGenerator that just uses the basic SchemaGeneratorConfig we already we using. Previously, every call to toSchema would create a new SchemaGenerator class which creates a new type cache and class scanner. Maybe this will help with the Github actions out of memory issues?

### :link: Related Issues
