### PR TITLE
[plugins] Update Gradle plugin extension to separate client and schema generation

### DIFF
--- a/docs/plugins/gradle-plugin.md
+++ b/docs/plugins/gradle-plugin.md
@@ -31,16 +31,18 @@ tasks.
 import com.expediagroup.graphql.plugin.gradle.graphql
 
 graphql {
-  // GraphQL server endpoint that will be used to for running introspection queries. Alternatively you can download schema directly from `sdlEndpoint`.
-  endpoint = "http://localhost:8080/graphql"
-  // GraphQL server SDL endpoint that will be used to download schema. Alternatively you can run introspection query against `endpoint`.
-  sdlEndpoint = "http://localhost:8080/sdl"
-  // Target package name to be used for generated classes.
-  packageName = "com.example.generated"
-  // Boolean flag indicating whether or not selection of deprecated fields is allowed.
-  allowDeprecatedFields = false
-  // Custom GraphQL scalar to converter mapping containing information about corresponding Java type and converter that should be used to serialize/deserialize values.
-  converters.put("UUID", ScalarConverterMapping("java.util.UUID", "com.example.UUIDScalarConverter"))
+  client {
+    // GraphQL server endpoint that will be used to for running introspection queries. Alternatively you can download schema directly from `sdlEndpoint`.
+    endpoint = "http://localhost:8080/graphql"
+    // GraphQL server SDL endpoint that will be used to download schema. Alternatively you can run introspection query against `endpoint`.
+    sdlEndpoint = "http://localhost:8080/sdl"
+    // Target package name to be used for generated classes.
+    packageName = "com.example.generated"
+    // Boolean flag indicating whether or not selection of deprecated fields is allowed.
+    allowDeprecatedFields = false
+    // Custom GraphQL scalar to converter mapping containing information about corresponding Java type and converter that should be used to serialize/deserialize values.
+    converters.put("UUID", ScalarConverterMapping("java.util.UUID", "com.example.UUIDScalarConverter"))
+  }
 }
 ```
 
@@ -268,8 +270,10 @@ provided under `src/main/resources` directory.
 import com.expediagroup.graphql.plugin.gradle.graphql
 
 graphql {
+  client {
     endpoint = "http://localhost:8080/graphql"
     packageName = "com.example.generated"
+  }
 }
 ```
 

--- a/examples/client/gradle-client/build.gradle.kts
+++ b/examples/client/gradle-client/build.gradle.kts
@@ -36,13 +36,15 @@ application {
 }
 
 graphql {
-    packageName = "com.expediagroup.graphql.generated"
-    // you can also use direct sdlEndpoint instead
-    endpoint = "http://localhost:8080/graphql"
+    client {
+        packageName = "com.expediagroup.graphql.generated"
+        // you can also use direct sdlEndpoint instead
+        endpoint = "http://localhost:8080/graphql"
+        allowDeprecatedFields = true
+        // optional
+        converters["UUID"] = ScalarConverterMapping("java.util.UUID", "com.expediagroup.graphql.examples.client.UUIDScalarConverter")
+    }
 
-    // optional
-    allowDeprecatedFields = true
-    converters.put("UUID", ScalarConverterMapping("java.util.UUID", "com.expediagroup.graphql.examples.client.UUIDScalarConverter"))
 }
 
 tasks {

--- a/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLPluginExtension.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLPluginExtension.kt
@@ -17,15 +17,29 @@
 package com.expediagroup.graphql.plugin.gradle
 
 import com.expediagroup.graphql.plugin.generator.ScalarConverterMapping
-import org.gradle.api.Project
-import org.gradle.api.file.ConfigurableFileCollection
-import org.gradle.api.provider.MapProperty
+import java.io.File
 
 /**
  * GraphQL Kotlin Gradle Plugin extension.
  */
 @Suppress("UnstableApiUsage")
-open class GraphQLPluginExtension(project: Project) {
+open class GraphQLPluginExtension {
+
+    private var clientExtensionConfigured: Boolean = false
+    internal val clientExtension: GraphQLPluginClientExtension by lazy {
+        clientExtensionConfigured = true
+        GraphQLPluginClientExtension()
+    }
+
+    /** Plugin configuration for generating GraphQL client. */
+    fun client(config: GraphQLPluginClientExtension.() -> Unit = {}) {
+        clientExtension.apply(config)
+    }
+
+    internal fun isClientConfigurationAvailable(): Boolean = clientExtensionConfigured
+}
+
+open class GraphQLPluginClientExtension {
     /** GraphQL server endpoint that will be used to for running introspection queries. Alternatively you can download schema directly from [sdlEndpoint]. */
     var endpoint: String? = null
     /** GraphQL server SDL endpoint that will be used to download schema. Alternatively you can run introspection query against [endpoint]. */
@@ -35,7 +49,7 @@ open class GraphQLPluginExtension(project: Project) {
     /** Boolean flag indicating whether or not selection of deprecated fields is allowed. */
     var allowDeprecatedFields: Boolean = false
     /** Custom GraphQL scalar to converter mapping containing information about corresponding Java type and converter that should be used to serialize/deserialize values. */
-    val converters: MapProperty<String, ScalarConverterMapping> = project.objects.mapProperty(String::class.java, ScalarConverterMapping::class.java)
+    var converters: MutableMap<String, ScalarConverterMapping> = mutableMapOf()
     /** List of query files to be processed. */
-    var queryFiles: ConfigurableFileCollection = project.objects.fileCollection()
+    var queryFiles: MutableList<File> = mutableListOf()
 }

--- a/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePluginIT.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePluginIT.kt
@@ -39,9 +39,11 @@ class GraphQLGradlePluginIT : GraphQLGradlePluginAbstractIT() {
             }
 
             graphql {
-              endpoint = "${wireMockServer.baseUrl()}/graphql"
-              packageName = "com.example.generated"
-              converters.put("UUID", ScalarConverterMapping("java.util.UUID", "com.example.UUIDScalarConverter"))
+              client {
+                endpoint = "${wireMockServer.baseUrl()}/graphql"
+                packageName = "com.example.generated"
+                converters.put("UUID", ScalarConverterMapping("java.util.UUID", "com.example.UUIDScalarConverter"))
+              }
             }
         """.trimIndent()
         generateDefaultBuildFile(testDirectory).appendText(buildFileContents)


### PR DESCRIPTION
### :pencil: Description

Updating from:
```
graphql {
  endpoint = "http://localhost:8080/graphql"
  packageName = "com.example.generated"
```

to
```
graphql {
  client {
    endpoint = "http://localhost:8080/graphql"
    packageName = "com.example.generated"
  }
}
```

This will allow us to create separate `schema` configuration block in the future.

### :link: Related Issues

Related: https://github.com/ExpediaGroup/graphql-kotlin/issues/705