### PR TITLE
Include csv and html reports for jacoco

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -92,7 +92,8 @@ subprojects {
         jacocoTestReport {
             reports {
                 xml.isEnabled = true
-                csv.isEnabled = false
+                csv.isEnabled = true
+                html.isEnabled = true
             }
         }
         jar {


### PR DESCRIPTION
### :pencil: Description
Codecov is still having issues. It reads the xml files in the build logs and is able to make a push to codecov.io and returns a link for the report, but the report is empty. Maybe it can also read csv file reports? I am shooting in the dark here. If this does not work we could just remove codecov all together since all we are really using it for is the badge since we have coverage limits set in the jacoco plugin

### :link: Related Issues
