### PR TITLE
Move id to scalars package

### DIFF
--- a/examples/client/server/src/main/kotlin/com/expediagroup/graphql/examples/SimpleQueries.kt
+++ b/examples/client/server/src/main/kotlin/com/expediagroup/graphql/examples/SimpleQueries.kt
@@ -14,7 +14,7 @@ import com.expediagroup.graphql.examples.model.SecondInterfaceImplementation
 import com.expediagroup.graphql.examples.model.SimpleArgument
 import com.expediagroup.graphql.examples.repository.BasicObjectRepository
 import com.expediagroup.graphql.spring.operations.Query
-import com.expediagroup.graphql.types.ID
+import com.expediagroup.graphql.scalars.ID
 import org.springframework.stereotype.Component
 import java.util.UUID
 import kotlin.random.Random

--- a/examples/client/server/src/main/kotlin/com/expediagroup/graphql/examples/model/ScalarWrapper.kt
+++ b/examples/client/server/src/main/kotlin/com/expediagroup/graphql/examples/model/ScalarWrapper.kt
@@ -1,7 +1,7 @@
 package com.expediagroup.graphql.examples.model
 
 import com.expediagroup.graphql.annotations.GraphQLDescription
-import com.expediagroup.graphql.types.ID
+import com.expediagroup.graphql.scalars.ID
 import java.util.UUID
 
 @GraphQLDescription("Wrapper that holds all supported scalar types")

--- a/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/query/ScalarQuery.kt
+++ b/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/query/ScalarQuery.kt
@@ -19,7 +19,7 @@ package com.expediagroup.graphql.examples.query
 import com.expediagroup.graphql.annotations.GraphQLDescription
 import com.expediagroup.graphql.spring.operations.Mutation
 import com.expediagroup.graphql.spring.operations.Query
-import com.expediagroup.graphql.types.ID
+import com.expediagroup.graphql.scalars.ID
 import org.springframework.stereotype.Component
 import java.util.UUID
 

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/generateScalar.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/generateScalar.kt
@@ -19,7 +19,7 @@ package com.expediagroup.graphql.generator.types
 import com.expediagroup.graphql.generator.SchemaGenerator
 import com.expediagroup.graphql.generator.extensions.getKClass
 import com.expediagroup.graphql.generator.extensions.safeCast
-import com.expediagroup.graphql.types.ID
+import com.expediagroup.graphql.scalars.ID
 import graphql.Scalars
 import graphql.schema.GraphQLScalarType
 import java.math.BigDecimal

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/scalars/ID.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/scalars/ID.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.expediagroup.graphql.types
+package com.expediagroup.graphql.scalars
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonValue

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/extensions/GraphQLSchemaExtensionsTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/extensions/GraphQLSchemaExtensionsTest.kt
@@ -24,7 +24,7 @@ import com.expediagroup.graphql.annotations.GraphQLName
 import com.expediagroup.graphql.getTestSchemaConfigWithMockedDirectives
 import com.expediagroup.graphql.testSchemaConfig
 import com.expediagroup.graphql.toSchema
-import com.expediagroup.graphql.types.ID
+import com.expediagroup.graphql.scalars.ID
 import graphql.introspection.Introspection
 import graphql.schema.GraphQLSchema
 import org.junit.jupiter.api.Test

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/ToSchemaTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/ToSchemaTest.kt
@@ -26,7 +26,7 @@ import com.expediagroup.graphql.exceptions.GraphQLKotlinException
 import com.expediagroup.graphql.extensions.deepName
 import com.expediagroup.graphql.testSchemaConfig
 import com.expediagroup.graphql.toSchema
-import com.expediagroup.graphql.types.ID
+import com.expediagroup.graphql.scalars.ID
 import graphql.ExceptionWhileDataFetching
 import graphql.GraphQL
 import graphql.Scalars

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/GenerateArgumentTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/GenerateArgumentTest.kt
@@ -20,7 +20,7 @@ import com.expediagroup.graphql.annotations.GraphQLDescription
 import com.expediagroup.graphql.annotations.GraphQLName
 import com.expediagroup.graphql.exceptions.InvalidInputFieldTypeException
 import com.expediagroup.graphql.test.utils.SimpleDirective
-import com.expediagroup.graphql.types.ID
+import com.expediagroup.graphql.scalars.ID
 import graphql.Scalars
 import graphql.Scalars.GraphQLString
 import graphql.schema.GraphQLList

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/GenerateFunctionTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/GenerateFunctionTest.kt
@@ -23,7 +23,7 @@ import com.expediagroup.graphql.annotations.GraphQLName
 import com.expediagroup.graphql.exceptions.TypeNotSupportedException
 import com.expediagroup.graphql.execution.FunctionDataFetcher
 import com.expediagroup.graphql.execution.GraphQLContext
-import com.expediagroup.graphql.types.ID
+import com.expediagroup.graphql.scalars.ID
 import graphql.ExceptionWhileDataFetching
 import graphql.Scalars
 import graphql.Scalars.GraphQLInt

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/GeneratePropertyTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/GeneratePropertyTest.kt
@@ -26,7 +26,7 @@ import com.expediagroup.graphql.generator.SchemaGenerator
 import com.expediagroup.graphql.generator.extensions.getSimpleName
 import com.expediagroup.graphql.hooks.SchemaGeneratorHooks
 import com.expediagroup.graphql.test.utils.SimpleDirective
-import com.expediagroup.graphql.types.ID
+import com.expediagroup.graphql.scalars.ID
 import graphql.Scalars
 import graphql.introspection.Introspection
 import graphql.schema.DataFetcher

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/GenerateScalarTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/GenerateScalarTest.kt
@@ -16,7 +16,7 @@
 
 package com.expediagroup.graphql.generator.types
 
-import com.expediagroup.graphql.types.ID
+import com.expediagroup.graphql.scalars.ID
 import graphql.Scalars
 import graphql.schema.GraphQLScalarType
 import org.junit.jupiter.api.Test

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/test/integration/NodeGraphTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/test/integration/NodeGraphTest.kt
@@ -19,7 +19,7 @@ package com.expediagroup.graphql.test.integration
 import com.expediagroup.graphql.TopLevelObject
 import com.expediagroup.graphql.testSchemaConfig
 import com.expediagroup.graphql.toSchema
-import com.expediagroup.graphql.types.ID
+import com.expediagroup.graphql.scalars.ID
 import graphql.schema.GraphQLObjectType
 import graphql.schema.GraphQLTypeReference
 import org.junit.jupiter.api.Test

--- a/plugins/graphql-kotlin-maven-plugin/pom.xml
+++ b/plugins/graphql-kotlin-maven-plugin/pom.xml
@@ -7,7 +7,7 @@
     <!-- this pom is only used to run integration tests -->
     <groupId>com.expediagroup</groupId>
     <artifactId>graphql-kotlin-maven-plugin-integration-test</artifactId>
-    <version>${graphql-kotlin.version}</version>
+    <version>${graphqlKotlinVersion}</version>
     <description>Project for running integration tests verifying graphql-kotlin-maven-plugin</description>
 
     <properties>


### PR DESCRIPTION
### :pencil: Description
Rename the package to `com.expediagroup.graphql.scalars` so that we can create a new common module `graphql-kotlin-types` that will use `com.expediagroup.graphql.types`

### :link: Related Issues
N\A