### PR TITLE
Add GraphQLTypeRestriction feature

### DIFF
--- a/docs/customizing-schemas/restricting-types.md
+++ b/docs/customizing-schemas/restricting-types.md
@@ -1,0 +1,20 @@
+---
+id: restricting-types
+title: Restricting Classes to GraphQL Types
+---
+
+Since we generate the types from code, your Kotlin code may have some generic class that can be used as a function argument or as a return type. However you may want to enforce that you can only use a certain class as input or output as
+GraphQL does make the distinction in its type system.
+
+With `@GraphQLTypeRestriction` you can specify what type the class should be used for and the schema generator will throw an exception if it is used incorrectly.
+
+```kotlin
+@GraphQLTypeRestriction(GraphQLType.INPUT)
+data class MyQueryInput(val value: String)
+
+// Passes generation
+fun getSomeData(input: MyQueryInput): String
+
+// Fails generation
+fun getSomeData(input: String): MyQueryInput
+```

--- a/docs/writing-schemas/annotations.md
+++ b/docs/writing-schemas/annotations.md
@@ -13,3 +13,4 @@ for things that can't be directly derived from Kotlin reflection.
 * [@GraphQLIgnore](../customizing-schemas/excluding-fields) - Exclude field from the GraphQL schema
 * [@GraphQLName](../customizing-schemas/renaming-fields) - Override the name used for the type
 * Kotlin built in [@Deprecated](../customizing-schemas/deprecating-schema) - Apply the GraphQL `@deprecated` directive on the field
+* [@GraphQLTypeRestriction](../customizing-schemas/restricting-types) - Restrict Kotlin classes to certain GraphQL types

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/annotations/GraphQLTypeRestriction.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/annotations/GraphQLTypeRestriction.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.annotations
+
+/**
+ * Marker annotation for the schema generator to fail
+ * if a class is not used for the correct input/output type.
+ *
+ * This can be helpful when you want to restrict certain classes from being
+ * used as both input and outout in the schema.
+ */
+@Target(AnnotationTarget.CLASS)
+annotation class GraphQLTypeRestriction(val type: GraphQLType) {
+    enum class GraphQLType { INPUT, OUTPUT }
+}

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/exceptions/TypeRestrictionException.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/exceptions/TypeRestrictionException.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2020 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.exceptions
+
+import com.expediagroup.graphql.annotations.GraphQLTypeRestriction
+import kotlin.reflect.KClass
+
+class TypeRestrictionException(kClass: KClass<*>, restrictionType: GraphQLTypeRestriction.GraphQLType) :
+    GraphQLKotlinException("The type $kClass can only be used as $restrictionType type")

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/generateInputObject.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/generateInputObject.kt
@@ -16,17 +16,21 @@
 
 package com.expediagroup.graphql.generator.types
 
+import com.expediagroup.graphql.annotations.GraphQLTypeRestriction
 import com.expediagroup.graphql.generator.SchemaGenerator
 import com.expediagroup.graphql.generator.extensions.getGraphQLDescription
 import com.expediagroup.graphql.generator.extensions.getSimpleName
 import com.expediagroup.graphql.generator.extensions.getValidProperties
 import com.expediagroup.graphql.generator.extensions.safeCast
