### PR TITLE
[plugin] generate separate file containing type aliases

### DIFF
--- a/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGenerateClientTaskIT.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGenerateClientTaskIT.kt
@@ -73,6 +73,7 @@ class GraphQLGenerateClientTaskIT : GraphQLGradlePluginAbstractIT() {
 
         assertEquals(TaskOutcome.SUCCESS, buildResult.task(":$GENERATE_CLIENT_TASK_NAME")?.outcome)
         assertTrue(File(testProjectDirectory, "build/generated/source/graphql/main/com/example/generated/JUnitQuery.kt").exists())
+        assertTrue(File(testProjectDirectory, "build/generated/source/graphql/main/com/example/generated/GraphQLTypeAliases.kt").exists())
         assertEquals(TaskOutcome.SUCCESS, buildResult.task(":run")?.outcome)
     }
 

--- a/plugins/graphql-kotlin-maven-plugin/src/integration/generate-client/src/test/kotlin/com/expediagroup/graphql/plugin/maven/GenerateClientMojoTest.kt
+++ b/plugins/graphql-kotlin-maven-plugin/src/integration/generate-client/src/test/kotlin/com/expediagroup/graphql/plugin/maven/GenerateClientMojoTest.kt
@@ -25,7 +25,9 @@ class GenerateClientMojoTest {
     @Test
     fun `verify client code was generated`() {
         val buildDirectory = System.getProperty("buildDirectory")
-        val path = Paths.get(buildDirectory, "generated-sources", "graphql", "com", "expediagroup", "graphql", "plugin", "generated", "ExampleQuery.kt")
-        assertTrue(path.toFile().exists(), "graphql client was generated")
+        val queryFilePath = Paths.get(buildDirectory, "generated-sources", "graphql", "com", "expediagroup", "graphql", "plugin", "generated", "ExampleQuery.kt")
+        assertTrue(queryFilePath.toFile().exists(), "graphql client query file was generated")
+        val typeAliasesFilePath = Paths.get(buildDirectory, "generated-sources", "graphql", "com", "expediagroup", "graphql", "plugin", "generated", "GraphQLTypeAliases.kt")
+        assertTrue(queryFilePath.toFile().exists(), "graphql client type aliases were generated")
     }
 }

--- a/plugins/graphql-kotlin-plugin-core/README.md
+++ b/plugins/graphql-kotlin-plugin-core/README.md
@@ -32,10 +32,7 @@ using [square/kotlinpoet](https://github.com/square/kotlinpoet) library.
 * Only a single operation per GraphQL query file is supported.
 * Subscriptions are currently NOT supported.
 * You cannot make multiple selections to the same GraphQL object with different fields within a single GraphQL query.
-  But you can have different selection sets across different GraphQL queries, e.g.
-* Anonymous operations are supported but will result in generic `AnonymousQuery` (for query operation) class. Plugins
-  do not keep track of state across different query generations so if you have multiple anonymous operations in a single
-  package your compilation will fail due to the generic class name collisions.
+  But you can have different selection sets across different GraphQL queries
 * Nested queries have limited support as same object will be used for ALL nested results. This means that you have to
   explicitly ask for data from ALL nested levels + the NULL/empty child following it (that may skip recursive field selection
   as it will be NULL)

--- a/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generateClient.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generateClient.kt
@@ -32,7 +32,5 @@ fun generateClient(
 ): List<FileSpec> {
     val graphQLSchema = SchemaParser().parse(schema)
     val generator = GraphQLClientGenerator(graphQLSchema, config)
-    return queries.map { queryFile ->
-        generator.generate(queryFile)
-    }
+    return generator.generate(queries)
 }

--- a/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/GraphQLTestUtils.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/GraphQLTestUtils.kt
@@ -16,6 +16,7 @@
 
 package com.expediagroup.graphql.plugin.generator
 
+import com.squareup.kotlinpoet.FileSpec
 import graphql.schema.idl.SchemaParser
 import graphql.schema.idl.TypeDefinitionRegistry
 import kotlin.test.assertEquals
@@ -27,17 +28,23 @@ internal fun testSchema(): TypeDefinitionRegistry {
     }
 }
 
