### PR TITLE
Add extends directive if not defined

### DIFF
--- a/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/FederatedSchemaGeneratorHooks.kt
+++ b/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/FederatedSchemaGeneratorHooks.kt
@@ -19,15 +19,16 @@ package com.expediagroup.graphql.federation
 import com.expediagroup.graphql.annotations.GraphQLName
 import com.expediagroup.graphql.directives.DEPRECATED_DIRECTIVE_NAME
 import com.expediagroup.graphql.extensions.print
-import com.expediagroup.graphql.federation.directives.EXTENDS_DIRECTIVE_NAME
-import com.expediagroup.graphql.federation.directives.EXTERNAL_DIRECTIVE_NAME
+import com.expediagroup.graphql.federation.directives.EXTENDS_DIRECTIVE_TYPE
+import com.expediagroup.graphql.federation.directives.EXTERNAL_DIRECTIVE_TYPE
 import com.expediagroup.graphql.federation.directives.FieldSet
 import com.expediagroup.graphql.federation.directives.KEY_DIRECTIVE_NAME
-import com.expediagroup.graphql.federation.directives.PROVIDES_DIRECTIVE_NAME
-import com.expediagroup.graphql.federation.directives.REQUIRES_DIRECTIVE_NAME
-import com.expediagroup.graphql.federation.directives.extendsDirectiveType
+import com.expediagroup.graphql.federation.directives.KEY_DIRECTIVE_TYPE
+import com.expediagroup.graphql.federation.directives.PROVIDES_DIRECTIVE_TYPE
+import com.expediagroup.graphql.federation.directives.REQUIRES_DIRECTIVE_TYPE
 import com.expediagroup.graphql.federation.execution.EntityResolver
 import com.expediagroup.graphql.federation.execution.FederatedTypeRegistry
+import com.expediagroup.graphql.federation.extensions.addDirectivesIfNotPresent
 import com.expediagroup.graphql.federation.types.ANY_SCALAR_TYPE
 import com.expediagroup.graphql.federation.types.FIELD_SET_SCALAR_TYPE
 import com.expediagroup.graphql.federation.types.SERVICE_FIELD_DEFINITION
