### PR TITLE
[generator] Support subscriptions of Publisher<DataFetcherResult<T>>

### DIFF
--- a/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/subscriptions/SimpleSubscription.kt
+++ b/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/subscriptions/SimpleSubscription.kt
@@ -64,7 +64,7 @@ class SimpleSubscription : Subscription {
 
     @GraphQLDescription("Returns stream of errors")
     fun flowOfErrors(): Publisher<DataFetcherResult<String?>> {
-        val dfr: DataFetcherResult<String?> = DataFetcherResult.newResult<String>()
+        val dfr: DataFetcherResult<String?> = DataFetcherResult.newResult<String?>()
             .data(null)
             .error(SimpleKotlinGraphQLError(Exception("error thrown")))
             .build()

--- a/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/subscriptions/SimpleSubscription.kt
+++ b/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/subscriptions/SimpleSubscription.kt
@@ -18,7 +18,9 @@ package com.expediagroup.graphql.examples.subscriptions
 
 import com.expediagroup.graphql.annotations.GraphQLDescription
 import com.expediagroup.graphql.examples.context.MyGraphQLContext
+import com.expediagroup.graphql.spring.exception.SimpleKotlinGraphQLError
 import com.expediagroup.graphql.spring.operations.Subscription
+import graphql.execution.DataFetcherResult
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.reactive.asPublisher
 import org.reactivestreams.Publisher
@@ -57,8 +59,18 @@ class SimpleSubscription : Subscription {
     fun singleValueThenError(): Flux<Int> = Flux.just(1, 2)
         .map { if (it == 2) throw Exception("Second value") else it }
 
-    @GraphQLDescription("Returns list of values")
+    @GraphQLDescription("Returns stream of values")
     fun flow(): Publisher<Int> = flowOf(1, 2, 4).asPublisher()
+
+    @GraphQLDescription("Returns stream of errors")
+    fun flowOfErrors(): Publisher<DataFetcherResult<String?>> {
+        val dfr: DataFetcherResult<String?> = DataFetcherResult.newResult<String>()
+            .data(null)
+            .error(SimpleKotlinGraphQLError(Exception("error thrown")))
+            .build()
+
+        return flowOf(dfr, dfr).asPublisher()
+    }
 
     @GraphQLDescription("Returns a value from the subscription context")
     fun subscriptionContext(myGraphQLContext: MyGraphQLContext): Publisher<String> =

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/utils/functionReturnTypes.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/utils/functionReturnTypes.kt
@@ -35,7 +35,7 @@ import kotlin.reflect.KType
  *      Valid type T
  *      DataFetcherResult<T>
  *      Publisher<T>
- *      Published<DataFetcherResult<T>>
+ *      Publisher<DataFetcherResult<T>>
  *      CompletableFuture<T>
  *      CompletableFuture<DataFetcherResult<T>>
  */

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/utils/functionReturnTypes.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/utils/functionReturnTypes.kt
@@ -33,7 +33,6 @@ import kotlin.reflect.KType
  *
  * We can return the following combination of types:
  *      Valid type T
- *      Optional<T>
  *      DataFetcherResult<T>
  *      Publisher<T>
  *      Published<DataFetcherResult<T>>

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/utils/FunctionReturnTypesKtTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/utils/FunctionReturnTypesKtTest.kt
@@ -23,38 +23,41 @@ import org.reactivestreams.Publisher
 import java.util.concurrent.CompletableFuture
 import kotlin.test.assertEquals
 
-internal class FunctionReturnTypesKtTest {
+class FunctionReturnTypesKtTest {
 
-    internal class MyClass {
+    class MyClass {
+        // Valid Types
         val string = "my string"
-
+        val dataFetcherResult: DataFetcherResult<String> = DataFetcherResult.newResult<String>().data(string).build()
         val publisher: Publisher<String> = Flowable.just(string)
         val flowable: Flowable<String> = Flowable.just(string)
-        val dataFetcherResult: DataFetcherResult<String> = DataFetcherResult.newResult<String>().data(string).build()
+        val publisherDataFetcherResult: Publisher<DataFetcherResult<String>> = Flowable.just(dataFetcherResult)
         val completableFuture: CompletableFuture<String> = CompletableFuture.completedFuture(string)
+        val completableFutureDataFetcher: CompletableFuture<DataFetcherResult<String>> = CompletableFuture.completedFuture(dataFetcherResult)
 
-        val invalidPublisher: Publisher<DataFetcherResult<String>> = Flowable.just(dataFetcherResult)
-        val invalidDataFetcherResult: DataFetcherResult<CompletableFuture<String>> = DataFetcherResult.newResult<CompletableFuture<String>>().data(completableFuture).build()
-        val validCompletableFutureDataFetcher: CompletableFuture<DataFetcherResult<String>> = CompletableFuture.completedFuture(dataFetcherResult)
+        // Invalid types
+        val invalidDataFetcherResultCompletableFuture: DataFetcherResult<CompletableFuture<String>> = DataFetcherResult.newResult<CompletableFuture<String>>().data(completableFuture).build()
+        val invalidDataFetcherResultPublisher: DataFetcherResult<Publisher<String>> = DataFetcherResult.newResult<Publisher<String>>().data(publisher).build()
         val invalidCompletableFuture: CompletableFuture<Publisher<String>> = CompletableFuture.completedFuture(publisher)
     }
 
     @Test
     fun `getWrappedReturnType of Publisher`() {
         assertEquals(MyClass::string.returnType, actual = getWrappedReturnType(MyClass::publisher.returnType))
-        assertEquals(MyClass::dataFetcherResult.returnType, actual = getWrappedReturnType(MyClass::invalidPublisher.returnType))
+        assertEquals(MyClass::string.returnType, actual = getWrappedReturnType(MyClass::publisherDataFetcherResult.returnType))
     }
 
     @Test
     fun `getWrappedReturnType of DataFetcherResult`() {
         assertEquals(MyClass::string.returnType, actual = getWrappedReturnType(MyClass::dataFetcherResult.returnType))
-        assertEquals(MyClass::completableFuture.returnType, actual = getWrappedReturnType(MyClass::invalidDataFetcherResult.returnType))
+        assertEquals(MyClass::completableFuture.returnType, actual = getWrappedReturnType(MyClass::invalidDataFetcherResultCompletableFuture.returnType))
+        assertEquals(MyClass::publisher.returnType, actual = getWrappedReturnType(MyClass::invalidDataFetcherResultPublisher.returnType))
     }
 
     @Test
     fun `getWrappedReturnType of CompletableFuture`() {
         assertEquals(MyClass::string.returnType, actual = getWrappedReturnType(MyClass::completableFuture.returnType))
-        assertEquals(MyClass::string.returnType, actual = getWrappedReturnType(MyClass::validCompletableFutureDataFetcher.returnType))
+        assertEquals(MyClass::string.returnType, actual = getWrappedReturnType(MyClass::completableFutureDataFetcher.returnType))
         assertEquals(MyClass::publisher.returnType, actual = getWrappedReturnType(MyClass::invalidCompletableFuture.returnType))
     }
 


### PR DESCRIPTION
### :pencil: Description
There was a bug in the schema generator config that errored out on a `Publisher<DataFetcherResult<T>>`

### :link: Related Issues
https://github.com/ExpediaGroup/graphql-kotlin/pull/742
https://github.com/ExpediaGroup/graphql-kotlin/issues/608