### PR TITLE
[generator] support returning GraphQL ID scalar from functions

### DIFF
--- a/docs/writing-schemas/scalars.md
+++ b/docs/writing-schemas/scalars.md
@@ -36,7 +36,10 @@ data class Person(
   val name: String
 )
 
-fun createPerson(@GraphQLID id: String) = Person(id, "Jane Doe")
+fun locatePerson(@GraphQLID id: String) = Person(id, "Jane Doe")
+
+@GraphQLID
+fun generateRandomId() = UUID.randomUUID().toString()
 ```
 
 This would produce the following schema:
@@ -46,8 +49,10 @@ schema {
   query: Query
 }
 
+
 type Query {
-  createPerson(id: ID!): Person!
+  locatePerson(id: ID!): Person!
+  generateRandomId: ID!
 }
 
 type Person {

--- a/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/query/ScalarQuery.kt
+++ b/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/query/ScalarQuery.kt
@@ -36,6 +36,10 @@ class ScalarQuery : Query {
     fun printUuids(uuids: List<UUID>) = "You sent $uuids"
 
     fun findPersonById(@GraphQLID id: String) = Person(id, "Nelson")
+
+    @GraphQLDescription("generates random GraphQL ID")
+    @GraphQLID
+    fun generateRandomId() = UUID.randomUUID().toString()
 }
 
 @Component

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/generateFunction.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/generateFunction.kt
@@ -22,6 +22,7 @@ import com.expediagroup.graphql.generator.extensions.getDeprecationReason
 import com.expediagroup.graphql.generator.extensions.getFunctionName
 import com.expediagroup.graphql.generator.extensions.getGraphQLDescription
 import com.expediagroup.graphql.generator.extensions.getValidArguments
+import com.expediagroup.graphql.generator.extensions.isGraphQLID
 import com.expediagroup.graphql.generator.extensions.safeCast
 import com.expediagroup.graphql.generator.types.utils.getWrappedReturnType
 import graphql.schema.FieldCoordinates
@@ -50,7 +51,7 @@ internal fun generateFunction(generator: SchemaGenerator, fn: KFunction<*>, pare
 
     val typeFromHooks = generator.config.hooks.willResolveMonad(fn.returnType)
     val returnType = getWrappedReturnType(typeFromHooks)
-    val graphQLOutputType = generateGraphQLType(generator, returnType).safeCast<GraphQLOutputType>()
+    val graphQLOutputType = generateGraphQLType(generator, returnType, annotatedAsID = fn.isGraphQLID()).safeCast<GraphQLOutputType>()
     val graphQLType = builder.type(graphQLOutputType).build()
     val coordinates = FieldCoordinates.coordinates(parentName, functionName)
 

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/GenerateFunctionTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/GenerateFunctionTest.kt
@@ -18,12 +18,14 @@ package com.expediagroup.graphql.generator.types
 
 import com.expediagroup.graphql.annotations.GraphQLDescription
 import com.expediagroup.graphql.annotations.GraphQLDirective
+import com.expediagroup.graphql.annotations.GraphQLID
 import com.expediagroup.graphql.annotations.GraphQLIgnore
 import com.expediagroup.graphql.annotations.GraphQLName
 import com.expediagroup.graphql.exceptions.TypeNotSupportedException
 import com.expediagroup.graphql.execution.FunctionDataFetcher
 import com.expediagroup.graphql.execution.GraphQLContext
 import graphql.ExceptionWhileDataFetching
+import graphql.Scalars
 import graphql.Scalars.GraphQLInt
 import graphql.Scalars.GraphQLString
 import graphql.execution.DataFetcherResult
@@ -104,6 +106,9 @@ internal class GenerateFunctionTest : TypeTestHelper() {
             val dataFetcherResult = DataFetcherResult.newResult<String>().data("Hello").build()
             return CompletableFuture.completedFuture(dataFetcherResult)
         }
+
+        @GraphQLID
+        fun randomId(): String = UUID.randomUUID().toString()
     }
 
     @Test
@@ -291,5 +296,15 @@ internal class GenerateFunctionTest : TypeTestHelper() {
 
         assertTrue(implResult.type is GraphQLNonNull)
         assertEquals(kInterfaceResult.type, implResult.type)
+    }
+
+    @Test
+    fun `function can return GraphQL ID scalar`() {
+        val kFunction = Happy::randomId
+        val result = generateFunction(generator, kFunction, "Query", target = null, abstract = false)
+
+        assertEquals("randomId", result.name)
+        val returnType = GraphQLTypeUtil.unwrapAll(result.type)
+        assertEquals(Scalars.GraphQLID, returnType)
     }
 }


### PR DESCRIPTION
### :pencil: Description
Our current logic was not checking whether function return type was annotated with `@GraphQLID` annotation so it was not possible to return `ID` scalar type.

### :link: Related Issues
Resolves https://github.com/ExpediaGroup/graphql-kotlin/issues/668