### PR TITLE
[generator] Add invalid packages exception

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ kotlinJvmVersion = 1.8
 kotlinVersion = 1.3.72
 kotlinCoroutinesVersion = 1.3.7
 
-classGraphVersion = 4.8.85
+classGraphVersion = 4.8.87
 graphQLJavaVersion = 15.0
 jacksonVersion = 2.11.0
 kotlinPoetVersion = 1.6.0

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/exceptions/InvalidPackagesException.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/exceptions/InvalidPackagesException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Expedia, Inc
+ * Copyright 2020 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,8 @@
 
 package com.expediagroup.graphql.exceptions
 
-import kotlin.reflect.KType
-
 /**
- * Thrown when the generator does not have a type to map to in GraphQL or in the hooks.
+ * Thrown when the scanned packages contain no classes
  */
-class TypeNotSupportedException(kType: KType, packageList: List<String>) :
-    GraphQLKotlinException("Cannot convert $kType since it is not a valid GraphQL type or outside the supported packages \"$packageList\"")
+class InvalidPackagesException(packages: List<String>) :
+    GraphQLKotlinException("The configured packages do not contain any valid classes: \"$packages\"")

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/SchemaGeneratorTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/SchemaGeneratorTest.kt
@@ -17,10 +17,12 @@
 package com.expediagroup.graphql.generator
 
 import com.expediagroup.graphql.SchemaGeneratorConfig
+import com.expediagroup.graphql.exceptions.InvalidPackagesException
 import com.expediagroup.graphql.extensions.deepName
 import org.junit.jupiter.api.Test
 import kotlin.reflect.KClass
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 
 class SchemaGeneratorTest {
 
@@ -49,6 +51,14 @@ class SchemaGeneratorTest {
 
         assertEquals(1, result.size)
         assertEquals("SomeObjectWithAnnotation!", result.first().deepName)
+    }
+
+    @Test
+    fun invalidPackagesThrowsException() {
+        assertFailsWith(InvalidPackagesException::class) {
+            val config = SchemaGeneratorConfig(listOf("foo.bar"))
+            SchemaGenerator(config)
+        }
     }
 
     class CustomSchemaGenerator(config: SchemaGeneratorConfig) : SchemaGenerator(config) {

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/state/ClassScannerTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/state/ClassScannerTest.kt
@@ -20,46 +20,46 @@ import com.expediagroup.graphql.defaultSupportedPackages
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
-@Suppress("Detekt.UnusedPrivateClass")
-internal class ClassScannerTest {
+class ClassScannerTest {
 
-    private interface NoSubTypesInterface
+    interface NoSubTypesInterface
 
-    private abstract class NoSubTypesClass
+    abstract class NoSubTypesClass
 
-    private interface MyInterface {
+    interface MyInterface {
         fun getValue(): Int
     }
 
-    private class FirstClass : MyInterface {
+    class FirstClass : MyInterface {
         override fun getValue() = 1
     }
 
-    private class SecondClass : MyInterface {
+    class SecondClass : MyInterface {
         override fun getValue() = 2
     }
 
     @Suppress("Detekt.UnnecessaryAbstractClass")
-    private abstract class MyAbstractClass {
+    abstract class MyAbstractClass {
         abstract fun someValue(): Int
     }
 
-    private class ThirdClass : MyAbstractClass() {
+    class ThirdClass : MyAbstractClass() {
         override fun someValue() = 3
     }
 
-    private abstract class FourthClass : MyAbstractClass() {
+    abstract class FourthClass : MyAbstractClass() {
         override fun someValue() = 3
 
         abstract fun getOtherValue(): Int
     }
 
-    private annotation class SimpleAnnotation
-    private annotation class OtherSimpleAnnotation
+    annotation class SimpleAnnotation
+    annotation class OtherSimpleAnnotation
 
     @SimpleAnnotation
-    private class MyClassWithAnnotaiton
+    class MyClassWithAnnotaiton
 
     private val basicClassScanner = ClassScanner(defaultSupportedPackages)
 
@@ -78,9 +78,11 @@ internal class ClassScannerTest {
     @Test
     fun `subtypes of non-supported packages`() {
         val classScannerOfOtherPackages = ClassScanner(listOf("com.example"))
-        val list = classScannerOfOtherPackages.getSubTypesOf(MyInterface::class)
-        assertEquals(expected = 0, actual = list.size)
-        classScannerOfOtherPackages.close()
+        classScannerOfOtherPackages.use {
+            assertTrue(classScannerOfOtherPackages.isEmptyScan())
+            val list = classScannerOfOtherPackages.getSubTypesOf(MyInterface::class)
+            assertEquals(expected = 0, actual = list.size)
+        }
     }
 
     @Test


### PR DESCRIPTION
### :pencil: Description
Fail with a new exception `InvalidPackagesException` when the `supportedPackages` config doesn't contain any valid packages. Also edit the exception message to add quotes around the package so the common error that `.properties` files should not use quotes is clear.

This does not cause any new exceptions, it just catches errors earlier instead of failing in the `TypesCache`

i.e.

```properties
# Valid
graphql.packages=foo.bar

# Invalid
graphql.packages="foo.bar"
```

```
The configured packages do not contain any valid classes: ""foo.bar""
```
### :link: Related Issues
Resolves https://github.com/ExpediaGroup/graphql-kotlin/issues/791