### PR TITLE
[client] support different selection sets against same object

### DIFF
--- a/plugins/graphql-kotlin-gradle-plugin/src/test/resources/mocks/JUnitQuery.graphql
+++ b/plugins/graphql-kotlin-gradle-plugin/src/test/resources/mocks/JUnitQuery.graphql
@@ -9,12 +9,10 @@ query JUnitQuery($simpleCriteria: SimpleArgumentInput!) {
     valid
   }
   listQuery {
-    __typename
     id
     name
   }
   complexObjectQuery {
-    __typename
     id
     name
     optional

--- a/plugins/graphql-kotlin-gradle-plugin/src/test/resources/mocks/JUnitQueryResponse.json
+++ b/plugins/graphql-kotlin-gradle-plugin/src/test/resources/mocks/JUnitQueryResponse.json
@@ -11,13 +11,11 @@
     },
     "listQuery": [
       {
-        "__typename": "BasicObject",
         "id": 195555040,
         "name": "whatever"
       }
     ],
     "complexObjectQuery": {
-      "__typename": "ComplexObject",
       "id": 888961957,
       "name": "whatever",
       "optional": null,

--- a/plugins/graphql-kotlin-gradle-plugin/src/test/resources/templates/Application.mustache
+++ b/plugins/graphql-kotlin-gradle-plugin/src/test/resources/templates/Application.mustache
@@ -28,7 +28,7 @@ fun main() {
         val interfaceResult = data?.interfaceQuery
         assert(interfaceResult is JUnitQuery.SecondInterfaceImplementation)
         val unionResult = data?.unionQuery
-        assert(unionResult is JUnitQuery.BasicObject)
+        assert(unionResult is JUnitQuery.BasicObject2)
         assert(response.errors == null)
         assert(response.extensions == null)
     }

--- a/plugins/graphql-kotlin-gradle-plugin/src/test/resources/templates/JUnit.mustache
+++ b/plugins/graphql-kotlin-gradle-plugin/src/test/resources/templates/JUnit.mustache
@@ -48,7 +48,7 @@ class GraphQLMavenPluginTest {
                 val interfaceResult = data?.interfaceQuery
                 assertTrue(interfaceResult is JUnitQuery.SecondInterfaceImplementation)
                 val unionResult = data?.unionQuery
-                assertTrue(unionResult is JUnitQuery.BasicObject)
+                assertTrue(unionResult is JUnitQuery.BasicObject2)
             }
         }
     }

--- a/plugins/graphql-kotlin-maven-plugin/src/integration/basic-setup/src/main/resources/ExampleQuery.graphql
+++ b/plugins/graphql-kotlin-maven-plugin/src/integration/basic-setup/src/main/resources/ExampleQuery.graphql
@@ -9,12 +9,10 @@ query ExampleQuery($simpleCriteria: SimpleArgumentInput!) {
     valid
   }
   listQuery {
-    __typename
     id
     name
   }
   complexObjectQuery {
-    __typename
     id
     name
     optional

--- a/plugins/graphql-kotlin-maven-plugin/src/integration/basic-setup/src/test/kotlin/com/expediagroup/graphql/plugin/maven/GraphQLMavenPluginTest.kt
+++ b/plugins/graphql-kotlin-maven-plugin/src/integration/basic-setup/src/test/kotlin/com/expediagroup/graphql/plugin/maven/GraphQLMavenPluginTest.kt
@@ -66,7 +66,7 @@ class GraphQLMavenPluginTest {
                 val interfaceResult = data?.interfaceQuery
                 assertTrue(interfaceResult is ExampleQuery.SecondInterfaceImplementation)
                 val unionResult = data?.unionQuery
-                assertTrue(unionResult is ExampleQuery.BasicObject)
+                assertTrue(unionResult is ExampleQuery.BasicObject2)
             }
         }
     }

