### PR TITLE
Update codecov action to latest config

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -19,11 +19,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: gradle/wrapper-validation-action@v1
+
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@v1
+
       - name: Set up Java ${{ matrix.java }}
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
+
       - name: Set up Gradle cache
         uses: actions/cache@v1
         with:
@@ -31,17 +35,17 @@ jobs:
           key: ${{ runner.os }}-${{ matrix.java }}-gradle-${{ hashFiles('**/*.gradle.kts') }}
           restore-keys: |
             ${{ runner.os }}-${{ matrix.java }}-gradle-
-      - name: Build library with Gradle
+
+      - name: Build libraries with Gradle
         run: ./gradlew clean build
+
       - name: Build examples with Gradle
         working-directory: examples
         run: ./gradlew clean build
+
       - name: Upload coverage to Codecov
         if: matrix.java == 8
         uses: codecov/codecov-action@v1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./codecov.yml
 
   release-notes:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - master
+      - '*.x.x'
     paths-ignore:
       - 'docs/**'
       - 'website/**'
@@ -18,11 +19,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: gradle/wrapper-validation-action@v1
+
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@v1
+
       - name: Set up Java ${{ matrix.java }}
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
+
       - name: Set up Gradle cache
         uses: actions/cache@v1
         with:
@@ -30,7 +35,8 @@ jobs:
           key: ${{ runner.os }}-${{ matrix.java }}-gradle-${{ hashFiles('**/*.gradle.kts') }}
           restore-keys: |
             ${{ runner.os }}-${{ matrix.java }}-gradle-
-      # used by maven-plugin integration tests
+
+      # Used by maven-plugin integration tests
       - name: Set up Maven cache
         uses: actions/cache@v1
         with:
@@ -38,8 +44,10 @@ jobs:
           key: ${{ runner.os }}-${{ matrix.java }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-${{ matrix.java }}-maven-
+
       - name: Build library with Gradle
         run: ./gradlew clean build
+
       - name: Build examples with Gradle
         working-directory: examples
         run: ./gradlew clean build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+
       - uses: gradle/wrapper-validation-action@v1
 
       - name: Set up Java 1.8


### PR DESCRIPTION
### :pencil: Description
The latest action config no longer requires a token for public repositories. This means we can delete the secret if this action works. I also made the formatting of other actions the same in newlines and spacing

### :link: Related Issues
https://github.com/codecov/codecov-action