### PR TITLE
[plugin] fix generate client MOJO converter parameter

### DIFF
--- a/docs/plugins/gradle-plugin.md
+++ b/docs/plugins/gradle-plugin.md
@@ -40,7 +40,7 @@ graphql {
   // Boolean flag indicating whether or not selection of deprecated fields is allowed.
   allowDeprecatedFields = false
   // Custom GraphQL scalar to converter mapping containing information about corresponding Java type and converter that should be used to serialize/deserialize values.
-  scalarConverters.put("UUID", ScalarConverterMapping("java.util.UUID", "com.example.UUIDScalarConverter"))
+  converters.put("UUID", ScalarConverterMapping("java.util.UUID", "com.example.UUIDScalarConverter"))
 }
 ```
 
@@ -73,10 +73,10 @@ file and are placed under specified `packageName`.
 | Property | Type | Required | Description |
 | -------- | ---- | -------- | ----------- |
 | `allowDeprecatedFields` | Boolean | | Boolean flag indicating whether selection of deprecated fields is allowed or not.<br/>**Default value is:** `false`.<br/>**Command line property is**: `allowDeprecatedFields`. |
+| `converters` | Map<String, ScalarConverter> | | Custom GraphQL scalar to converter mapping containing information about corresponding Java type and converter that should be used to serialize/deserialize values. |
 | `packageName` | String | yes | Target package name for generated code.<br/>**Command line property is**: `packageName`. |
 | `queryFiles` | FileCollection | | List of query files to be processed. Instead of a list of files to be processed you can specify `queryFileDirectory` directory instead. If this property is specified it will take precedence over the corresponding directory property. |
 | `queryFileDirectory` | String | | Directory file containing GraphQL queries. Instead of specifying a directory you can also specify list of query file by using `queryFiles` property instead.<br/>**Default value is:** `src/main/resources`.<br/>**Command line property is**: `queryFileDirectory`. |
-| `scalarConverters` | Map<String, ScalarConverter> | | Custom GraphQL scalar to converter mapping containing information about corresponding Java type and converter that should be used to serialize/deserialize values. |
 | `schemaFile` | File | `schemaFileName` or `schemaFile` has to be provided | GraphQL schema file that will be used to generate client code. |
 | `schemaFileName` | String | `schemaFileName` or `schemaFile` has to be provided | Path to GraphQL schema file that will be used to generate client code.<br/>**Command line property is**: `schemaFileName`. |
 
@@ -203,7 +203,7 @@ import com.expediagroup.graphql.plugin.gradle.tasks.GraphQLGenerateClientTask
 val graphqlGenerateClient by tasks.getting(GraphQLGenerateClientTask::class) {
   packageName.set("com.example.generated")
   schemaFileName.set("mySchema.graphql")
-  scalarConverters.put("UUID", ScalarConverterMapping("java.util.UUID", "com.example.UUIDScalarConverter"))
+  converters.put("UUID", ScalarConverterMapping("java.util.UUID", "com.example.UUIDScalarConverter"))
 }
 ```
 

--- a/plugins/graphql-kotlin-gradle-plugin/README.md
+++ b/plugins/graphql-kotlin-gradle-plugin/README.md
@@ -54,10 +54,10 @@ file and are placed under specified `packageName`.
 | Property | Type | Required | Description |
 | -------- | ---- | -------- | ----------- |
 | `allowDeprecatedFields` | Boolean | | Boolean flag indicating whether selection of deprecated fields is allowed or not.<br/>**Default value is:** `false`.<br/>**Command line property is**: `allowDeprecatedFields`. |
+| `converters` | Map<String, ScalarConverter> | | Custom GraphQL scalar to converter mapping containing information about corresponding Java type and converter that should be used to serialize/deserialize values. |
 | `packageName` | String | yes | Target package name for generated code.<br/>**Command line property is**: `packageName`. |
 | `queryFiles` | FileCollection | | List of query files to be processed. Instead of a list of files to be processed you can specify `queryFileDirectory` directory instead. If this property is specified it will take precedence over the corresponding directory property. |
 | `queryFileDirectory` | String | | Directory file containing GraphQL queries. Instead of specifying a directory you can also specify list of query file by using `queryFiles` property instead.<br/>**Default value is:** `src/main/resources`.<br/>**Command line property is**: `queryFileDirectory`. |