--- a/plugins/graphql-kotlin-maven-plugin/src/integration/complete-setup/src/main/resources/ExampleQuery.graphql
+++ b/plugins/graphql-kotlin-maven-plugin/src/integration/complete-setup/src/main/resources/ExampleQuery.graphql
@@ -9,12 +9,10 @@ query ExampleQuery($simpleCriteria: SimpleArgumentInput!) {
     valid
   }
   listQuery {
-    __typename
     id
     name
   }
   complexObjectQuery {
-    __typename
     id
     name
     optional

--- a/plugins/graphql-kotlin-maven-plugin/src/integration/complete-setup/src/test/kotlin/com/expediagroup/graphql/plugin/maven/GraphQLMavenPluginTest.kt
+++ b/plugins/graphql-kotlin-maven-plugin/src/integration/complete-setup/src/test/kotlin/com/expediagroup/graphql/plugin/maven/GraphQLMavenPluginTest.kt
@@ -66,7 +66,7 @@ class GraphQLMavenPluginTest {
                 val interfaceResult = data?.interfaceQuery
                 assertTrue(interfaceResult is ExampleQuery.SecondInterfaceImplementation)
                 val unionResult = data?.unionQuery
-                assertTrue(unionResult is ExampleQuery.BasicObject)
+                assertTrue(unionResult is ExampleQuery.BasicObject2)
             }
         }
     }

