### PR TITLE
[plugins] fix GraphQLClientGenerator findRootType bug

### DIFF
--- a/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/GraphQLClientGenerator.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/GraphQLClientGenerator.kt
@@ -123,8 +123,8 @@ class GraphQLClientGenerator(
         } else {
             mapOf(
                 OperationDefinition.Operation.QUERY.name to "Query",
-                OperationDefinition.Operation.MUTATION to "Mutation",
-                OperationDefinition.Operation.SUBSCRIPTION to "Subscription"
+                OperationDefinition.Operation.MUTATION.name to "Mutation",
+                OperationDefinition.Operation.SUBSCRIPTION.name to "Subscription"
             )
         }
         val rootType = operationNames[operationDefinition.operation.name]


### PR DESCRIPTION
### :pencil: Description
Client generator did not generate `mutation` and `subscription` codes due to missing .name property call on enums, so changed that part

### :link: Related Issues
