### PR TITLE
[generator] explicitly escape special characters in SDL

### DIFF
--- a/examples/federation/base-app/src/main/kotlin/com/expediagroup/graphql/examples/query/SimpleQuery.kt
+++ b/examples/federation/base-app/src/main/kotlin/com/expediagroup/graphql/examples/query/SimpleQuery.kt
@@ -16,6 +16,7 @@
 
 package com.expediagroup.graphql.examples.query
 
+import com.expediagroup.graphql.annotations.GraphQLDescription
 import com.expediagroup.graphql.spring.operations.Query
 import org.springframework.stereotype.Component
 
@@ -26,4 +27,7 @@ class SimpleQuery : Query {
 
     @Deprecated(message = "old deprecated query", replaceWith = ReplaceWith("dataFromBaseApp"))
     fun deprecatedBaseAppQuery() = "this is deprecated"
+
+    @GraphQLDescription("Comment with pattern: `^\\+[1-9]\\d{7,14}$")
+    fun commentsWithEscapeCharacters() = "escaping \\"
 }

--- a/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/FederatedSchemaGeneratorHooks.kt
+++ b/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/FederatedSchemaGeneratorHooks.kt
@@ -88,9 +88,6 @@ open class FederatedSchemaGeneratorHooks(private val federatedTypeRegistry: Fede
          * - new federated scalars
          */
         val sdl = originalSchema.print(includeDefaultSchemaDefinition = false, includeDirectivesFilter = customDirectivePredicate)
-            /**
-             * TODO: this can be simplified once this is solved: https://github.com/apollographql/apollo-server/issues/3334
-             */
             .replace(directiveDefinitionRegex, "")
             .replace(scalarDefinitionRegex, "")
             .replace(emptyQueryRegex, "")

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/extensions/GraphQLSchemaExtensions.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/extensions/GraphQLSchemaExtensions.kt
@@ -51,5 +51,7 @@ fun GraphQLSchema.print(
             .includeDirectives(includeDirectivesFilter)
     )
 
+    // escape special characters to preserve them in the SDL
     return schemaPrinter.print(this)
+        .replace("\\", "\\\\")
 }

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/extensions/GraphQLSchemaExtensionsTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/extensions/GraphQLSchemaExtensionsTest.kt
@@ -186,6 +186,12 @@ class GraphQLSchemaExtensionsTest {
     class DocumentedQuery {
         @GraphQLDescription("documented query")
         fun documented(@GraphQLDescription("documented argument") id: Int) = DocumentedType(id)
+
+        @GraphQLDescription("escaped pattern: `^\\+[1-9]\\d{7,14}$`")
+        fun documentedWithEscapeCharacters() = "escaped \\"
+
+        @GraphQLDescription("""raw pattern: `^\+[1-9]\d{7,14}$`""")
+        fun documentedWithRawEscapeCharacters() = """escaped raw \"""
     }
 
     @GraphQLDescription("documented type")
@@ -212,6 +218,10 @@ class GraphQLSchemaExtensionsTest {
                 "documented argument"
                 id: Int!
               ): DocumentedType!
+              "escaped pattern: `^\\+[1-9]\\d{7,14}${'$'}`"
+              documentedWithEscapeCharacters: String!
+              "raw pattern: `^\\+[1-9]\\d{7,14}${'$'}`"
+              documentedWithRawEscapeCharacters: String!
             }
         """.trimIndent()
         assertEquals(expected, sdl)


### PR DESCRIPTION
### :pencil: Description
The underlying issue is due to a bug in how we print out SDL - basically if you have escape characters they will be printed out in nicely formatted String intended for output. This unfortunately leads to invalid SDL as those comments will no longer be valid Strings. You can see the issue in the SDL that gets printed out at the startup when you use comments like:

```kotlin
@GraphQLDescription("Comment with pattern: `^\\+[1-9]\\d{7,14}$")
fun commentsWithEscapeCharacters() = "escaping \\"
```

### :link: Related Issues
Resolves https://github.com/ExpediaGroup/graphql-kotlin/issues/666
Resolves https://github.com/ExpediaGroup/graphql-kotlin/issues/667