### PR TITLE
[generator] built-in support for optional input

### DIFF
--- a/docs/schema-generator/execution/optional-undefined-arguments.md
+++ b/docs/schema-generator/execution/optional-undefined-arguments.md
@@ -3,13 +3,44 @@ id: optional-undefined-arguments
 title: Optional Undefined Arguments
 ---
 
-In GraphQL, input types can be optional which means that the client can either:
+In the GraphQL world, input types can be optional which means that the client can either:
 
 * Not specify a value at all
-* Send null explictly
+* Send null explicitly
 * Send the non-null type
 
-Optional input types are represented as nullable parameters in Kotlin
+This is in contrast with the JVM world where objects can either have some specific value or don't have any value (i.e.
+are `null`). As a result, when using default serialization logic it is not possible to distinguish between missing/unspecified
+value and explicit `null` value.
+
+## Using OptionalInput wrapper
+
+`OptionalInput` sealed class is a convenient wrapper that provides easy distinction between unspecified, `null` and non-null
+value. If target argument is not specified in the request it will be represented as `Undefined` object, otherwise actual
+value will be wrapped in `Defined` class.
+
+```kotlin
+fun optionalInput(input: OptionalInput<String>): String = when (input) {
+    is OptionalInput.Undefined -> "input was not specified"
+    is OptionalInput.Defined<String> -> "input value: ${input.value}"
+}
+```
+
+```graphql
+query OptionalInputQuery {
+  undefined: optionalInput
+  null: optionalInput(value: null)
+  foo: optionalInput(value: "foo")
+}
+```
+
+> NOTE: Regardless whether generic type of `OptionalInput` is specified as nullable or not it will always result in nullable
+> value in `Defined` class.
+
+## Using DataFetchingEnvironment
+
+Optional input types can be represented as nullable parameters in Kotlin
+
 ```kotlin
 fun optionalInput(value: String?): String? = value
 ```
