### PR TITLE
[build] attempt to use default mavenJava publication for plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -124,7 +124,7 @@ subprojects {
         }
         publishing {
             publications {
-                withType<MavenPublication> {
+                create<MavenPublication>("mavenJava") {
                     pom {
                         name.set("${currentProject.group}:${currentProject.name}")
                         url.set("https://github.com/ExpediaGroup/graphql-kotlin")
@@ -158,18 +158,12 @@ subprojects {
                             mavenPom.description.set(currentProject.description)
                         }
                     }
+
+                    from(jarComponent)
                     // no need to publish sources or javadocs for SNAPSHOT builds
-                    // do not attach sources/javadoc to the Gradle plugin marker
-                    if (rootProject.extra["isReleaseVersion"] as Boolean && name != "graphQLPluginPluginMarkerMaven") {
+                    if (rootProject.extra["isReleaseVersion"] as Boolean) {
                         artifact(sourcesJar.get())
                         artifact(javadocJar.get())
-                    }
-                }
-
-                // workaround for java-gradle-plugin creating separate hardcoded pluginMaven publication
-                if (currentProject.name != "graphql-kotlin-gradle-plugin") {
-                    create<MavenPublication>("mavenJava") {
-                        from(jarComponent)
                     }
                 }
             }


### PR DESCRIPTION
### :pencil: Description

Our current build does not upload Gradle plugin jar artifact to Sonatype. Reverting back to the original publication logic - originally had an issue with mutliple artifacts sharing the coordinates, checking if that is still an issue. If nothing else works we might need to disable Sonatype publish of Gradle artifact for now.

### :link: Related Issues
