### PR TITLE
[build] publish Gradle plugin to Maven Central

### DIFF
--- a/plugins/graphql-kotlin-gradle-plugin/README.md
+++ b/plugins/graphql-kotlin-gradle-plugin/README.md
@@ -1,5 +1,6 @@
 # GraphQL Kotlin Gradle Plugin
-
+[![Maven Central](https://img.shields.io/maven-central/v/com.expediagroup/graphql-kotlin-gradle-plugin.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22com.expediagroup%22%20AND%20a:%22graphql-kotlin-gradle-plugin%22)
+[![Javadocs](https://img.shields.io/maven-central/v/com.expediagroup/graphql-kotlin-gradle-plugin.svg?label=javadoc&colorB=brightgreen)](https://www.javadoc.io/doc/com.expediagroup/graphql-kotlin-gradle-plugin)
 [![Plugin Portal](https://img.shields.io/maven-metadata/v?label=Plugin%20Portal&metadataUrl=https%3A%2F%2Fplugins.gradle.org%2Fm2%2Fcom%2Fexpediagroup%2Fgraphql-kotlin-gradle-plugin%2Fmaven-metadata.xml)](https://plugins.gradle.org/plugin/com.expediagroup.graphql)
 
 GraphQL gradle plugin provides functionality to introspect GraphQL schemas and generate a lightweight GraphQL HTTP client.

--- a/plugins/graphql-kotlin-gradle-plugin/build.gradle.kts
+++ b/plugins/graphql-kotlin-gradle-plugin/build.gradle.kts
@@ -45,9 +45,18 @@ tasks {
             System.setProperty("gradle.publish.secret", System.getenv("PLUGIN_PORTAL_SECRET"))
         }
     }
-    withType<PublishToMavenRepository> {
-        // explicitly disable maven-publish tasks - task will be listed but will be disabled
-        enabled = false
+    publishing {
+        publications {
+            afterEvaluate {
+                named<MavenPublication>("graphQLPluginPluginMarkerMaven") {
+                    // update auto-generated pom.xml for plugin marker with required information
+                    pom {
+                        name.set(artifactId)
+                        description.set("Plugin descriptor for GraphQL Kotlin Gradle plugin")
+                    }
+                }
+            }
+        }
     }
     test {
         systemProperty("graphQLKotlinVersion", project.version)


### PR DESCRIPTION
### :pencil: Description
Enable publish of Gradle plugin to Maven Central.

### :link: Related Issues
Resolves https://github.com/ExpediaGroup/graphql-kotlin/issues/715