### PR TITLE
Replace regex with printer option

### DIFF
--- a/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/FederatedSchemaGeneratorHooks.kt
+++ b/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/FederatedSchemaGeneratorHooks.kt
@@ -52,7 +52,6 @@ import kotlin.reflect.full.findAnnotation
  * Hooks for generating federated GraphQL schema.
  */
 open class FederatedSchemaGeneratorHooks(private val federatedTypeRegistry: FederatedTypeRegistry) : SchemaGeneratorHooks {
-    private val directiveDefinitionRegex = "(^\".+\"$[\\r\\n])?^directive @\\w+\\(.+\\) on .+?\$[\\r\\n]*".toRegex(setOf(RegexOption.MULTILINE, RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL))
     private val scalarDefinitionRegex = "(^\".+\"$[\\r\\n])?^scalar (_FieldSet|_Any)$[\\r\\n]*".toRegex(setOf(RegexOption.MULTILINE, RegexOption.IGNORE_CASE))
     private val emptyQueryRegex = "^type Query(?!\\s*\\{)\\s+".toRegex(setOf(RegexOption.MULTILINE, RegexOption.IGNORE_CASE))
     private val validator = FederatedSchemaValidator()
@@ -94,9 +93,11 @@ open class FederatedSchemaGeneratorHooks(private val federatedTypeRegistry: Fede
          *   - any custom directives
          *   - new federated scalars
          */
-        val sdl = originalSchema.print(includeDefaultSchemaDefinition = false, includeDirectivesFilter = customDirectivePredicate)
-            .replace(directiveDefinitionRegex, "")
-            .replace(scalarDefinitionRegex, "")
+        val sdl = originalSchema.print(
+            includeDefaultSchemaDefinition = false,
+            includeDirectiveDefinitions = false,
+            includeDirectivesFilter = customDirectivePredicate
+        ).replace(scalarDefinitionRegex, "")
             .replace(emptyQueryRegex, "")
             .trim()
         federatedCodeRegistry.dataFetcher(FieldCoordinates.coordinates(originalQuery.name, SERVICE_FIELD_DEFINITION.name), DataFetcher { _Service(sdl) })

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/extensions/GraphQLSchemaExtensions.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/extensions/GraphQLSchemaExtensions.kt
@@ -30,13 +30,15 @@ import java.util.function.Predicate
  *   default root type names
  * @param includeDirectives boolean flag indicating whether SDL should include directive information
  * @param includeDirectivesFilter Predicate to filter out specifc directives. Defaults to filter all directives by the value of [includeDirectives]
+ * @param includeDirectiveDefinitions Include the definitions of directives at the top of the schema
  */
 fun GraphQLSchema.print(
     includeIntrospectionTypes: Boolean = false,
     includeScalarTypes: Boolean = true,
     includeDefaultSchemaDefinition: Boolean = true,
     includeDirectives: Boolean = true,
-    includeDirectivesFilter: Predicate<GraphQLDirective> = Predicate { includeDirectives }
+    includeDirectivesFilter: Predicate<GraphQLDirective> = Predicate { includeDirectives },
+    includeDirectiveDefinitions: Boolean = true
 ): String {
     val schemaPrinter = SchemaPrinter(
         SchemaPrinter.Options.defaultOptions()
@@ -45,6 +47,7 @@ fun GraphQLSchema.print(
             .includeSchemaDefinition(includeDefaultSchemaDefinition)
             .includeDirectives(includeDirectives)
             .includeDirectives(includeDirectivesFilter)
+            .includeDirectiveDefinitions(includeDirectiveDefinitions)
     )
     return schemaPrinter.print(this)
 }


### PR DESCRIPTION
### :pencil: Description
With the graphql-java 15 update, there was a new printer option to not include directive definitions so we can use that instead of a regex

### :link: Related Issues
https://github.com/ExpediaGroup/graphql-kotlin/pull/731