### PR TITLE
[docs] GraphQL client documentation and configuration fixes

### DIFF
--- a/docs/client/client-customization.md
+++ b/docs/client/client-customization.md
@@ -5,19 +5,27 @@ title: Client Customization
 
 ## Ktor HTTP Client Customization
 
-`GraphQLClient` uses the Ktor HTTP Client to execute the underlying queries. Client can be customized with different
-engines (defaults to Coroutine-based IO) and HTTP client features. 
+`GraphQLClient` uses the Ktor HTTP Client to execute the underlying queries. Clients can be customized with different
+engines (defaults to Coroutine-based IO) and HTTP client features. Custom configurations can be applied through Ktor DSL
+style builders.
 
 ```kotlin
-val okHttpEngine = OkHttp.create {
-    config {
-        connectTimeout(1, TimeUnit.SECONDS)
-        readTimeout(60, TimeUnit.SECONDS)
-        writeTimeout(60, TimeUnit.SECONDS)
+val client = GraphQLClient(
+        url = URL("http://localhost:8080/graphql"),
+        engineFactory = OkHttp
+) {
+    engine {
+        config {
+            connectTimeout(10, TimeUnit.SECONDS)
+            readTimeout(60, TimeUnit.SECONDS)
+            writeTimeout(60, TimeUnit.SECONDS)
+        }
     }
-    addInterceptor(myInterceptor)
+    install(Logging) {
+        logger = Logger.DEFAULT
+        level = LogLevel.HEADERS
+    }
 }
-val client = GraphQLClient(url = URL("http://localhost:8080/graphql"), engine = okHttpEngine)
 ```
 
 See [Ktor HTTP Client documentation](https://ktor.io/clients/index.html) for additional details.

--- a/docs/client/client-customization.md
+++ b/docs/client/client-customization.md
@@ -1,0 +1,76 @@
+---
+id: client-customization
+title: Client Customization
+---
+
+## Ktor HTTP Client Customization
+
+`GraphQLClient` uses the Ktor HTTP Client to execute the underlying queries. Client can be customized with different
+engines (defaults to Coroutine-based IO) and HTTP client features. 
+
+```kotlin
+val okHttpEngine = OkHttp.create {
+    config {
+        connectTimeout(1, TimeUnit.SECONDS)
+        readTimeout(60, TimeUnit.SECONDS)
+        writeTimeout(60, TimeUnit.SECONDS)
+    }
+    addInterceptor(myInterceptor)
+}
+val client = GraphQLClient(url = URL("http://localhost:8080/graphql"), engine = okHttpEngine)
+```
+
+See [Ktor HTTP Client documentation](https://ktor.io/clients/index.html) for additional details.
+
+## Jackson Customization
+
+`GraphQLClient` relies on Jackson to handle polymorphic types and default enum values. Due to the necessary logic to
+handle the above, currently we don't support other JSON libraries.
+
+```kotlin
+val customObjectMapper = jacksonObjectMapper()
+val client = GraphQLClient(url = URL("http://localhost:8080/graphql"), mapper = customObjectMapper)
+```
+
+## Deprecated Field Usage
+
+Build plugins will automatically fail generation of a client if any of the specified query files are referencing
+deprecated fields. This ensures that your clients have to explicitly opt-in into deprecated usage by specifying
+`allowDeprecatedFields` configuration option.
+
+## Custom GraphQL Scalars
+
+By default, custom GraphQL scalars are serialized and [type-aliased](https://kotlinlang.org/docs/reference/type-aliases.html)
+to a String. GraphQL Kotlin plugins also support custom serialization based on provided configuration.
+
+In order to automatically convert between custom GraphQL `UUID` scalar type and `java.util.UUID`, we first need to create
+our custom `ScalarConverter`.
+
+```kotlin
+package com.example.client
+
+import com.expediagroup.graphql.client.converter.ScalarConverter
+import java.util.UUID
+
+class UUIDScalarConverter : ScalarConverter<UUID> {
+    override fun toScalar(rawValue: String): UUID = UUID.fromString(rawValue)
+    override fun toJson(value: UUID): String = value.toString()
+}
+```
+
+And then configure build plugin by specifying
+* custom GraphQL scalar name
+* target class name
+* converter that provides logic to map between GraphQL and Kotlin type
+
+```kotlin
+graphql {
+    packageName = "com.example.generated"
+    endpoint = "http://localhost:8080/graphql"
+    converters.put("UUID", ScalarConverterMapping("java.util.UUID", "com.example.UUIDScalarConverter"))
+}
+```
+
+See [Gradle](https://expediagroup.github.io/graphql-kotlin/docs/plugins/gradle-plugin#generating-client-with-custom-scalars)
+and [Maven](https://expediagroup.github.io/graphql-kotlin/docs/plugins/maven-plugin#generating-client-with-custom-scalars)
+plugin documentation for additional details.

--- a/docs/client/client-customization.md
+++ b/docs/client/client-customization.md
@@ -67,9 +67,9 @@ class UUIDScalarConverter : ScalarConverter<UUID> {
 ```
 
 And then configure build plugin by specifying
-* custom GraphQL scalar name
-* target class name
-* converter that provides logic to map between GraphQL and Kotlin type
+* Custom GraphQL scalar name
+* Target class name
+* Converter that provides logic to map between GraphQL and Kotlin type
 
 ```kotlin
 graphql {

--- a/docs/client/client-features.md
+++ b/docs/client/client-features.md
@@ -1,0 +1,135 @@
+---
+id: client-features
+title: Client Features
+---
+
+## Polymorphic Types Support
+
+GraphQL supports polymorphic types through unions and interfaces which can be represented in Kotlin as marker and
+regular interfaces. In order to ensure generated objects are not empty, GraphQL queries referencing polymorphic types
+have to **explicitly specify all implementations**. Polymorphic queries also have to explicitly request `__typename`
+field so it can be used to Jackson correctly distinguish between different implementations.
+
+Given example schema
+
+```graphql
+type Query {
+  interfaceQuery: BasicInterface!
+}
+
+interface BasicInterface {
+  id: Int!
+  name: String!
+}
+
+type FirstInterfaceImplementation implements BasicInterface {
+  id: Int!
+  intValue: Int!
+  name: String!
+}
+
+type SecondInterfaceImplementation implements BasicInterface {
+  floatValue: Float!
+  id: Int!
+  name: String!
+}
+```
+
+We can query interface field as
+
+```graphql
+query PolymorphicQuery {
+  interfaceQuery {
+    __typename
+    id
+    name
+    ... on FirstInterfaceImplementation {
+      intValue
+    }
+    ... on SecondInterfaceImplementation {
+      floatValue
+    }
+  }
+}
+```
+
+Which will generate following data model
+
+```kotlin
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "__typename"
+)
+@JsonSubTypes(value = [com.fasterxml.jackson.annotation.JsonSubTypes.Type(value =
+    PolymorphicQuery.FirstInterfaceImplementation::class,
+    name="FirstInterfaceImplementation"),com.fasterxml.jackson.annotation.JsonSubTypes.Type(value
+    = PolymorphicQuery.SecondInterfaceImplementation::class, name="SecondInterfaceImplementation")])
+interface BasicInterface {
+  val id: Int
+  val name: String
+}
+
+data class FirstInterfaceImplementation(
+  override val id: Int,
+  override val name: String,
+  val intValue: Int
+) : PolymorphicQuery.BasicInterface
+
+data class SecondInterfaceImplementation(
+  override val id: Int,
+  override val name: String,
+  val floatValue: Float
+) : PolymorphicQuery.BasicInterface
+```
+
+## Default Enum Values
+
+Enums represent predefined set of values. Adding additional enum values could be a potentially breaking change as your
+clients may not be able to process it. GraphQL Kotlin Client automatically adds default `@JsonEnumDefaultValue __UNKNOWN_VALUE`
+to all generated enums as a catch all safeguard for handling new enum values.
+
+## Auto Generated Documentation
+
+GraphQL Kotlin build plugins automatically pull in GraphQL descriptions of the queried fields from the target schema and
+add it as KDoc to corresponding data models.
+
+Given simple GraphQL object definition
+
+```graphql
+"Some basic description"
+type BasicObject {
+  "Unique identifier"
+  id: Int!
+  "Object name"
+  name: String!
+}
+```
+
+Will result in a corresponding auto generated data class
+
+```kotlin
+/**
+ * Some basic description
+ */
+data class BasicObject(
+  /**
+   * Unique identifier
+   */
+  val id: Int,
+  /**
+   * Object name
+   */
+  val name: String
+)
+```
+
+## Native Support for Coroutines
+
+GraphQL Kotlin Client is a thin wrapper on top of [Ktor HTTP Client](https://ktor.io/clients/index.html) which provides
+fully asynchronous communication through Kotlin coroutines. `GraphQLClient` exposes single `execute` method that will
+suspend your GraphQL operation until it gets a response back without blocking the underlying thread. In order to fetch
+data asynchronously and perform some additional computations at the same time you should wrap your client execution in
+`launch` or `async` coroutine builder and explicitly `await` for their results.
+
+See [Kotlin coroutines documentation](https://kotlinlang.org/docs/reference/coroutines-overview.html) for additional details.

--- a/docs/client/client-overview.md
+++ b/docs/client/client-overview.md
@@ -104,7 +104,7 @@ See our documentation for more details on supported [Gradle tasks](https://exped
 and [Maven Mojos](https://expediagroup.github.io/graphql-kotlin/docs/plugins/maven-plugin#goals).
 
 When creating your GraphQL queries make sure to always specify an operation name and name the files accordingly. Each
-one of your query files will result in a generation of a corresponding Kotlin file with a class matching your operation
+one of your query files will generate a corresponding Kotlin file with a class matching your operation
 name that will act as a wrapper for all corresponding data classes. For example, given `HelloWorldQuery.graphql` with
 `HelloWorldQuery` as the operation name, GraphQL Kotlin plugins will generate a corresponding `HelloWorldQuery.kt` file
 with a `HelloWorldQuery` class under the configured package.

--- a/docs/client/client-overview.md
+++ b/docs/client/client-overview.md
@@ -97,7 +97,7 @@ working examples of Gradle and Maven based projects.
 
 ## Generating GraphQL Client
 
-By default, GraphQL Kotlin build plugins will attempt to generate GraphQL clients from all query files located under
+By default, GraphQL Kotlin build plugins will attempt to generate GraphQL clients from all `*graphql` files located under
 `src/main/resources`. Queries are validated against target GraphQL schema which can be manually provided, retrieved by
 the plugins through introspection (as configured in examples above) or downloaded directly from a custom SDL endpoint.
 See our documentation for more details on supported [Gradle tasks](https://expediagroup.github.io/graphql-kotlin/docs/plugins/gradle-plugin#tasks)

--- a/docs/client/client-overview.md
+++ b/docs/client/client-overview.md
@@ -149,7 +149,7 @@ class HelloWorldQuery(
 ```
 
 Generated classes requires an instance of `GraphQLClient` and exposes a single `execute` suspendable method that executes
-the underlying GraphQL operation using provided client.
+the underlying GraphQL operation using the provided client.
 
 ## Executing Queries
 

--- a/docs/client/client-overview.md
+++ b/docs/client/client-overview.md
@@ -8,7 +8,7 @@ by the GraphQL Kotlin [Gradle](https://expediagroup.github.io/graphql-kotlin/doc
 [Maven](https://expediagroup.github.io/graphql-kotlin/docs/plugins/maven-plugin) plugins.
 
 `GraphQLClient` is a thin wrapper on top of [Ktor HTTP Client](https://ktor.io/clients/index.html) and supports fully
-asynchronous non-blocking communication. Client is highly customizable and can be configured with any supported HTTP
+asynchronous non-blocking communication. It is highly customizable and can be configured with any supported Ktor HTTP
 [engine](https://ktor.io/clients/http-client/engines.html) and [features](https://ktor.io/clients/http-client/features.html).
 
 ## Project Configuration

--- a/docs/client/client-overview.md
+++ b/docs/client/client-overview.md
@@ -98,7 +98,7 @@ working examples of Gradle and Maven based projects.
 ## Generating GraphQL Client
 
 By default, GraphQL Kotlin build plugins will attempt to generate GraphQL clients from all `*graphql` files located under
-`src/main/resources`. Queries are validated against target GraphQL schema which can be manually provided, retrieved by
+`src/main/resources`. Queries are validated against the target GraphQL schema, which can be manually provided, retrieved by
 the plugins through introspection (as configured in examples above) or downloaded directly from a custom SDL endpoint.
 See our documentation for more details on supported [Gradle tasks](https://expediagroup.github.io/graphql-kotlin/docs/plugins/gradle-plugin#tasks)
 and [Maven Mojos](https://expediagroup.github.io/graphql-kotlin/docs/plugins/maven-plugin#goals).

--- a/docs/client/client-overview.md
+++ b/docs/client/client-overview.md
@@ -148,7 +148,7 @@ class HelloWorldQuery(
 }
 ```
 
-Generated class requires an instance of `GraphQLClient` and exposes a single `execute` suspendable method that executes
+Generated classes requires an instance of `GraphQLClient` and exposes a single `execute` suspendable method that executes
 the underlying GraphQL operation using provided client.
 
 ## Executing Queries

--- a/docs/client/client-overview.md
+++ b/docs/client/client-overview.md
@@ -1,0 +1,177 @@
+---
+id: client-overview
+title: Client Overview
+---
+
+`graphql-kotlin-client` is a lightweight type-safe GraphQL HTTP client. Type-safe data models are generated at build time
+by the GraphQL Kotlin [Gradle](https://expediagroup.github.io/graphql-kotlin/docs/plugins/gradle-plugin) and
+[Maven](https://expediagroup.github.io/graphql-kotlin/docs/plugins/maven-plugin) plugins.
+
+`GraphQLClient` is a thin wrapper on top of [Ktor HTTP Client](https://ktor.io/clients/index.html) and supports fully
+asynchronous non-blocking communication. Client is highly customizable and can be configured with any supported HTTP
+[engine](https://ktor.io/clients/http-client/engines.html) and [features](https://ktor.io/clients/http-client/features.html).
+
+## Project Configuration
+
+GraphQL Kotlin provides both Gradle and Maven plugins to automatically generate your client code at build time. Once
+your data classes are generated, you can then execute their underlying GraphQL operations using `graphql-kotlin-client`
+runtime dependency.
+
+Basic `build.gradle.kts` Gradle configuration:
+
+```kotlin
+import com.expediagroup.graphql.plugin.gradle.graphql
+
+plugins {
+    id("com.expediagroup.graphql") version $latestGraphQLKotlinVersion
+}
+
+dependencies {
+  implementation("com.expediagroup:graphql-kotlin-client:$latestGraphQLKotlinVersion")
+}
+
+graphql {
+    endpoint = "http://localhost:8080/graphql"
+    packageName = "com.example.generated"
+}
+```
+
+Equivalent `pom.xml` Maven configuration
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>graphql-kotlin-maven-client-example</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+
+    <properties>
+        <graphql-kotlin.version>$latestGraphQLKotlinVersion</graphql-kotlin.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.expediagroup</groupId>
+            <artifactId>graphql-kotlin-client</artifactId>
+            <version>${graphql-kotlin.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.expediagroup</groupId>
+                <artifactId>graphql-kotlin-maven-plugin</artifactId>
+                <version>${graphql-kotlin.version}</version>
+                <executions>
+                    <execution>
+                        <id>introspect-schema</id>
+                        <goals>
+                            <goal>introspectSchema</goal>
+                        </goals>
+                        <configuration>
+                            <endpoint>http://localhost:8080/graphql</endpoint>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>generate-client</id>
+                        <goals>
+                            <goal>generateClient</goal>
+                        </goals>
+                        <configuration>
+                            <packageName>com.example.generated</packageName>
+                            <schemaFile>${project.build.directory}/schema.graphql</schemaFile>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>
+```
+
+See [graphql-kotlin-client-example](https://github.com/dariuszkuc/graphql-kotlin-client-example) project for complete
+working examples of Gradle and Maven based projects.
+
+## Generating GraphQL Client
+
+By default, GraphQL Kotlin build plugins will attempt to generate GraphQL clients from all query files located under
+`src/main/resources`. Queries are validated against target GraphQL schema which can be manually provided, retrieved by
+the plugins through introspection (as configured in examples above) or downloaded directly from a custom SDL endpoint.
+See our documentation for more details on supported [Gradle tasks](https://expediagroup.github.io/graphql-kotlin/docs/plugins/gradle-plugin#tasks)
+and [Maven Mojos](https://expediagroup.github.io/graphql-kotlin/docs/plugins/maven-plugin#goals).
+
+When creating your GraphQL queries make sure to always specify an operation name and name the files accordingly. Each
+one of your query files will result in a generation of a corresponding Kotlin file with a class matching your operation
+name that will act as a wrapper for all corresponding data classes. For example, given `HelloWorldQuery.graphql` with
+`HelloWorldQuery` as the operation name, GraphQL Kotlin plugins will generate a corresponding `HelloWorldQuery.kt` file
+with a `HelloWorldQuery` class under the configured package.
+
+For example, given a simple schema
+
+```graphql
+type Query {
+  helloWorld: String
+}
+```
+
+And a corresponding `HelloWorldQuery.graphql` query
+
+```graphql
+query HelloWorldQuery {
+  helloWorld
+}
+```
+
+Plugins will generate following client code
+
+```kotlin
+package com.example.generated
+
+import com.expediagroup.graphql.client.GraphQLClient
+import com.expediagroup.graphql.client.GraphQLResult
+import kotlin.String
+
+const val HELLO_WORLD_QUERY: String = "query HelloWorldQuery {\n    helloWorld\n}"
+
+class HelloWorldQuery(
+  private val graphQLClient: GraphQLClient
+) {
+  suspend fun execute(): GraphQLResult<HelloWorldQuery.HelloWorldQueryResult> =
+      graphQLClient.execute(HELLO_WORLD_QUERY, "HelloWorldQuery", null)
+
+  data class HelloWorldQueryResult(
+    val helloWorld: String
+  )
+}
+```
+
+Generated class requires an instance of `GraphQLClient` and exposes a single `execute` suspendable method that executes
+the underlying GraphQL operation using provided client.
+
+## Executing Queries
+
+Your auto generated classes accept an instance of `GraphQLClient` which is a thin wrapper around Ktor HTTP client that
+ensures proper serialization and deserialization of your GraphQL objects. `GraphQLClient` requires target URL to be
+specified and defaults to fully asynchronous non-blocking [Coroutine-based IO engine](https://ktor.io/clients/http-client/engines.html#cio).
+
+```kotlin
+package com.example.client
+
+import com.expediagroup.graphql.client.GraphQLClient
+import com.expediagroup.graphql.generated.HelloWorldQuery
+import kotlinx.coroutines.runBlocking
+import java.net.URL
+
+fun main() {
+    val client = GraphQLClient(url = URL("http://localhost:8080/graphql"))
+    val helloWorldQuery = HelloWorldQuery(client)
+    runBlocking {
+        val result = helloWorldQuery.execute()
+        println("hello world query result: ${result.data?.helloWorld}")
+    }
+    client.close()
+}
+```

--- a/docs/client/client-overview.md
+++ b/docs/client/client-overview.md
@@ -139,10 +139,10 @@ const val HELLO_WORLD_QUERY: String = "query HelloWorldQuery {\n    helloWorld\n
 class HelloWorldQuery(
   private val graphQLClient: GraphQLClient
 ) {
-  suspend fun execute(): GraphQLResult<HelloWorldQuery.HelloWorldQueryResult> =
+  suspend fun execute(): GraphQLResult<HelloWorldQuery.Result> =
       graphQLClient.execute(HELLO_WORLD_QUERY, "HelloWorldQuery", null)
 
-  data class HelloWorldQueryResult(
+  data class Result(
     val helloWorld: String
   )
 }

--- a/graphql-kotlin-client/README.md
+++ b/graphql-kotlin-client/README.md
@@ -16,6 +16,7 @@ together with one of the GraphQL Kotlin build plugins to auto-generate type safe
 * Supports default enum values to gracefully handle new/unknown server values
 * Native support for coroutines
 * Easily configurable Ktor HTTP Client
+* Documentation generated from the underlying GraphQL schema
 
 ## Install it
 
@@ -55,7 +56,7 @@ as part of your build/release process.
 
 ```kotlin
 // build.gradle.kts
-import com.expediagroup.graphql.plugin.gradle.tasks.GraphQLGenerateClientTask
+import com.expediagroup.graphql.plugin.gradle.tasks.GraphQLIntrospectSchemaTask
 
 val graphqlIntrospectSchema by tasks.getting(GraphQLIntrospectSchemaTask::class) {
     endpoint.set("http://localhost:8080/graphql")
@@ -70,8 +71,8 @@ Generated top level class will contain all your data classes. For example, given
 `myAwesomeQuery` as the operation name, GraphQL Kotlin plugins will generate a corresponding `MyAwesomeGraphQLQuery.kt`
 file with a `MyAwesomeQuery` class under the configured package.
 
-Refer to our [documentation](https://expediagroup.github.io/graphql-kotlin) for additional details and considerations
-while writing your GraphQL queries.
+Refer to our [documentation](https://expediagroup.github.io/graphql-kotlin/docs/client/client-overview) for additional
+details and considerations while writing your GraphQL queries.
 
 ### Generate Client
 
@@ -102,7 +103,7 @@ details.
 ```kotlin
 val client = GraphQLClient(url = URL("http://localhost:8080/graphql"))
 val query = MyAwesomeQuery(client)
-val result = query.myAwesomeQuery()
+val result = query.execute()
 ```
 
 The result of your query is a type safe object that corresponds to your GraphQL query.
@@ -112,8 +113,8 @@ Additional information about Gradle and Maven plugins as well as their respectiv
 
 ## Documentation
 
-Additional information can be found in our [documentation](https://expediagroup.github.io/graphql-kotlin) and the
-[Javadocs](https://www.javadoc.io/doc/com.expediagroup/graphql-kotlin-client) of all published versions.
+Additional information can be found in our [documentation](https://expediagroup.github.io/graphql-kotlin/docs/client/client-overview)
+and the [Javadocs](https://www.javadoc.io/doc/com.expediagroup/graphql-kotlin-client) of all published versions.
 
 If you have a question about something you can not find in our documentation or Javadocs, feel free to
 [create an issue](https://github.com/ExpediaGroup/graphql-kotlin/issues) and tag it with the question label.

--- a/graphql-kotlin-client/src/main/kotlin/com/expediagroup/graphql/client/GraphQLClient.kt
+++ b/graphql-kotlin-client/src/main/kotlin/com/expediagroup/graphql/client/GraphQLClient.kt
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.JavaType
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.ktor.client.HttpClient
+import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.engine.HttpClientEngineFactory
 import io.ktor.client.engine.cio.CIO
 import io.ktor.client.features.HttpClientFeature
@@ -41,7 +42,7 @@ import java.net.URL
 class GraphQLClient(
     private val url: URL,
     private val mapper: ObjectMapper = jacksonObjectMapper(),
-    engine: HttpClientEngineFactory<*> = CIO,
+    engine: HttpClientEngine = CIO.create(),
     vararg features: HttpClientFeature<*, *>
 ) : Closeable {
     private val typeCache = mutableMapOf<Class<*>, JavaType>()
@@ -49,7 +50,7 @@ class GraphQLClient(
         mapper.enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE)
     }
 
-    private val client = HttpClient(engineFactory = engine) {
+    private val client = HttpClient(engine = engine) {
         for (feature in features) {
             install(feature)
         }

--- a/graphql-kotlin-client/src/main/kotlin/com/expediagroup/graphql/client/GraphQLClient.kt
+++ b/graphql-kotlin-client/src/main/kotlin/com/expediagroup/graphql/client/GraphQLClient.kt
@@ -21,9 +21,11 @@ import com.fasterxml.jackson.databind.JavaType
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.ktor.client.HttpClient
-import io.ktor.client.engine.HttpClientEngine
+import io.ktor.client.HttpClientConfig
+import io.ktor.client.engine.HttpClientEngineConfig
+import io.ktor.client.engine.HttpClientEngineFactory
 import io.ktor.client.engine.cio.CIO
-import io.ktor.client.features.HttpClientFeature
+import io.ktor.client.engine.cio.CIOEngineConfig
 import io.ktor.client.features.json.JacksonSerializer
 import io.ktor.client.features.json.JsonFeature
 import io.ktor.client.request.accept
@@ -38,22 +40,22 @@ import java.net.URL
  * A lightweight typesafe GraphQL HTTP client.
  */
 @KtorExperimentalAPI
-class GraphQLClient(
+class GraphQLClient<in T : HttpClientEngineConfig>(
     private val url: URL,
+    engineFactory: HttpClientEngineFactory<T>,
     private val mapper: ObjectMapper = jacksonObjectMapper(),
-    engine: HttpClientEngine = CIO.create(),
-    vararg features: HttpClientFeature<*, *>
+    configuration: HttpClientConfig<T>.() -> Unit = {}
 ) : Closeable {
+
     private val typeCache = mutableMapOf<Class<*>, JavaType>()
     init {
         mapper.enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE)
     }
 
-    private val client = HttpClient(engine = engine) {
-        for (feature in features) {
-            install(feature)
-        }
-        // install default serializer
+    private val client = HttpClient(engineFactory = engineFactory) {
+        apply(configuration)
+
+        // install default JSON serializer
         install(JsonFeature) {
             serializer = JacksonSerializer(mapper)
         }
@@ -100,5 +102,10 @@ class GraphQLClient(
 
     override fun close() {
         client.close()
+    }
+
+    companion object {
+        operator fun invoke(url: URL, mapper: ObjectMapper = jacksonObjectMapper(), config: HttpClientConfig<CIOEngineConfig>.() -> Unit = {}) =
+            GraphQLClient(url = url, engineFactory = CIO, mapper = mapper, configuration = config)
     }
 }

--- a/graphql-kotlin-client/src/main/kotlin/com/expediagroup/graphql/client/GraphQLClient.kt
+++ b/graphql-kotlin-client/src/main/kotlin/com/expediagroup/graphql/client/GraphQLClient.kt
@@ -22,7 +22,6 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.HttpClientEngine
-import io.ktor.client.engine.HttpClientEngineFactory
 import io.ktor.client.engine.cio.CIO
 import io.ktor.client.features.HttpClientFeature
 import io.ktor.client.features.json.JacksonSerializer

--- a/plugins/graphql-kotlin-gradle-plugin/README.md
+++ b/plugins/graphql-kotlin-gradle-plugin/README.md
@@ -21,7 +21,10 @@ GraphQL Kotlin Gradle Plugin uses an extension on the project named `graphql` of
 This extension can be used to configure global options instead of explicitly configuring individual tasks.
 
 ```kotlin
-
+graphql {
+    packageName = "com.expediagroup.graphql.generated"
+    endpoint = "http://localhost:8080/graphql"
+}
 ```
 
 ## Tasks

--- a/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePlugin.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePlugin.kt
@@ -59,7 +59,7 @@ class GraphQLGradlePlugin : Plugin<Project> {
                 val generateClientTask = project.tasks.named(GENERATE_CLIENT_TASK_NAME, GraphQLGenerateClientTask::class.java).get()
                 generateClientTask.packageName.convention(project.provider { extension.packageName })
                 generateClientTask.allowDeprecatedFields.convention(project.provider { extension.allowDeprecatedFields })
-                generateClientTask.converters.convention(extension.scalarConverters)
+                generateClientTask.converters.convention(extension.converters)
                 generateClientTask.queryFiles.setFrom(extension.queryFiles.from)
 
                 if (extension.endpoint != null) {

--- a/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLPluginExtension.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLPluginExtension.kt
@@ -35,7 +35,7 @@ open class GraphQLPluginExtension(project: Project) {
     /** Boolean flag indicating whether or not selection of deprecated fields is allowed. */
     var allowDeprecatedFields: Boolean = false
     /** Custom GraphQL scalar to converter mapping containing information about corresponding Java type and converter that should be used to serialize/deserialize values. */
-    val scalarConverters: MapProperty<String, ScalarConverterMapping> = project.objects.mapProperty(String::class.java, ScalarConverterMapping::class.java)
+    val converters: MapProperty<String, ScalarConverterMapping> = project.objects.mapProperty(String::class.java, ScalarConverterMapping::class.java)
     /** List of query files to be processed. */
     var queryFiles: ConfigurableFileCollection = project.objects.fileCollection()
 }

--- a/plugins/graphql-kotlin-maven-plugin/README.md
+++ b/plugins/graphql-kotlin-maven-plugin/README.md
@@ -24,6 +24,16 @@ Plugin should be configured as part of your `pom.xml` build file.
                 <endpoint>http://localhost:8080/graphql</endpoint>
             </configuration>
         </execution>
+        <execution>
+            <id>generate-client</id>
+            <goals>
+                <goal>generateClient</goal>
+            </goals>
+            <configuration>
+                <packageName>com.expediagroup.graphql.generated</packageName>
+                <schemaFile>${project.build.directory}/schema.graphql</schemaFile>
+            </configuration>
+        </execution>
     </executions>
 </plugin>
 ```

--- a/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/GraphQLClientGenerator.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/GraphQLClientGenerator.kt
@@ -24,6 +24,7 @@ import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.PropertySpec
+import com.squareup.kotlinpoet.STAR
 import com.squareup.kotlinpoet.STRING
 import com.squareup.kotlinpoet.TypeSpec
 import graphql.language.ObjectTypeDefinition
@@ -89,10 +90,13 @@ class GraphQLClientGenerator(
             val queryConstName = operationName.toUpperUnderscore()
             funSpec.addStatement("return graphQLClient.execute($queryConstName, \"$operationTypeName\", $variableCode)")
 
+            val gqlCLientClassName = ClassName(LIBRARY_PACKAGE, "GraphQLClient").parameterizedBy(STAR)
             operationTypeSpec.primaryConstructor(FunSpec.constructorBuilder()
-                .addParameter("graphQLClient", ClassName(LIBRARY_PACKAGE, "GraphQLClient"))
+                .addParameter(
+                    "graphQLClient",
+                    gqlCLientClassName)
                 .build())
-            operationTypeSpec.addProperty(PropertySpec.builder("graphQLClient", ClassName(LIBRARY_PACKAGE, "GraphQLClient"), KModifier.PRIVATE)
+            operationTypeSpec.addProperty(PropertySpec.builder("graphQLClient", gqlCLientClassName, KModifier.PRIVATE)
                 .initializer("graphQLClient").build())
             operationTypeSpec.addFunction(funSpec.build())
 

--- a/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/GraphQLClientGenerator.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/GraphQLClientGenerator.kt
@@ -72,7 +72,7 @@ class GraphQLClientGenerator(
             val variableType: TypeSpec? = generateVariableTypeSpec(context, operationDefinition.variableDefinitions)
 
             val rootType = findRootType(operationDefinition)
-            val graphQLResultTypeSpec = generateGraphQLObjectTypeSpec(context, rootType, operationDefinition.selectionSet, "${operationTypeName}Result")
+            val graphQLResultTypeSpec = generateGraphQLObjectTypeSpec(context, rootType, operationDefinition.selectionSet, "Result")
             val kotlinResultTypeName = ClassName(context.packageName, "${context.rootType}.${graphQLResultTypeSpec.name}")
 
             val operationTypeSpec = TypeSpec.classBuilder(operationTypeName)

--- a/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLCustomScalarTypeAliasIT.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLCustomScalarTypeAliasIT.kt
@@ -41,7 +41,7 @@ class GenerateGraphQLCustomScalarTypeAliasIT {
             class ScalarAliasTestQuery(
               private val graphQLClient: GraphQLClient<*>
             ) {
-              suspend fun execute(): GraphQLResult<ScalarAliasTestQuery.ScalarAliasTestQueryResult> =
+              suspend fun execute(): GraphQLResult<ScalarAliasTestQuery.Result> =
                   graphQLClient.execute(SCALAR_ALIAS_TEST_QUERY, "ScalarAliasTestQuery", null)
 
               /**
@@ -54,7 +54,7 @@ class GenerateGraphQLCustomScalarTypeAliasIT {
                 val custom: UUID
               )
 
-              data class ScalarAliasTestQueryResult(
+              data class Result(
                 /**
                  * Query that returns wrapper object with all supported scalar types
                  */

--- a/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLCustomScalarTypeAliasIT.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLCustomScalarTypeAliasIT.kt
@@ -39,7 +39,7 @@ class GenerateGraphQLCustomScalarTypeAliasIT {
                 "query ScalarAliasTestQuery {\n  scalarQuery {\n    custom\n  }\n}"
 
             class ScalarAliasTestQuery(
-              private val graphQLClient: GraphQLClient
+              private val graphQLClient: GraphQLClient<*>
             ) {
               suspend fun execute(): GraphQLResult<ScalarAliasTestQuery.ScalarAliasTestQueryResult> =
                   graphQLClient.execute(SCALAR_ALIAS_TEST_QUERY, "ScalarAliasTestQuery", null)

--- a/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLCustomScalarTypeSpecIT.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLCustomScalarTypeSpecIT.kt
@@ -40,7 +40,7 @@ class GenerateGraphQLCustomScalarTypeSpecIT {
                 "query CustomScalarTestQuery {\n  scalarQuery {\n    custom\n  }\n}"
 
             class CustomScalarTestQuery(
-              private val graphQLClient: GraphQLClient
+              private val graphQLClient: GraphQLClient<*>
             ) {
               suspend fun execute(): GraphQLResult<CustomScalarTestQuery.CustomScalarTestQueryResult> =
                   graphQLClient.execute(CUSTOM_SCALAR_TEST_QUERY, "CustomScalarTestQuery", null)

--- a/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLCustomScalarTypeSpecIT.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLCustomScalarTypeSpecIT.kt
@@ -42,7 +42,7 @@ class GenerateGraphQLCustomScalarTypeSpecIT {
             class CustomScalarTestQuery(
               private val graphQLClient: GraphQLClient<*>
             ) {
-              suspend fun execute(): GraphQLResult<CustomScalarTestQuery.CustomScalarTestQueryResult> =
+              suspend fun execute(): GraphQLResult<CustomScalarTestQuery.Result> =
                   graphQLClient.execute(CUSTOM_SCALAR_TEST_QUERY, "CustomScalarTestQuery", null)
 
               /**
@@ -73,7 +73,7 @@ class GenerateGraphQLCustomScalarTypeSpecIT {
                 val custom: CustomScalarTestQuery.UUID
               )
 
-              data class CustomScalarTestQueryResult(
+              data class Result(
                 /**
                  * Query that returns wrapper object with all supported scalar types
                  */

--- a/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLEnumTypeSpecIT.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLEnumTypeSpecIT.kt
@@ -35,7 +35,7 @@ class GenerateGraphQLEnumTypeSpecIT {
             const val ENUM_TEST_QUERY: String = "query EnumTestQuery {\n  enumQuery\n}"
 
             class EnumTestQuery(
-              private val graphQLClient: GraphQLClient
+              private val graphQLClient: GraphQLClient<*>
             ) {
               suspend fun execute(): GraphQLResult<EnumTestQuery.EnumTestQueryResult> =
                   graphQLClient.execute(ENUM_TEST_QUERY, "EnumTestQuery", null)

--- a/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLEnumTypeSpecIT.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLEnumTypeSpecIT.kt
@@ -37,7 +37,7 @@ class GenerateGraphQLEnumTypeSpecIT {
             class EnumTestQuery(
               private val graphQLClient: GraphQLClient<*>
             ) {
-              suspend fun execute(): GraphQLResult<EnumTestQuery.EnumTestQueryResult> =
+              suspend fun execute(): GraphQLResult<EnumTestQuery.Result> =
                   graphQLClient.execute(ENUM_TEST_QUERY, "EnumTestQuery", null)
 
               /**
@@ -67,7 +67,7 @@ class GenerateGraphQLEnumTypeSpecIT {
                 __UNKNOWN_VALUE
               }
 
-              data class EnumTestQueryResult(
+              data class Result(
                 /**
                  * Query that returns enum value
                  */

--- a/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLInputObjectTypeSpecIT.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLInputObjectTypeSpecIT.kt
@@ -37,10 +37,10 @@ class GenerateGraphQLInputObjectTypeSpecIT {
             class InputObjectTestQuery(
               private val graphQLClient: GraphQLClient<*>
             ) {
-              suspend fun execute(): GraphQLResult<InputObjectTestQuery.InputObjectTestQueryResult> =
+              suspend fun execute(): GraphQLResult<InputObjectTestQuery.Result> =
                   graphQLClient.execute(INPUT_OBJECT_TEST_QUERY, "InputObjectTestQuery", null)
 
-              data class InputObjectTestQueryResult(
+              data class Result(
                 /**
                  * Query that accepts some input arguments
                  */
@@ -73,10 +73,10 @@ class GenerateGraphQLInputObjectTypeSpecIT {
             class AliasTestQuery(
               private val graphQLClient: GraphQLClient<*>
             ) {
-              suspend fun execute(): GraphQLResult<AliasTestQuery.AliasTestQueryResult> =
+              suspend fun execute(): GraphQLResult<AliasTestQuery.Result> =
                   graphQLClient.execute(ALIAS_TEST_QUERY, "AliasTestQuery", null)
 
-              data class AliasTestQueryResult(
+              data class Result(
                 /**
                  * Query that accepts some input arguments
                  */

--- a/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLInputObjectTypeSpecIT.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLInputObjectTypeSpecIT.kt
@@ -35,7 +35,7 @@ class GenerateGraphQLInputObjectTypeSpecIT {
                 "query InputObjectTestQuery {\n  inputObjectQuery(criteria: { min: 1.0, max: 5.0 } )\n}"
 
             class InputObjectTestQuery(
-              private val graphQLClient: GraphQLClient
+              private val graphQLClient: GraphQLClient<*>
             ) {
               suspend fun execute(): GraphQLResult<InputObjectTestQuery.InputObjectTestQueryResult> =
                   graphQLClient.execute(INPUT_OBJECT_TEST_QUERY, "InputObjectTestQuery", null)
@@ -71,7 +71,7 @@ class GenerateGraphQLInputObjectTypeSpecIT {
                 "query AliasTestQuery {\n  first: inputObjectQuery(criteria: { min: 1.0, max: 5.0 } )\n  second: inputObjectQuery(criteria: { min: 5.0, max: 10.0 } )\n}"
 
             class AliasTestQuery(
-              private val graphQLClient: GraphQLClient
+              private val graphQLClient: GraphQLClient<*>
             ) {
               suspend fun execute(): GraphQLResult<AliasTestQuery.AliasTestQueryResult> =
                   graphQLClient.execute(ALIAS_TEST_QUERY, "AliasTestQuery", null)

--- a/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLInterfaceTypeSpecIT.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLInterfaceTypeSpecIT.kt
@@ -43,7 +43,7 @@ class GenerateGraphQLInterfaceTypeSpecIT {
                 "query InterfaceWithInlineFragmentsTestQuery {\n  interfaceQuery {\n    __typename\n    id\n    name\n    ... on FirstInterfaceImplementation {\n      intValue\n    }\n    ... on SecondInterfaceImplementation {\n      floatValue\n    }\n  }\n}"
 
             class InterfaceWithInlineFragmentsTestQuery(
-              private val graphQLClient: GraphQLClient
+              private val graphQLClient: GraphQLClient<*>
             ) {
               suspend fun execute():
                   GraphQLResult<InterfaceWithInlineFragmentsTestQuery.InterfaceWithInlineFragmentsTestQueryResult>
@@ -157,7 +157,7 @@ class GenerateGraphQLInterfaceTypeSpecIT {
                 "query InterfaceWithNamedFragmentsTestQuery {\n  interfaceQuery {\n    __typename\n    id\n    name\n    ... firstInterfaceImplFields\n    ... secondInterfaceImplFields\n  }\n}\n\nfragment firstInterfaceImplFields on FirstInterfaceImplementation {\n  id\n  name\n  intValue\n}\nfragment secondInterfaceImplFields on SecondInterfaceImplementation {\n  id\n  name\n  floatValue\n}"
 
             class InterfaceWithNamedFragmentsTestQuery(
-              private val graphQLClient: GraphQLClient
+              private val graphQLClient: GraphQLClient<*>
             ) {
               suspend fun execute():
                   GraphQLResult<InterfaceWithNamedFragmentsTestQuery.InterfaceWithNamedFragmentsTestQueryResult>

--- a/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLInterfaceTypeSpecIT.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLInterfaceTypeSpecIT.kt
@@ -45,9 +45,8 @@ class GenerateGraphQLInterfaceTypeSpecIT {
             class InterfaceWithInlineFragmentsTestQuery(
               private val graphQLClient: GraphQLClient<*>
             ) {
-              suspend fun execute():
-                  GraphQLResult<InterfaceWithInlineFragmentsTestQuery.InterfaceWithInlineFragmentsTestQueryResult>
-                  = graphQLClient.execute(INTERFACE_WITH_INLINE_FRAGMENTS_TEST_QUERY,
+              suspend fun execute(): GraphQLResult<InterfaceWithInlineFragmentsTestQuery.Result> =
+                  graphQLClient.execute(INTERFACE_WITH_INLINE_FRAGMENTS_TEST_QUERY,
                   "InterfaceWithInlineFragmentsTestQuery", null)
 
               /**
@@ -111,7 +110,7 @@ class GenerateGraphQLInterfaceTypeSpecIT {
                 val name: String
               }
 
-              data class InterfaceWithInlineFragmentsTestQueryResult(
+              data class Result(
                 /**
                  * Query returning an interface
                  */
@@ -159,9 +158,8 @@ class GenerateGraphQLInterfaceTypeSpecIT {
             class InterfaceWithNamedFragmentsTestQuery(
               private val graphQLClient: GraphQLClient<*>
             ) {
-              suspend fun execute():
-                  GraphQLResult<InterfaceWithNamedFragmentsTestQuery.InterfaceWithNamedFragmentsTestQueryResult>
-                  = graphQLClient.execute(INTERFACE_WITH_NAMED_FRAGMENTS_TEST_QUERY,
+              suspend fun execute(): GraphQLResult<InterfaceWithNamedFragmentsTestQuery.Result> =
+                  graphQLClient.execute(INTERFACE_WITH_NAMED_FRAGMENTS_TEST_QUERY,
                   "InterfaceWithNamedFragmentsTestQuery", null)
 
               /**
@@ -225,7 +223,7 @@ class GenerateGraphQLInterfaceTypeSpecIT {
                 val name: String
               }
 
-              data class InterfaceWithNamedFragmentsTestQueryResult(
+              data class Result(
                 /**
                  * Query returning an interface
                  */

--- a/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLObjectTypeSpecIT.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLObjectTypeSpecIT.kt
@@ -42,7 +42,7 @@ class GenerateGraphQLObjectTypeSpecIT {
             class ComplexObjectTestQuery(
               private val graphQLClient: GraphQLClient<*>
             ) {
-              suspend fun execute(): GraphQLResult<ComplexObjectTestQuery.ComplexObjectTestQueryResult> =
+              suspend fun execute(): GraphQLResult<ComplexObjectTestQuery.Result> =
                   graphQLClient.execute(COMPLEX_OBJECT_TEST_QUERY, "ComplexObjectTestQuery", null)
 
               /**
@@ -88,7 +88,7 @@ class GenerateGraphQLObjectTypeSpecIT {
                 val details: ComplexObjectTestQuery.DetailsObject
               )
 
-              data class ComplexObjectTestQueryResult(
+              data class Result(
                 /**
                  * Query returning an object that references another object
                  */
@@ -129,8 +129,7 @@ class GenerateGraphQLObjectTypeSpecIT {
             class ComplexObjectQueryWithNamedFragment(
               private val graphQLClient: GraphQLClient<*>
             ) {
-              suspend fun execute():
-                  GraphQLResult<ComplexObjectQueryWithNamedFragment.ComplexObjectQueryWithNamedFragmentResult> =
+              suspend fun execute(): GraphQLResult<ComplexObjectQueryWithNamedFragment.Result> =
                   graphQLClient.execute(COMPLEX_OBJECT_QUERY_WITH_NAMED_FRAGMENT,
                   "ComplexObjectQueryWithNamedFragment", null)
 
@@ -164,7 +163,7 @@ class GenerateGraphQLObjectTypeSpecIT {
                 val details: ComplexObjectQueryWithNamedFragment.DetailsObject
               )
 
-              data class ComplexObjectQueryWithNamedFragmentResult(
+              data class Result(
                 /**
                  * Query returning an object that references another object
                  */
@@ -249,7 +248,7 @@ class GenerateGraphQLObjectTypeSpecIT {
             class JUnitTestQuery(
               private val graphQLClient: GraphQLClient<*>
             ) {
-              suspend fun execute(): GraphQLResult<JUnitTestQuery.JUnitTestQueryResult> =
+              suspend fun execute(): GraphQLResult<JUnitTestQuery.Result> =
                   graphQLClient.execute(J_UNIT_TEST_QUERY, "JUnitTestQuery", null)
 
               /**
@@ -263,7 +262,7 @@ class GenerateGraphQLObjectTypeSpecIT {
                 val name: String
               )
 
-              data class JUnitTestQueryResult(
+              data class Result(
                 /**
                  * Query returning list of simple objects
                  */
@@ -310,10 +309,10 @@ class GenerateGraphQLObjectTypeSpecIT {
             class DeprecatedFieldQuery(
               private val graphQLClient: GraphQLClient<*>
             ) {
-              suspend fun execute(): GraphQLResult<DeprecatedFieldQuery.DeprecatedFieldQueryResult> =
+              suspend fun execute(): GraphQLResult<DeprecatedFieldQuery.Result> =
                   graphQLClient.execute(DEPRECATED_FIELD_QUERY, "DeprecatedFieldQuery", null)
 
-              data class DeprecatedFieldQueryResult(
+              data class Result(
                 /**
                  * Deprecated query that should not be used anymore
                  */
@@ -354,8 +353,8 @@ class GenerateGraphQLObjectTypeSpecIT {
             class NestedQuery(
               private val graphQLClient: GraphQLClient<*>
             ) {
-              suspend fun execute(): GraphQLResult<NestedQuery.NestedQueryResult> =
-                  graphQLClient.execute(NESTED_QUERY, "NestedQuery", null)
+              suspend fun execute(): GraphQLResult<NestedQuery.Result> = graphQLClient.execute(NESTED_QUERY,
+                  "NestedQuery", null)
 
               /**
                * Example of an object self-referencing itself
@@ -375,7 +374,7 @@ class GenerateGraphQLObjectTypeSpecIT {
                 val children: List<NestedQuery.NestedObject>
               )
 
-              data class NestedQueryResult(
+              data class Result(
                 /**
                  * Query returning object referencing itself
                  */

--- a/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLObjectTypeSpecIT.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLObjectTypeSpecIT.kt
@@ -40,7 +40,7 @@ class GenerateGraphQLObjectTypeSpecIT {
                 "query ComplexObjectTestQuery {\n  complexObjectQuery {\n    id\n    name\n    optional\n    details {\n      id\n      flag\n      value\n    }\n  }\n}"
 
             class ComplexObjectTestQuery(
-              private val graphQLClient: GraphQLClient
+              private val graphQLClient: GraphQLClient<*>
             ) {
               suspend fun execute(): GraphQLResult<ComplexObjectTestQuery.ComplexObjectTestQueryResult> =
                   graphQLClient.execute(COMPLEX_OBJECT_TEST_QUERY, "ComplexObjectTestQuery", null)
@@ -127,7 +127,7 @@ class GenerateGraphQLObjectTypeSpecIT {
                 "query ComplexObjectQueryWithNamedFragment {\n  complexObjectQuery {\n    ...complexObjectFields\n  }\n}\n\nfragment complexObjectFields on ComplexObject {\n  id\n  name\n  details {\n    ...detailObjectFields\n  }\n}\n\nfragment detailObjectFields on DetailsObject {\n  value\n}"
 
             class ComplexObjectQueryWithNamedFragment(
-              private val graphQLClient: GraphQLClient
+              private val graphQLClient: GraphQLClient<*>
             ) {
               suspend fun execute():
                   GraphQLResult<ComplexObjectQueryWithNamedFragment.ComplexObjectQueryWithNamedFragmentResult> =
@@ -247,7 +247,7 @@ class GenerateGraphQLObjectTypeSpecIT {
                 "query JUnitTestQuery {\n  listQuery {\n    id\n    name\n  }\n}"
 
             class JUnitTestQuery(
-              private val graphQLClient: GraphQLClient
+              private val graphQLClient: GraphQLClient<*>
             ) {
               suspend fun execute(): GraphQLResult<JUnitTestQuery.JUnitTestQueryResult> =
                   graphQLClient.execute(J_UNIT_TEST_QUERY, "JUnitTestQuery", null)
@@ -308,7 +308,7 @@ class GenerateGraphQLObjectTypeSpecIT {
             const val DEPRECATED_FIELD_QUERY: String = "query DeprecatedFieldQuery {\n  deprecatedQuery\n}"
 
             class DeprecatedFieldQuery(
-              private val graphQLClient: GraphQLClient
+              private val graphQLClient: GraphQLClient<*>
             ) {
               suspend fun execute(): GraphQLResult<DeprecatedFieldQuery.DeprecatedFieldQueryResult> =
                   graphQLClient.execute(DEPRECATED_FIELD_QUERY, "DeprecatedFieldQuery", null)
@@ -352,7 +352,7 @@ class GenerateGraphQLObjectTypeSpecIT {
                 "query NestedQuery {\n  nestedObjectQuery {\n    id\n    name\n    children {\n      id\n      name\n    }\n  }\n}"
 
             class NestedQuery(
-              private val graphQLClient: GraphQLClient
+              private val graphQLClient: GraphQLClient<*>
             ) {
               suspend fun execute(): GraphQLResult<NestedQuery.NestedQueryResult> =
                   graphQLClient.execute(NESTED_QUERY, "NestedQuery", null)

--- a/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLUnionTypeSpecIT.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLUnionTypeSpecIT.kt
@@ -43,7 +43,7 @@ class GenerateGraphQLUnionTypeSpecIT {
                 "query UnionQueryWithInlineFragments {\n  unionQuery {\n    __typename\n    ... on BasicObject {\n      id\n      name\n    }\n    ... on ComplexObject {\n      id\n      name\n      optional\n    }\n  }\n}"
 
             class UnionQueryWithInlineFragments(
-              private val graphQLClient: GraphQLClient
+              private val graphQLClient: GraphQLClient<*>
             ) {
               suspend fun execute():
                   GraphQLResult<UnionQueryWithInlineFragments.UnionQueryWithInlineFragmentsResult> =
@@ -141,7 +141,7 @@ class GenerateGraphQLUnionTypeSpecIT {
                 "query UnionQueryWithNamedFragments {\n  unionQuery {\n    ... basicObjectFields\n    ... complexObjectFields\n  }\n}\n\nfragment basicObjectFields on BasicObject {\n  __typename\n  id\n  name\n}\nfragment complexObjectFields on ComplexObject {\n  __typename\n  id\n  name\n  optional\n}"
 
             class UnionQueryWithNamedFragments(
-              private val graphQLClient: GraphQLClient
+              private val graphQLClient: GraphQLClient<*>
             ) {
               suspend fun execute():
                   GraphQLResult<UnionQueryWithNamedFragments.UnionQueryWithNamedFragmentsResult> =

--- a/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLUnionTypeSpecIT.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLUnionTypeSpecIT.kt
@@ -45,8 +45,7 @@ class GenerateGraphQLUnionTypeSpecIT {
             class UnionQueryWithInlineFragments(
               private val graphQLClient: GraphQLClient<*>
             ) {
-              suspend fun execute():
-                  GraphQLResult<UnionQueryWithInlineFragments.UnionQueryWithInlineFragmentsResult> =
+              suspend fun execute(): GraphQLResult<UnionQueryWithInlineFragments.Result> =
                   graphQLClient.execute(UNION_QUERY_WITH_INLINE_FRAGMENTS, "UnionQueryWithInlineFragments",
                   null)
 
@@ -96,7 +95,7 @@ class GenerateGraphQLUnionTypeSpecIT {
                   UnionQueryWithInlineFragments.ComplexObject::class, name="ComplexObject")])
               interface BasicUnion
 
-              data class UnionQueryWithInlineFragmentsResult(
+              data class Result(
                 /**
                  * Query returning union
                  */
@@ -143,8 +142,7 @@ class GenerateGraphQLUnionTypeSpecIT {
             class UnionQueryWithNamedFragments(
               private val graphQLClient: GraphQLClient<*>
             ) {
-              suspend fun execute():
-                  GraphQLResult<UnionQueryWithNamedFragments.UnionQueryWithNamedFragmentsResult> =
+              suspend fun execute(): GraphQLResult<UnionQueryWithNamedFragments.Result> =
                   graphQLClient.execute(UNION_QUERY_WITH_NAMED_FRAGMENTS, "UnionQueryWithNamedFragments", null)
 
               /**
@@ -193,7 +191,7 @@ class GenerateGraphQLUnionTypeSpecIT {
                   UnionQueryWithNamedFragments.ComplexObject::class, name="ComplexObject")])
               interface BasicUnion
 
-              data class UnionQueryWithNamedFragmentsResult(
+              data class Result(
                 /**
                  * Query returning union
                  */

--- a/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateVariableTypeSpecIT.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateVariableTypeSpecIT.kt
@@ -37,7 +37,7 @@ class GenerateVariableTypeSpecIT {
                 "query TestQueryWithVariables(${'$'}{'${'$'}'}criteria: SimpleArgumentInput) {\n  inputObjectQuery(criteria: ${'$'}{'${'$'}'}criteria)\n}"
 
             class TestQueryWithVariables(
-              private val graphQLClient: GraphQLClient
+              private val graphQLClient: GraphQLClient<*>
             ) {
               suspend fun execute(variables: TestQueryWithVariables.Variables):
                   GraphQLResult<TestQueryWithVariables.TestQueryWithVariablesResult> =

--- a/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateVariableTypeSpecIT.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateVariableTypeSpecIT.kt
@@ -40,7 +40,7 @@ class GenerateVariableTypeSpecIT {
               private val graphQLClient: GraphQLClient<*>
             ) {
               suspend fun execute(variables: TestQueryWithVariables.Variables):
-                  GraphQLResult<TestQueryWithVariables.TestQueryWithVariablesResult> =
+                  GraphQLResult<TestQueryWithVariables.Result> =
                   graphQLClient.execute(TEST_QUERY_WITH_VARIABLES, "TestQueryWithVariables", variables)
 
               data class Variables(
@@ -65,7 +65,7 @@ class GenerateVariableTypeSpecIT {
                 val newName: String?
               )
 
-              data class TestQueryWithVariablesResult(
+              data class Result(
                 /**
                  * Query that accepts some input arguments
                  */

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -61,6 +61,11 @@
       "spring-server/spring-graphql-context",
       "spring-server/subscriptions"
     ],
+    "HTTP Client": [
+      "client/client-overview",
+      "client/client-features",
+      "client/client-customization"
+    ],
     "Build Plugins": [
       "plugins/gradle-plugin",
       "plugins/maven-plugin"


### PR DESCRIPTION
* Update the client result class to be called `Result`
* Add the client docs to the docs website