### PR TITLE
[build] update release process to publish Gradle plugin after sonatype publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           NEW_VERSION=$(echo "${GITHUB_REF}" | cut -d "/" -f3)
           echo "New version: ${NEW_VERSION}"
-          ./gradlew publish closeAndReleaseRepository -Pversion=${NEW_VERSION}
+          ./gradlew :initializeSonatypeStagingRepository publish :closeAndReleaseRepository publishPlugins -Pversion=${NEW_VERSION}
         env:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -207,8 +207,4 @@ tasks {
         numberOfRetries = 60
         delayBetweenRetriesInMillis = 5000
     }
-
-    publish {
-        dependsOn(":initializeSonatypeStagingRepository")
-    }
 }

--- a/plugins/graphql-kotlin-gradle-plugin/build.gradle.kts
+++ b/plugins/graphql-kotlin-gradle-plugin/build.gradle.kts
@@ -45,11 +45,8 @@ tasks {
             System.setProperty("gradle.publish.secret", System.getenv("PLUGIN_PORTAL_SECRET"))
         }
     }
-    publish {
-        dependsOn(":graphql-kotlin-gradle-plugin:publishPlugins")
-    }
     withType<PublishToMavenRepository> {
-        // explicitly disable maven-publish tasks
+        // explicitly disable maven-publish tasks - task will be listed but will be disabled
         enabled = false
     }
     test {


### PR DESCRIPTION
### :pencil: Description

Recent RC releases were failing to publish sonatype but were successfully publish Gradle plugin. Attempting to publish plugin only after successful sonatype publish by explicitly specifying tasks to execute. Unfortunately cannot easily configure the order using `build.gradle.kts` as `finalizedBy` clause will always run finalized tasks regardless whether previous one succeeded or not.

New release command
`./gradlew :initializeSonatypeStagingRepository publish :closeAndReleaseRepository publishPlugins -Pversion=${NEW_VERSION}`

