### PR TITLE
[server] GraphQL Error response type should allow null locations

### DIFF
--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/exception/SimpleKotlinGraphQLError.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/exception/SimpleKotlinGraphQLError.kt
@@ -26,7 +26,7 @@ import graphql.language.SourceLocation
  */
 open class SimpleKotlinGraphQLError(
     private val exception: Throwable,
-    private val locations: List<SourceLocation> = emptyList(),
+    private val locations: List<SourceLocation>? = null,
     private val path: List<Any>? = null,
     private val errorType: ErrorClassification = ErrorType.DataFetchingException
 ) : GraphQLError {
@@ -39,7 +39,7 @@ open class SimpleKotlinGraphQLError(
             emptyMap()
         }
 
-    override fun getLocations(): List<SourceLocation> = locations
+    override fun getLocations(): List<SourceLocation>? = locations
 
     override fun getMessage(): String = "Exception while fetching data (${path?.joinToString("/").orEmpty()}) : ${exception.message}"
 

--- a/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/exception/SimpleKotlinGraphQLErrorTest.kt
+++ b/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/exception/SimpleKotlinGraphQLErrorTest.kt
@@ -32,7 +32,7 @@ internal class SimpleKotlinGraphQLErrorTest {
     fun `Verify default values on contstructor`() {
         val error = SimpleKotlinGraphQLError(Throwable())
         assertNotNull(error.message)
-        assertTrue(error.locations.isEmpty())
+        assertNull(error.locations)
         assertNull(error.path)
         assertEquals(expected = ErrorType.DataFetchingException, actual = error.errorType)
     }


### PR DESCRIPTION
### :pencil: Description
Based on the [Graphql spec](https://spec.graphql.org/June2018/#sec-Errors), error response should contain list of locations if error can be associated with particular point in the requested GraphQL document. We should not populate it if `locations` information is unavailable.

### :link: Related Issues
Resolves: https://github.com/ExpediaGroup/graphql-kotlin/issues/675