### PR TITLE
Generate xml report for codecov

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -89,6 +89,12 @@ subprojects {
         jacoco {
             toolVersion = jacocoVersion
         }
+        jacocoTestReport {
+            reports {
+                xml.isEnabled = true
+                csv.isEnabled = false
+            }
+        }
         jar {
             manifest {
                 attributes["Built-By"] = "Expedia Group"

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,6 +2,10 @@
 # codecov.io Configuration
 # See the docs here: https://docs.codecov.io/docs/codecov-yaml
 #
+# To verify changes locally, run a gradle build then run the following command from the root:
+#
+#   bash <(curl -s https://codecov.io/bash)
+#
 
 # Ingore the example apps and docs from coverage reports
 ignore:


### PR DESCRIPTION
### :pencil: Description
Codecov is looking in the directories for the xml reports. HTML reports are still generated for easier debugging

### :link: Related Issues
https://github.com/codecov/example-kotlin

Failed action that finds no reports: https://github.com/ExpediaGroup/graphql-kotlin/runs/847614672?check_suite_focus=true#step:8:24

## Example of action script running locally
![Screen Shot 2020-07-07 at 4 08 24 PM](https://user-images.githubusercontent.com/2446877/86853985-716a1500-c06c-11ea-83bf-fb5831bdcb43.png)
