### PR TITLE
[build] fix publishing of Gradle plugin marker

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,3 @@
-
 import de.marcphilipp.gradle.nexus.NexusPublishExtension
 import io.gitlab.arturbosch.detekt.detekt
 import org.jetbrains.dokka.gradle.DokkaTask
@@ -160,7 +159,8 @@ subprojects {
                         }
                     }
                     // no need to publish sources or javadocs for SNAPSHOT builds
-                    if (rootProject.extra["isReleaseVersion"] as Boolean) {
+                    // do not attach sources/javadoc to the Gradle plugin marker
+                    if (rootProject.extra["isReleaseVersion"] as Boolean && name != "graphQLPluginPluginMarkerMaven") {
                         artifact(sourcesJar.get())
                         artifact(javadocJar.get())
                     }


### PR DESCRIPTION
### :pencil: Description

Current logic was incorrectly attaching project sources+javadoc to the Maven publication. Since Gradle plugin produces two publications -> plugin + plugin marker both of them were uploaded with attached plugin sources+javadoc jars.

### :link: Related Issues
