### PR TITLE
Support sealed classes for interfaces

### DIFF
--- a/docs/writing-schemas/interfaces.md
+++ b/docs/writing-schemas/interfaces.md
@@ -92,7 +92,7 @@ sealed class Pet(val name: String) {
 ```
 
 ### Known Issues
-> NOTE: Due to a feature added in 1.0.0, we no longer support multiple levels of interfaces in a schema because the GraphQL spec does not support this feature.  [See 419](https://github.com/ExpediaGroup/graphql-kotlin/issues/419). If you do have multiple interfaces you will have to either combine them into a single interface or ignore all the parent interfaces.
+> We currently do not support multiple levels of interfaces in a schema. We are waiting until graphql-java supports the newly added feature to the GraphQL spec. [See 589](https://github.com/ExpediaGroup/graphql-kotlin/issues/589). If you do have multiple interfaces you will have to either combine them into a single interface or ignore all the parent interfaces by marking them private or using `@GraphQLIgnore`.
 
 #### Invalid Schema
 ```kotlin

--- a/docs/writing-schemas/interfaces.md
+++ b/docs/writing-schemas/interfaces.md
@@ -7,7 +7,7 @@ Functions returning interfaces will automatically expose all the types implement
 the classpath. Due to the GraphQL distinction between interface and a union type, interfaces need to specify at least
 one common field (property or a function).
 
-Abstract classes will also be converted to a GraphQL Interface.
+Abstract and sealed classes will also be converted to a GraphQL Interface.
 
 ```kotlin
 interface Animal {
@@ -46,7 +46,7 @@ class PolymorphicQuery {
 }
 ```
 
-Code above will produce the following GraphQL schema
+The above code will produce the following GraphQL schema:
 
 ```graphql
 interface Animal {
@@ -75,6 +75,20 @@ type TopLevelQuery {
   animal(type: AnimalType!): Animal
 }
 
+```
+
+### Abstract and Sealed Classes
+[Abstract](https://kotlinlang.org/docs/reference/classes.html#abstract-classes) and [sealed](https://kotlinlang.org/docs/reference/sealed-classes.html) classes can also be used for interface types.
+
+```kotlin
+abstract class Shape(val area: Double)
+class Circle(radius: Double) : Shape(PI * radius * radius)
+class Square(sideLength: Double) : Shape(sideLength * sideLength)
+
+sealed class Pet(val name: String) {
+    class Dog(name: String, val goodBoysReceived: Int) : Pet(name)
+    class Cat(name: String, val livesRemaining: Int) : Pet(name)
+}
 ```
 
 ### Known Issues

--- a/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/model/Fruit.kt
+++ b/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/model/Fruit.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2020 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.examples.model
+
+sealed class Fruit(val color: String) {
+    class Apple(private val variety: String) : Fruit(if (variety == "red delicious") "red" else "green")
+    class Orange() : Fruit("orange")
+}

--- a/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/query/PolymorphicQuery.kt
+++ b/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/query/PolymorphicQuery.kt
@@ -22,6 +22,7 @@ import com.expediagroup.graphql.examples.model.AnimalType
 import com.expediagroup.graphql.examples.model.BodyPart
 import com.expediagroup.graphql.examples.model.Cat
 import com.expediagroup.graphql.examples.model.Dog
+import com.expediagroup.graphql.examples.model.Fruit
 import com.expediagroup.graphql.examples.model.LeftHand
 import com.expediagroup.graphql.examples.model.RightHand
 import com.expediagroup.graphql.spring.operations.Query
@@ -46,4 +47,7 @@ class PolymorphicQuery : Query {
         "right" -> RightHand(12)
         else -> LeftHand("hello world")
     }
+
+    @GraphQLDescription("Example of interfaces with sealed classes")
+    fun getFruit(orange: Boolean) = if (orange) Fruit.Orange() else Fruit.Apple("granny smith")
 }

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/extensions/kClassExtensions.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/extensions/kClassExtensions.kt
@@ -58,7 +58,7 @@ internal fun KClass<*>.getValidSuperclasses(hooks: SchemaGeneratorHooks): List<K
 internal fun KClass<*>.findConstructorParameter(name: String): KParameter? =
     this.primaryConstructor?.findParameterByName(name)
 
-internal fun KClass<*>.isInterface(): Boolean = this.java.isInterface || this.isAbstract
+internal fun KClass<*>.isInterface(): Boolean = this.java.isInterface || this.isAbstract || this.isSealed
 
 internal fun KClass<*>.isUnion(): Boolean =
     this.isInterface() && this.declaredMemberProperties.isEmpty() && this.declaredMemberFunctions.isEmpty()

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/PolymorphicTests.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/PolymorphicTests.kt
@@ -257,8 +257,6 @@ data class Father(
 
 class QueryWithAbstract {
     fun query(): MyAbstract = MyClass(id = 1, name = "JUnit")
-
-    fun queryImplementation(): MyClass = MyClass(id = 1, name = "JUnit_2")
 }
 
 @Suppress("UnnecessaryAbstractClass")

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/extensions/KClassExtensionsTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/extensions/KClassExtensionsTest.kt
@@ -131,6 +131,11 @@ open class KClassExtensionsTest {
 
     interface TestInterface
 
+    sealed class Pet(val name: String) {
+        class Dog(name: String, val goodBoysReceived: Int) : Pet(name)
+        class Cat(name: String, val livesRemaining: Int) : Pet(name)
+    }
+
     private interface InvalidPropertyUnionInterface {
         val test: Int
             get() = 1
@@ -258,6 +263,7 @@ open class KClassExtensionsTest {
     fun `test graphql interface extension`() {
         assertTrue(TestInterface::class.isInterface())
         assertTrue(SomeAbstractClass::class.isInterface())
+        assertTrue(Pet::class.isInterface())
         assertFalse(MyTestClass::class.isInterface())
     }
 
@@ -266,6 +272,7 @@ open class KClassExtensionsTest {
         assertTrue(TestInterface::class.isUnion())
         assertFalse(InvalidPropertyUnionInterface::class.isUnion())
         assertFalse(InvalidFunctionUnionInterface::class.isUnion())
+        assertFalse(Pet::class.isUnion())
     }
 
     // TODO remove JUnit condition once we only build artifacts using Java 11

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/GenerateGraphQLTypeKtTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/GenerateGraphQLTypeKtTest.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.generator.types
+
+import com.expediagroup.graphql.extensions.unwrapType
+import graphql.schema.GraphQLInterfaceType
+import org.junit.jupiter.api.Test
+import kotlin.reflect.full.createType
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class GenerateGraphQLTypeKtTest : TypeTestHelper() {
+
+    @Test
+    fun generateGraphQLType() {
+        assertEquals(0, generator.additionalTypes.size)
+        val result = generateGraphQLType(generator, Pet::class.createType()).unwrapType()
+        assertTrue(result is GraphQLInterfaceType)
+        assertEquals("name", result.fieldDefinitions.first().name)
+        assertEquals(2, generator.additionalTypes.size)
+    }
+
+    sealed class Pet(open val name: String) {
+        data class Dog(override val name: String, val goodBoysReceived: Int) : Pet(name)
+        data class Cat(override val name: String, val livesRemaining: Int) : Pet(name)
+    }
+}

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/GenerateInterfaceTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/GenerateInterfaceTest.kt
@@ -18,21 +18,15 @@ package com.expediagroup.graphql.generator.types
 
 import com.expediagroup.graphql.annotations.GraphQLDescription
 import com.expediagroup.graphql.annotations.GraphQLName
+import com.expediagroup.graphql.generator.extensions.getSimpleName
 import com.expediagroup.graphql.test.utils.SimpleDirective
 import graphql.schema.GraphQLInterfaceType
 import org.junit.jupiter.api.Test
+import kotlin.math.PI
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 
 internal class GenerateInterfaceTest : TypeTestHelper() {
-
-    @Suppress("Detekt.UnusedPrivateClass")
-    @GraphQLDescription("The truth")
-    @SimpleDirective
-    private interface HappyInterface
-
-    @Suppress("Detekt.UnusedPrivateClass")
-    @GraphQLName("HappyInterfaceRenamed")
-    private interface HappyInterfaceCustomName
 
     @Test
     fun `Test naming`() {
@@ -57,5 +51,43 @@ internal class GenerateInterfaceTest : TypeTestHelper() {
         val result = generateInterface(generator, HappyInterface::class) as? GraphQLInterfaceType
         assertEquals(1, result?.directives?.size)
         assertEquals("simpleDirective", result?.directives?.first()?.name)
+    }
+
+    @Test
+    fun `absctract classes generate interfaces`() {
+        assertEquals(0, generator.additionalTypes.size)
+        val result = generateInterface(generator, Shape::class) as? GraphQLInterfaceType
+        assertEquals("Shape", result?.name)
+        assertEquals(2, generator.additionalTypes.size)
+        assertNotNull(generator.additionalTypes.find { it.getSimpleName() == "Circle" })
+        assertNotNull(generator.additionalTypes.find { it.getSimpleName() == "Square" })
+    }
+
+    @Test
+    fun `sealed classes generate interfaces`() {
+        assertEquals(0, generator.additionalTypes.size)
+        val result = generateInterface(generator, Pet::class) as? GraphQLInterfaceType
+        assertEquals("Pet", result?.name)
+        assertEquals(2, generator.additionalTypes.size)
+        assertNotNull(generator.additionalTypes.find { it.getSimpleName() == "Cat" })
+        assertNotNull(generator.additionalTypes.find { it.getSimpleName() == "Dog" })
+    }
+
+    @Suppress("Detekt.UnusedPrivateClass")
+    @GraphQLDescription("The truth")
+    @SimpleDirective
+    interface HappyInterface
+
+    @Suppress("Detekt.UnusedPrivateClass")
+    @GraphQLName("HappyInterfaceRenamed")
+    interface HappyInterfaceCustomName
+
+    abstract class Shape(val area: Double)
+    class Circle(radius: Double) : Shape(PI * radius * radius)
+    class Square(sideLength: Double) : Shape(sideLength * sideLength)
+
+    sealed class Pet(val name: String) {
+        class Dog(name: String, val goodBoysReceived: Int) : Pet(name)
+        class Cat(name: String, val livesRemaining: Int) : Pet(name)
     }
 }

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/TypeTestHelper.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/TypeTestHelper.kt
@@ -60,7 +60,10 @@ open class TypeTestHelper {
     fun setup() {
         beforeSetup()
 
+        generator.additionalTypes.clear()
+        generator.directives.clear()
         generator.cache.clear()
+
         every { config.hooks } returns hooks
         every { config.dataFetcherFactoryProvider } returns dataFetcherFactory
         every { spyWiringFactory.getSchemaDirectiveWiring(any()) } returns object : KotlinSchemaDirectiveWiring {}


### PR DESCRIPTION
### :pencil: Description
Allows sealed classes to be used as GraphQL Interfaces. This means that you can restrict the possible implementations of the interfaces since subclasses can only be declared with the root class

https://kotlinlang.org/docs/reference/sealed-classes.html

### :link: Related Issues
Fixes https://github.com/ExpediaGroup/graphql-kotlin/issues/642