### PR TITLE
Support renaming of enum values

### DIFF
--- a/docs/schema-generator/customizing-schemas/renaming-fields.md
+++ b/docs/schema-generator/customizing-schemas/renaming-fields.md
@@ -31,8 +31,9 @@ data class MyInputClass(
     val field1: String
 )
 
+// GraphQL enums should use UPPER_CASE naming if possible, but any case is supported
 enum class Selection {
-
+  
   @JsonProperty("first")
   @GraphQLName("first")
   ONE,
@@ -58,7 +59,6 @@ input MyInputClassInput {
   renamedField: String!
 }
 
-# You should keep UPPERCASE naming if possible in GraphQL enums, but any case is supported
 enum Selection {
   first,
   second

--- a/docs/schema-generator/customizing-schemas/renaming-fields.md
+++ b/docs/schema-generator/customizing-schemas/renaming-fields.md
@@ -22,7 +22,7 @@ type MyCustomName {
 ```
 
 ## Known Issues
-> NOTE: Due to how we deserialize input classes, if you rename a field of an input class or enum you must also annotate the field with the Jackson annotation @JsonProperty. See [issue 493](https://github.com/ExpediaGroup/graphql-kotlin/issues/493) for more info.
+> NOTE: Due to how we deserialize input classes, if you rename a field of an input class or an enum value you must also annotate it with the Jackson annotation @JsonProperty. See [issue 493](https://github.com/ExpediaGroup/graphql-kotlin/issues/493) for more info.
 
 ```kotlin
 data class MyInputClass(

--- a/docs/schema-generator/customizing-schemas/renaming-fields.md
+++ b/docs/schema-generator/customizing-schemas/renaming-fields.md
@@ -22,7 +22,7 @@ type MyCustomName {
 ```
 
 ## Known Issues
-> NOTE: Due to how we deserialize input classes, if you rename a field of an input class you must also annotate the field with the Jackson annotation @JsonProperty. See [issue 493](https://github.com/ExpediaGroup/graphql-kotlin/issues/493) for more info.
+> NOTE: Due to how we deserialize input classes, if you rename a field of an input class or enum you must also annotate the field with the Jackson annotation @JsonProperty. See [issue 493](https://github.com/ExpediaGroup/graphql-kotlin/issues/493) for more info.
 
 ```kotlin
 data class MyInputClass(
@@ -31,8 +31,24 @@ data class MyInputClass(
     val field1: String
 )
 
+enum class Selection {
+
+  @JsonProperty("first")
+  @GraphQLName("first")
+  ONE,
+
+  @JsonProperty("second")
+  @GraphQLName("second")
+  TWO
+}
+
 class QueryClass {
   fun parseData(arg: MyInputClass) = "You sent ${arg.field1}"
+
+  fun chooseValue(selection: Selection): String = when (selection) {
+    Selection.ONE -> "You chose the first value"
+    Selection.TWO -> "You chose the second value"
+  }
 }
 ```
 
@@ -42,7 +58,14 @@ input MyInputClassInput {
   renamedField: String!
 }
 
+# You should keep UPPERCASE naming if possible in GraphQL enums, but any case is supported
+enum Selection {
+  first,
+  second
+}
+
 type Query {
   parseData(arg: MyInputClass!): String!
+  chooseValue(selection: Selection!): String!
 }
 ```

--- a/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/model/Selection.kt
+++ b/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/model/Selection.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Expedia, Inc
+ * Copyright 2020 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,14 +14,21 @@
  * limitations under the License.
  */
 
-package com.expediagroup.graphql.generator.extensions
+package com.expediagroup.graphql.examples.model
 
 import com.expediagroup.graphql.annotations.GraphQLDescription
 import com.expediagroup.graphql.annotations.GraphQLName
-import java.lang.reflect.Field
+import com.fasterxml.jackson.annotation.JsonProperty
 
-internal fun Field.getGraphQLDescription(): String? = this.getAnnotation(GraphQLDescription::class.java)?.value
+@GraphQLDescription("Use to represent a selection when choosing a value")
+enum class Selection {
 
-internal fun Field.getDeprecationReason(): String? = this.getDeclaredAnnotation(Deprecated::class.java)?.getReason()
+    @GraphQLDescription("Use this when you want the first one")
+    ONE,
 
-internal fun Field.getGraphQLName(): String = this.getAnnotation(GraphQLName::class.java)?.value ?: this.name
+    // If we change the name, we need to update Jackson as well
+    @JsonProperty("second")
+    @GraphQLName("second")
+    @GraphQLDescription("Use this when you want the second one")
+    TWO
+}

--- a/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/model/Widget.kt
+++ b/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/model/Widget.kt
@@ -21,13 +21,17 @@ import com.expediagroup.graphql.annotations.GraphQLIgnore
 
 @GraphQLDescription("A useful widget")
 data class Widget(
+
     @GraphQLDescription("The widget's value that can be null")
     var value: Int? = null,
+
     @Deprecated(message = "This field is deprecated", replaceWith = ReplaceWith("value"))
     @GraphQLDescription("The widget's deprecated value that shouldn't be used")
     val deprecatedValue: Int? = value,
+
     @GraphQLIgnore
     val ignoredField: String? = "ignored",
+
     private val hiddenField: String? = "hidden"
 ) {
 

--- a/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/query/SimpleQuery.kt
+++ b/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/query/SimpleQuery.kt
@@ -18,6 +18,7 @@ package com.expediagroup.graphql.examples.query
 
 import com.expediagroup.graphql.annotations.GraphQLDescription
 import com.expediagroup.graphql.annotations.GraphQLIgnore
+import com.expediagroup.graphql.examples.model.Selection
 import com.expediagroup.graphql.spring.operations.Query
 import org.springframework.stereotype.Component
 import java.util.Random
@@ -76,4 +77,10 @@ class SimpleQuery : Query {
         @GraphQLDescription("this field is optional") optionalValue: Int? = null
     ) =
         "required value=$requiredValue, optional value=$optionalValue"
+
+    @GraphQLDescription("Demonstrate the usage of custom enum input")
+    fun getAValue(selection: Selection): String = when (selection) {
+        Selection.ONE -> "You chose the first one"
+        Selection.TWO -> "You chose the second one"
+    }
 }

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/generateArgument.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/generateArgument.kt
@@ -37,7 +37,7 @@ internal fun generateArgument(generator: SchemaGenerator, parameter: KParameter)
     // This is not currently supported by the GraphQL spec
     // https://github.com/graphql/graphql-spec/blob/master/rfcs/InputUnion.md
     val unwrappedClass = getUnwrappedClass(parameter)
-    if (unwrappedClass.isInterface() || unwrappedClass.isUnion()) {
+    if (unwrappedClass.isUnion() || unwrappedClass.isInterface()) {
         throw InvalidInputFieldTypeException(parameter)
     }
 

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/generateEnum.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/generateEnum.kt
@@ -20,6 +20,7 @@ import com.expediagroup.graphql.directives.deprecatedDirectiveWithReason
 import com.expediagroup.graphql.generator.SchemaGenerator
 import com.expediagroup.graphql.generator.extensions.getDeprecationReason
 import com.expediagroup.graphql.generator.extensions.getGraphQLDescription
+import com.expediagroup.graphql.generator.extensions.getGraphQLName
 import com.expediagroup.graphql.generator.extensions.getSimpleName
 import com.expediagroup.graphql.generator.extensions.safeCast
 import graphql.schema.GraphQLEnumType
@@ -44,11 +45,11 @@ internal fun generateEnum(generator: SchemaGenerator, kClass: KClass<out Enum<*>
 
 private fun getEnumValueDefinition(generator: SchemaGenerator, enum: Enum<*>, kClass: KClass<out Enum<*>>): GraphQLEnumValueDefinition {
     val valueBuilder = GraphQLEnumValueDefinition.newEnumValueDefinition()
-
-    valueBuilder.name(enum.name)
-    valueBuilder.value(enum.name)
-
     val valueField = kClass.java.getField(enum.name)
+
+    val name = valueField.getGraphQLName()
+    valueBuilder.name(name)
+    valueBuilder.value(name)
 
     generateFieldDirectives(generator, valueField).forEach {
         valueBuilder.withDirective(it)

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/extensions/FieldExtenstionsKtTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/extensions/FieldExtenstionsKtTest.kt
@@ -17,15 +17,17 @@
 package com.expediagroup.graphql.generator.extensions
 
 import com.expediagroup.graphql.annotations.GraphQLDescription
+import com.expediagroup.graphql.annotations.GraphQLName
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 
-internal class FieldExtenstionsKtTest {
+class FieldExtenstionsKtTest {
 
-    internal enum class AnnotatedEnum {
+    enum class AnnotatedEnum {
         @GraphQLDescription("field description")
         @Deprecated("do not use", ReplaceWith("TWO"))
+        @GraphQLName("customOne")
         ONE,
         TWO
     }
@@ -42,5 +44,14 @@ internal class FieldExtenstionsKtTest {
     fun `verify @Deprecated on fields`() {
         val propertyDeprecation = AnnotatedEnum::class.java.getField("ONE").getDeprecationReason()
         assertEquals(expected = "do not use, replace with TWO", actual = propertyDeprecation)
+    }
+
+    @Test
+    fun `verify @GraphQLName on fields`() {
+        val customNameField = AnnotatedEnum::class.java.getField("ONE")
+        assertEquals(expected = "customOne", actual = customNameField.getGraphQLName())
+
+        val basicNameField = AnnotatedEnum::class.java.getField("TWO")
+        assertEquals(expected = "TWO", actual = basicNameField.getGraphQLName())
     }
 }

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/GenerateEnumTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/GenerateEnumTest.kt
@@ -27,12 +27,12 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
-internal class GenerateEnumTest : TypeTestHelper() {
+class GenerateEnumTest : TypeTestHelper() {
 
     @Suppress("Detekt.UnusedPrivateClass")
     @GraphQLDescription("MyTestEnum description")
     @SimpleDirective
-    private enum class MyTestEnum {
+    enum class MyTestEnum {
         @GraphQLDescription("enum 'ONE' description")
         @SimpleDirective
         ONE,
@@ -44,21 +44,25 @@ internal class GenerateEnumTest : TypeTestHelper() {
         @SimpleDirective
         @CustomDirective("foo bar")
         @Deprecated("THREE is out", replaceWith = ReplaceWith("TWO"))
-        THREE
+        THREE,
+
+        @GraphQLName("customFour")
+        FOUR
     }
 
     @Suppress("Detekt.UnusedPrivateClass")
     @GraphQLName("MyTestEnumRenamed")
-    private enum class MyTestEnumCustomName
+    enum class MyTestEnumCustomName
 
     @Test
     fun enumType() {
         val actual = generateEnum(generator, MyTestEnum::class)
-        assertEquals(expected = 3, actual = actual.values.size)
+        assertEquals(expected = 4, actual = actual.values.size)
         assertEquals(expected = "MyTestEnum", actual = actual.name)
         assertEquals(expected = "ONE", actual = actual.values[0].value)
         assertEquals(expected = "TWO", actual = actual.values[1].value)
         assertEquals(expected = "THREE", actual = actual.values[2].value)
+        assertEquals(expected = "customFour", actual = actual.values[3].value)
     }
 
     @Test
@@ -105,7 +109,8 @@ internal class GenerateEnumTest : TypeTestHelper() {
     fun `Enum values can have directives`() {
         val gqlEnum = assertNotNull(generateEnum(generator, MyTestEnum::class))
 
-        val enumValuesDirectives = gqlEnum.values.last().directives
+        val enumValuesDirectives = gqlEnum.values.find { it.name == "THREE" }?.directives
+        assertNotNull(enumValuesDirectives)
         assertEquals(3, enumValuesDirectives.size)
         assertEquals("simpleDirective", enumValuesDirectives[0].name)
         assertEquals("customName", enumValuesDirectives[1].name)
@@ -117,5 +122,12 @@ internal class GenerateEnumTest : TypeTestHelper() {
         val gqlEnum = assertNotNull(generateEnum(generator, MyTestEnum::class))
         assertEquals(1, gqlEnum.values.first().directives.size)
         assertEquals("simpleDirective", gqlEnum.values.first().directives.first().name)
+    }
+
+    @Test
+    fun `Enum values can have a custom name`() {
+        val gqlEnum = assertNotNull(generateEnum(generator, MyTestEnum::class))
+
+        assertNotNull(gqlEnum.getValue("customFour"))
     }
 }


### PR DESCRIPTION
### :pencil: Description
`@GraphQLName` was supported for enum classes and object fields but not on enum fields. It is possible to support changing the name in the generator, library users will just also have to add the Jackson annotations to inform the execution engine of the name change

![Screen Shot 2020-07-17 at 11 07 16 AM](https://user-images.githubusercontent.com/2446877/87818263-1fb94b80-c81f-11ea-8303-74a1697e686e.png)
![Screen Shot 2020-07-17 at 11 07 29 AM](https://user-images.githubusercontent.com/2446877/87818266-20ea7880-c81f-11ea-88f3-5f66be9727fe.png)


### :link: Related Issues
https://github.com/ExpediaGroup/graphql-kotlin/issues/493