+import com.expediagroup.graphql.generator.types.utils.throwIfInvalidRestrictionType
 import graphql.schema.GraphQLInputObjectType
 import kotlin.reflect.KClass
 
 internal fun generateInputObject(generator: SchemaGenerator, kClass: KClass<*>): GraphQLInputObjectType {
-    val builder = GraphQLInputObjectType.newInputObject()
 
+    throwIfInvalidRestrictionType(kClass, GraphQLTypeRestriction.GraphQLType.INPUT)
+
+    val builder = GraphQLInputObjectType.newInputObject()
     builder.name(kClass.getSimpleName(isInputClass = true))
     builder.description(kClass.getGraphQLDescription())
 

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/generateObject.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/generateObject.kt
@@ -16,6 +16,7 @@
 
 package com.expediagroup.graphql.generator.types
 
+import com.expediagroup.graphql.annotations.GraphQLTypeRestriction
 import com.expediagroup.graphql.extensions.unwrapType
 import com.expediagroup.graphql.generator.SchemaGenerator
 import com.expediagroup.graphql.generator.extensions.getGraphQLDescription
@@ -24,6 +25,7 @@ import com.expediagroup.graphql.generator.extensions.getValidFunctions
 import com.expediagroup.graphql.generator.extensions.getValidProperties
 import com.expediagroup.graphql.generator.extensions.getValidSuperclasses
 import com.expediagroup.graphql.generator.extensions.safeCast
+import com.expediagroup.graphql.generator.types.utils.throwIfInvalidRestrictionType
 import graphql.schema.GraphQLInterfaceType
 import graphql.schema.GraphQLObjectType
 import graphql.schema.GraphQLTypeReference
@@ -31,8 +33,10 @@ import kotlin.reflect.KClass
 import kotlin.reflect.full.createType
 
 internal fun generateObject(generator: SchemaGenerator, kClass: KClass<*>): GraphQLObjectType {
-    val builder = GraphQLObjectType.newObject()
 
+    throwIfInvalidRestrictionType(kClass, GraphQLTypeRestriction.GraphQLType.OUTPUT)
+
+    val builder = GraphQLObjectType.newObject()
     val name = kClass.getSimpleName()
     builder.name(name)
     builder.description(kClass.getGraphQLDescription())

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/utils/restrictionTypes.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/utils/restrictionTypes.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.generator.types.utils
+
+import com.expediagroup.graphql.annotations.GraphQLTypeRestriction
+import com.expediagroup.graphql.exceptions.TypeRestrictionException
+import kotlin.reflect.KClass
+import kotlin.reflect.full.findAnnotation
+
+/**
+ * Throws an exception if the type is being used incorrectly
+ */
+internal fun throwIfInvalidRestrictionType(kClass: KClass<*>, restrictionType: GraphQLTypeRestriction.GraphQLType) {
+    val typeFromClass = kClass.findAnnotation<GraphQLTypeRestriction>()?.type
+    if (typeFromClass != null && typeFromClass != restrictionType) {
+        throw TypeRestrictionException(kClass, typeFromClass)
+    }
+}

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/GenerateInputObjectTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/GenerateInputObjectTest.kt
@@ -18,13 +18,18 @@ package com.expediagroup.graphql.generator.types
 
 import com.expediagroup.graphql.annotations.GraphQLDescription
 import com.expediagroup.graphql.annotations.GraphQLName
+import com.expediagroup.graphql.annotations.GraphQLTypeRestriction
+import com.expediagroup.graphql.annotations.GraphQLTypeRestriction.GraphQLType
+import com.expediagroup.graphql.exceptions.TypeRestrictionException
 import com.expediagroup.graphql.test.utils.SimpleDirective
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
 
-internal class GenerateInputObjectTest : TypeTestHelper() {
+@Suppress("Detekt.UnusedPrivateClass")
+class GenerateInputObjectTest : TypeTestHelper() {
 
-    @Suppress("Detekt.UnusedPrivateClass")
     @GraphQLDescription("The truth")
     @SimpleDirective
     private class InputClass {
@@ -32,10 +37,19 @@ internal class GenerateInputObjectTest : TypeTestHelper() {
         val myField: String = "car"
     }
 
-    @Suppress("Detekt.UnusedPrivateClass")
     @GraphQLName("InputClassRenamed")
     private class InputClassCustomName {
         @GraphQLName("myFieldRenamed")
+        val myField: String = "car"
+    }
+
+    @GraphQLTypeRestriction(GraphQLType.INPUT)
+    private class InputOnly {
+        val myField: String = "car"
+    }
+
+    @GraphQLTypeRestriction(GraphQLType.OUTPUT)
+    private class OutputOnly {
         val myField: String = "car"
     }
 
@@ -76,5 +90,15 @@ internal class GenerateInputObjectTest : TypeTestHelper() {
         val result = generateInputObject(generator, InputClass::class)
         assertEquals(1, result.fields.first().directives.size)
         assertEquals("simpleDirective", result.fields.first().directives.first().name)
+    }
+
+    @Test
+    fun `Test type restrictions`() {
+        val result = generateInputObject(generator, InputOnly::class)
+        assertNotNull(result)
+
+        assertFailsWith(TypeRestrictionException::class) {
+            generateInputObject(generator, OutputOnly::class)
+        }
     }
 }

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/GenerateObjectTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/GenerateObjectTest.kt
@@ -19,12 +19,16 @@ package com.expediagroup.graphql.generator.types
 import com.expediagroup.graphql.annotations.GraphQLDescription
 import com.expediagroup.graphql.annotations.GraphQLDirective
 import com.expediagroup.graphql.annotations.GraphQLName
+import com.expediagroup.graphql.annotations.GraphQLTypeRestriction
+import com.expediagroup.graphql.annotations.GraphQLTypeRestriction.GraphQLType
+import com.expediagroup.graphql.exceptions.TypeRestrictionException
 import graphql.Scalars
 import graphql.introspection.Introspection
 import graphql.schema.GraphQLNonNull
 import graphql.schema.GraphQLObjectType
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 
 class GenerateObjectTest : TypeTestHelper() {
@@ -44,6 +48,16 @@ class GenerateObjectTest : TypeTestHelper() {
     }
 
     class ClassWithInterface(override val foo: String) : MyInterface
+
+    @GraphQLTypeRestriction(GraphQLType.INPUT)
+    private class InputOnly {
+        val myField: String = "car"
+    }
+
+    @GraphQLTypeRestriction(GraphQLType.OUTPUT)
+    private class OutputOnly {
+        val myField: String = "car"
+    }
 
     @Test
     fun `Test naming`() {
@@ -89,5 +103,15 @@ class GenerateObjectTest : TypeTestHelper() {
         assertNotNull(result)
         assertEquals(1, result.interfaces.size)
         assertEquals(1, result.fieldDefinitions.size)
+    }
+
+    @Test
+    fun `Test type restrictions for output classes`() {
+        val result = generateObject(generator, OutputOnly::class)
+        assertNotNull(result)
+
+        assertFailsWith(TypeRestrictionException::class) {
+            generateObject(generator, InputOnly::class)
+        }
     }
 }

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/utils/RestrictionTypesKtTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/utils/RestrictionTypesKtTest.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.generator.types.utils
+
+import com.expediagroup.graphql.annotations.GraphQLTypeRestriction
+import com.expediagroup.graphql.annotations.GraphQLTypeRestriction.GraphQLType
+import com.expediagroup.graphql.exceptions.TypeRestrictionException
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import kotlin.test.assertFailsWith
+
+class RestrictionTypesKtTest {
+
+    private class AnyType
+
+    @GraphQLTypeRestriction(GraphQLType.INPUT)
+    private class InputOnly
+
+    @GraphQLTypeRestriction(GraphQLType.OUTPUT)
+    private class OutputOnly
+
+    @Test
+    fun throwIfInvalidRestrictionType() {
+        assertDoesNotThrow {
+            throwIfInvalidRestrictionType(AnyType::class, GraphQLType.OUTPUT)
+            throwIfInvalidRestrictionType(AnyType::class, GraphQLType.INPUT)
+            throwIfInvalidRestrictionType(OutputOnly::class, GraphQLType.OUTPUT)
+            throwIfInvalidRestrictionType(InputOnly::class, GraphQLType.INPUT)
+        }
+        assertFailsWith(TypeRestrictionException::class) {
+            throwIfInvalidRestrictionType(OutputOnly::class, GraphQLType.INPUT)
+        }
+        assertFailsWith(TypeRestrictionException::class) {
+            throwIfInvalidRestrictionType(InputOnly::class, GraphQLType.OUTPUT)
+        }
+    }
+}


### PR DESCRIPTION
### :pencil: Description
Add new annotation for the schema generator that allows users to restrict a class to a specific GraphQL input/output type

### :link: Related Issues
N\A