### PR TITLE
[generator] allow disabling introspection query

### DIFF
--- a/docs/customizing-schemas/generator-config.md
+++ b/docs/customizing-schemas/generator-config.md
@@ -19,6 +19,7 @@ schema.
   `Subscription`
 * `hooks` _[Optional]_ - Set custom behaviors for generating the schema, see below for details.
 * `dataFetcherFactory` _[Optional]_ - Sets custom behavior for generating data fetchers
+* `introspectionEnabled` _[Optional]_ - Boolean flag indicating whether introspection queries are enabled, introspection queries are enabled by default
 
 ## Schema generator hooks
 

--- a/docs/execution/introspection.md
+++ b/docs/execution/introspection.md
@@ -12,6 +12,8 @@ by the schema (including built-in scalars and introspection types) as well as al
 * ___type(name: String!)_ - root level query field that provides information about the requested type (if it exists)
 * ___typename_ - field that can be added to *ANY* selection and will return the name of the enclosing type, `__typename`
 is often used in polymorphic queries in order to easily determine underlying implementation type
+* ___Directive_, ___DirectiveLocation_, ___EnumValue_, ___Field_, ___InputValue_, ___Schema_, ___Type_, ___TypeKind_ - built-in
+introspection types that are used to describe the schema.
 
 For example, the query below will return a root Query object name as well as names of all types and all directives.
 
