### PR TITLE
Allow for trailing slashes on context filter

### DIFF
--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/execution/ContextWebFilter.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/execution/ContextWebFilter.kt
@@ -39,7 +39,7 @@ const val GRAPHQL_CONTEXT_FILTER_ODER = 0
 open class ContextWebFilter<out T : GraphQLContext>(config: GraphQLConfigurationProperties, private val contextFactory: GraphQLContextFactory<T>) : WebFilter, Ordered {
     private val graphQLRoute = enforceAbsolutePath(config.endpoint)
     private val subscriptionsRoute = enforceAbsolutePath(config.subscriptions.endpoint)
-    private val parser = getParser()
+    private val parser = getPathPatternParser()
     private val graphQLRoutePattern = parser.parse(graphQLRoute)
     private val subscriptionsRoutePattern = parser.parse(subscriptionsRoute)
 
@@ -64,9 +64,10 @@ open class ContextWebFilter<out T : GraphQLContext>(config: GraphQLConfiguration
 
     private fun enforceAbsolutePath(path: String) = if (path.startsWith("/")) { path } else { "/$path" }
 
-    private fun getParser(): PathPatternParser {
+    private fun getPathPatternParser(): PathPatternParser {
         val parser = PathPatternParser()
         parser.isCaseSensitive = false
+        parser.isMatchOptionalTrailingSeparator = true
         return parser
     }
 }

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/execution/ContextWebFilter.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/execution/ContextWebFilter.kt
@@ -24,6 +24,7 @@ import org.springframework.http.server.PathContainer
 import org.springframework.web.server.ServerWebExchange
 import org.springframework.web.server.WebFilter
 import org.springframework.web.server.WebFilterChain
+import org.springframework.web.util.pattern.PathPattern
 import org.springframework.web.util.pattern.PathPatternParser
 import reactor.core.publisher.Mono
 
@@ -37,11 +38,16 @@ const val GRAPHQL_CONTEXT_FILTER_ODER = 0
  * Default web filter that populates GraphQL context in the reactor subscriber context.
  */
 open class ContextWebFilter<out T : GraphQLContext>(config: GraphQLConfigurationProperties, private val contextFactory: GraphQLContextFactory<T>) : WebFilter, Ordered {
-    private val graphQLRoute = enforceAbsolutePath(config.endpoint)
-    private val subscriptionsRoute = enforceAbsolutePath(config.subscriptions.endpoint)
-    private val parser = getPathPatternParser()
-    private val graphQLRoutePattern = parser.parse(graphQLRoute)
-    private val subscriptionsRoutePattern = parser.parse(subscriptionsRoute)
+    private val graphQLRoutePattern: PathPattern
+    private val subscriptionsRoutePattern: PathPattern
+
+    init {
+        val graphQLRoute = enforceAbsolutePath(config.endpoint)
+        val subscriptionsRoute = enforceAbsolutePath(config.subscriptions.endpoint)
+        val parser = getPathPatternParser()
+        graphQLRoutePattern = parser.parse(graphQLRoute)
+        subscriptionsRoutePattern = parser.parse(subscriptionsRoute)
+    }
 
     @Suppress("ForbiddenVoid")
     override fun filter(exchange: ServerWebExchange, chain: WebFilterChain): Mono<Void> =

--- a/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/context/ContextWebFilterTest.kt
+++ b/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/context/ContextWebFilterTest.kt
@@ -111,6 +111,14 @@ class ContextWebFilterTest {
     }
 
     @Test
+    fun `verify context web filter is applicable on routes with different cases and trailing slashes`() {
+        val contextFilter = ContextWebFilter(GraphQLConfigurationProperties(packages = listOf("com.expediagroup.graphql")), mockk<GraphQLContextFactory<*>>())
+        for (path in listOf("/GrAphQl", "/graphql/", "/sUbscRiptions", "/subscriptions/")) {
+            assertTrue(contextFilter.isApplicable(path), "$path was invalid")
+        }
+    }
+
+    @Test
     fun `verify context web filter is applicable on non-default graphql routes`() {
         val graphQLRoute = "myGraphQL"
         val subscriptionRoute = "mySubscription"


### PR DESCRIPTION
### :pencil: Description
The `ContextWebFilter` did a simple string compare to match the path. Instead we should use a proper `PathParser` to check the route and provide additional options like being case-insensitive and ignoring trailing slashes

### :link: Related Issues
https://github.com/ExpediaGroup/graphql-kotlin/issues/672