### PR TITLE
[client] expose request builder to allow customization per query execution

### DIFF
--- a/docs/client/client-customization.md
+++ b/docs/client/client-customization.md
@@ -13,13 +13,13 @@ See [Ktor HTTP Client documentation](https://ktor.io/clients/index.html) for add
 
 ### Global Client Customization
 
-Single instance of `GraphQLClient` can be used to power many GraphQL queries. You can specify target engine factory and
-configure it through corresponding [HttpClientConfig](https://api.ktor.io/1.3.2/io.ktor.client/-http-client-config/index.html).
-Ktor HTTP client provides a number of [standard features](https://ktor.io/clients/http-client/features.html) as well as
+A single instance of `GraphQLClient` can be used to power many GraphQL operations. You can specify a target engine factory and
+configure it through the corresponding [HttpClientConfig](https://api.ktor.io/1.3.2/io.ktor.client/-http-client-config/index.html).
+Ktor also provides a number of [standard HTTP features](https://ktor.io/clients/http-client/features.html) and
 allows you to easily create custom ones that can be configured globally.
 
-Example below configures new `GraphQLClient` to use `OkHttp` engine with custom timeouts, adds default `X-MY-API-KEY`
-header to all requests as well enables basic logging of the requests.
+The below example configures a new `GraphQLClient` to use the `OkHttp` engine with custom timeouts, adds a default `X-MY-API-KEY`
+header to all requests, and enables basic logging of the requests.
 
 ```kotlin
 val client = GraphQLClient(

--- a/docs/client/client-customization.md
+++ b/docs/client/client-customization.md
@@ -9,6 +9,18 @@ title: Client Customization
 engines (defaults to Coroutine-based IO) and HTTP client features. Custom configurations can be applied through Ktor DSL
 style builders.
 
+See [Ktor HTTP Client documentation](https://ktor.io/clients/index.html) for additional details.
+
+### Global Client Customization
+
+Single instance of `GraphQLClient` can be used to power many GraphQL queries. You can specify target engine factory and
+configure it through corresponding [HttpClientConfig](https://api.ktor.io/1.3.2/io.ktor.client/-http-client-config/index.html).
+Ktor HTTP client provides a number of [standard features](https://ktor.io/clients/http-client/features.html) as well as
+allows you to easily create custom ones that can be configured globally.
+
+Example below configures new `GraphQLClient` to use `OkHttp` engine with custom timeouts, adds default `X-MY-API-KEY`
+header to all requests as well enables basic logging of the requests.
+
 ```kotlin
 val client = GraphQLClient(
         url = URL("http://localhost:8080/graphql"),
@@ -21,18 +33,33 @@ val client = GraphQLClient(
             writeTimeout(60, TimeUnit.SECONDS)
         }
     }
+    defaultRequest {
+        header("X-MY-API-KEY", "someSecretApiKey")
+    }
     install(Logging) {
         logger = Logger.DEFAULT
-        level = LogLevel.HEADERS
+        level = LogLevel.INFO
     }
 }
 ```
 
-See [Ktor HTTP Client documentation](https://ktor.io/clients/index.html) for additional details.
+### Per Request Customization
+
+Individual GraphQL requests can be customized through [HttpRequestBuilder](https://api.ktor.io/1.3.2/io.ktor.client.request/-http-request-builder/).
+You can use this mechanism to specify custom headers, update target url to include custom query parameters, configure
+attributes that can be accessed from the pipeline features as well specify timeouts per request.
+
+```kotlin
+val helloWorldQuery = HelloWorldQuery(client)
+val result = helloWorldQuery.execute(variables = HelloWorldQuery.Variables(name = null)) {
+    header("X-B3-TraceId", "0123456789abcdef")
+}
+```
 
 ## Jackson Customization
 
-`GraphQLClient` relies on Jackson to handle polymorphic types and default enum values. Due to the necessary logic to
+`GraphQLClient` relies on Jackson to handle polymorphic types and default enum values. You can specify your own custom
+object mapper configured with some additional serialization/deserialization features but due to the necessary logic to
 handle the above, currently we don't support other JSON libraries.
 
 ```kotlin

--- a/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePluginAbstractIT.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePluginAbstractIT.kt
@@ -73,7 +73,7 @@ abstract class GraphQLGradlePluginAbstractIT {
         BufferedReader(it.reader()).readText()
     } ?: throw RuntimeException("unable to load $resourceName")
 
-    fun loadTemplate(templateName: String, configuration: Map<String, Any>): String {
+    fun loadTemplate(templateName: String, configuration: Map<String, Any> = emptyMap()): String {
         val testApplicationMustache = mustacheFactory.compile("templates/$templateName.mustache")
         return testApplicationMustache.execute(StringWriter(), configuration).toString()
     }

--- a/plugins/graphql-kotlin-gradle-plugin/src/test/resources/templates/Application.mustache
+++ b/plugins/graphql-kotlin-gradle-plugin/src/test/resources/templates/Application.mustache
@@ -2,16 +2,35 @@ package com.example
 
 import com.example.generated.JUnitQuery
 import com.expediagroup.graphql.client.GraphQLClient
+import io.ktor.client.features.defaultRequest
+import io.ktor.client.request.header
 import kotlinx.coroutines.runBlocking
 import java.net.URL
 
 fun main() {
-    val client = GraphQLClient(URL(System.getProperty("graphQLEndpoint")))
+    {{^defaultHeader}}
+        val client = GraphQLClient(URL(System.getProperty("graphQLEndpoint")))
+    {{/defaultHeader}}
+    {{#defaultHeader}}
+        val client = GraphQLClient(URL(System.getProperty("graphQLEndpoint"))) {
+            defaultRequest {
+                header("{{name}}", "{{value}}")
+            }
+        }
+    {{/defaultHeader}}
     val query = JUnitQuery(client)
 
     val variables = JUnitQuery.Variables(JUnitQuery.SimpleArgumentInput(min = null, max = null, newName = "blah"))
     runBlocking {
-        val response = query.execute(variables = variables)
+        {{^requestHeader}}
+            val response = query.execute(variables = variables)
+        {{/requestHeader}}
+        {{#requestHeader}}
+            val response = query.execute(variables = variables) {
+                header("{{name}}", "{{value}}")
+            }
+        {{/requestHeader}}
+
         val data = response.data
         assert(data != null)
         val scalarResult = data?.scalarQuery

--- a/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLClientIT.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLClientIT.kt
@@ -37,15 +37,18 @@ class GenerateGraphQLClientIT {
 
                 import com.expediagroup.graphql.client.GraphQLClient
                 import com.expediagroup.graphql.types.GraphQLResponse
+                import io.ktor.client.request.HttpRequestBuilder
                 import kotlin.String
+                import kotlin.Unit
 
                 const val MI_XE_DCA_SE_QUERY: String = "query miXEDcaSEQuery {\n  scalarQuery {\n    name\n  }\n}"
 
                 class MiXEDcaSEQuery(
                   private val graphQLClient: GraphQLClient<*>
                 ) {
-                  suspend fun execute(): GraphQLResponse<MiXEDcaSEQuery.Result> =
-                      graphQLClient.execute(MI_XE_DCA_SE_QUERY, "miXEDcaSEQuery", null)
+                  suspend fun execute(requestBuilder: HttpRequestBuilder.() -> Unit = {}):
+                      GraphQLResponse<MiXEDcaSEQuery.Result> = graphQLClient.execute(MI_XE_DCA_SE_QUERY,
+                      "miXEDcaSEQuery", null, requestBuilder)
 
                   /**
                    * Wrapper that holds all supported scalar types
@@ -85,15 +88,18 @@ class GenerateGraphQLClientIT {
 
                 import com.expediagroup.graphql.client.GraphQLClient
                 import com.expediagroup.graphql.types.GraphQLResponse
+                import io.ktor.client.request.HttpRequestBuilder
                 import kotlin.String
+                import kotlin.Unit
 
                 const val ANONYMOUS_TEST_QUERY: String = "query {\n  scalarQuery {\n    name\n  }\n}"
 
                 class AnonymousTestQuery(
                   private val graphQLClient: GraphQLClient<*>
                 ) {
-                  suspend fun execute(): GraphQLResponse<AnonymousTestQuery.Result> =
-                      graphQLClient.execute(ANONYMOUS_TEST_QUERY, null, null)
+                  suspend fun execute(requestBuilder: HttpRequestBuilder.() -> Unit = {}):
+                      GraphQLResponse<AnonymousTestQuery.Result> = graphQLClient.execute(ANONYMOUS_TEST_QUERY, null,
+                      null, requestBuilder)
 
                   /**
                    * Wrapper that holds all supported scalar types
@@ -141,8 +147,10 @@ class GenerateGraphQLClientIT {
 
                 import com.expediagroup.graphql.client.GraphQLClient
                 import com.expediagroup.graphql.types.GraphQLResponse
+                import io.ktor.client.request.HttpRequestBuilder
                 import kotlin.Boolean
                 import kotlin.String
+                import kotlin.Unit
 
                 const val ALIAS_TEST_QUERY: String =
                     "query AliasTestQuery {\n  first: inputObjectQuery(criteria: { min: 1.0, max: 5.0 } )\n  second: inputObjectQuery(criteria: { min: 5.0, max: 10.0 } )\n}"
@@ -150,8 +158,9 @@ class GenerateGraphQLClientIT {
                 class AliasTestQuery(
                   private val graphQLClient: GraphQLClient<*>
                 ) {
-                  suspend fun execute(): GraphQLResponse<AliasTestQuery.Result> =
-                      graphQLClient.execute(ALIAS_TEST_QUERY, "AliasTestQuery", null)
+                  suspend fun execute(requestBuilder: HttpRequestBuilder.() -> Unit = {}):
+                      GraphQLResponse<AliasTestQuery.Result> = graphQLClient.execute(ALIAS_TEST_QUERY,
+                      "AliasTestQuery", null, requestBuilder)
 
                   data class Result(
                     /**
@@ -197,16 +206,19 @@ class GenerateGraphQLClientIT {
 
                 import com.expediagroup.graphql.client.GraphQLClient
                 import com.expediagroup.graphql.types.GraphQLResponse
+                import io.ktor.client.request.HttpRequestBuilder
                 import kotlin.Deprecated
                 import kotlin.String
+                import kotlin.Unit
 
                 const val DEPRECATED_FIELD_QUERY: String = "query DeprecatedFieldQuery {\n  deprecatedQuery\n}"
 
                 class DeprecatedFieldQuery(
                   private val graphQLClient: GraphQLClient<*>
                 ) {
-                  suspend fun execute(): GraphQLResponse<DeprecatedFieldQuery.Result> =
-                      graphQLClient.execute(DEPRECATED_FIELD_QUERY, "DeprecatedFieldQuery", null)
+                  suspend fun execute(requestBuilder: HttpRequestBuilder.() -> Unit = {}):
+                      GraphQLResponse<DeprecatedFieldQuery.Result> = graphQLClient.execute(DEPRECATED_FIELD_QUERY,
+                      "DeprecatedFieldQuery", null, requestBuilder)
 
                   data class Result(
                     /**

--- a/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLCustomScalarTypeAliasIT.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLCustomScalarTypeAliasIT.kt
@@ -43,7 +43,9 @@ class GenerateGraphQLCustomScalarTypeAliasIT {
 
                 import com.expediagroup.graphql.client.GraphQLClient
                 import com.expediagroup.graphql.types.GraphQLResponse
+                import io.ktor.client.request.HttpRequestBuilder
                 import kotlin.String
+                import kotlin.Unit
 
                 const val SCALAR_ALIAS_TEST_QUERY: String =
                     "query ScalarAliasTestQuery {\n  scalarQuery {\n    id\n    custom\n  }\n}"
@@ -51,8 +53,9 @@ class GenerateGraphQLCustomScalarTypeAliasIT {
                 class ScalarAliasTestQuery(
                   private val graphQLClient: GraphQLClient<*>
                 ) {
-                  suspend fun execute(): GraphQLResponse<ScalarAliasTestQuery.Result> =
-                      graphQLClient.execute(SCALAR_ALIAS_TEST_QUERY, "ScalarAliasTestQuery", null)
+                  suspend fun execute(requestBuilder: HttpRequestBuilder.() -> Unit = {}):
+                      GraphQLResponse<ScalarAliasTestQuery.Result> = graphQLClient.execute(SCALAR_ALIAS_TEST_QUERY,
+                      "ScalarAliasTestQuery", null, requestBuilder)
 
                   /**
                    * Wrapper that holds all supported scalar types

--- a/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLEnumTypeSpecIT.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLEnumTypeSpecIT.kt
@@ -30,16 +30,19 @@ class GenerateGraphQLEnumTypeSpecIT {
                 import com.expediagroup.graphql.client.GraphQLClient
                 import com.expediagroup.graphql.types.GraphQLResponse
                 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue
+                import io.ktor.client.request.HttpRequestBuilder
                 import kotlin.Deprecated
                 import kotlin.String
+                import kotlin.Unit
 
                 const val ENUM_TEST_QUERY: String = "query EnumTestQuery {\n  enumQuery\n}"
 
                 class EnumTestQuery(
                   private val graphQLClient: GraphQLClient<*>
                 ) {
-                  suspend fun execute(): GraphQLResponse<EnumTestQuery.Result> =
-                      graphQLClient.execute(ENUM_TEST_QUERY, "EnumTestQuery", null)
+                  suspend fun execute(requestBuilder: HttpRequestBuilder.() -> Unit = {}):
+                      GraphQLResponse<EnumTestQuery.Result> = graphQLClient.execute(ENUM_TEST_QUERY,
+                      "EnumTestQuery", null, requestBuilder)
 
                   /**
                    * Custom enum description

--- a/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLInputObjectTypeSpecIT.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLInputObjectTypeSpecIT.kt
@@ -25,29 +25,32 @@ class GenerateGraphQLInputObjectTypeSpecIT {
     fun `verify we can generate valid input object type spec`() {
         val expected =
             """
-            package com.expediagroup.graphql.plugin.generator.integration
+                package com.expediagroup.graphql.plugin.generator.integration
 
-            import com.expediagroup.graphql.client.GraphQLClient
-            import com.expediagroup.graphql.types.GraphQLResponse
-            import kotlin.Boolean
-            import kotlin.String
+                import com.expediagroup.graphql.client.GraphQLClient
+                import com.expediagroup.graphql.types.GraphQLResponse
+                import io.ktor.client.request.HttpRequestBuilder
+                import kotlin.Boolean
+                import kotlin.String
+                import kotlin.Unit
 
-            const val INPUT_OBJECT_TEST_QUERY: String =
-                "query InputObjectTestQuery {\n  inputObjectQuery(criteria: { min: 1.0, max: 5.0 } )\n}"
+                const val INPUT_OBJECT_TEST_QUERY: String =
+                    "query InputObjectTestQuery {\n  inputObjectQuery(criteria: { min: 1.0, max: 5.0 } )\n}"
 
-            class InputObjectTestQuery(
-              private val graphQLClient: GraphQLClient<*>
-            ) {
-              suspend fun execute(): GraphQLResponse<InputObjectTestQuery.Result> =
-                  graphQLClient.execute(INPUT_OBJECT_TEST_QUERY, "InputObjectTestQuery", null)
+                class InputObjectTestQuery(
+                  private val graphQLClient: GraphQLClient<*>
+                ) {
+                  suspend fun execute(requestBuilder: HttpRequestBuilder.() -> Unit = {}):
+                      GraphQLResponse<InputObjectTestQuery.Result> = graphQLClient.execute(INPUT_OBJECT_TEST_QUERY,
+                      "InputObjectTestQuery", null, requestBuilder)
 
-              data class Result(
-                /**
-                 * Query that accepts some input arguments
-                 */
-                val inputObjectQuery: Boolean
-              )
-            }
+                  data class Result(
+                    /**
+                     * Query that accepts some input arguments
+                     */
+                    val inputObjectQuery: Boolean
+                  )
+                }
             """.trimIndent()
 
         val query =

--- a/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLInterfaceTypeSpecIT.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLInterfaceTypeSpecIT.kt
@@ -36,9 +36,11 @@ class GenerateGraphQLInterfaceTypeSpecIT {
                 import com.fasterxml.jackson.annotation.JsonTypeInfo
                 import com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY
                 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME
+                import io.ktor.client.request.HttpRequestBuilder
                 import kotlin.Float
                 import kotlin.Int
                 import kotlin.String
+                import kotlin.Unit
 
                 const val INTERFACE_WITH_INLINE_FRAGMENTS_TEST_QUERY: String =
                     "query InterfaceWithInlineFragmentsTestQuery {\n  interfaceQuery {\n    __typename\n    id\n    name\n    ... on FirstInterfaceImplementation {\n      intValue\n    }\n    ... on SecondInterfaceImplementation {\n      floatValue\n    }\n  }\n}"
@@ -46,9 +48,10 @@ class GenerateGraphQLInterfaceTypeSpecIT {
                 class InterfaceWithInlineFragmentsTestQuery(
                   private val graphQLClient: GraphQLClient<*>
                 ) {
-                  suspend fun execute(): GraphQLResponse<InterfaceWithInlineFragmentsTestQuery.Result> =
+                  suspend fun execute(requestBuilder: HttpRequestBuilder.() -> Unit = {}):
+                      GraphQLResponse<InterfaceWithInlineFragmentsTestQuery.Result> =
                       graphQLClient.execute(INTERFACE_WITH_INLINE_FRAGMENTS_TEST_QUERY,
-                      "InterfaceWithInlineFragmentsTestQuery", null)
+                      "InterfaceWithInlineFragmentsTestQuery", null, requestBuilder)
 
                   /**
                    * Example interface implementation where value is an integer
@@ -151,9 +154,11 @@ class GenerateGraphQLInterfaceTypeSpecIT {
                 import com.fasterxml.jackson.annotation.JsonTypeInfo
                 import com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY
                 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME
+                import io.ktor.client.request.HttpRequestBuilder
                 import kotlin.Float
                 import kotlin.Int
                 import kotlin.String
+                import kotlin.Unit
 
                 const val INTERFACE_WITH_NAMED_FRAGMENTS_TEST_QUERY: String =
                     "query InterfaceWithNamedFragmentsTestQuery {\n  interfaceQuery {\n    __typename\n    id\n    name\n    ... firstInterfaceImplFields\n    ... secondInterfaceImplFields\n  }\n}\n\nfragment firstInterfaceImplFields on FirstInterfaceImplementation {\n  id\n  name\n  intValue\n}\nfragment secondInterfaceImplFields on SecondInterfaceImplementation {\n  id\n  name\n  floatValue\n}"
@@ -161,9 +166,10 @@ class GenerateGraphQLInterfaceTypeSpecIT {
                 class InterfaceWithNamedFragmentsTestQuery(
                   private val graphQLClient: GraphQLClient<*>
                 ) {
-                  suspend fun execute(): GraphQLResponse<InterfaceWithNamedFragmentsTestQuery.Result> =
+                  suspend fun execute(requestBuilder: HttpRequestBuilder.() -> Unit = {}):
+                      GraphQLResponse<InterfaceWithNamedFragmentsTestQuery.Result> =
                       graphQLClient.execute(INTERFACE_WITH_NAMED_FRAGMENTS_TEST_QUERY,
-                      "InterfaceWithNamedFragmentsTestQuery", null)
+                      "InterfaceWithNamedFragmentsTestQuery", null, requestBuilder)
 
                   /**
                    * Example interface implementation where value is an integer
@@ -322,9 +328,11 @@ class GenerateGraphQLInterfaceTypeSpecIT {
                 import com.fasterxml.jackson.annotation.JsonTypeInfo
                 import com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY
                 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME
+                import io.ktor.client.request.HttpRequestBuilder
                 import kotlin.Float
                 import kotlin.Int
                 import kotlin.String
+                import kotlin.Unit
 
                 const val DIFFERENT_SELECTION_SET_QUERY: String =
                     "query DifferentSelectionSetQuery {\n  first: interfaceQuery {\n    __typename\n    id\n    name\n    ... on FirstInterfaceImplementation {\n      intValue\n    }\n    ... on SecondInterfaceImplementation {\n      floatValue\n    }\n  }\n  second: interfaceQuery {\n    __typename\n    name\n    ... on FirstInterfaceImplementation {\n      intValue\n    }\n    ... on SecondInterfaceImplementation {\n      floatValue\n    }\n  }\n}"
@@ -332,8 +340,10 @@ class GenerateGraphQLInterfaceTypeSpecIT {
                 class DifferentSelectionSetQuery(
                   private val graphQLClient: GraphQLClient<*>
                 ) {
-                  suspend fun execute(): GraphQLResponse<DifferentSelectionSetQuery.Result> =
-                      graphQLClient.execute(DIFFERENT_SELECTION_SET_QUERY, "DifferentSelectionSetQuery", null)
+                  suspend fun execute(requestBuilder: HttpRequestBuilder.() -> Unit = {}):
+                      GraphQLResponse<DifferentSelectionSetQuery.Result> =
+                      graphQLClient.execute(DIFFERENT_SELECTION_SET_QUERY, "DifferentSelectionSetQuery", null,
+                      requestBuilder)
 
                   /**
                    * Example interface implementation where value is an integer
@@ -497,9 +507,11 @@ class GenerateGraphQLInterfaceTypeSpecIT {
                 import com.fasterxml.jackson.annotation.JsonTypeInfo
                 import com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY
                 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME
+                import io.ktor.client.request.HttpRequestBuilder
                 import kotlin.Float
                 import kotlin.Int
                 import kotlin.String
+                import kotlin.Unit
 
                 const val DIFFERENT_SELECTION_SET_QUERY: String =
                     "query DifferentSelectionSetQuery {\n  first: interfaceQuery {\n    __typename\n    id\n    ... on FirstInterfaceImplementation {\n      intValue\n    }\n    ... on SecondInterfaceImplementation {\n      floatValue\n    }\n  }\n  second: interfaceQuery {\n    __typename\n    id\n    ... on FirstInterfaceImplementation {\n      name\n      intValue\n    }\n    ... on SecondInterfaceImplementation {\n      name\n      floatValue\n    }\n  }\n}"
@@ -507,8 +519,10 @@ class GenerateGraphQLInterfaceTypeSpecIT {
                 class DifferentSelectionSetQuery(
                   private val graphQLClient: GraphQLClient<*>
                 ) {
-                  suspend fun execute(): GraphQLResponse<DifferentSelectionSetQuery.Result> =
-                      graphQLClient.execute(DIFFERENT_SELECTION_SET_QUERY, "DifferentSelectionSetQuery", null)
+                  suspend fun execute(requestBuilder: HttpRequestBuilder.() -> Unit = {}):
+                      GraphQLResponse<DifferentSelectionSetQuery.Result> =
+                      graphQLClient.execute(DIFFERENT_SELECTION_SET_QUERY, "DifferentSelectionSetQuery", null,
+                      requestBuilder)
 
                   /**
                    * Example interface implementation where value is an integer

--- a/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLObjectTypeSpecIT.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLObjectTypeSpecIT.kt
@@ -32,9 +32,11 @@ class GenerateGraphQLObjectTypeSpecIT {
 
                 import com.expediagroup.graphql.client.GraphQLClient
                 import com.expediagroup.graphql.types.GraphQLResponse
+                import io.ktor.client.request.HttpRequestBuilder
                 import kotlin.Boolean
                 import kotlin.Int
                 import kotlin.String
+                import kotlin.Unit
 
                 const val COMPLEX_OBJECT_TEST_QUERY: String =
                     "query ComplexObjectTestQuery {\n  complexObjectQuery {\n    id\n    name\n    optional\n    details {\n      id\n      flag\n      value\n    }\n  }\n}"
@@ -42,8 +44,10 @@ class GenerateGraphQLObjectTypeSpecIT {
                 class ComplexObjectTestQuery(
                   private val graphQLClient: GraphQLClient<*>
                 ) {
-                  suspend fun execute(): GraphQLResponse<ComplexObjectTestQuery.Result> =
-                      graphQLClient.execute(COMPLEX_OBJECT_TEST_QUERY, "ComplexObjectTestQuery", null)
+                  suspend fun execute(requestBuilder: HttpRequestBuilder.() -> Unit = {}):
+                      GraphQLResponse<ComplexObjectTestQuery.Result> =
+                      graphQLClient.execute(COMPLEX_OBJECT_TEST_QUERY, "ComplexObjectTestQuery", null,
+                      requestBuilder)
 
                   /**
                    * Inner type object description
@@ -122,8 +126,10 @@ class GenerateGraphQLObjectTypeSpecIT {
 
                 import com.expediagroup.graphql.client.GraphQLClient
                 import com.expediagroup.graphql.types.GraphQLResponse
+                import io.ktor.client.request.HttpRequestBuilder
                 import kotlin.Int
                 import kotlin.String
+                import kotlin.Unit
 
                 const val COMPLEX_OBJECT_QUERY_WITH_NAMED_FRAGMENT: String =
                     "query ComplexObjectQueryWithNamedFragment {\n  complexObjectQuery {\n    ...complexObjectFields\n  }\n}\n\nfragment complexObjectFields on ComplexObject {\n  id\n  name\n  details {\n    ...detailObjectFields\n  }\n}\n\nfragment detailObjectFields on DetailsObject {\n  value\n}"
@@ -131,9 +137,10 @@ class GenerateGraphQLObjectTypeSpecIT {
                 class ComplexObjectQueryWithNamedFragment(
                   private val graphQLClient: GraphQLClient<*>
                 ) {
-                  suspend fun execute(): GraphQLResponse<ComplexObjectQueryWithNamedFragment.Result> =
+                  suspend fun execute(requestBuilder: HttpRequestBuilder.() -> Unit = {}):
+                      GraphQLResponse<ComplexObjectQueryWithNamedFragment.Result> =
                       graphQLClient.execute(COMPLEX_OBJECT_QUERY_WITH_NAMED_FRAGMENT,
-                      "ComplexObjectQueryWithNamedFragment", null)
+                      "ComplexObjectQueryWithNamedFragment", null, requestBuilder)
 
                   /**
                    * Inner type object description
@@ -244,8 +251,10 @@ class GenerateGraphQLObjectTypeSpecIT {
 
                 import com.expediagroup.graphql.client.GraphQLClient
                 import com.expediagroup.graphql.types.GraphQLResponse
+                import io.ktor.client.request.HttpRequestBuilder
                 import kotlin.Int
                 import kotlin.String
+                import kotlin.Unit
                 import kotlin.collections.List
 
                 const val J_UNIT_TEST_QUERY: String =
@@ -254,8 +263,9 @@ class GenerateGraphQLObjectTypeSpecIT {
                 class JUnitTestQuery(
                   private val graphQLClient: GraphQLClient<*>
                 ) {
-                  suspend fun execute(): GraphQLResponse<JUnitTestQuery.Result> =
-                      graphQLClient.execute(J_UNIT_TEST_QUERY, "JUnitTestQuery", null)
+                  suspend fun execute(requestBuilder: HttpRequestBuilder.() -> Unit = {}):
+                      GraphQLResponse<JUnitTestQuery.Result> = graphQLClient.execute(J_UNIT_TEST_QUERY,
+                      "JUnitTestQuery", null, requestBuilder)
 
                   /**
                    * Some basic description
@@ -293,48 +303,51 @@ class GenerateGraphQLObjectTypeSpecIT {
     fun `verify we can generate nested objects`() {
         val expected =
             """
-            package com.expediagroup.graphql.plugin.generator.integration
+                package com.expediagroup.graphql.plugin.generator.integration
 
-            import com.expediagroup.graphql.client.GraphQLClient
-            import com.expediagroup.graphql.types.GraphQLResponse
-            import kotlin.Int
-            import kotlin.String
-            import kotlin.collections.List
+                import com.expediagroup.graphql.client.GraphQLClient
+                import com.expediagroup.graphql.types.GraphQLResponse
+                import io.ktor.client.request.HttpRequestBuilder
+                import kotlin.Int
+                import kotlin.String
+                import kotlin.Unit
+                import kotlin.collections.List
 
-            const val NESTED_QUERY: String =
-                "query NestedQuery {\n  nestedObjectQuery {\n    id\n    name\n    children {\n      id\n      name\n    }\n  }\n}"
+                const val NESTED_QUERY: String =
+                    "query NestedQuery {\n  nestedObjectQuery {\n    id\n    name\n    children {\n      id\n      name\n    }\n  }\n}"
 
-            class NestedQuery(
-              private val graphQLClient: GraphQLClient<*>
-            ) {
-              suspend fun execute(): GraphQLResponse<NestedQuery.Result> = graphQLClient.execute(NESTED_QUERY,
-                  "NestedQuery", null)
+                class NestedQuery(
+                  private val graphQLClient: GraphQLClient<*>
+                ) {
+                  suspend fun execute(requestBuilder: HttpRequestBuilder.() -> Unit = {}):
+                      GraphQLResponse<NestedQuery.Result> = graphQLClient.execute(NESTED_QUERY, "NestedQuery", null,
+                      requestBuilder)
 
-              /**
-               * Example of an object self-referencing itself
-               */
-              data class NestedObject(
-                /**
-                 * Unique identifier
-                 */
-                val id: Int,
-                /**
-                 * Name of the object
-                 */
-                val name: String,
-                /**
-                 * Children elements
-                 */
-                val children: List<NestedQuery.NestedObject>
-              )
+                  /**
+                   * Example of an object self-referencing itself
+                   */
+                  data class NestedObject(
+                    /**
+                     * Unique identifier
+                     */
+                    val id: Int,
+                    /**
+                     * Name of the object
+                     */
+                    val name: String,
+                    /**
+                     * Children elements
+                     */
+                    val children: List<NestedQuery.NestedObject>
+                  )
 
-              data class Result(
-                /**
-                 * Query returning object referencing itself
-                 */
-                val nestedObjectQuery: NestedQuery.NestedObject
-              )
-            }
+                  data class Result(
+                    /**
+                     * Query returning object referencing itself
+                     */
+                    val nestedObjectQuery: NestedQuery.NestedObject
+                  )
+                }
             """.trimIndent()
         val nestedQuery =
             """
@@ -360,8 +373,10 @@ class GenerateGraphQLObjectTypeSpecIT {
 
                 import com.expediagroup.graphql.client.GraphQLClient
                 import com.expediagroup.graphql.types.GraphQLResponse
+                import io.ktor.client.request.HttpRequestBuilder
                 import kotlin.Int
                 import kotlin.String
+                import kotlin.Unit
 
                 const val DIFFERENT_SELECTIONS_QUERY: String =
                     "query DifferentSelectionsQuery {\n  first: complexObjectQuery {\n    id\n    name\n  }\n  second: complexObjectQuery {\n    id\n    name\n    details {\n      id\n      value\n    }\n  }\n}"
@@ -369,8 +384,10 @@ class GenerateGraphQLObjectTypeSpecIT {
                 class DifferentSelectionsQuery(
                   private val graphQLClient: GraphQLClient<*>
                 ) {
-                  suspend fun execute(): GraphQLResponse<DifferentSelectionsQuery.Result> =
-                      graphQLClient.execute(DIFFERENT_SELECTIONS_QUERY, "DifferentSelectionsQuery", null)
+                  suspend fun execute(requestBuilder: HttpRequestBuilder.() -> Unit = {}):
+                      GraphQLResponse<DifferentSelectionsQuery.Result> =
+                      graphQLClient.execute(DIFFERENT_SELECTIONS_QUERY, "DifferentSelectionsQuery", null,
+                      requestBuilder)
 
                   /**
                    * Multi line description of a complex type.
@@ -462,9 +479,11 @@ class GenerateGraphQLObjectTypeSpecIT {
 
                 import com.expediagroup.graphql.client.GraphQLClient
                 import com.expediagroup.graphql.types.GraphQLResponse
+                import io.ktor.client.request.HttpRequestBuilder
                 import kotlin.Boolean
                 import kotlin.Int
                 import kotlin.String
+                import kotlin.Unit
 
                 const val DIFFERENT_SELECTIONS_QUERY: String =
                     "query DifferentSelectionsQuery {\n  first: complexObjectQuery {\n    id\n    name\n    details {\n      id\n      value\n      flag\n    }\n  }\n  second: complexObjectQuery {\n    id\n    name\n    details {\n      id\n      value\n    }\n  }\n}"
@@ -472,8 +491,10 @@ class GenerateGraphQLObjectTypeSpecIT {
                 class DifferentSelectionsQuery(
                   private val graphQLClient: GraphQLClient<*>
                 ) {
-                  suspend fun execute(): GraphQLResponse<DifferentSelectionsQuery.Result> =
-                      graphQLClient.execute(DIFFERENT_SELECTIONS_QUERY, "DifferentSelectionsQuery", null)
+                  suspend fun execute(requestBuilder: HttpRequestBuilder.() -> Unit = {}):
+                      GraphQLResponse<DifferentSelectionsQuery.Result> =
+                      graphQLClient.execute(DIFFERENT_SELECTIONS_QUERY, "DifferentSelectionsQuery", null,
+                      requestBuilder)
 
                   /**
                    * Inner type object description

--- a/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLUnionTypeSpecIT.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLUnionTypeSpecIT.kt
@@ -36,8 +36,10 @@ class GenerateGraphQLUnionTypeSpecIT {
                 import com.fasterxml.jackson.annotation.JsonTypeInfo
                 import com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY
                 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME
+                import io.ktor.client.request.HttpRequestBuilder
                 import kotlin.Int
                 import kotlin.String
+                import kotlin.Unit
 
                 const val UNION_QUERY_WITH_INLINE_FRAGMENTS: String =
                     "query UnionQueryWithInlineFragments {\n  unionQuery {\n    __typename\n    ... on BasicObject {\n      id\n      name\n    }\n    ... on ComplexObject {\n      id\n      name\n      optional\n    }\n  }\n}"
@@ -45,9 +47,10 @@ class GenerateGraphQLUnionTypeSpecIT {
                 class UnionQueryWithInlineFragments(
                   private val graphQLClient: GraphQLClient<*>
                 ) {
-                  suspend fun execute(): GraphQLResponse<UnionQueryWithInlineFragments.Result> =
+                  suspend fun execute(requestBuilder: HttpRequestBuilder.() -> Unit = {}):
+                      GraphQLResponse<UnionQueryWithInlineFragments.Result> =
                       graphQLClient.execute(UNION_QUERY_WITH_INLINE_FRAGMENTS, "UnionQueryWithInlineFragments",
-                      null)
+                      null, requestBuilder)
 
                   /**
                    * Some basic description
@@ -135,8 +138,10 @@ class GenerateGraphQLUnionTypeSpecIT {
                 import com.fasterxml.jackson.annotation.JsonTypeInfo
                 import com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY
                 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME
+                import io.ktor.client.request.HttpRequestBuilder
                 import kotlin.Int
                 import kotlin.String
+                import kotlin.Unit
 
                 const val UNION_QUERY_WITH_NAMED_FRAGMENTS: String =
                     "query UnionQueryWithNamedFragments {\n  unionQuery {\n    ... basicObjectFields\n    ... complexObjectFields\n  }\n}\n\nfragment basicObjectFields on BasicObject {\n  __typename\n  id\n  name\n}\nfragment complexObjectFields on ComplexObject {\n  __typename\n  id\n  name\n  optional\n}"
@@ -144,8 +149,10 @@ class GenerateGraphQLUnionTypeSpecIT {
                 class UnionQueryWithNamedFragments(
                   private val graphQLClient: GraphQLClient<*>
                 ) {
-                  suspend fun execute(): GraphQLResponse<UnionQueryWithNamedFragments.Result> =
-                      graphQLClient.execute(UNION_QUERY_WITH_NAMED_FRAGMENTS, "UnionQueryWithNamedFragments", null)
+                  suspend fun execute(requestBuilder: HttpRequestBuilder.() -> Unit = {}):
+                      GraphQLResponse<UnionQueryWithNamedFragments.Result> =
+                      graphQLClient.execute(UNION_QUERY_WITH_NAMED_FRAGMENTS, "UnionQueryWithNamedFragments", null,
+                      requestBuilder)
 
                   /**
                    * Some basic description
@@ -286,8 +293,10 @@ class GenerateGraphQLUnionTypeSpecIT {
                 import com.fasterxml.jackson.annotation.JsonTypeInfo
                 import com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY
                 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME
+                import io.ktor.client.request.HttpRequestBuilder
                 import kotlin.Int
                 import kotlin.String
+                import kotlin.Unit
 
                 const val DIFFERENT_SELECTION_SET_QUERY: String =
                     "query DifferentSelectionSetQuery {\n  unionQuery {\n    __typename\n    ... on BasicObject {\n      id\n      name\n    }\n    ... on ComplexObject {\n      id\n      name\n      optional\n    }\n  }\n  complexObjectQuery {\n    id\n    name\n    details {\n      value\n    }\n  }\n}"
@@ -295,8 +304,10 @@ class GenerateGraphQLUnionTypeSpecIT {
                 class DifferentSelectionSetQuery(
                   private val graphQLClient: GraphQLClient<*>
                 ) {
-                  suspend fun execute(): GraphQLResponse<DifferentSelectionSetQuery.Result> =
-                      graphQLClient.execute(DIFFERENT_SELECTION_SET_QUERY, "DifferentSelectionSetQuery", null)
+                  suspend fun execute(requestBuilder: HttpRequestBuilder.() -> Unit = {}):
+                      GraphQLResponse<DifferentSelectionSetQuery.Result> =
+                      graphQLClient.execute(DIFFERENT_SELECTION_SET_QUERY, "DifferentSelectionSetQuery", null,
+                      requestBuilder)
 
                   /**
                    * Some basic description
@@ -425,8 +436,10 @@ class GenerateGraphQLUnionTypeSpecIT {
                 import com.fasterxml.jackson.annotation.JsonTypeInfo
                 import com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY
                 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME
+                import io.ktor.client.request.HttpRequestBuilder
                 import kotlin.Int
                 import kotlin.String
+                import kotlin.Unit
 
                 const val DIFFERENT_SELECTION_SET_QUERY: String =
                     "query DifferentSelectionSetQuery {\n  first: unionQuery {\n    __typename\n    ... on BasicObject {\n      id\n    }\n    ... on ComplexObject {\n      id\n    }\n  }\n  second: unionQuery {\n    __typename\n    ... on BasicObject {\n      name\n    }\n    ... on ComplexObject {\n      name\n    }\n  }\n}"
@@ -434,8 +447,10 @@ class GenerateGraphQLUnionTypeSpecIT {
                 class DifferentSelectionSetQuery(
                   private val graphQLClient: GraphQLClient<*>
                 ) {
-                  suspend fun execute(): GraphQLResponse<DifferentSelectionSetQuery.Result> =
-                      graphQLClient.execute(DIFFERENT_SELECTION_SET_QUERY, "DifferentSelectionSetQuery", null)
+                  suspend fun execute(requestBuilder: HttpRequestBuilder.() -> Unit = {}):
+                      GraphQLResponse<DifferentSelectionSetQuery.Result> =
+                      graphQLClient.execute(DIFFERENT_SELECTION_SET_QUERY, "DifferentSelectionSetQuery", null,
+                      requestBuilder)
 
                   /**
                    * Some basic description

--- a/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateVariableTypeSpecIT.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateVariableTypeSpecIT.kt
@@ -30,9 +30,11 @@ class GenerateVariableTypeSpecIT {
 
                 import com.expediagroup.graphql.client.GraphQLClient
                 import com.expediagroup.graphql.types.GraphQLResponse
+                import io.ktor.client.request.HttpRequestBuilder
                 import kotlin.Boolean
                 import kotlin.Float
                 import kotlin.String
+                import kotlin.Unit
 
                 const val TEST_QUERY_WITH_VARIABLES: String =
                     "query TestQueryWithVariables(${'$'}{'${'$'}'}criteria: SimpleArgumentInput) {\n  inputObjectQuery(criteria: ${'$'}{'${'$'}'}criteria)\n}"
@@ -40,9 +42,11 @@ class GenerateVariableTypeSpecIT {
                 class TestQueryWithVariables(
                   private val graphQLClient: GraphQLClient<*>
                 ) {
-                  suspend fun execute(variables: TestQueryWithVariables.Variables):
+                  suspend fun execute(variables: TestQueryWithVariables.Variables,
+                      requestBuilder: HttpRequestBuilder.() -> Unit = {}):
                       GraphQLResponse<TestQueryWithVariables.Result> =
-                      graphQLClient.execute(TEST_QUERY_WITH_VARIABLES, "TestQueryWithVariables", variables)
+                      graphQLClient.execute(TEST_QUERY_WITH_VARIABLES, "TestQueryWithVariables", variables,
+                      requestBuilder)
 
                   data class Variables(
                     val criteria: TestQueryWithVariables.SimpleArgumentInput?


### PR DESCRIPTION
### :pencil: Description

Update client to allow specifying optional Ktor HttpRequestBuilder block that allows usage of DSL for specifying custom headers as well as provide some additional configuration options like timeouts per request, specify URL query parameters as well as custom attributes that could be referenced from the feature pipeline.

After client is generated we can configure it as follows:

```kotlin
val client = GraphQLClient(
  url = URL("http://localhost:8080/graphql"),
  engineFactory = OkHttp,
  mapper = jackson
) {
  // existing global client customization through Ktor HttpClientConfig
  engine {
    config {
      connectTimeout(10, TimeUnit.SECONDS)
      readTimeout(60, TimeUnit.SECONDS)
      writeTimeout(60, TimeUnit.SECONDS)
    }
  }
  install(Logging) {
    logger = Logger.DEFAULT
    level = LogLevel.HEADERS
  }
}
// create client for specific query
val helloWorldQuery = HelloWorldQuery(client)
val result = helloWorldQuery.execute(variables = HelloWorldQuery.Variables(name = null)) {
  // per query customization using Ktor HttpRequestBuilder
  header("X-B3-TraceId", "0123456789abcdef")
}
```

See https://api.ktor.io/1.3.2/io.ktor.client.request/-http-request-builder/ for available customization options.

### :link: Related Issues

Resolves: https://github.com/ExpediaGroup/graphql-kotlin/issues/764