-| `scalarConverters` | Map<String, ScalarConverter> | | Custom GraphQL scalar to converter mapping containing information about corresponding Java type and converter that should be used to serialize/deserialize values. |
 | `schemaFile` | File | `schemaFileName` or `schemaFile` has to be provided | GraphQL schema file that will be used to generate client code. |
 | `schemaFileName` | String | `schemaFileName` or `schemaFile` has to be provided | Path to GraphQL schema file that will be used to generate client code.<br/>**Command line property is**: `schemaFileName`. |
 

--- a/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePlugin.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePlugin.kt
@@ -59,7 +59,7 @@ class GraphQLGradlePlugin : Plugin<Project> {
                 val generateClientTask = project.tasks.named(GENERATE_CLIENT_TASK_NAME, GraphQLGenerateClientTask::class.java).get()
                 generateClientTask.packageName.convention(project.provider { extension.packageName })
                 generateClientTask.allowDeprecatedFields.convention(project.provider { extension.allowDeprecatedFields })
-                generateClientTask.scalarConverters.convention(extension.scalarConverters)
+                generateClientTask.converters.convention(extension.scalarConverters)
                 generateClientTask.queryFiles.setFrom(extension.queryFiles.from)
 
                 if (extension.endpoint != null) {

--- a/plugins/graphql-kotlin-maven-plugin/src/integration/complete-setup/pom.xml
+++ b/plugins/graphql-kotlin-maven-plugin/src/integration/complete-setup/pom.xml
@@ -98,6 +98,16 @@
                         <configuration>
                             <packageName>com.expediagroup.graphql.plugin.generated</packageName>
                             <schemaFile>${project.build.directory}/schema.graphql</schemaFile>
+                            <converters>
+                                <!-- custom scalar UUID type -->
+                                <UUID>
+                                    <!-- fully qualified Java class name of a custom scalar type -->
+                                    <type>java.util.UUID</type>
+                                    <!-- fully qualified Java class name of a custom com.expediagroup.graphql.client.converter.ScalarConverter
+                                       used to convert to/from raw JSON and scalar type -->
+                                    <converter>com.example.UUIDScalarConverter</converter>
+                                </UUID>
+                            </converters>
                         </configuration>
                     </execution>
                 </executions>

--- a/plugins/graphql-kotlin-maven-plugin/src/integration/complete-setup/src/main/kotlin/com/example/UUIDScalarConverter.kt
+++ b/plugins/graphql-kotlin-maven-plugin/src/integration/complete-setup/src/main/kotlin/com/example/UUIDScalarConverter.kt
@@ -1,0 +1,9 @@
+package com.example
+
+import com.expediagroup.graphql.client.converter.ScalarConverter
+import java.util.UUID
+
+class UUIDScalarConverter : ScalarConverter<UUID> {
+    override fun toScalar(rawValue: String): UUID = UUID.fromString(rawValue)
+    override fun toJson(value: UUID): String = value.toString()
+}

--- a/plugins/graphql-kotlin-maven-plugin/src/integration/complete-setup/src/test/kotlin/com/expediagroup/graphql/plugin/maven/GraphQLMavenPluginTest.kt
+++ b/plugins/graphql-kotlin-maven-plugin/src/integration/complete-setup/src/test/kotlin/com/expediagroup/graphql/plugin/maven/GraphQLMavenPluginTest.kt
@@ -57,6 +57,11 @@ class GraphQLMavenPluginTest {
                 assertTrue(response.errors == null)
                 val data = response.data
                 assertNotNull(data)
+                val scalarResult = data?.scalarQuery
+                assertTrue(scalarResult is ExampleQuery.ScalarWrapper)
+                assertNotNull(scalarResult)
+                assertTrue(scalarResult?.count is Int)
+                assertTrue(scalarResult?.custom is ExampleQuery.UUID)
                 assertEquals(ExampleQuery.CustomEnum.ONE, data?.enumQuery)
                 val interfaceResult = data?.interfaceQuery
                 assertTrue(interfaceResult is ExampleQuery.SecondInterfaceImplementation)


### PR DESCRIPTION
### :pencil: Description

In order for Maven to recognize complex objects all their fields need to be annoated with `@Parameter` annotation.

Additonal changes
- add debug messages for logging generate client task/mojo configuration
- update integration tests to validate custom scalar logic
- update Gradle task `converters` parameter to match Maven MOJO parameter

### :link: Related Issues
