### PR TITLE
[plugin] update generated GraphQL client execute query method

### DIFF
--- a/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePluginIT.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePluginIT.kt
@@ -132,7 +132,7 @@ class GraphQLGradlePluginIT {
         // unsure if there is a better way - correct values are set from Gradle build
         // when running directly from IDE you will need to manually update those to correct values
 
-        val gqlKotlinVersion = System.getProperty("graphQLKotlinVersion") ?: "2.0.0-SNAPSHOT"
+        val gqlKotlinVersion = System.getProperty("graphQLKotlinVersion") ?: "3.0.0-SNAPSHOT"
         val kotlinVersion = System.getProperty("kotlinVersion") ?: "1.3.71"
         val buildFileContents = """
             import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
@@ -199,7 +199,7 @@ class GraphQLGradlePluginIT {
 
                     val variables = JUnitQuery.Variables(JUnitQuery.SimpleArgumentInput(min = null, max = null, newName = "blah"))
                     runBlocking {
-                        val result = query.jUnitQuery(variables)
+                        val result = query.execute(variables)
                         val data = result.data
                         assert(data != null)
                         assert(JUnitQuery.CustomEnum.ONE == data?.enumQuery)

--- a/plugins/graphql-kotlin-maven-plugin/src/integration/complete-setup/src/test/kotlin/com/expediagroup/graphql/plugin/maven/GraphQLMavenPluginTest.kt
+++ b/plugins/graphql-kotlin-maven-plugin/src/integration/complete-setup/src/test/kotlin/com/expediagroup/graphql/plugin/maven/GraphQLMavenPluginTest.kt
@@ -53,7 +53,7 @@ class GraphQLMavenPluginTest {
         val variables = ExampleQuery.Variables(simpleCriteria = ExampleQuery.SimpleArgumentInput(newName = "whatever", min = null, max = null))
         assertDoesNotThrow {
             runBlocking {
-                val response = query.exampleQuery(variables = variables)
+                val response = query.execute(variables = variables)
                 assertTrue(response.errors == null)
                 val data = response.data
                 assertNotNull(data)

--- a/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/GraphQLClientGenerator.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/GraphQLClientGenerator.kt
@@ -75,7 +75,7 @@ class GraphQLClientGenerator(
             val kotlinResultTypeName = ClassName(context.packageName, "${context.rootType}.${graphQLResultTypeSpec.name}")
 
             val operationTypeSpec = TypeSpec.classBuilder(operationTypeName)
-            val funSpec = FunSpec.builder(operationName.decapitalize())
+            val funSpec = FunSpec.builder("execute")
                 .returns(ClassName(LIBRARY_PACKAGE, "GraphQLResult").parameterizedBy(kotlinResultTypeName))
                 .addModifiers(KModifier.SUSPEND)
             val variableCode = if (variableType != null) {

--- a/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLCustomScalarTypeAliasIT.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLCustomScalarTypeAliasIT.kt
@@ -41,8 +41,8 @@ class GenerateGraphQLCustomScalarTypeAliasIT {
             class ScalarAliasTestQuery(
               private val graphQLClient: GraphQLClient
             ) {
-              suspend fun scalarAliasTestQuery(): GraphQLResult<ScalarAliasTestQuery.ScalarAliasTestQueryResult>
-                  = graphQLClient.execute(SCALAR_ALIAS_TEST_QUERY, "ScalarAliasTestQuery", null)
+              suspend fun execute(): GraphQLResult<ScalarAliasTestQuery.ScalarAliasTestQueryResult> =
+                  graphQLClient.execute(SCALAR_ALIAS_TEST_QUERY, "ScalarAliasTestQuery", null)
 
               /**
                * Wrapper that holds all supported scalar types

--- a/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLCustomScalarTypeSpecIT.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLCustomScalarTypeSpecIT.kt
@@ -42,8 +42,7 @@ class GenerateGraphQLCustomScalarTypeSpecIT {
             class CustomScalarTestQuery(
               private val graphQLClient: GraphQLClient
             ) {
-              suspend fun customScalarTestQuery():
-                  GraphQLResult<CustomScalarTestQuery.CustomScalarTestQueryResult> =
+              suspend fun execute(): GraphQLResult<CustomScalarTestQuery.CustomScalarTestQueryResult> =
                   graphQLClient.execute(CUSTOM_SCALAR_TEST_QUERY, "CustomScalarTestQuery", null)
 
               /**

--- a/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLEnumTypeSpecIT.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLEnumTypeSpecIT.kt
@@ -37,7 +37,7 @@ class GenerateGraphQLEnumTypeSpecIT {
             class EnumTestQuery(
               private val graphQLClient: GraphQLClient
             ) {
-              suspend fun enumTestQuery(): GraphQLResult<EnumTestQuery.EnumTestQueryResult> =
+              suspend fun execute(): GraphQLResult<EnumTestQuery.EnumTestQueryResult> =
                   graphQLClient.execute(ENUM_TEST_QUERY, "EnumTestQuery", null)
 
               /**

--- a/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLInputObjectTypeSpecIT.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLInputObjectTypeSpecIT.kt
@@ -37,8 +37,8 @@ class GenerateGraphQLInputObjectTypeSpecIT {
             class InputObjectTestQuery(
               private val graphQLClient: GraphQLClient
             ) {
-              suspend fun inputObjectTestQuery(): GraphQLResult<InputObjectTestQuery.InputObjectTestQueryResult>
-                  = graphQLClient.execute(INPUT_OBJECT_TEST_QUERY, "InputObjectTestQuery", null)
+              suspend fun execute(): GraphQLResult<InputObjectTestQuery.InputObjectTestQueryResult> =
+                  graphQLClient.execute(INPUT_OBJECT_TEST_QUERY, "InputObjectTestQuery", null)
 
               data class InputObjectTestQueryResult(
                 /**
@@ -73,7 +73,7 @@ class GenerateGraphQLInputObjectTypeSpecIT {
             class AliasTestQuery(
               private val graphQLClient: GraphQLClient
             ) {
-              suspend fun aliasTestQuery(): GraphQLResult<AliasTestQuery.AliasTestQueryResult> =
+              suspend fun execute(): GraphQLResult<AliasTestQuery.AliasTestQueryResult> =
                   graphQLClient.execute(ALIAS_TEST_QUERY, "AliasTestQuery", null)
 
               data class AliasTestQueryResult(

--- a/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLInterfaceTypeSpecIT.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLInterfaceTypeSpecIT.kt
@@ -45,7 +45,7 @@ class GenerateGraphQLInterfaceTypeSpecIT {
             class InterfaceWithInlineFragmentsTestQuery(
               private val graphQLClient: GraphQLClient
             ) {
-              suspend fun interfaceWithInlineFragmentsTestQuery():
+              suspend fun execute():
                   GraphQLResult<InterfaceWithInlineFragmentsTestQuery.InterfaceWithInlineFragmentsTestQueryResult>
                   = graphQLClient.execute(INTERFACE_WITH_INLINE_FRAGMENTS_TEST_QUERY,
                   "InterfaceWithInlineFragmentsTestQuery", null)
@@ -159,7 +159,7 @@ class GenerateGraphQLInterfaceTypeSpecIT {
             class InterfaceWithNamedFragmentsTestQuery(
               private val graphQLClient: GraphQLClient
             ) {
-              suspend fun interfaceWithNamedFragmentsTestQuery():
+              suspend fun execute():
                   GraphQLResult<InterfaceWithNamedFragmentsTestQuery.InterfaceWithNamedFragmentsTestQueryResult>
                   = graphQLClient.execute(INTERFACE_WITH_NAMED_FRAGMENTS_TEST_QUERY,
                   "InterfaceWithNamedFragmentsTestQuery", null)

--- a/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLObjectTypeSpecIT.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLObjectTypeSpecIT.kt
@@ -42,8 +42,7 @@ class GenerateGraphQLObjectTypeSpecIT {
             class ComplexObjectTestQuery(
               private val graphQLClient: GraphQLClient
             ) {
-              suspend fun complexObjectTestQuery():
-                  GraphQLResult<ComplexObjectTestQuery.ComplexObjectTestQueryResult> =
+              suspend fun execute(): GraphQLResult<ComplexObjectTestQuery.ComplexObjectTestQueryResult> =
                   graphQLClient.execute(COMPLEX_OBJECT_TEST_QUERY, "ComplexObjectTestQuery", null)
 
               /**
@@ -130,7 +129,7 @@ class GenerateGraphQLObjectTypeSpecIT {
             class ComplexObjectQueryWithNamedFragment(
               private val graphQLClient: GraphQLClient
             ) {
-              suspend fun complexObjectQueryWithNamedFragment():
+              suspend fun execute():
                   GraphQLResult<ComplexObjectQueryWithNamedFragment.ComplexObjectQueryWithNamedFragmentResult> =
                   graphQLClient.execute(COMPLEX_OBJECT_QUERY_WITH_NAMED_FRAGMENT,
                   "ComplexObjectQueryWithNamedFragment", null)
@@ -250,7 +249,7 @@ class GenerateGraphQLObjectTypeSpecIT {
             class JUnitTestQuery(
               private val graphQLClient: GraphQLClient
             ) {
-              suspend fun jUnitTestQuery(): GraphQLResult<JUnitTestQuery.JUnitTestQueryResult> =
+              suspend fun execute(): GraphQLResult<JUnitTestQuery.JUnitTestQueryResult> =
                   graphQLClient.execute(J_UNIT_TEST_QUERY, "JUnitTestQuery", null)
 
               /**
@@ -311,8 +310,8 @@ class GenerateGraphQLObjectTypeSpecIT {
             class DeprecatedFieldQuery(
               private val graphQLClient: GraphQLClient
             ) {
-              suspend fun deprecatedFieldQuery(): GraphQLResult<DeprecatedFieldQuery.DeprecatedFieldQueryResult>
-                  = graphQLClient.execute(DEPRECATED_FIELD_QUERY, "DeprecatedFieldQuery", null)
+              suspend fun execute(): GraphQLResult<DeprecatedFieldQuery.DeprecatedFieldQueryResult> =
+                  graphQLClient.execute(DEPRECATED_FIELD_QUERY, "DeprecatedFieldQuery", null)
 
               data class DeprecatedFieldQueryResult(
                 /**
@@ -355,7 +354,7 @@ class GenerateGraphQLObjectTypeSpecIT {
             class NestedQuery(
               private val graphQLClient: GraphQLClient
             ) {
-              suspend fun nestedQuery(): GraphQLResult<NestedQuery.NestedQueryResult> =
+              suspend fun execute(): GraphQLResult<NestedQuery.NestedQueryResult> =
                   graphQLClient.execute(NESTED_QUERY, "NestedQuery", null)
 
               /**

--- a/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLUnionTypeSpecIT.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLUnionTypeSpecIT.kt
@@ -45,7 +45,7 @@ class GenerateGraphQLUnionTypeSpecIT {
             class UnionQueryWithInlineFragments(
               private val graphQLClient: GraphQLClient
             ) {
-              suspend fun unionQueryWithInlineFragments():
+              suspend fun execute():
                   GraphQLResult<UnionQueryWithInlineFragments.UnionQueryWithInlineFragmentsResult> =
                   graphQLClient.execute(UNION_QUERY_WITH_INLINE_FRAGMENTS, "UnionQueryWithInlineFragments",
                   null)
@@ -143,7 +143,7 @@ class GenerateGraphQLUnionTypeSpecIT {
             class UnionQueryWithNamedFragments(
               private val graphQLClient: GraphQLClient
             ) {
-              suspend fun unionQueryWithNamedFragments():
+              suspend fun execute():
                   GraphQLResult<UnionQueryWithNamedFragments.UnionQueryWithNamedFragmentsResult> =
                   graphQLClient.execute(UNION_QUERY_WITH_NAMED_FRAGMENTS, "UnionQueryWithNamedFragments", null)
 

--- a/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateVariableTypeSpecIT.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateVariableTypeSpecIT.kt
@@ -39,7 +39,7 @@ class GenerateVariableTypeSpecIT {
             class TestQueryWithVariables(
               private val graphQLClient: GraphQLClient
             ) {
-              suspend fun testQueryWithVariables(variables: TestQueryWithVariables.Variables):
+              suspend fun execute(variables: TestQueryWithVariables.Variables):
                   GraphQLResult<TestQueryWithVariables.TestQueryWithVariablesResult> =
                   graphQLClient.execute(TEST_QUERY_WITH_VARIABLES, "TestQueryWithVariables", variables)
 


### PR DESCRIPTION
### :pencil: Description

Update generated client query method from `<operationName>` to simple `execute`, e.g. given operation name `HelloWorldQuery` we would end up generating it as `HelloWorldQuery.helloWorldQuery`, instead we will now generate it as `HelloWorldQuery.execute`.

### :link: Related Issues
