### PR TITLE
Allow for custom subscription return types

### DIFF
--- a/docs/execution/subscriptions.md
+++ b/docs/execution/subscriptions.md
@@ -28,9 +28,14 @@ toSchema(
 
 ### Subscription Hooks
 
-Through the hooks a new method was added `didGenerateSubscriptionType` which is called after a new subscription type is
-generated but before it is added to the schema. The other hook are still called so you can add logic for the types and
+#### `didGenerateSubscriptionType`
+This hook is called after a new subscription type is generated but before it is added to the schema. The other generator hooks are still called so you can add logic for the types and
 validation of subscriptions the same as queries and mutations.
+
+#### `isValidSubscriptionReturnType`
+This hook is called when generating the functions for each subscription. It allows for changing the rules of what classes can be used as the return type. By default, graphql-java supports `org.reactivestreams.Publisher`.
+
+To effectively use this hook, you should also override the `willResolveMonad` hook, and if you are using `graphql-kotlin-spring-server` you should override the `GraphQL` bean to specify a custom subscription execution strategy.
 
 ### Server Implementation
 

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/exceptions/InvalidSubscriptionTypeException.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/exceptions/InvalidSubscriptionTypeException.kt
@@ -22,7 +22,7 @@ import kotlin.reflect.KFunction
 
 class InvalidSubscriptionTypeException(kClass: KClass<*>, kFunction: KFunction<*>? = null) :
     GraphQLKotlinException(
-        "Schema requires all subscriptions to be public and return a type of Publisher. " +
+        "Schema requires all subscriptions to be public and return a valid type from the hooks. " +
         "${kClass.simpleName} has ${kClass.visibility} visibility modifier. " +
         if (kFunction != null) "The function return type is ${kFunction.returnType.getSimpleName()}" else ""
     )

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/hooks/SchemaGeneratorHooks.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/hooks/SchemaGeneratorHooks.kt
@@ -23,6 +23,7 @@ import com.expediagroup.graphql.exceptions.EmptyMutationTypeException
 import com.expediagroup.graphql.exceptions.EmptyObjectTypeException
 import com.expediagroup.graphql.exceptions.EmptyQueryTypeException
 import com.expediagroup.graphql.exceptions.EmptySubscriptionTypeException
+import com.expediagroup.graphql.generator.extensions.isSubclassOf
 import graphql.schema.FieldCoordinates
 import graphql.schema.GraphQLCodeRegistry
 import graphql.schema.GraphQLFieldDefinition
@@ -33,6 +34,7 @@ import graphql.schema.GraphQLSchema
 import graphql.schema.GraphQLSchemaElement
 import graphql.schema.GraphQLType
 import graphql.schema.GraphQLTypeUtil
+import org.reactivestreams.Publisher
 import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
 import kotlin.reflect.KProperty
@@ -90,6 +92,15 @@ interface SchemaGeneratorHooks {
      */
     @Suppress("Detekt.FunctionOnlyReturningConstant")
     fun isValidFunction(kClass: KClass<*>, function: KFunction<*>): Boolean = true
+
+    /**
+     * Called when looking at the subscription functions to determine if it is using a valid return type.
+     * By default, graphql-java supports org.reactivestreams.Publisher in the subscription execution strategy.
+     * If you want to provide a custom execution strategy, you may need to override this hook.
+     *
+     * NOTE: You will most likely need to also override the [willResolveMonad] hook to allow for your custom type to be generated.
+     */
+    fun isValidSubscriptionReturnType(kClass: KClass<*>, function: KFunction<*>): Boolean = function.returnType.isSubclassOf(Publisher::class)
 
     /**
      * Called after `willGenerateGraphQLType` and before `didGenerateGraphQLType`.

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/GenerateSubscriptionTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/GenerateSubscriptionTest.kt
@@ -139,7 +139,6 @@ internal class GenerateSubscriptionTest : TypeTestHelper() {
                 type.isSubclassOf(Flow::class) -> type.getTypeOfFirstArgument()
                 else -> this.willResolveMonad(type)
             }
-
         }
 
         every { config.hooks } returns CustomHooks()


### PR DESCRIPTION
### :pencil: Description
Allow for the use of custom types for subscriptions. This requires that you override two hooks, and the execution strategy, but at least this is now possible and we don't have to worry about blocking others from using their own types

### :link: Related Issues
https://github.com/ExpediaGroup/graphql-kotlin/pull/629