@@ -56,7 +57,8 @@ open class FederatedSchemaGeneratorHooks(private val federatedTypeRegistry: Fede
     private val emptyQueryRegex = "^type Query \\{$\\s+^\\}$\\s+".toRegex(setOf(RegexOption.MULTILINE, RegexOption.IGNORE_CASE))
     private val validator = FederatedSchemaValidator()
 
-    private val directivesToInclude = listOf(EXTENDS_DIRECTIVE_NAME, EXTERNAL_DIRECTIVE_NAME, KEY_DIRECTIVE_NAME, PROVIDES_DIRECTIVE_NAME, REQUIRES_DIRECTIVE_NAME, DEPRECATED_DIRECTIVE_NAME)
+    private val federatedDirectiveTypes: List<GraphQLDirective> = listOf(EXTERNAL_DIRECTIVE_TYPE, REQUIRES_DIRECTIVE_TYPE, PROVIDES_DIRECTIVE_TYPE, KEY_DIRECTIVE_TYPE, EXTENDS_DIRECTIVE_TYPE)
+    private val directivesToInclude: List<String> = federatedDirectiveTypes.map { it.name }.plus(DEPRECATED_DIRECTIVE_NAME)
     private val customDirectivePredicate: Predicate<GraphQLDirective> = Predicate { directivesToInclude.contains(it.name) }
 
     override fun willGenerateGraphQLType(type: KType): GraphQLType? = when (type.classifier) {
@@ -73,23 +75,24 @@ open class FederatedSchemaGeneratorHooks(private val federatedTypeRegistry: Fede
         val originalSchema = builder.build()
         val originalQuery = originalSchema.queryType
         val federatedCodeRegistry = GraphQLCodeRegistry.newCodeRegistry(originalSchema.codeRegistry)
-        val federatedSchemaBuilder = GraphQLSchema.newSchema(originalSchema)
+
+        // Add all the federation directives if they are not present
+        val federatedSchemaBuilder = originalSchema.addDirectivesIfNotPresent(federatedDirectiveTypes)
+
+        // Modify the query type to have the service field and extends directive
         val federatedQuery = GraphQLObjectType.newObject(originalQuery)
             .field(SERVICE_FIELD_DEFINITION)
-            .withDirective(extendsDirectiveType)
-
-        // Add the @extends directive definition if it is not defined as we are using it on the Query object
-        if (originalSchema.getDirective(EXTENDS_DIRECTIVE_NAME) == null) {
-            federatedSchemaBuilder.additionalDirective(extendsDirectiveType)
-        }
+            .withDirective(EXTENDS_DIRECTIVE_TYPE)
 
         /**
-         * SDL returned by _service query should NOT contain
-         * - default schema definition
-         * - empty Query type
-         * - any directive definitions
-         * - any custom directives
-         * - new federated scalars
+         * Register the data fetcher for the SDL returned by _service field.
+         *
+         * It should NOT contain:
+         *   - default schema definition
+         *   - empty Query type
+         *   - any directive definitions
+         *   - any custom directives
+         *   - new federated scalars
          */
         val sdl = originalSchema.print(includeDefaultSchemaDefinition = false, includeDirectivesFilter = customDirectivePredicate)
             .replace(directiveDefinitionRegex, "")
@@ -105,7 +108,7 @@ open class FederatedSchemaGeneratorHooks(private val federatedTypeRegistry: Fede
             .map { it.name }
             .toSet()
 
-        // register new federated queries
+        // Add the _entities field to the query
         if (entityTypeNames.isNotEmpty()) {
             val entityField = generateEntityFieldDefinition(entityTypeNames)
             federatedQuery.field(entityField)

--- a/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/directives/ExtendsDirective.kt
+++ b/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/directives/ExtendsDirective.kt
@@ -17,10 +17,7 @@
 package com.expediagroup.graphql.federation.directives
 
 import com.expediagroup.graphql.annotations.GraphQLDirective
-import graphql.introspection.Introspection
-
-internal const val EXTENDS_DIRECTIVE_NAME = "extends"
-private const val DESCRIPTION = "Marks target object as extending part of the federated schema"
+import graphql.introspection.Introspection.DirectiveLocation
 
 /**
  * ```graphql
@@ -55,12 +52,15 @@ private const val DESCRIPTION = "Marks target object as extending part of the fe
 @GraphQLDirective(
     name = EXTENDS_DIRECTIVE_NAME,
     description = DESCRIPTION,
-    locations = [Introspection.DirectiveLocation.OBJECT, Introspection.DirectiveLocation.INTERFACE]
+    locations = [DirectiveLocation.OBJECT, DirectiveLocation.INTERFACE]
 )
 annotation class ExtendsDirective
 
-internal val extendsDirectiveType: graphql.schema.GraphQLDirective = graphql.schema.GraphQLDirective.newDirective()
+internal const val EXTENDS_DIRECTIVE_NAME = "extends"
+private const val DESCRIPTION = "Marks target object as extending part of the federated schema"
+
+internal val EXTENDS_DIRECTIVE_TYPE: graphql.schema.GraphQLDirective = graphql.schema.GraphQLDirective.newDirective()
     .name(EXTENDS_DIRECTIVE_NAME)
     .description(DESCRIPTION)
-    .validLocations(Introspection.DirectiveLocation.OBJECT, Introspection.DirectiveLocation.INTERFACE)
+    .validLocations(DirectiveLocation.OBJECT, DirectiveLocation.INTERFACE)
     .build()

--- a/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/directives/ExternalDirective.kt
+++ b/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/directives/ExternalDirective.kt
@@ -17,7 +17,7 @@
 package com.expediagroup.graphql.federation.directives
 
 import com.expediagroup.graphql.annotations.GraphQLDirective
-import graphql.introspection.Introspection
+import graphql.introspection.Introspection.DirectiveLocation
 
 /**
  * ```graphql
@@ -53,9 +53,16 @@ import graphql.introspection.Introspection
  */
 @GraphQLDirective(
     name = EXTERNAL_DIRECTIVE_NAME,
-    description = "Marks target field as external meaning it will be resolved by federated schema",
-    locations = [Introspection.DirectiveLocation.FIELD_DEFINITION]
+    description = EXTERNAL_DIRECTIVE_DESCRIPTION,
+    locations = [DirectiveLocation.FIELD_DEFINITION]
 )
 annotation class ExternalDirective
 
 internal const val EXTERNAL_DIRECTIVE_NAME = "external"
+private const val EXTERNAL_DIRECTIVE_DESCRIPTION = "Marks target field as external meaning it will be resolved by federated schema"
+
+internal val EXTERNAL_DIRECTIVE_TYPE: graphql.schema.GraphQLDirective = graphql.schema.GraphQLDirective.newDirective()
+    .name(EXTERNAL_DIRECTIVE_NAME)
+    .description(EXTERNAL_DIRECTIVE_DESCRIPTION)
+    .validLocations(DirectiveLocation.FIELD_DEFINITION)
+    .build()

--- a/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/directives/FieldSet.kt
+++ b/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/directives/FieldSet.kt
@@ -16,6 +16,9 @@
 
 package com.expediagroup.graphql.federation.directives
 
+import com.expediagroup.graphql.federation.types.FIELD_SET_SCALAR_TYPE
+import graphql.schema.GraphQLArgument
+
 /**
  * Annotation representing _FieldSet scalar type that is used to represent a set of fields.
  *
@@ -29,3 +32,10 @@ package com.expediagroup.graphql.federation.directives
  * @see com.expediagroup.graphql.federation.types.FIELD_SET_SCALAR_TYPE
  */
 annotation class FieldSet(val value: String)
+
+internal const val FIELD_SET_ARGUMENT_NAME = "fields"
+
+internal val FIELD_SET_ARGUMENT = GraphQLArgument.newArgument()
+    .name(FIELD_SET_ARGUMENT_NAME)
+    .type(FIELD_SET_SCALAR_TYPE)
+    .build()

--- a/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/directives/KeyDirective.kt
+++ b/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/directives/KeyDirective.kt
@@ -17,7 +17,7 @@
 package com.expediagroup.graphql.federation.directives
 
 import com.expediagroup.graphql.annotations.GraphQLDirective
-import graphql.introspection.Introspection
+import graphql.introspection.Introspection.DirectiveLocation
 
 /**
  * ```graphql
@@ -56,9 +56,17 @@ import graphql.introspection.Introspection
  */
 @GraphQLDirective(
     name = KEY_DIRECTIVE_NAME,
-    description = "Space separated list of primary keys needed to access federated object",
-    locations = [Introspection.DirectiveLocation.OBJECT, Introspection.DirectiveLocation.INTERFACE]
+    description = KEY_DIRECTIVE_DESCRIPTION,
+    locations = [DirectiveLocation.OBJECT, DirectiveLocation.INTERFACE]
 )
 annotation class KeyDirective(val fields: FieldSet)
 
 internal const val KEY_DIRECTIVE_NAME = "key"
+private const val KEY_DIRECTIVE_DESCRIPTION = "Space separated list of primary keys needed to access federated object"
+
+internal val KEY_DIRECTIVE_TYPE: graphql.schema.GraphQLDirective = graphql.schema.GraphQLDirective.newDirective()
+    .name(KEY_DIRECTIVE_NAME)
+    .description(KEY_DIRECTIVE_DESCRIPTION)
+    .validLocations(DirectiveLocation.OBJECT, DirectiveLocation.INTERFACE)
+    .argument(FIELD_SET_ARGUMENT)
+    .build()

--- a/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/directives/ProvidesDirective.kt
+++ b/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/directives/ProvidesDirective.kt
@@ -17,7 +17,7 @@
 package com.expediagroup.graphql.federation.directives
 
 import com.expediagroup.graphql.annotations.GraphQLDirective
-import graphql.introspection.Introspection
+import graphql.introspection.Introspection.DirectiveLocation
 
 /**
  * ```graphql
@@ -69,9 +69,17 @@ import graphql.introspection.Introspection
  */
 @GraphQLDirective(
     name = PROVIDES_DIRECTIVE_NAME,
-    description = "Specifies the base type field set that will be selectable by the gateway",
-    locations = [Introspection.DirectiveLocation.FIELD_DEFINITION]
+    description = PROVIDES_DIRECTIVE_DESCRIPTION,
+    locations = [DirectiveLocation.FIELD_DEFINITION]
 )
 annotation class ProvidesDirective(val fields: FieldSet)
 
 internal const val PROVIDES_DIRECTIVE_NAME = "provides"
+private const val PROVIDES_DIRECTIVE_DESCRIPTION = "Specifies the base type field set that will be selectable by the gateway"
+
+internal val PROVIDES_DIRECTIVE_TYPE: graphql.schema.GraphQLDirective = graphql.schema.GraphQLDirective.newDirective()
+    .name(PROVIDES_DIRECTIVE_NAME)
+    .description(PROVIDES_DIRECTIVE_DESCRIPTION)
+    .validLocations(DirectiveLocation.FIELD_DEFINITION)
+    .argument(FIELD_SET_ARGUMENT)
+    .build()

--- a/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/directives/RequiresDirective.kt
+++ b/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/directives/RequiresDirective.kt
@@ -17,7 +17,7 @@
 package com.expediagroup.graphql.federation.directives
 
 import com.expediagroup.graphql.annotations.GraphQLDirective
-import graphql.introspection.Introspection
+import graphql.introspection.Introspection.DirectiveLocation
 
 /**
  * ```graphql
@@ -74,9 +74,17 @@ import graphql.introspection.Introspection
  */
 @GraphQLDirective(
     name = REQUIRES_DIRECTIVE_NAME,
-    description = "Specifies required input field set from the base type for a resolver",
-    locations = [Introspection.DirectiveLocation.FIELD_DEFINITION]
+    description = REQUIRES_DIRECTIVE_DESCRIPTION,
+    locations = [DirectiveLocation.FIELD_DEFINITION]
 )
 annotation class RequiresDirective(val fields: FieldSet)
 
 internal const val REQUIRES_DIRECTIVE_NAME = "requires"
+private const val REQUIRES_DIRECTIVE_DESCRIPTION = "Specifies required input field set from the base type for a resolver"
+
+internal val REQUIRES_DIRECTIVE_TYPE: graphql.schema.GraphQLDirective = graphql.schema.GraphQLDirective.newDirective()
+    .name(REQUIRES_DIRECTIVE_NAME)
+    .description(REQUIRES_DIRECTIVE_DESCRIPTION)
+    .validLocations(DirectiveLocation.FIELD_DEFINITION)
+    .argument(FIELD_SET_ARGUMENT)
+    .build()

--- a/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/extensions/graphQLSchemaExtensions.kt
+++ b/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/extensions/graphQLSchemaExtensions.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.federation.extensions
+
+import graphql.schema.GraphQLDirective
+import graphql.schema.GraphQLSchema
+
+/**
+ * Add all the directives to the schema if they are not present.
+ * Returns a new schema builder so you can continue adding more types if needed.
+ */
+internal fun GraphQLSchema.addDirectivesIfNotPresent(directives: List<GraphQLDirective>): GraphQLSchema.Builder {
+    val newBuilder = GraphQLSchema.newSchema(this)
+
+    directives.forEach {
+        if (this.getDirective(it.name) == null) {
+            newBuilder.additionalDirective(it)
+        }
+    }
+
+    return newBuilder
+}

--- a/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/validation/validateDirective.kt
+++ b/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/validation/validateDirective.kt
@@ -16,6 +16,7 @@
 
 package com.expediagroup.graphql.federation.validation
 
+import com.expediagroup.graphql.federation.directives.FIELD_SET_ARGUMENT_NAME
 import com.expediagroup.graphql.federation.directives.FieldSet
 import graphql.schema.GraphQLDirective
 import graphql.schema.GraphQLFieldDefinition
@@ -33,7 +34,7 @@ internal fun validateDirective(
     if (directive == null) {
         validationErrors.add("@$targetDirective directive is missing on federated $validatedType type")
     } else {
-        val fieldSetValue = (directive.getArgument("fields")?.value as? FieldSet)?.value
+        val fieldSetValue = (directive.getArgument(FIELD_SET_ARGUMENT_NAME)?.value as? FieldSet)?.value
         val fieldSet = fieldSetValue?.split(" ")?.filter { it.isNotEmpty() }.orEmpty()
         if (fieldSet.isEmpty()) {
             validationErrors.add("@$targetDirective directive on $validatedType is missing field information")

--- a/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/FederatedSchemaGeneratorTest.kt
+++ b/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/FederatedSchemaGeneratorTest.kt
@@ -141,7 +141,28 @@ class FederatedSchemaGeneratorTest {
               query: Query
             }
 
-            type Query {
+            "Directs the executor to include this field or fragment only when the `if` argument is true"
+            directive @include(
+                "Included when true."
+                if: Boolean!
+              ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+            "Directs the executor to skip this field or fragment when the `if`'argument is true."
+            directive @skip(
+                "Skipped when true."
+                if: Boolean!
+              ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+            "Marks the field or enum value as deprecated"
+            directive @deprecated(
+                "The reason for the deprecation"
+                reason: String! = "No longer supported"
+              ) on FIELD_DEFINITION | ENUM_VALUE
+
+            "Marks target object as extending part of the federated schema"
+            directive @extends on OBJECT | INTERFACE
+
+            type Query @extends {
               _service: _Service
               hello(name: String!): String!
             }
@@ -157,7 +178,7 @@ class FederatedSchemaGeneratorTest {
         )
 
         val schema = toFederatedSchema(config, listOf(TopLevelObject(SimpleQuery())))
-        assertEquals(expectedSchema, schema.print(includeDirectives = false).trim())
+        assertEquals(expectedSchema, schema.print().trim())
     }
 
     @Test

--- a/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/FederatedSchemaGeneratorTest.kt
+++ b/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/FederatedSchemaGeneratorTest.kt
@@ -159,6 +159,18 @@ class FederatedSchemaGeneratorTest {
                 reason: String! = "No longer supported"
               ) on FIELD_DEFINITION | ENUM_VALUE
 
+            "Marks target field as external meaning it will be resolved by federated schema"
+            directive @external on FIELD_DEFINITION
+
+            "Specifies required input field set from the base type for a resolver"
+            directive @requires(fields: _FieldSet) on FIELD_DEFINITION
+
+            "Specifies the base type field set that will be selectable by the gateway"
+            directive @provides(fields: _FieldSet) on FIELD_DEFINITION
+
+            "Space separated list of primary keys needed to access federated object"
+            directive @key(fields: _FieldSet) on OBJECT | INTERFACE
+
             "Marks target object as extending part of the federated schema"
             directive @extends on OBJECT | INTERFACE
 
@@ -170,6 +182,9 @@ class FederatedSchemaGeneratorTest {
             type _Service {
               sdl: String!
             }
+
+            "Federation type representing set of fields"
+            scalar _FieldSet
         """.trimIndent()
 
         val config = FederatedSchemaGeneratorConfig(
@@ -202,6 +217,9 @@ class FederatedSchemaGeneratorTest {
             type _Service {
               sdl: String!
             }
+
+            "Federation type representing set of fields"
+            scalar _FieldSet
         """.trimIndent()
 
         val config = FederatedSchemaGeneratorConfig(

--- a/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/extensions/GraphQLDirectiveContainerExtensionsKtTest.kt
+++ b/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/extensions/GraphQLDirectiveContainerExtensionsKtTest.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.federation.extensions
+
+import org.junit.jupiter.api.Test
+
+class GraphQLDirectiveContainerExtensionsKtTest {
+
+    @Test
+    fun isFederatedType() {
+    }
+
+    @Test
+    fun isExtendedType() {
+    }
+}

--- a/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/extensions/GraphQLSchemaExtensionsKtTest.kt
+++ b/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/extensions/GraphQLSchemaExtensionsKtTest.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2020 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.federation.extensions
+
+import com.expediagroup.graphql.federation.directives.EXTENDS_DIRECTIVE_TYPE
+import graphql.Scalars.GraphQLString
+import graphql.schema.GraphQLFieldDefinition
+import graphql.schema.GraphQLObjectType
+import graphql.schema.GraphQLSchema
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class GraphQLSchemaExtensionsKtTest {
+
+    private val simplQuery = GraphQLObjectType.newObject()
+        .name("Query")
+        .field(GraphQLFieldDefinition.newFieldDefinition()
+            .name("foo")
+            .type(GraphQLString)
+        )
+
+    @Test
+    fun `addDirectivesIfNotPresent does nothing on empty list`() {
+        val oldSchema = GraphQLSchema.newSchema()
+            .query(simplQuery)
+            .build()
+        val numberOfDirectives = oldSchema.directives.size
+        val newSchema = oldSchema.addDirectivesIfNotPresent(emptyList()).build()
+        assertEquals(expected = numberOfDirectives, actual = newSchema.directives.size)
+    }
+
+    @Test
+    fun `addDirectivesIfNotPresent does nothing if directive is already present`() {
+        val oldSchema = GraphQLSchema.newSchema()
+            .query(simplQuery)
+            .additionalDirective(EXTENDS_DIRECTIVE_TYPE)
+            .build()
+        val numberOfDirectives = oldSchema.directives.size
+        val newSchema = oldSchema.addDirectivesIfNotPresent(listOf(EXTENDS_DIRECTIVE_TYPE)).build()
+        assertNotNull(newSchema.getDirective(EXTENDS_DIRECTIVE_TYPE.name))
+        assertEquals(expected = numberOfDirectives, actual = newSchema.directives.size)
+    }
+
+    @Test
+    fun `addDirectivesIfNotPresent adds directive if not present`() {
+        val oldSchema = GraphQLSchema.newSchema()
+            .query(simplQuery)
+            .build()
+        val numberOfDirectives = oldSchema.directives.size
+        val newSchema = oldSchema.addDirectivesIfNotPresent(listOf(EXTENDS_DIRECTIVE_TYPE)).build()
+        assertNotNull(newSchema.getDirective(EXTENDS_DIRECTIVE_TYPE.name))
+        assertEquals(expected = numberOfDirectives + 1, actual = newSchema.directives.size)
+    }
+}

--- a/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/types/AnyTest.kt
+++ b/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/types/AnyTest.kt
@@ -35,7 +35,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
 
-internal class AnyTest {
+class AnyTest {
 
     @Test
     fun `_Any scalar should allow all types`() {

--- a/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/types/EntityTest.kt
+++ b/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/types/EntityTest.kt
@@ -24,7 +24,7 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 
-internal class EntityTest {
+class EntityTest {
 
     @Test
     fun `generateEntityFieldDefinition should fail on empty set`() {

--- a/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/types/FieldSetTest.kt
+++ b/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/types/FieldSetTest.kt
@@ -28,7 +28,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
-internal class FieldSetTest {
+class FieldSetTest {
     private val coercing: Coercing<Any, Any> = FIELD_SET_SCALAR_TYPE.coercing
 
     @Test

--- a/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/types/ServiceTest.kt
+++ b/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/types/ServiceTest.kt
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 
-internal class ServiceTest {
+class ServiceTest {
 
     @Test
     fun `service object should have the correct naming`() {

--- a/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/validation/FederatedSchemaValidatorTest.kt
+++ b/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/validation/FederatedSchemaValidatorTest.kt
@@ -19,7 +19,7 @@ package com.expediagroup.graphql.federation.validation
 import com.expediagroup.graphql.federation.directives.KEY_DIRECTIVE_NAME
 import com.expediagroup.graphql.federation.directives.PROVIDES_DIRECTIVE_NAME
 import com.expediagroup.graphql.federation.directives.REQUIRES_DIRECTIVE_NAME
-import com.expediagroup.graphql.federation.directives.extendsDirectiveType
+import com.expediagroup.graphql.federation.directives.EXTENDS_DIRECTIVE_TYPE
 import com.expediagroup.graphql.federation.exception.InvalidFederatedSchema
 import com.expediagroup.graphql.federation.externalDirective
 import com.expediagroup.graphql.federation.getKeyDirective
@@ -73,7 +73,7 @@ class FederatedSchemaValidatorTest {
     fun `validate federated GraphQLObjectType with no fields`() {
         val typeToValidate = GraphQLObjectType.newObject()
             .name("Foo")
-            .withDirective(extendsDirectiveType)
+            .withDirective(EXTENDS_DIRECTIVE_TYPE)
             .build()
 
         assertFailsWith<InvalidFederatedSchema> {
@@ -95,7 +95,7 @@ class FederatedSchemaValidatorTest {
         val typeToValidate = GraphQLObjectType.newObject()
             .name("Foo")
             .field(field)
-            .withDirective(extendsDirectiveType)
+            .withDirective(EXTENDS_DIRECTIVE_TYPE)
             .build()
 
         assertFailsWith<InvalidFederatedSchema> {
@@ -160,7 +160,7 @@ class FederatedSchemaValidatorTest {
             .field(field)
             .field(id)
             .withDirective(keyDirective)
-            .withDirective(extendsDirectiveType)
+            .withDirective(EXTENDS_DIRECTIVE_TYPE)
             .build()
 
         val result = kotlin.runCatching {
@@ -200,7 +200,7 @@ class FederatedSchemaValidatorTest {
             .field(field)
             .field(id)
             .withDirective(keyDirective)
-            .withDirective(extendsDirectiveType)
+            .withDirective(EXTENDS_DIRECTIVE_TYPE)
             .build()
 
         val result = kotlin.runCatching {

--- a/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/validation/ValidateProvidesDirectiveKtTest.kt
+++ b/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/validation/ValidateProvidesDirectiveKtTest.kt
@@ -16,7 +16,7 @@
 
 package com.expediagroup.graphql.federation.validation
 
-import com.expediagroup.graphql.federation.directives.extendsDirectiveType
+import com.expediagroup.graphql.federation.directives.EXTENDS_DIRECTIVE_TYPE
 import graphql.Scalars.GraphQLString
 import graphql.schema.GraphQLFieldDefinition
 import graphql.schema.GraphQLObjectType
@@ -102,7 +102,7 @@ class ValidateProvidesDirectiveKtTest {
         val objectType = GraphQLObjectType.newObject()
             .name("MyObject")
             .field(GraphQLFieldDefinition.newFieldDefinition().name("bar").type(GraphQLString))
-            .withDirective(extendsDirectiveType)
+            .withDirective(EXTENDS_DIRECTIVE_TYPE)
             .build()
 
         val federatedType = GraphQLFieldDefinition.newFieldDefinition()


### PR DESCRIPTION
### :pencil: Description
Since the extends directive is always used in federation on the Query object we should always have the directive definition in the schema. However it may already be added if the generated schema uses it, so only add the definition if it is not yet defined

The schema we generate today will still work on the server, it just fails if you happen to run through the generated SDL through the Apollo CLI or Gateway.

### :link: Related Issues
N\A