### PR TITLE
[spring] Refactor config classes and internal functions

### DIFF
--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/FederatedSchemaAutoConfiguration.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/FederatedSchemaAutoConfiguration.kt
@@ -23,6 +23,7 @@ import com.expediagroup.graphql.federation.FederatedSchemaGeneratorConfig
 import com.expediagroup.graphql.federation.FederatedSchemaGeneratorHooks
 import com.expediagroup.graphql.federation.execution.FederatedTypeRegistry
 import com.expediagroup.graphql.federation.toFederatedSchema
+import com.expediagroup.graphql.spring.extensions.toTopLevelObjects
 import com.expediagroup.graphql.spring.operations.Mutation
 import com.expediagroup.graphql.spring.operations.Query
 import com.expediagroup.graphql.spring.operations.Subscription
@@ -39,9 +40,9 @@ import java.util.Optional
  */
 @ConditionalOnProperty(value = ["graphql.federation.enabled"], havingValue = "true")
 @Configuration
-class FederationAutoConfiguration {
+class FederatedSchemaAutoConfiguration {
 
-    private val logger = LoggerFactory.getLogger(FederationAutoConfiguration::class.java)
+    private val logger = LoggerFactory.getLogger(FederatedSchemaAutoConfiguration::class.java)
 
     @Bean
     @ConditionalOnMissingBean

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/GraphQLAutoConfiguration.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/GraphQLAutoConfiguration.kt
@@ -57,7 +57,7 @@ const val DEFAULT_INSTRUMENTATION_ORDER = 0
 @Import(
     RoutesConfiguration::class,
     SchemaAutoConfiguration::class,
-    FederationAutoConfiguration::class,
+    FederatedSchemaAutoConfiguration::class,
     SubscriptionAutoConfiguration::class,
     PlaygroundAutoConfiguration::class
 )

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/PlaygroundAutoConfiguration.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/PlaygroundAutoConfiguration.kt
@@ -21,8 +21,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.core.io.Resource
-import org.springframework.web.reactive.function.server.RouterFunction
-import org.springframework.web.reactive.function.server.ServerResponse
 import org.springframework.web.reactive.function.server.bodyValueAndAwait
 import org.springframework.web.reactive.function.server.coRouter
 import org.springframework.web.reactive.function.server.html

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/PlaygroundAutoConfiguration.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/PlaygroundAutoConfiguration.kt
@@ -37,17 +37,16 @@ class PlaygroundAutoConfiguration(
     @Value("classpath:/graphql-playground.html") private val playgroundHtml: Resource
 ) {
 
+    private val body = playgroundHtml.inputStream.bufferedReader().use { reader ->
+        reader.readText()
+            .replace("\${graphQLEndpoint}", config.endpoint)
+            .replace("\${subscriptionsEndpoint}", config.subscriptions.endpoint)
+    }
+
     @Bean
-    fun playgroundRoute(): RouterFunction<ServerResponse> {
-        val body = playgroundHtml.inputStream.bufferedReader().use { reader ->
-            reader.readText()
-                .replace("\${graphQLEndpoint}", config.endpoint)
-                .replace("\${subscriptionsEndpoint}", config.subscriptions.endpoint)
-        }
-        return coRouter {
-            GET(config.playground.endpoint) {
-                ok().html().bodyValueAndAwait(body)
-            }
+    fun playgroundRoute() = coRouter {
+        GET(config.playground.endpoint) {
+            ok().html().bodyValueAndAwait(body)
         }
     }
 }

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/SchemaAutoConfiguration.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/SchemaAutoConfiguration.kt
@@ -23,6 +23,7 @@ import com.expediagroup.graphql.execution.KotlinDataFetcherFactoryProvider
 import com.expediagroup.graphql.extensions.print
 import com.expediagroup.graphql.hooks.NoopSchemaGeneratorHooks
 import com.expediagroup.graphql.hooks.SchemaGeneratorHooks
+import com.expediagroup.graphql.spring.extensions.toTopLevelObjects
 import com.expediagroup.graphql.spring.operations.Mutation
 import com.expediagroup.graphql.spring.operations.Query
 import com.expediagroup.graphql.spring.operations.Subscription
@@ -83,13 +84,4 @@ class SchemaAutoConfiguration {
 
         return schema
     }
-}
-
-internal fun List<Any>.toTopLevelObjects() = this.map {
-    val klazz = if (AopUtils.isAopProxy(it) && it is Advised) {
-        it.targetSource.target!!::class
-    } else {
-        it::class
-    }
-    TopLevelObject(it, klazz)
 }

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/SchemaAutoConfiguration.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/SchemaAutoConfiguration.kt
@@ -18,7 +18,6 @@ package com.expediagroup.graphql.spring
 
 import com.expediagroup.graphql.SchemaGeneratorConfig
 import com.expediagroup.graphql.TopLevelNames
-import com.expediagroup.graphql.TopLevelObject
 import com.expediagroup.graphql.execution.KotlinDataFetcherFactoryProvider
 import com.expediagroup.graphql.extensions.print
 import com.expediagroup.graphql.hooks.NoopSchemaGeneratorHooks
@@ -30,8 +29,6 @@ import com.expediagroup.graphql.spring.operations.Subscription
 import com.expediagroup.graphql.toSchema
 import graphql.schema.GraphQLSchema
 import org.slf4j.LoggerFactory
-import org.springframework.aop.framework.Advised
-import org.springframework.aop.support.AopUtils
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/extensions/generatorExtensions.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/extensions/generatorExtensions.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.spring.extensions
+
+import com.expediagroup.graphql.TopLevelObject
+import org.springframework.aop.framework.Advised
+import org.springframework.aop.support.AopUtils
+
+/**
+ * Convert a list of spring objects into a list of [TopLevelObject]s that
+ * the schema generator can use
+ */
+internal fun List<Any>.toTopLevelObjects() = this.map {
+    val klazz = if (AopUtils.isAopProxy(it) && it is Advised) {
+        it.targetSource.target!!::class
+    } else {
+        it::class
+    }
+    TopLevelObject(it, klazz)
+}

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/model/GraphQLResponse.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/model/GraphQLResponse.kt
@@ -21,7 +21,6 @@ import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonInclude.Include
 import graphql.ExecutionResult
 import graphql.GraphQLError
-import java.lang.Exception
 
 @JsonInclude(Include.NON_NULL)
 data class GraphQLResponse(


### PR DESCRIPTION
### :pencil: Description
Renamed the federation config class to match the same pattern and reuse the imported html for the playground.

### :link: Related Issues
Initially a large change in https://github.com/ExpediaGroup/graphql-kotlin/pull/652