### PR TITLE
Valid polymorphic types in lists as input

### DIFF
--- a/examples/spark/src/main/kotlin/com/expediagroup/graphql/examples/spark/Application.kt
+++ b/examples/spark/src/main/kotlin/com/expediagroup/graphql/examples/spark/Application.kt
@@ -59,7 +59,7 @@ class Application {
                 graphQLHandler.handle(request, response)
             }
 
-            internalServerError() { _, response ->
+            internalServerError { _, response ->
                 response.status(500)
                 response.type("application/text")
                 "Unable to process request"

--- a/examples/spark/src/main/kotlin/com/expediagroup/graphql/examples/spark/schema/LoginMutationService.kt
+++ b/examples/spark/src/main/kotlin/com/expediagroup/graphql/examples/spark/schema/LoginMutationService.kt
@@ -19,7 +19,7 @@ import com.expediagroup.graphql.examples.spark.schema.models.User
 
 data class AuthPayload(val token: String? = null, val user: User? = null)
 
-class LoginMutationService() {
+class LoginMutationService {
     suspend fun login(email: String, password: String, aliasUUID: String?): AuthPayload {
         val token = "fake-token"
         val user = User(

--- a/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/model/Fruit.kt
+++ b/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/model/Fruit.kt
@@ -18,5 +18,5 @@ package com.expediagroup.graphql.examples.model
 
 sealed class Fruit(val color: String) {
     class Apple(private val variety: String) : Fruit(if (variety == "red delicious") "red" else "green")
-    class Orange() : Fruit("orange")
+    class Orange : Fruit("orange")
 }

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/extensions/kParameterExtensions.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/extensions/kParameterExtensions.kt
@@ -26,7 +26,7 @@ internal fun KParameter.isInterface() = this.type.getKClass().isInterface()
 
 internal fun KParameter.isList() = this.type.getKClass().isSubclassOf(List::class)
 
-internal fun KParameter.isListType() = this.isList() || this.javaClass.isArray
+internal fun KParameter.isListType() = this.isList() || this.type.getJavaClass().isArray
 
 internal fun KParameter.isGraphQLContext() = this.type.getKClass().isSubclassOf(GraphQLContext::class)
 

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/extensions/kParameterExtensions.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/extensions/kParameterExtensions.kt
@@ -26,6 +26,8 @@ internal fun KParameter.isInterface() = this.type.getKClass().isInterface()
 
 internal fun KParameter.isList() = this.type.getKClass().isSubclassOf(List::class)
 
+internal fun KParameter.isListType() = this.isList() || this.javaClass.isArray
+
 internal fun KParameter.isGraphQLContext() = this.type.getKClass().isSubclassOf(GraphQLContext::class)
 
 internal fun KParameter.isDataFetchingEnvironment() = this.type.classifier == DataFetchingEnvironment::class

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/extensions/FieldExtenstionsKtTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/extensions/FieldExtenstionsKtTest.kt
@@ -40,7 +40,7 @@ internal class FieldExtenstionsKtTest {
 
     @Test
     fun `verify @Deprecated on fields`() {
-        val propertyDeprecation = AnnotatedEnum::class.java.getField("ONE")?.getDeprecationReason()
+        val propertyDeprecation = AnnotatedEnum::class.java.getField("ONE").getDeprecationReason()
         assertEquals(expected = "do not use, replace with TWO", actual = propertyDeprecation)
     }
 }

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/extensions/KParameterExtensionsKtTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/extensions/KParameterExtensionsKtTest.kt
@@ -30,40 +30,42 @@ import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
-internal class KParameterExtensionsKtTest {
+class KParameterExtensionsKtTest {
 
     @GraphQLDescription("class description")
-    internal data class MyClass(val foo: String)
+    data class MyClass(val foo: String)
 
-    internal interface MyInterface {
+    interface MyInterface {
         val value: String
     }
 
-    internal abstract class MyAbstractClass {
+    abstract class MyAbstractClass {
 
         abstract val implementMe: String
 
         val value: String = "test"
     }
 
-    internal class Container {
+    class Container {
 
-        internal fun interfaceInput(myInterface: MyInterface) = myInterface
+        fun interfaceInput(myInterface: MyInterface) = myInterface
 
-        internal fun absctractInput(myAbstractClass: MyAbstractClass) = myAbstractClass
+        fun absctractInput(myAbstractClass: MyAbstractClass) = myAbstractClass
 
-        internal fun listInput(myList: List<Int>) = myList
+        fun listInput(myList: List<Int>) = myList
 
-        internal fun arrayInput(myArray: IntArray) = myArray
+        fun arrayListInput(myList: ArrayList<Int>) = myList
 
-        internal fun noDescription(myClass: MyClass) = myClass
+        fun arrayInput(myArray: IntArray) = myArray
 
-        internal fun paramDescription(@GraphQLDescription("param description") myClass: MyClass) = myClass
+        fun noDescription(myClass: MyClass) = myClass
 
-        internal fun dataFetchingEnvironment(environment: DataFetchingEnvironment) = environment.field.name
+        fun paramDescription(@GraphQLDescription("param description") myClass: MyClass) = myClass
+
+        fun dataFetchingEnvironment(environment: DataFetchingEnvironment) = environment.field.name
     }
 
-    internal class MyKotlinClass {
+    class MyKotlinClass {
         fun stringFun(string: String) = "hello $string"
     }
 
@@ -130,5 +132,13 @@ internal class KParameterExtensionsKtTest {
         assertTrue(Container::listInput.findParameterByName("myList")?.isList() == true)
         assertTrue(Container::arrayInput.findParameterByName("myArray")?.isList() == false)
         assertTrue(Container::interfaceInput.findParameterByName("myInterface")?.isList() == false)
+    }
+
+    @Test
+    fun isListType() {
+        assertTrue(Container::listInput.findParameterByName("myList")?.isListType() == true)
+        assertTrue(Container::arrayListInput.findParameterByName("myList")?.isListType() == true)
+        assertTrue(Container::arrayInput.findParameterByName("myArray")?.isListType() == true)
+        assertTrue(Container::interfaceInput.findParameterByName("myInterface")?.isListType() == false)
     }
 }

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/GenerateArgumentTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/GenerateArgumentTest.kt
@@ -34,11 +34,13 @@ import kotlin.test.assertNotNull
 
 class GenerateArgumentTest : TypeTestHelper() {
 
-    internal interface MyInterface {
+    interface MyInterface {
         val id: String
     }
 
-    internal class ArgumentTestClass {
+    interface MyUnion
+
+    class ArgumentTestClass {
         fun description(@GraphQLDescription("Argument description") input: String) = input
 
         fun directive(@SimpleDirective input: String) = input
@@ -53,7 +55,15 @@ class GenerateArgumentTest : TypeTestHelper() {
 
         fun arrayListArg(input: ArrayList<String>) = input
 
+        fun arrayListInterfaceArg(input: ArrayList<MyInterface>) = input
+
+        fun arrayListUnionArg(input: ArrayList<MyUnion>) = input
+
         fun listArg(input: List<String>) = input
+
+        fun listInterfaceArg(input: List<MyInterface>) = input
+
+        fun listUnionArg(input: List<MyUnion>) = input
     }
 
     @Test
@@ -128,6 +138,26 @@ class GenerateArgumentTest : TypeTestHelper() {
     }
 
     @Test
+    fun `ArrayList of interfaces as input is invalid`() {
+        val kParameter = ArgumentTestClass::arrayListInterfaceArg.findParameterByName("input")
+        assertNotNull(kParameter)
+
+        assertFailsWith(InvalidInputFieldTypeException::class) {
+            generateArgument(generator, kParameter)
+        }
+    }
+
+    @Test
+    fun `ArrayList of unions as input is invalid`() {
+        val kParameter = ArgumentTestClass::arrayListUnionArg.findParameterByName("input")
+        assertNotNull(kParameter)
+
+        assertFailsWith(InvalidInputFieldTypeException::class) {
+            generateArgument(generator, kParameter)
+        }
+    }
+
+    @Test
     fun `List argument type is valid`() {
         val kParameter = ArgumentTestClass::listArg.findParameterByName("input")
         assertNotNull(kParameter)
@@ -135,5 +165,25 @@ class GenerateArgumentTest : TypeTestHelper() {
 
         assertEquals(expected = "input", actual = result.name)
         assertNotNull(GraphQLTypeUtil.unwrapNonNull(result.type) as? GraphQLList)
+    }
+
+    @Test
+    fun `List of interfaces as input is invalid`() {
+        val kParameter = ArgumentTestClass::listInterfaceArg.findParameterByName("input")
+        assertNotNull(kParameter)
+
+        assertFailsWith(InvalidInputFieldTypeException::class) {
+            generateArgument(generator, kParameter)
+        }
+    }
+
+    @Test
+    fun `List of unions as input is invalid`() {
+        val kParameter = ArgumentTestClass::listUnionArg.findParameterByName("input")
+        assertNotNull(kParameter)
+
+        assertFailsWith(InvalidInputFieldTypeException::class) {
+            generateArgument(generator, kParameter)
+        }
     }
 }


### PR DESCRIPTION
### :pencil: Description
Polymorphic types (interface, union) are not supported as input types yet, and a `List<>` of those types is also unsupported. However a `List<Interface>` or `ArrayList<Union>` currently passes schema generation then fails at run time. We should instead catch this at generation.

### :link: Related Issues
Fixes https://github.com/ExpediaGroup/graphql-kotlin/issues/799