### PR TITLE
Incorrect Execution Command for base-app

### DIFF
--- a/examples/federation/base-app/README.md
+++ b/examples/federation/base-app/README.md
@@ -21,7 +21,7 @@ Start the server:
 * Alternatively you can also use the spring boot plugin from the command line in the root examples directory.
 
 ```shell script
-./gradlew ::federation-example:base-app:bootRun
+./gradlew :federation-example:base-app:bootRun
 ```
 
 


### PR DESCRIPTION
The command to execute the base app was incorrect. It had two preceding colons, not one.