@@ -39,6 +41,6 @@ Introspection system can be disabled by specifying `introspectionEnabled=false` 
 `SchemaGeneratorConfig` that will be used by the `SchemaGenerator` to generate the GraphQL schema.
 
 Many GraphQL tools (e.g. [GraphQL Playground](https://github.com/prisma-labs/graphql-playground) or [GraphiQL](https://github.com/graphql/graphiql))
-rely on introspection queries to function properly. Disabling introspection will prevent clients from accessing any of
-the introspection types (i.e. fields prefixed with `__` which includes `__typename` often used within polymorphic queries).
-This may break some of the functionality that your clients might rely on and should be used with extreme caution.
+rely on introspection queries to function properly. Disabling introspection will prevent clients from accessing `__schema`
+and `__type` fields. This may break some of the functionality that your clients might rely on and should be used with
+extreme caution.

--- a/docs/execution/introspection.md
+++ b/docs/execution/introspection.md
@@ -1,0 +1,44 @@
+---
+id: introspection
+title: Introspection
+---
+By default, GraphQL servers expose a built-in system, called **introspection**, that exposes details about the underlying schema.
+Clients can use introspection to obtain information about all the supported queries as well as all the types exposed in the schema.
+
+## Introspection types
+
+* ___schema_ - root level query field that provides information about all entry points (e.g. `queryType`), all types exposed
+by the schema (including built-in scalars and introspection types) as well as all directives supported by the system
+* ___type(name: String!)_ - root level query field that provides information about the requested type (if it exists)
+* ___typename_ - field that can be added to *ANY* selection and will return the name of the enclosing type, `__typename`
+is often used in polymorphic queries in order to easily determine underlying implementation type
+
+For example, the query below will return a root Query object name as well as names of all types and all directives.
+
+```graphql
+query {
+  __schema {
+    queryType {
+      name
+    }
+    types {
+      name
+    }
+    directives {
+      name
+    }
+  }
+}
+```
+
+Additional information on introspection can be found on [GraphQL.org](https://graphql.org/learn/introspection/).
+
+## Disabling Introspection
+
+Introspection system can be disabled by specifying `introspectionEnabled=false` configuration option on an instance of
+`SchemaGeneratorConfig` that will be used by the `SchemaGenerator` to generate the GraphQL schema.
+
+Many GraphQL tools (e.g. [GraphQL Playground](https://github.com/prisma-labs/graphql-playground) or [GraphiQL](https://github.com/graphql/graphiql))
+rely on introspection queries to function properly. Disabling introspection will prevent clients from accessing any of
+the introspection types (i.e. fields prefixed with `__` which includes `__typename` often used within polymorphic queries).
+This may break some of the functionality that your clients might rely on and should be used with extreme caution.

--- a/docs/spring-server/spring-properties.md
+++ b/docs/spring-server/spring-properties.md
@@ -3,7 +3,7 @@ id: spring-properties
 title: Configuration Properties
 ---
 
-`graphql-kotlin-spring-server` relies on [GraphQLConfigurationProperties](https://github.com/ExpediaGroup/graphql-kotlin/blob/master/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/GraphQLConfigurationProperties.kt) 
+`graphql-kotlin-spring-server` relies on [GraphQLConfigurationProperties](https://github.com/ExpediaGroup/graphql-kotlin/blob/master/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/GraphQLConfigurationProperties.kt)
 to provide various customizations of the auto-configuration library. All applicable configuration properties expose [configuration
 metadata](https://docs.spring.io/spring-boot/docs/current/reference/html/configuration-metadata.html) that provide
 details on the supported configuration properties.
@@ -13,6 +13,7 @@ details on the supported configuration properties.
 | graphql.endpoint | GraphQL server endpoint | graphql |
 | graphql.packages | List of supported packages that can contain GraphQL schema type definitions | |
 | graphql.federation.enabled | Boolean flag indicating whether to generate federated GraphQL model | false |
+| graphql.introspection.enabled | Boolean flag indicating whether introspection queries are enabled | true |
 | graphql.playground.enabled | Boolean flag indicating whether to enabled Prisma Labs Playground GraphQL IDE | true |
 | graphql.playground.endpoint | Prisma Labs Playground GraphQL IDE endpoint | playground |
 | graphql.sdl.enabled | Boolean flag indicating whether to expose SDL endpoint | true |

--- a/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/FederatedSchemaGeneratorConfig.kt
+++ b/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/FederatedSchemaGeneratorConfig.kt
@@ -28,5 +28,6 @@ class FederatedSchemaGeneratorConfig(
     override val supportedPackages: List<String>,
     override val topLevelNames: TopLevelNames = TopLevelNames(),
     override val hooks: FederatedSchemaGeneratorHooks,
-    override val dataFetcherFactoryProvider: KotlinDataFetcherFactoryProvider = SimpleKotlinDataFetcherFactoryProvider()
-) : SchemaGeneratorConfig(supportedPackages, topLevelNames, hooks, dataFetcherFactoryProvider)
+    override val dataFetcherFactoryProvider: KotlinDataFetcherFactoryProvider = SimpleKotlinDataFetcherFactoryProvider(),
+    override val introspectionEnabled: Boolean = true
+) : SchemaGeneratorConfig(supportedPackages, topLevelNames, hooks, dataFetcherFactoryProvider, introspectionEnabled)

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/SchemaGeneratorConfig.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/SchemaGeneratorConfig.kt
@@ -28,5 +28,6 @@ open class SchemaGeneratorConfig(
     open val supportedPackages: List<String>,
     open val topLevelNames: TopLevelNames = TopLevelNames(),
     open val hooks: SchemaGeneratorHooks = NoopSchemaGeneratorHooks,
-    open val dataFetcherFactoryProvider: KotlinDataFetcherFactoryProvider = SimpleKotlinDataFetcherFactoryProvider()
+    open val dataFetcherFactoryProvider: KotlinDataFetcherFactoryProvider = SimpleKotlinDataFetcherFactoryProvider(),
+    open val introspectionEnabled: Boolean = true
 )

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/SchemaGenerator.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/SchemaGenerator.kt
@@ -28,6 +28,7 @@ import graphql.schema.GraphQLCodeRegistry
 import graphql.schema.GraphQLDirective
 import graphql.schema.GraphQLSchema
 import graphql.schema.GraphQLType
+import graphql.schema.visibility.NoIntrospectionGraphqlFieldVisibility
 import java.io.Closeable
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.reflect.KClass
@@ -65,6 +66,10 @@ open class SchemaGenerator(internal val config: SchemaGeneratorConfig) : Closeab
         builder.subscription(generateSubscriptions(this, subscriptions))
         builder.additionalTypes(generateAdditionalTypes())
         builder.additionalDirectives(directives.values.toSet())
+
+        if (!config.introspectionEnabled) {
+            codeRegistry.fieldVisibility(NoIntrospectionGraphqlFieldVisibility.NO_INTROSPECTION_FIELD_VISIBILITY)
+        }
         builder.codeRegistry(codeRegistry.build())
 
         return config.hooks.willBuildSchema(builder).build()

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/ToSchemaTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/ToSchemaTest.kt
@@ -16,6 +16,7 @@
 
 package com.expediagroup.graphql.generator
 
+import com.expediagroup.graphql.SchemaGeneratorConfig
 import com.expediagroup.graphql.TopLevelObject
 import com.expediagroup.graphql.annotations.GraphQLDescription
 import com.expediagroup.graphql.annotations.GraphQLID
@@ -32,6 +33,7 @@ import graphql.GraphQL
 import graphql.Scalars
 import graphql.execution.DataFetcherResult
 import graphql.execution.ExecutionPath
+import graphql.introspection.IntrospectionQuery
 import graphql.language.SourceLocation
 import graphql.schema.GraphQLNonNull
 import graphql.schema.GraphQLObjectType
@@ -40,6 +42,7 @@ import java.net.CookieManager
 import java.util.UUID
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -347,6 +350,19 @@ class ToSchemaTest {
 
         assertNotNull(errors)
         assertEquals(expected = 1, actual = errors.size)
+    }
+
+    @Test
+    fun `SchemaGenerator disables introspection query`() {
+        val config = SchemaGeneratorConfig(listOf("com.expediagroup.graphql.generator"), introspectionEnabled = false)
+        val generator = SchemaGenerator(config)
+        val schema = generator.generateSchema(listOf(TopLevelObject(QueryObject())))
+
+        val graphql = GraphQL.newGraphQL(schema)
+            .build()
+        val result = graphql.execute(IntrospectionQuery.INTROSPECTION_QUERY)
+        assertFalse(result.isDataPresent)
+        assertTrue(result.errors?.isEmpty() == false)
     }
 
     class QueryObject {

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/FederationAutoConfiguration.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/FederationAutoConfiguration.kt
@@ -62,7 +62,8 @@ class FederationAutoConfiguration {
         supportedPackages = config.packages,
         topLevelNames = topLevelNames.orElse(TopLevelNames()),
         hooks = hooks,
-        dataFetcherFactoryProvider = dataFetcherFactoryProvider
+        dataFetcherFactoryProvider = dataFetcherFactoryProvider,
+        introspectionEnabled = config.introspection.enabled
     )
 
     @Bean

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/GraphQLAutoConfiguration.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/GraphQLAutoConfiguration.kt
@@ -80,7 +80,8 @@ class GraphQLAutoConfiguration {
         dataFetcherExceptionHandler: DataFetcherExceptionHandler,
         instrumentations: Optional<List<Instrumentation>>,
         executionIdProvider: Optional<ExecutionIdProvider>,
-        preparsedDocumentProvider: Optional<PreparsedDocumentProvider>
+        preparsedDocumentProvider: Optional<PreparsedDocumentProvider>,
+        config: GraphQLConfigurationProperties
     ): GraphQL {
         val graphQL = GraphQL.newGraphQL(schema)
             .queryExecutionStrategy(AsyncExecutionStrategy(dataFetcherExceptionHandler))

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/GraphQLConfigurationProperties.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/GraphQLConfigurationProperties.kt
@@ -32,7 +32,8 @@ data class GraphQLConfigurationProperties(
     val federation: FederationConfigurationProperties = FederationConfigurationProperties(),
     val subscriptions: SubscriptionConfigurationProperties = SubscriptionConfigurationProperties(),
     val playground: PlaygroundConfigurationProperties = PlaygroundConfigurationProperties(),
-    val sdl: SDLConfigurationProperties = SDLConfigurationProperties()
+    val sdl: SDLConfigurationProperties = SDLConfigurationProperties(),
+    val introspection: IntrospectionConfigurationProperties = IntrospectionConfigurationProperties()
 ) {
     /**
      * Apollo Federation configuration properties.
@@ -70,5 +71,13 @@ data class GraphQLConfigurationProperties(
         val enabled: Boolean = true,
         /** GraphQL SDL endpoint */
         val endpoint: String = "sdl"
+    )
+
+    /**
+     * Introspection configuration properties.
+     */
+    data class IntrospectionConfigurationProperties(
+        /** Boolean flag indicating whether introspection queries are enabled. */
+        val enabled: Boolean = true
     )
 }

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/SchemaAutoConfiguration.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/SchemaAutoConfiguration.kt
@@ -59,7 +59,8 @@ class SchemaAutoConfiguration {
             supportedPackages = config.packages,
             topLevelNames = topLevelNames.orElse(TopLevelNames()),
             hooks = generatorHooks,
-            dataFetcherFactoryProvider = dataFetcherFactoryProvider
+            dataFetcherFactoryProvider = dataFetcherFactoryProvider,
+            introspectionEnabled = config.introspection.enabled
         )
     }
 

--- a/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/execution/DataFetcherIT.kt
+++ b/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/execution/DataFetcherIT.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.expediagroup.graphql.spring.execution
 
 import com.expediagroup.graphql.hooks.SchemaGeneratorHooks

--- a/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/execution/IntrospectionIT.kt
+++ b/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/execution/IntrospectionIT.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2020 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.expediagroup.graphql.spring.execution
+
+import com.expediagroup.graphql.spring.model.GraphQLRequest
+import com.expediagroup.graphql.spring.operations.Query
+import graphql.introspection.IntrospectionQuery
+import graphql.validation.ValidationErrorType
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.MediaType
+import org.springframework.test.web.reactive.server.WebTestClient
+import kotlin.random.Random
+
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = ["graphql.packages=com.expediagroup.graphql.spring.execution",
+        "graphql.introspection.enabled=false"]
+)
+@EnableAutoConfiguration
+class IntrospectionIT(@Autowired private val testClient: WebTestClient) {
+
+    @Test
+    fun `verify custom jackson bindings work with function data fetcher`() {
+        val request = GraphQLRequest(query = IntrospectionQuery.INTROSPECTION_QUERY)
+        testClient.post()
+            .uri("/graphql")
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(request)
+            .exchange()
+            .expectBody()
+            .jsonPath("$.data").doesNotExist()
+            .jsonPath("$.errors").isArray
+            .jsonPath("$.errors[0].description").isEqualTo("""Field 'queryType' in type '__Schema' is undefined""")
+            .jsonPath("$.errors[0].validationErrorType").isEqualTo(ValidationErrorType.FieldUndefined.name)
+    }
+
+    @Configuration
+    class TestConfiguration {
+
+        @Bean
+        fun query(): Query = RandomQuery()
+    }
+
+    class RandomQuery: Query {
+        fun randomBoolean(): Boolean = Random.nextBoolean()
+    }
+}

--- a/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/execution/IntrospectionIT.kt
+++ b/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/execution/IntrospectionIT.kt
@@ -55,12 +55,11 @@ class IntrospectionIT(@Autowired private val testClient: WebTestClient) {
 
     @Configuration
     class TestConfiguration {
-
         @Bean
         fun query(): Query = RandomQuery()
     }
 
-    class RandomQuery: Query {
+    class RandomQuery : Query {
         fun randomBoolean(): Boolean = Random.nextBoolean()
     }
 }

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -43,7 +43,8 @@
           "execution/exceptions",
           "execution/data-fetching-environment",
           "execution/contextual-data",
-          "execution/subscriptions"
+          "execution/subscriptions",
+          "execution/introspection"
         ]
       }
     ],


### PR DESCRIPTION
### :pencil: Description

Schema generator should provide an option to easily disable introspection queries. Add new `introspectionEnabled` Boolean option to `SchemaGeneratorConfig` that is enabled by default.

spring-server was also updated to expose `graphql.introspection.enabled` property that will automatically configure the `SchemaGeneratorConfig` with the specified value.

### :link: Related Issues
Resolves: https://github.com/ExpediaGroup/graphql-kotlin/issues/651