### PR TITLE
Make SchemaGenerator closeable

### DIFF
--- a/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/toFederatedSchema.kt
+++ b/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/toFederatedSchema.kt
@@ -38,5 +38,7 @@ fun toFederatedSchema(
     subscriptions: List<TopLevelObject> = emptyList()
 ): GraphQLSchema {
     val generator = FederatedSchemaGenerator(config)
-    return generator.generateSchema(queries, mutations, subscriptions)
+    return generator.use {
+        it.generateSchema(queries, mutations, subscriptions)
+    }
 }

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/state/ClassScanner.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/state/ClassScanner.kt
@@ -19,10 +19,11 @@ package com.expediagroup.graphql.generator.state
 import io.github.classgraph.ClassGraph
 import io.github.classgraph.ClassInfo
 import io.github.classgraph.ClassInfoList
+import java.io.Closeable
 import kotlin.reflect.KClass
 import kotlin.reflect.jvm.jvmName
 
-internal class ClassScanner(supportedPackages: List<String>) {
+internal class ClassScanner(supportedPackages: List<String>) : Closeable {
 
     @Suppress("Detekt.SpreadOperator")
     private val scanResult = ClassGraph()
@@ -41,7 +42,7 @@ internal class ClassScanner(supportedPackages: List<String>) {
 
     fun getClassesWithAnnotation(annotation: KClass<*>) = scanResult.getClassesWithAnnotation(annotation.jvmName).map { it.loadClass().kotlin }
 
-    fun close() = scanResult.close()
+    override fun close() = scanResult.close()
 
     @Suppress("Detekt.SwallowedException")
     private fun getImplementingClasses(classInfo: ClassInfo) =

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/toSchema.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/toSchema.kt
@@ -38,5 +38,7 @@ fun toSchema(
     subscriptions: List<TopLevelObject> = emptyList()
 ): GraphQLSchema {
     val generator = SchemaGenerator(config)
-    return generator.generateSchema(queries, mutations, subscriptions)
+    return generator.use {
+        it.generateSchema(queries, mutations, subscriptions)
+    }
 }

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/testSchemaConfig.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/testSchemaConfig.kt
@@ -22,7 +22,7 @@ import com.expediagroup.graphql.hooks.SchemaGeneratorHooks
 import io.mockk.every
 import io.mockk.spyk
 
-val defaultSupportedPackages = listOf("com.expediagroup")
+val defaultSupportedPackages = listOf("com.expediagroup.graphql")
 val testSchemaConfig = SchemaGeneratorConfig(defaultSupportedPackages)
 
 fun getTestSchemaConfigWithHooks(hooks: SchemaGeneratorHooks) = SchemaGeneratorConfig(defaultSupportedPackages, hooks = hooks)


### PR DESCRIPTION
### :pencil: Description
Extracting separate changes from https://github.com/ExpediaGroup/graphql-kotlin/pull/641 that cleans up the resources used when creating a new schema generator. Hopefully this will help with our unit test out of memory issues

### :link: Related Issues
https://github.com/ExpediaGroup/graphql-kotlin/pull/641