### PR TITLE
Revert "[server] GraphQL Error response type should allow null locations"

### DIFF
--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/exception/SimpleKotlinGraphQLError.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/exception/SimpleKotlinGraphQLError.kt
@@ -26,7 +26,7 @@ import graphql.language.SourceLocation
  */
 open class SimpleKotlinGraphQLError(
     private val exception: Throwable,
-    private val locations: List<SourceLocation>? = null,
+    private val locations: List<SourceLocation> = emptyList(),
     private val path: List<Any>? = null,
     private val errorType: ErrorClassification = ErrorType.DataFetchingException
 ) : GraphQLError {
@@ -39,7 +39,7 @@ open class SimpleKotlinGraphQLError(
             emptyMap()
         }
 
-    override fun getLocations(): List<SourceLocation>? = locations
+    override fun getLocations(): List<SourceLocation> = locations
 
     override fun getMessage(): String = "Exception while fetching data (${path?.joinToString("/").orEmpty()}) : ${exception.message}"
 

--- a/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/exception/SimpleKotlinGraphQLErrorTest.kt
+++ b/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/exception/SimpleKotlinGraphQLErrorTest.kt
@@ -32,7 +32,7 @@ internal class SimpleKotlinGraphQLErrorTest {
     fun `Verify default values on contstructor`() {
         val error = SimpleKotlinGraphQLError(Throwable())
         assertNotNull(error.message)
-        assertNull(error.locations)
+        assertTrue(error.locations.isEmpty())
         assertNull(error.path)
         assertEquals(expected = ErrorType.DataFetchingException, actual = error.errorType)
     }


### PR DESCRIPTION
Reverts ExpediaGroup/graphql-kotlin#677

I am going to revert to merge some other PRs first as there seems to be an issue with releasing different branches so I would like to get the bug fixes in the master branch first before we cut over to the 3.0.0 breaking changes

I will create a revert for the revert right after this is merged