--- a/plugins/graphql-kotlin-maven-plugin/src/integration/generate-client/src/main/resources/ExampleQuery.graphql
+++ b/plugins/graphql-kotlin-maven-plugin/src/integration/generate-client/src/main/resources/ExampleQuery.graphql
@@ -9,12 +9,10 @@ query ExampleQuery($simpleCriteria: SimpleArgumentInput!) {
     valid
   }
   listQuery {
-    __typename
     id
     name
   }
   complexObjectQuery {
-    __typename
     id
     name
     optional

--- a/plugins/graphql-kotlin-maven-plugin/src/integration/generate-test-client/src/test/resources/ExampleQuery.graphql
+++ b/plugins/graphql-kotlin-maven-plugin/src/integration/generate-test-client/src/test/resources/ExampleQuery.graphql
@@ -9,12 +9,10 @@ query ExampleQuery($simpleCriteria: SimpleArgumentInput!) {
     valid
   }
   listQuery {
-    __typename
     id
     name
   }
   complexObjectQuery {
-    __typename
     id
     name
     optional

--- a/plugins/graphql-kotlin-maven-plugin/src/integration/wiremock/__files/response.json
+++ b/plugins/graphql-kotlin-maven-plugin/src/integration/wiremock/__files/response.json
@@ -11,13 +11,11 @@
     },
     "listQuery": [
       {
-        "__typename": "BasicObject",
         "id": 195555040,
         "name": "whatever"
       }
     ],
     "complexObjectQuery": {
-      "__typename": "ComplexObject",
       "id": 888961957,
       "name": "whatever",
       "optional": null,

--- a/plugins/graphql-kotlin-plugin-core/README.md
+++ b/plugins/graphql-kotlin-plugin-core/README.md
@@ -31,8 +31,6 @@ using [square/kotlinpoet](https://github.com/square/kotlinpoet) library.
 * Due to the custom logic required for deserialization of polymorphic types and default enum values only Jackson is currently supported.
 * Only a single operation per GraphQL query file is supported.
 * Subscriptions are currently NOT supported.
-* You cannot make multiple selections to the same GraphQL object with different fields within a single GraphQL query.
-  But you can have different selection sets across different GraphQL queries
 * Nested queries have limited support as same object will be used for ALL nested results. This means that you have to
   explicitly ask for data from ALL nested levels + the NULL/empty child following it (that may skip recursive field selection
   as it will be NULL)

--- a/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/GraphQLClientGeneratorContext.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/GraphQLClientGeneratorContext.kt
@@ -35,7 +35,7 @@ data class GraphQLClientGeneratorContext(
     val allowDeprecated: Boolean = false,
     val scalarTypeToConverterMapping: Map<String, ScalarConverterMapping> = emptyMap()
 ) {
-    val classNameCache: MutableMap<String, ClassName> = mutableMapOf()
+    val classNameCache: MutableMap<String, MutableList<ClassName>> = mutableMapOf()
     val typeSpecs: MutableMap<String, TypeSpec> = mutableMapOf()
     val typeAliases: MutableMap<String, TypeAliasSpec> = mutableMapOf()
     val objectsWithTypeNameSelection: MutableSet<String> = mutableSetOf()

--- a/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/types/generateGraphQLInterfaceTypeSpec.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/types/generateGraphQLInterfaceTypeSpec.kt
@@ -27,21 +27,27 @@ import graphql.language.SelectionSet
  * @see generateGraphQLUnionTypeSpec
  * @see generateInterfaceTypeSpec
  */
-internal fun generateGraphQLInterfaceTypeSpec(context: GraphQLClientGeneratorContext, interfaceDefinition: InterfaceTypeDefinition, selectionSet: SelectionSet?): TypeSpec {
+internal fun generateGraphQLInterfaceTypeSpec(
+    context: GraphQLClientGeneratorContext,
+    interfaceDefinition: InterfaceTypeDefinition,
+    selectionSet: SelectionSet?,
+    interfaceNameOverride: String? = null
+): TypeSpec {
     if (selectionSet == null || selectionSet.selections.isEmpty()) {
         throw RuntimeException("cannot select empty interface")
     }
 
+    val interfaceName = interfaceNameOverride ?: interfaceDefinition.name
     val implementations = context.graphQLSchema.getImplementationsOf(interfaceDefinition).map { it.name }
     val interfaceType = generateInterfaceTypeSpec(
         context = context,
-        interfaceName = interfaceDefinition.name,
+        interfaceName = interfaceName,
         kdoc = interfaceDefinition.description?.content,
         fields = interfaceDefinition.fieldDefinitions,
         selectionSet = selectionSet,
         implementations = implementations
     )
 
-    context.typeSpecs[interfaceDefinition.name] = interfaceType
+    context.typeSpecs[interfaceName] = interfaceType
     return interfaceType
 }

--- a/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/types/generateGraphQLObjectTypeSpec.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/types/generateGraphQLObjectTypeSpec.kt
@@ -28,7 +28,12 @@ import graphql.language.SelectionSet
 /**
  * Generate [TypeSpec] data class from the GraphQL object definition based on the selection set.
  */
-internal fun generateGraphQLObjectTypeSpec(context: GraphQLClientGeneratorContext, objectDefinition: ObjectTypeDefinition, selectionSet: SelectionSet?, objectNameOverride: String? = null): TypeSpec {
+internal fun generateGraphQLObjectTypeSpec(
+    context: GraphQLClientGeneratorContext,
+    objectDefinition: ObjectTypeDefinition,
+    selectionSet: SelectionSet?,
+    objectNameOverride: String? = null
+): TypeSpec {
     if (selectionSet == null || selectionSet.selections.isEmpty()) {
         throw RuntimeException("cannot select empty objects")
     }
@@ -66,6 +71,7 @@ internal fun generateGraphQLObjectTypeSpec(context: GraphQLClientGeneratorContex
                 constructorBuilder.addParameter(propertySpec.name, propertySpec.type)
             }
         }
+
     objectTypeSpecBuilder.primaryConstructor(constructorBuilder.build())
 
     val objectTypeSpec = objectTypeSpecBuilder.build()

--- a/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/types/generateGraphQLUnionTypeSpec.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/types/generateGraphQLUnionTypeSpec.kt
@@ -28,20 +28,26 @@ import graphql.language.UnionTypeDefinition
  * @see generateGraphQLInterfaceTypeSpec
  * @see generateInterfaceTypeSpec
  */
-internal fun generateGraphQLUnionTypeSpec(context: GraphQLClientGeneratorContext, unionDefinition: UnionTypeDefinition, selectionSet: SelectionSet?): TypeSpec {
+internal fun generateGraphQLUnionTypeSpec(
+    context: GraphQLClientGeneratorContext,
+    unionDefinition: UnionTypeDefinition,
+    selectionSet: SelectionSet?,
+    unionNameOverride: String? = null
+): TypeSpec {
     if (selectionSet == null || selectionSet.selections.isEmpty()) {
         throw RuntimeException("cannot select empty union")
     }
 
+    val unionName = unionNameOverride ?: unionDefinition.name
     val unionImplementations = unionDefinition.memberTypes.filterIsInstance(TypeName::class.java).map { it.name }
     val unionType = generateInterfaceTypeSpec(
         context = context,
-        interfaceName = unionDefinition.name,
+        interfaceName = unionName,
         kdoc = unionDefinition.description?.content,
         selectionSet = selectionSet,
         implementations = unionImplementations
     )
 
-    context.typeSpecs[unionDefinition.name] = unionType
+    context.typeSpecs[unionName] = unionType
     return unionType
 }

--- a/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLInputObjectTypeSpecIT.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLInputObjectTypeSpecIT.kt
@@ -56,45 +56,4 @@ class GenerateGraphQLInputObjectTypeSpecIT {
         """.trimIndent()
         verifyGeneratedFileSpecContents(query, expected)
     }
-
-    @Test
-    fun `verify we can generate objects using aliases`() {
-        val expected = """
-            package com.expediagroup.graphql.plugin.generator.integration
-
-            import com.expediagroup.graphql.client.GraphQLClient
-            import com.expediagroup.graphql.types.GraphQLResponse
-            import kotlin.Boolean
-            import kotlin.String
-
-            const val ALIAS_TEST_QUERY: String =
-                "query AliasTestQuery {\n  first: inputObjectQuery(criteria: { min: 1.0, max: 5.0 } )\n  second: inputObjectQuery(criteria: { min: 5.0, max: 10.0 } )\n}"
-
-            class AliasTestQuery(
-              private val graphQLClient: GraphQLClient<*>
-            ) {
-              suspend fun execute(): GraphQLResponse<AliasTestQuery.Result> =
-                  graphQLClient.execute(ALIAS_TEST_QUERY, "AliasTestQuery", null)
-
-              data class Result(
-                /**
-                 * Query that accepts some input arguments
-                 */
-                val first: Boolean,
-                /**
-                 * Query that accepts some input arguments
-                 */
-                val second: Boolean
-              )
-            }
-        """.trimIndent()
-
-        val query = """
-            query AliasTestQuery {
-              first: inputObjectQuery(criteria: { min: 1.0, max: 5.0 } )
-              second: inputObjectQuery(criteria: { min: 5.0, max: 10.0 } )
-            }
-        """.trimIndent()
-        verifyGeneratedFileSpecContents(query, expected)
-    }
 }

--- a/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLInterfaceTypeSpecIT.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLInterfaceTypeSpecIT.kt
@@ -303,4 +303,346 @@ class GenerateGraphQLInterfaceTypeSpecIT {
             verifyGeneratedFileSpecContents(invalidQuery, "will throw exception")
         }
     }
+
+    @Test
+    fun `verify graphql client generation supports different selection sets between interfaces`() {
+        val expected = """
+            package com.expediagroup.graphql.plugin.generator.integration
+
+            import com.expediagroup.graphql.client.GraphQLClient
+            import com.expediagroup.graphql.types.GraphQLResponse
+            import com.fasterxml.jackson.annotation.JsonSubTypes
+            import com.fasterxml.jackson.annotation.JsonTypeInfo
+            import com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY
+            import com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME
+            import kotlin.Float
+            import kotlin.Int
+            import kotlin.String
+
+            const val DIFFERENT_SELECTION_SET_QUERY: String =
+                "query DifferentSelectionSetQuery {\n  first: interfaceQuery {\n    __typename\n    id\n    name\n    ... on FirstInterfaceImplementation {\n      intValue\n    }\n    ... on SecondInterfaceImplementation {\n      floatValue\n    }\n  }\n  second: interfaceQuery {\n    __typename\n    name\n    ... on FirstInterfaceImplementation {\n      intValue\n    }\n    ... on SecondInterfaceImplementation {\n      floatValue\n    }\n  }\n}"
+
+            class DifferentSelectionSetQuery(
+              private val graphQLClient: GraphQLClient<*>
+            ) {
+              suspend fun execute(): GraphQLResponse<DifferentSelectionSetQuery.Result> =
+                  graphQLClient.execute(DIFFERENT_SELECTION_SET_QUERY, "DifferentSelectionSetQuery", null)
+
+              /**
+               * Example interface implementation where value is an integer
+               */
+              data class FirstInterfaceImplementation(
+                /**
+                 * Unique identifier of the first implementation
+                 */
+                override val id: Int,
+                /**
+                 * Name of the first implementation
+                 */
+                override val name: String,
+                /**
+                 * Custom field integer value
+                 */
+                val intValue: Int
+              ) : DifferentSelectionSetQuery.BasicInterface
+
+              /**
+               * Example interface implementation where value is a float
+               */
+              data class SecondInterfaceImplementation(
+                /**
+                 * Unique identifier of the second implementation
+                 */
+                override val id: Int,
+                /**
+                 * Name of the second implementation
+                 */
+                override val name: String,
+                /**
+                 * Custom field float value
+                 */
+                val floatValue: Float
+              ) : DifferentSelectionSetQuery.BasicInterface
+
+              /**
+               * Very basic interface
+               */
+              @JsonTypeInfo(
+                use = JsonTypeInfo.Id.NAME,
+                include = JsonTypeInfo.As.PROPERTY,
+                property = "__typename"
+              )
+              @JsonSubTypes(value = [com.fasterxml.jackson.annotation.JsonSubTypes.Type(value =
+                  DifferentSelectionSetQuery.FirstInterfaceImplementation::class,
+                  name="FirstInterfaceImplementation"),com.fasterxml.jackson.annotation.JsonSubTypes.Type(value
+                  = DifferentSelectionSetQuery.SecondInterfaceImplementation::class,
+                  name="SecondInterfaceImplementation")])
+              interface BasicInterface {
+                /**
+                 * Unique identifier of an interface
+                 */
+                val id: Int
+
+                /**
+                 * Name field
+                 */
+                val name: String
+              }
+
+              /**
+               * Example interface implementation where value is an integer
+               */
+              data class FirstInterfaceImplementation2(
+                /**
+                 * Name of the first implementation
+                 */
+                override val name: String,
+                /**
+                 * Custom field integer value
+                 */
+                val intValue: Int
+              ) : DifferentSelectionSetQuery.BasicInterface2
+
+              /**
+               * Example interface implementation where value is a float
+               */
+              data class SecondInterfaceImplementation2(
+                /**
+                 * Name of the second implementation
+                 */
+                override val name: String,
+                /**
+                 * Custom field float value
+                 */
+                val floatValue: Float
+              ) : DifferentSelectionSetQuery.BasicInterface2
+
+              /**
+               * Very basic interface
+               */
+              @JsonTypeInfo(
+                use = JsonTypeInfo.Id.NAME,
+                include = JsonTypeInfo.As.PROPERTY,
+                property = "__typename"
+              )
+              @JsonSubTypes(value = [com.fasterxml.jackson.annotation.JsonSubTypes.Type(value =
+                  DifferentSelectionSetQuery.FirstInterfaceImplementation2::class,
+                  name="FirstInterfaceImplementation"),com.fasterxml.jackson.annotation.JsonSubTypes.Type(value
+                  = DifferentSelectionSetQuery.SecondInterfaceImplementation2::class,
+                  name="SecondInterfaceImplementation")])
+              interface BasicInterface2 {
+                /**
+                 * Name field
+                 */
+                val name: String
+              }
+
+              data class Result(
+                /**
+                 * Query returning an interface
+                 */
+                val first: DifferentSelectionSetQuery.BasicInterface,
+                /**
+                 * Query returning an interface
+                 */
+                val second: DifferentSelectionSetQuery.BasicInterface2
+              )
+            }
+        """.trimIndent()
+        val differentSelectionQuery = """
+            query DifferentSelectionSetQuery {
+              first: interfaceQuery {
+                __typename
+                id
+                name
+                ... on FirstInterfaceImplementation {
+                  intValue
+                }
+                ... on SecondInterfaceImplementation {
+                  floatValue
+                }
+              }
+              second: interfaceQuery {
+                __typename
+                name
+                ... on FirstInterfaceImplementation {
+                  intValue
+                }
+                ... on SecondInterfaceImplementation {
+                  floatValue
+                }
+              }
+            }
+        """.trimIndent()
+        verifyGeneratedFileSpecContents(differentSelectionQuery, expected)
+    }
+
+    @Test
+    fun `verify graphql client generation supports different selection sets between interface implementations`() {
+        val expected = """
+            package com.expediagroup.graphql.plugin.generator.integration
+
+            import com.expediagroup.graphql.client.GraphQLClient
+            import com.expediagroup.graphql.types.GraphQLResponse
+            import com.fasterxml.jackson.annotation.JsonSubTypes
+            import com.fasterxml.jackson.annotation.JsonTypeInfo
+            import com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY
+            import com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME
+            import kotlin.Float
+            import kotlin.Int
+            import kotlin.String
+
+            const val DIFFERENT_SELECTION_SET_QUERY: String =
+                "query DifferentSelectionSetQuery {\n  first: interfaceQuery {\n    __typename\n    id\n    ... on FirstInterfaceImplementation {\n      intValue\n    }\n    ... on SecondInterfaceImplementation {\n      floatValue\n    }\n  }\n  second: interfaceQuery {\n    __typename\n    id\n    ... on FirstInterfaceImplementation {\n      name\n      intValue\n    }\n    ... on SecondInterfaceImplementation {\n      name\n      floatValue\n    }\n  }\n}"
+
+            class DifferentSelectionSetQuery(
+              private val graphQLClient: GraphQLClient<*>
+            ) {
+              suspend fun execute(): GraphQLResponse<DifferentSelectionSetQuery.Result> =
+                  graphQLClient.execute(DIFFERENT_SELECTION_SET_QUERY, "DifferentSelectionSetQuery", null)
+
+              /**
+               * Example interface implementation where value is an integer
+               */
+              data class FirstInterfaceImplementation(
+                /**
+                 * Unique identifier of the first implementation
+                 */
+                override val id: Int,
+                /**
+                 * Custom field integer value
+                 */
+                val intValue: Int
+              ) : DifferentSelectionSetQuery.BasicInterface
+
+              /**
+               * Example interface implementation where value is a float
+               */
+              data class SecondInterfaceImplementation(
+                /**
+                 * Unique identifier of the second implementation
+                 */
+                override val id: Int,
+                /**
+                 * Custom field float value
+                 */
+                val floatValue: Float
+              ) : DifferentSelectionSetQuery.BasicInterface
+
+              /**
+               * Very basic interface
+               */
+              @JsonTypeInfo(
+                use = JsonTypeInfo.Id.NAME,
+                include = JsonTypeInfo.As.PROPERTY,
+                property = "__typename"
+              )
+              @JsonSubTypes(value = [com.fasterxml.jackson.annotation.JsonSubTypes.Type(value =
+                  DifferentSelectionSetQuery.FirstInterfaceImplementation::class,
+                  name="FirstInterfaceImplementation"),com.fasterxml.jackson.annotation.JsonSubTypes.Type(value
+                  = DifferentSelectionSetQuery.SecondInterfaceImplementation::class,
+                  name="SecondInterfaceImplementation")])
+              interface BasicInterface {
+                /**
+                 * Unique identifier of an interface
+                 */
+                val id: Int
+              }
+
+              /**
+               * Example interface implementation where value is an integer
+               */
+              data class FirstInterfaceImplementation2(
+                /**
+                 * Unique identifier of the first implementation
+                 */
+                override val id: Int,
+                /**
+                 * Name of the first implementation
+                 */
+                val name: String,
+                /**
+                 * Custom field integer value
+                 */
+                val intValue: Int
+              ) : DifferentSelectionSetQuery.BasicInterface2
+
+              /**
+               * Example interface implementation where value is a float
+               */
+              data class SecondInterfaceImplementation2(
+                /**
+                 * Unique identifier of the second implementation
+                 */
+                override val id: Int,
+                /**
+                 * Name of the second implementation
+                 */
+                val name: String,
+                /**
+                 * Custom field float value
+                 */
+                val floatValue: Float
+              ) : DifferentSelectionSetQuery.BasicInterface2
+
+              /**
+               * Very basic interface
+               */
+              @JsonTypeInfo(
+                use = JsonTypeInfo.Id.NAME,
+                include = JsonTypeInfo.As.PROPERTY,
+                property = "__typename"
+              )
+              @JsonSubTypes(value = [com.fasterxml.jackson.annotation.JsonSubTypes.Type(value =
+                  DifferentSelectionSetQuery.FirstInterfaceImplementation2::class,
+                  name="FirstInterfaceImplementation"),com.fasterxml.jackson.annotation.JsonSubTypes.Type(value
+                  = DifferentSelectionSetQuery.SecondInterfaceImplementation2::class,
+                  name="SecondInterfaceImplementation")])
+              interface BasicInterface2 {
+                /**
+                 * Unique identifier of an interface
+                 */
+                val id: Int
+              }
+
+              data class Result(
+                /**
+                 * Query returning an interface
+                 */
+                val first: DifferentSelectionSetQuery.BasicInterface,
+                /**
+                 * Query returning an interface
+                 */
+                val second: DifferentSelectionSetQuery.BasicInterface2
+              )
+            }
+        """.trimIndent()
+        val differentSelectionQuery = """
+            query DifferentSelectionSetQuery {
+              first: interfaceQuery {
+                __typename
+                id
+                ... on FirstInterfaceImplementation {
+                  intValue
+                }
+                ... on SecondInterfaceImplementation {
+                  floatValue
+                }
+              }
+              second: interfaceQuery {
+                __typename
+                id
+                ... on FirstInterfaceImplementation {
+                  name
+                  intValue
+                }
+                ... on SecondInterfaceImplementation {
+                  name
+                  floatValue
+                }
+              }
+            }
+        """.trimIndent()
+        verifyGeneratedFileSpecContents(differentSelectionQuery, expected)
+    }
 }


### PR DESCRIPTION
### :pencil: Description

Allow querying same object type with different selection sets, e.g. given schema

```graphql
type Query {
  someObject: SomeObject!
}
type SomeObject {
  id: Int!
  name: String!
  optional: String
}
```

You can now write following queries

```graphql
query {
  first: someObject {
    id
    name
  }
  second: someObject {
    id
    name
    optional
  }
}
```

Plugins in turn will generate `SomeObject(id, name)` and `SomeObject2(id, name, optional)` data classes.

### :link: Related Issues

Resolves: https://github.com/ExpediaGroup/graphql-kotlin/issues/737