@@ -23,9 +54,10 @@ query OptionalInputQuery {
 ```
 
 By default, if an optional input value is not specified, then the execution engine will set the argument in Kotlin to `null`.
-This means that you can not tell, by just the value alone, whether the request did not contain any argument or the client explicitly passed in `null`.
+This means that you can not tell, by just the value alone, whether the request did not contain any argument or the client
+explicitly passed in `null`.
 
-Instead, you should inspect the [DataFetchingEnvironment](./data-fetching-environment.md) where you can see if the request had the variable defined and even check parent arguments as well.
+Instead, you can inspect all passed in arguments using the [DataFetchingEnvironment](./data-fetching-environment.md).
 
 ```kotlin
 fun optionalInput(value: String?, dataFetchingEnvironment: DataFetchingEnvironment): String =

--- a/graphql-kotlin-schema-generator/build.gradle.kts
+++ b/graphql-kotlin-schema-generator/build.gradle.kts
@@ -6,6 +6,7 @@ val jacksonVersion: String by project
 val kotlinVersion: String by project
 val kotlinCoroutinesVersion: String by project
 val rxjavaVersion: String by project
+val junitVersion: String by project
 
 dependencies {
     api("com.graphql-java:graphql-java:$graphQLJavaVersion")
@@ -14,6 +15,7 @@ dependencies {
     implementation(kotlin("reflect", kotlinVersion))
     implementation("io.github.classgraph:classgraph:$classGraphVersion")
     testImplementation("io.reactivex.rxjava3:rxjava:$rxjavaVersion")
+    testImplementation("org.junit.jupiter:junit-jupiter-params:$junitVersion")
 }
 
 tasks {

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/execution/OptionalInput.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/execution/OptionalInput.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2020 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.execution
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonValue
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.BeanProperty
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.JsonDeserializer
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import com.fasterxml.jackson.databind.deser.ContextualDeserializer
+import com.fasterxml.jackson.databind.util.AccessPattern
+
+/**
+ * Wrapper used to represent optionally defined input arguments that allows us to distinguish between undefined value, explicit NULL value
+ * and specified value.
+ */
+@JsonDeserialize(using = OptionalInputDeserializer::class)
+sealed class OptionalInput<out T> {
+
+    /**
+     * Represents missing/undefined value.
+     */
+    object Undefined : OptionalInput<Nothing>()
+
+    /**
+     * Wrapper holding explicitly specified value including NULL.
+     */
+    class Defined<out U> @JsonCreator constructor(@JsonValue val value: U?) : OptionalInput<U>()
+}
+
+/**
+ * Null aware deserializer that distinguishes between undefined value, explicit NULL value
+ * and specified value.
+ */
+class OptionalInputDeserializer(private val klazz: Class<*>? = null) : JsonDeserializer<OptionalInput<*>>(), ContextualDeserializer {
+
+    override fun createContextual(ctxt: DeserializationContext, property: BeanProperty?): JsonDeserializer<*> {
+        val type = if (property != null) {
+            property.type.containedType(0)
+        } else {
+            ctxt.contextualType
+        }
+        return OptionalInputDeserializer(type.rawClass)
+    }
+
+    override fun deserialize(p: JsonParser, ctxt: DeserializationContext): OptionalInput<*> {
+        val result: Any = ctxt.readValue(p, klazz)
+        return OptionalInput.Defined(result)
+    }
+
+    override fun getNullAccessPattern(): AccessPattern = AccessPattern.CONSTANT
+
+    override fun getNullValue(ctxt: DeserializationContext): OptionalInput<*> = if (ctxt.parser.parsingContext.currentName != null) {
+        OptionalInput.Defined(null)
+    } else {
+        OptionalInput.Undefined
+    }
+}

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/extensions/kTypeExtensions.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/extensions/kTypeExtensions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Expedia, Inc
+ * Copyright 2020 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,12 @@
 package com.expediagroup.graphql.generator.extensions
 
 import com.expediagroup.graphql.exceptions.InvalidListTypeException
+import com.expediagroup.graphql.execution.OptionalInput
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
 import kotlin.reflect.full.createType
 import kotlin.reflect.full.isSubclassOf
+import kotlin.reflect.full.withNullability
 import kotlin.reflect.jvm.jvmErasure
 
 private val primitiveArrayTypes = mapOf(
@@ -38,6 +40,16 @@ internal fun KType.getKClass() = this.jvmErasure
 internal fun KType.getJavaClass(): Class<*> = this.getKClass().java
 
 internal fun KType.isSubclassOf(kClass: KClass<*>) = this.getKClass().isSubclassOf(kClass)
+
+internal fun KType.isListType() = this.isSubclassOf(List::class) || this.getJavaClass().isArray
+
+internal fun KType.isOptionalInputType() = this.isSubclassOf(OptionalInput::class)
+
+internal fun KType.unwrapOptionalInputType() = if (this.isOptionalInputType()) {
+    this.getWrappedType().withNullability(true)
+} else {
+    this
+}
 
 @Throws(InvalidListTypeException::class)
 internal fun KType.getTypeOfFirstArgument(): KType =

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/generateInputProperty.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/generateInputProperty.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Expedia, Inc
+ * Copyright 2020 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import com.expediagroup.graphql.generator.SchemaGenerator
 import com.expediagroup.graphql.generator.extensions.getPropertyDescription
 import com.expediagroup.graphql.generator.extensions.getPropertyName
 import com.expediagroup.graphql.generator.extensions.safeCast
+import com.expediagroup.graphql.generator.extensions.unwrapOptionalInputType
 import graphql.schema.GraphQLInputObjectField
 import graphql.schema.GraphQLInputType
 import kotlin.reflect.KClass
@@ -29,7 +30,9 @@ internal fun generateInputProperty(generator: SchemaGenerator, prop: KProperty<*
     val builder = GraphQLInputObjectField.newInputObjectField()
 
     // Verfiy that the unwrapped GraphQL type is a valid input type
-    val graphQLInputType = generateGraphQLType(generator = generator, type = prop.returnType, inputType = true).safeCast<GraphQLInputType>()
+    val inputTypeFromHooks = generator.config.hooks.willResolveInputMonad(prop.returnType)
+    val unwrappedType = inputTypeFromHooks.unwrapOptionalInputType()
+    val graphQLInputType = generateGraphQLType(generator = generator, type = unwrappedType, inputType = true).safeCast<GraphQLInputType>()
 
     builder.description(prop.getPropertyDescription(parentClass))
     builder.name(prop.getPropertyName(parentClass))

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/hooks/SchemaGeneratorHooks.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/hooks/SchemaGeneratorHooks.kt
@@ -74,6 +74,12 @@ interface SchemaGeneratorHooks {
     fun willResolveMonad(type: KType): KType = type
 
     /**
+     * Called before resolving a KType to the input GraphQL type.
+     * This allows resolvers for custom deserialization logic of wrapped input values, like in an Optional.
+     */
+    fun willResolveInputMonad(type: KType): KType = type
+
+    /**
      * Called when looking at the KClass superclasses to determine if it valid for adding to the generated schema.
      * If any filter returns false, it is rejected.
      */

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/GenerateArgumentTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/GenerateArgumentTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Expedia, Inc
+ * Copyright 2020 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,10 +19,10 @@ package com.expediagroup.graphql.generator.types
 import com.expediagroup.graphql.annotations.GraphQLDescription
 import com.expediagroup.graphql.annotations.GraphQLName
 import com.expediagroup.graphql.exceptions.InvalidInputFieldTypeException
+import com.expediagroup.graphql.execution.OptionalInput
 import com.expediagroup.graphql.scalars.ID
 import com.expediagroup.graphql.test.utils.SimpleDirective
 import graphql.Scalars
-import graphql.Scalars.GraphQLString
 import graphql.schema.GraphQLList
 import graphql.schema.GraphQLNonNull
 import graphql.schema.GraphQLTypeUtil
@@ -64,6 +64,11 @@ class GenerateArgumentTest : TypeTestHelper() {
         fun listInterfaceArg(input: List<MyInterface>) = input
 
         fun listUnionArg(input: List<MyUnion>) = input
+
+        fun optionalArg(input: OptionalInput<String>): String? = when (input) {
+            is OptionalInput.Undefined -> null
+            is OptionalInput.Defined -> input.value
+        }
     }
 
     @Test
@@ -72,7 +77,7 @@ class GenerateArgumentTest : TypeTestHelper() {
         assertNotNull(kParameter)
         val result = generateArgument(generator, kParameter)
 
-        assertEquals(GraphQLString, (result.type as? GraphQLNonNull)?.wrappedType)
+        assertEquals(Scalars.GraphQLString, (result.type as? GraphQLNonNull)?.wrappedType)
         assertEquals("Argument description", result.description)
     }
 
@@ -82,7 +87,7 @@ class GenerateArgumentTest : TypeTestHelper() {
         assertNotNull(kParameter)
         val result = generateArgument(generator, kParameter)
 
-        assertEquals(GraphQLString, (result.type as? GraphQLNonNull)?.wrappedType)
+        assertEquals(Scalars.GraphQLString, (result.type as? GraphQLNonNull)?.wrappedType)
         assertEquals(1, result.directives.size)
         assertEquals("simpleDirective", result.directives.firstOrNull()?.name)
     }
@@ -93,7 +98,7 @@ class GenerateArgumentTest : TypeTestHelper() {
         assertNotNull(kParameter)
         val result = generateArgument(generator, kParameter)
 
-        assertEquals(GraphQLString, (result.type as? GraphQLNonNull)?.wrappedType)
+        assertEquals(Scalars.GraphQLString, (result.type as? GraphQLNonNull)?.wrappedType)
         assertEquals("newName", result.name)
     }
 
@@ -185,5 +190,16 @@ class GenerateArgumentTest : TypeTestHelper() {
         assertFailsWith(InvalidInputFieldTypeException::class) {
             generateArgument(generator, kParameter)
         }
+    }
+
+    @Test
+    fun `Input wrapped in optional is valid`() {
+        val kParameter = ArgumentTestClass::optionalArg.findParameterByName("input")
+        assertNotNull(kParameter)
+
+        val result = generateArgument(generator, kParameter)
+
+        assertEquals(expected = "input", actual = result.name)
+        assertEquals(Scalars.GraphQLString, result.type)
     }
 }

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/test/integration/OptionalInputTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/test/integration/OptionalInputTest.kt
@@ -1,0 +1,87 @@
+package com.expediagroup.graphql.test.integration
+
+import com.expediagroup.graphql.TopLevelObject
+import com.expediagroup.graphql.execution.OptionalInput
+import com.expediagroup.graphql.testSchemaConfig
+import com.expediagroup.graphql.toSchema
+import graphql.GraphQL
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.stream.Stream
+import kotlin.test.assertEquals
+
+class OptionalInputTest {
+    private val schema = toSchema(
+        queries = listOf(TopLevelObject(OptionalInputQuery())),
+        config = testSchemaConfig
+    )
+    private val graphQL = GraphQL.newGraphQL(schema).build()
+
+    @DisplayName("verify optional arguments can be correctly deserialized")
+    @ParameterizedTest(name = "{index} ==> {1}")
+    @MethodSource("optionalInputTestArguments")
+    fun `verify optional arguments can be correctly deserialized`(query: String, expectedResult: String) {
+        val result = graphQL.execute(query)
+        val data: Map<String, String>? = result.getData()
+
+        val optionalInputResults = data?.values?.first()
+        assertEquals(expectedResult, optionalInputResults)
+    }
+
+    companion object {
+        @JvmStatic
+        fun optionalInputTestArguments(): Stream<Arguments> = Stream.of(
+            Arguments.of("{ optionalScalarInput }", "input scalar was not specified"),
+            Arguments.of("{ optionalScalarInput(input: null) }", "input scalar value: null"),
+            Arguments.of("{ optionalScalarInput(input: \"ABC\") }", "input scalar value: ABC"),
+            Arguments.of("{ optionalObjectInput }", "input object was not specified"),
+            Arguments.of("{ optionalObjectInput(input: null) }", "input object value: null"),
+            Arguments.of("{ optionalObjectInput(input: { id: 1, name: \"ABC\" } )  }", "input object value: SimpleArgument(id=1, name=ABC)"),
+            Arguments.of("{ inputWithOptionalScalarValues(input: { required: \"ABC\" }) }", "argument with optional scalar was not specified"),
+            Arguments.of("{ inputWithOptionalScalarValues(input: { required: \"ABC\" optional: null }) }", "argument scalar value: null"),
+            Arguments.of("{ inputWithOptionalScalarValues(input: { required: \"ABC\" optional: 1 }) }", "argument scalar value: 1"),
+            Arguments.of("{ inputWithOptionalValues(input: { required: \"ABC\" }) }", "argument with optional object was not specified"),
+            Arguments.of("{ inputWithOptionalValues(input: { required: \"ABC\" optional: null }) }", "argument object value: null"),
+            Arguments.of("{ inputWithOptionalValues(input: { required: \"ABC\" optional: { id: 1, name: \"XYZ\" } }) }", "argument object value: SimpleArgument(id=1, name=XYZ)")
+        )
+    }
+}
+
+data class SimpleArgument(
+    val id: Int,
+    val name: String
+)
+
+data class HasOptionalScalarArguments(
+    val required: String,
+    val optional: OptionalInput<Int>
+)
+
+data class HasOptionalArguments(
+    val required: String,
+    val optional: OptionalInput<SimpleArgument>
+)
+
+class OptionalInputQuery {
+    fun optionalScalarInput(input: OptionalInput<String>): String = when (input) {
+        is OptionalInput.Undefined -> "input scalar was not specified"
+        is OptionalInput.Defined<String> -> "input scalar value: ${input.value}"
+    }
+
+    fun optionalObjectInput(input: OptionalInput<SimpleArgument>): String = when (input) {
+        is OptionalInput.Undefined -> "input object was not specified"
+        is OptionalInput.Defined<SimpleArgument> -> "input object value: ${input.value}"
+    }
+
+    fun inputWithOptionalScalarValues(input: HasOptionalScalarArguments): String = when (input.optional) {
+        is OptionalInput.Undefined -> "argument with optional scalar was not specified"
+        is OptionalInput.Defined<Int> -> "argument scalar value: ${input.optional.value}"
+    }
+
+    fun inputWithOptionalValues(input: HasOptionalArguments): String = when (input.optional) {
+        is OptionalInput.Undefined -> "argument with optional object was not specified"
+        is OptionalInput.Defined<SimpleArgument> -> "argument object value: ${input.optional.value}"
+    }
+}


### PR DESCRIPTION
### :pencil: Description

In the GraphQL world, input types can be optional which means that the client can either:

* Not specify a value at all
* Send null explicitly
* Send the non-null type

This is in contrast with the JVM world where objects can either have some specific value or don't have any value (i.e. are `null`). As a result, when using default serialization logic it is not possible to distinguish between missing/unspecified value and explicit `null` value.

This PR introduces new `OptionalInput` sealed class wrapper that when used for query arguments will be automatically deserialized to `Undefined` object if argument was not specified OR to `Defined` wrapper class when argument was specified (including explicit null).

### :link: Related Issues
Resolves: #783