### PR TITLE
[generator] support returning GraphQL ID scalar from functions 1.x.x

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -3,7 +3,7 @@ name: Maven CI
 on:
   pull_request:
     branches:
-      - master
+      - 1.x.x
 
 jobs:
   build:

--- a/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/query/ScalarQuery.kt
+++ b/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/query/ScalarQuery.kt
@@ -33,6 +33,9 @@ class ScalarQuery: Query {
     fun generateRandomUUID() = UUID.randomUUID()
 
     fun findPersonById(@GraphQLID id: String) = Person(id, "Nelson")
+
+    @GraphQLID
+    fun generateRandomId() = UUID.randomUUID().toString()
 }
 
 @Component

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/FunctionBuilder.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/FunctionBuilder.kt
@@ -23,6 +23,7 @@ import com.expediagroup.graphql.generator.extensions.getDeprecationReason
 import com.expediagroup.graphql.generator.extensions.getFunctionName
 import com.expediagroup.graphql.generator.extensions.getGraphQLDescription
 import com.expediagroup.graphql.generator.extensions.getValidArguments
+import com.expediagroup.graphql.generator.extensions.isGraphQLID
 import com.expediagroup.graphql.generator.extensions.safeCast
 import com.expediagroup.graphql.generator.types.utils.getWrappedReturnType
 import graphql.schema.FieldCoordinates
@@ -53,7 +54,7 @@ internal class FunctionBuilder(generator: SchemaGenerator) : TypeBuilder(generat
 
         val typeFromHooks = config.hooks.willResolveMonad(fn.returnType)
         val returnType = getWrappedReturnType(typeFromHooks)
-        val graphQLOutputType = graphQLTypeOf(returnType).safeCast<GraphQLOutputType>()
+        val graphQLOutputType = graphQLTypeOf(returnType, annotatedAsID = fn.isGraphQLID()).safeCast<GraphQLOutputType>()
         val graphQLType = builder.type(graphQLOutputType).build()
         val coordinates = FieldCoordinates.coordinates(parentName, functionName)
 

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/FunctionBuilderTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/FunctionBuilderTest.kt
@@ -19,6 +19,7 @@ package com.expediagroup.graphql.generator.types
 import com.expediagroup.graphql.annotations.GraphQLContext
 import com.expediagroup.graphql.annotations.GraphQLDescription
 import com.expediagroup.graphql.annotations.GraphQLDirective
+import com.expediagroup.graphql.annotations.GraphQLID
 import com.expediagroup.graphql.annotations.GraphQLIgnore
 import com.expediagroup.graphql.annotations.GraphQLName
 import com.expediagroup.graphql.exceptions.TypeNotSupportedException
@@ -107,6 +108,9 @@ internal class FunctionBuilderTest : TypeTestHelper() {
             val dataFetcherResult = DataFetcherResult.newResult<String>().data("Hello").build()
             return CompletableFuture.completedFuture(dataFetcherResult)
         }
+
+        @GraphQLID
+        fun randomId() = UUID.randomUUID().toString()
     }
 
     @Test
@@ -294,5 +298,15 @@ internal class FunctionBuilderTest : TypeTestHelper() {
 
         assertTrue(implResult.type is GraphQLNonNull)
         assertEquals(kInterfaceResult.type, implResult.type)
+    }
+
+    @Test
+    fun `function can return GraphQL ID scalar`() {
+        val kFunction = Happy::randomId
+        val result = builder.function(kFunction, "Query", target = null, abstract = false)
+
+        assertEquals("randomId", result.name)
+        val returnType = GraphQLTypeUtil.unwrapAll(result.type)
+        assertEquals(Scalars.GraphQLID, returnType)
     }
 }


### PR DESCRIPTION
### :pencil: Description
Backport to 1.x.x

Our current logic was not checking whether function return type was annotated with @GraphQLID annotation so it was not possible to return ID scalar type.

### :link: Related Issues

* https://github.com/ExpediaGroup/graphql-kotlin/pull/669
* https://github.com/ExpediaGroup/graphql-kotlin/issues/668