-internal fun verifyGraphQLClientGeneration(
+internal fun generateTestFileSpec(
     query: String,
-    expected: String,
     graphQLConfig: GraphQLClientGeneratorConfig = GraphQLClientGeneratorConfig(packageName = "com.expediagroup.graphql.plugin.generator.integration")
-) {
+): List<FileSpec> {
     val queryFile = createTempFile(suffix = ".graphql")
     queryFile.deleteOnExit()
     queryFile.writeText(query)
 
     val generator = GraphQLClientGenerator(testSchema(), graphQLConfig)
-    val fileSpec = generator.generate(queryFile)
+    return generator.generate(listOf(queryFile))
+}
 
-    assertEquals(expected, fileSpec.toString().trim())
+internal fun verifyGeneratedFileSpecContents(
+    query: String,
+    expected: String,
+    graphQLConfig: GraphQLClientGeneratorConfig = GraphQLClientGeneratorConfig(packageName = "com.expediagroup.graphql.plugin.generator.integration")
+) {
+    val fileSpecs = generateTestFileSpec(query, graphQLConfig)
+    assertEquals(expected, fileSpecs.first().toString().trim())
 }

--- a/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLCustomScalarTypeSpecIT.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLCustomScalarTypeSpecIT.kt
@@ -18,7 +18,7 @@ package com.expediagroup.graphql.plugin.generator.types
 
 import com.expediagroup.graphql.plugin.generator.GraphQLClientGeneratorConfig
 import com.expediagroup.graphql.plugin.generator.ScalarConverterMapping
-import com.expediagroup.graphql.plugin.generator.verifyGraphQLClientGeneration
+import com.expediagroup.graphql.plugin.generator.verifyGeneratedFileSpecContents
 import org.junit.jupiter.api.Test
 
 class GenerateGraphQLCustomScalarTypeSpecIT {
@@ -90,7 +90,7 @@ class GenerateGraphQLCustomScalarTypeSpecIT {
             }
         """.trimIndent()
 
-        verifyGraphQLClientGeneration(
+        verifyGeneratedFileSpecContents(
             query,
             expected,
             GraphQLClientGeneratorConfig(

--- a/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLEnumTypeSpecIT.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLEnumTypeSpecIT.kt
@@ -16,7 +16,7 @@
 
 package com.expediagroup.graphql.plugin.generator.types
 
-import com.expediagroup.graphql.plugin.generator.verifyGraphQLClientGeneration
+import com.expediagroup.graphql.plugin.generator.verifyGeneratedFileSpecContents
 import org.junit.jupiter.api.Test
 
 class GenerateGraphQLEnumTypeSpecIT {
@@ -82,6 +82,6 @@ class GenerateGraphQLEnumTypeSpecIT {
             }
         """.trimIndent()
 
-        verifyGraphQLClientGeneration(query, expected)
+        verifyGeneratedFileSpecContents(query, expected)
     }
 }

--- a/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLInputObjectTypeSpecIT.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLInputObjectTypeSpecIT.kt
@@ -16,7 +16,7 @@
 
 package com.expediagroup.graphql.plugin.generator.types
 
-import com.expediagroup.graphql.plugin.generator.verifyGraphQLClientGeneration
+import com.expediagroup.graphql.plugin.generator.verifyGeneratedFileSpecContents
 import org.junit.jupiter.api.Test
 
 class GenerateGraphQLInputObjectTypeSpecIT {
@@ -54,7 +54,7 @@ class GenerateGraphQLInputObjectTypeSpecIT {
               inputObjectQuery(criteria: { min: 1.0, max: 5.0 } )
             }
         """.trimIndent()
-        verifyGraphQLClientGeneration(query, expected)
+        verifyGeneratedFileSpecContents(query, expected)
     }
 
     @Test
@@ -95,6 +95,6 @@ class GenerateGraphQLInputObjectTypeSpecIT {
               second: inputObjectQuery(criteria: { min: 5.0, max: 10.0 } )
             }
         """.trimIndent()
-        verifyGraphQLClientGeneration(query, expected)
+        verifyGeneratedFileSpecContents(query, expected)
     }
 }

--- a/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLInterfaceTypeSpecIT.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLInterfaceTypeSpecIT.kt
@@ -16,7 +16,7 @@
 
 package com.expediagroup.graphql.plugin.generator.types
 
-import com.expediagroup.graphql.plugin.generator.verifyGraphQLClientGeneration
+import com.expediagroup.graphql.plugin.generator.verifyGeneratedFileSpecContents
 import graphql.language.SelectionSet
 import io.mockk.mockk
 import org.junit.jupiter.api.Test
@@ -134,7 +134,7 @@ class GenerateGraphQLInterfaceTypeSpecIT {
               }
             }
         """.trimIndent()
-        verifyGraphQLClientGeneration(query, expected)
+        verifyGeneratedFileSpecContents(query, expected)
     }
 
     @Test
@@ -254,7 +254,7 @@ class GenerateGraphQLInterfaceTypeSpecIT {
               floatValue
             }
         """.trimIndent()
-        verifyGraphQLClientGeneration(queryWithNamedFragments, expected)
+        verifyGeneratedFileSpecContents(queryWithNamedFragments, expected)
     }
 
     @Test
@@ -281,7 +281,7 @@ class GenerateGraphQLInterfaceTypeSpecIT {
             }
         """.trimIndent()
         assertThrows<RuntimeException> {
-            verifyGraphQLClientGeneration(invalidQuery, "will throw exception")
+            verifyGeneratedFileSpecContents(invalidQuery, "will throw exception")
         }
     }
 
@@ -300,7 +300,7 @@ class GenerateGraphQLInterfaceTypeSpecIT {
             }
         """.trimIndent()
         assertThrows<RuntimeException> {
-            verifyGraphQLClientGeneration(invalidQuery, "will throw exception")
+            verifyGeneratedFileSpecContents(invalidQuery, "will throw exception")
         }
     }
 }

--- a/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLObjectTypeSpecIT.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLObjectTypeSpecIT.kt
@@ -17,7 +17,7 @@
 package com.expediagroup.graphql.plugin.generator.types
 
 import com.expediagroup.graphql.plugin.generator.GraphQLClientGeneratorConfig
-import com.expediagroup.graphql.plugin.generator.verifyGraphQLClientGeneration
+import com.expediagroup.graphql.plugin.generator.verifyGeneratedFileSpecContents
 import graphql.language.SelectionSet
 import io.mockk.mockk
 import org.junit.jupiter.api.Test
@@ -110,7 +110,7 @@ class GenerateGraphQLObjectTypeSpecIT {
               }
             }
         """.trimIndent()
-        verifyGraphQLClientGeneration(query, expected)
+        verifyGeneratedFileSpecContents(query, expected)
     }
 
     @Test
@@ -191,7 +191,7 @@ class GenerateGraphQLObjectTypeSpecIT {
               value
             }
         """.trimIndent()
-        verifyGraphQLClientGeneration(queryWithNamedFragment, expected)
+        verifyGeneratedFileSpecContents(queryWithNamedFragment, expected)
     }
 
     @Test
@@ -204,7 +204,7 @@ class GenerateGraphQLObjectTypeSpecIT {
             }
         """.trimIndent()
         assertThrows<RuntimeException> {
-            verifyGraphQLClientGeneration(invalidQuery, "will throw exception")
+            verifyGeneratedFileSpecContents(invalidQuery, "will throw exception")
         }
     }
 
@@ -227,7 +227,7 @@ class GenerateGraphQLObjectTypeSpecIT {
             }
         """.trimIndent()
         assertThrows<RuntimeException> {
-            verifyGraphQLClientGeneration(invalidQuery, "will throw exception")
+            verifyGeneratedFileSpecContents(invalidQuery, "will throw exception")
         }
     }
 
@@ -279,7 +279,7 @@ class GenerateGraphQLObjectTypeSpecIT {
               }
             }
         """.trimIndent()
-        verifyGraphQLClientGeneration(query, expected)
+        verifyGeneratedFileSpecContents(query, expected)
     }
 
     @Test
@@ -290,7 +290,7 @@ class GenerateGraphQLObjectTypeSpecIT {
             }
         """.trimIndent()
         assertThrows<RuntimeException> {
-            verifyGraphQLClientGeneration(invalidQuery, "will throw exception")
+            verifyGeneratedFileSpecContents(invalidQuery, "will throw exception")
         }
     }
 
@@ -327,7 +327,7 @@ class GenerateGraphQLObjectTypeSpecIT {
               deprecatedQuery
             }
         """.trimIndent()
-        verifyGraphQLClientGeneration(
+        verifyGeneratedFileSpecContents(
             invalidQuery,
             expected,
             GraphQLClientGeneratorConfig(
@@ -394,6 +394,6 @@ class GenerateGraphQLObjectTypeSpecIT {
               }
             }
         """.trimIndent()
-        verifyGraphQLClientGeneration(nestedQuery, expected)
+        verifyGeneratedFileSpecContents(nestedQuery, expected)
     }
 }

--- a/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLUnionTypeSpecIT.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLUnionTypeSpecIT.kt
@@ -16,7 +16,7 @@
 
 package com.expediagroup.graphql.plugin.generator.types
 
-import com.expediagroup.graphql.plugin.generator.verifyGraphQLClientGeneration
+import com.expediagroup.graphql.plugin.generator.verifyGeneratedFileSpecContents
 import graphql.language.SelectionSet
 import io.mockk.mockk
 import org.junit.jupiter.api.Test
@@ -119,7 +119,7 @@ class GenerateGraphQLUnionTypeSpecIT {
               }
             }
         """.trimIndent()
-        verifyGraphQLClientGeneration(queryWithInlineFragments, expected)
+        verifyGeneratedFileSpecContents(queryWithInlineFragments, expected)
     }
 
     @Test
@@ -219,7 +219,7 @@ class GenerateGraphQLUnionTypeSpecIT {
               optional
             }
         """.trimIndent()
-        verifyGraphQLClientGeneration(queryWithNamedFragments, expected)
+        verifyGeneratedFileSpecContents(queryWithNamedFragments, expected)
     }
 
     @Test
@@ -236,7 +236,7 @@ class GenerateGraphQLUnionTypeSpecIT {
             }
         """.trimIndent()
         assertThrows<RuntimeException> {
-            verifyGraphQLClientGeneration(invalidQuery, "should throw exception")
+            verifyGeneratedFileSpecContents(invalidQuery, "should throw exception")
         }
     }
 
@@ -258,7 +258,7 @@ class GenerateGraphQLUnionTypeSpecIT {
             }
         """.trimIndent()
         assertThrows<RuntimeException> {
-            verifyGraphQLClientGeneration(invalidQuery, "should throw exception")
+            verifyGeneratedFileSpecContents(invalidQuery, "should throw exception")
         }
     }
 
@@ -295,7 +295,7 @@ class GenerateGraphQLUnionTypeSpecIT {
             }
         """.trimIndent()
         assertThrows<RuntimeException> {
-            verifyGraphQLClientGeneration(invalidQuery, "will throw exception")
+            verifyGeneratedFileSpecContents(invalidQuery, "will throw exception")
         }
     }
 
@@ -323,7 +323,7 @@ class GenerateGraphQLUnionTypeSpecIT {
             }
         """.trimIndent()
         val exception = assertThrows<RuntimeException> {
-            verifyGraphQLClientGeneration(invalidQuery, "will throw exception")
+            verifyGeneratedFileSpecContents(invalidQuery, "will throw exception")
         }
         assertEquals("multiple selections of ComplexObject GraphQL type with different selection sets - missing __typename", exception.message)
     }

--- a/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateVariableTypeSpecIT.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateVariableTypeSpecIT.kt
@@ -16,7 +16,7 @@
 
 package com.expediagroup.graphql.plugin.generator.types
 
-import com.expediagroup.graphql.plugin.generator.verifyGraphQLClientGeneration
+import com.expediagroup.graphql.plugin.generator.verifyGeneratedFileSpecContents
 import org.junit.jupiter.api.Test
 
 class GenerateVariableTypeSpecIT {
@@ -78,6 +78,6 @@ class GenerateVariableTypeSpecIT {
               inputObjectQuery(criteria: ${'$'}criteria)
             }
         """.trimIndent()
-        verifyGraphQLClientGeneration(query, expected)
+        verifyGeneratedFileSpecContents(query, expected)
     }
 }


### PR DESCRIPTION
### :pencil: Description

Type aliases are unique per package so in order to ensure consistency we should generate separate file that will contain all String type aliases for custom scalars/IDs. Currently we generate typealiases per query file which means that if there are multiple queries referencing IDs (or custom scalars without custom mappers) we end up with invalid generated code due to the type aliases clash.

With this PR also update default anonymous operation handling to use enclosing file name as the class name (instead of generic `AnonymousQuery/AnonymousMutation`).

### :link: Related Issues

Resolves: https://github.com/ExpediaGroup/graphql-kotlin/issues/746