### PR TITLE
[client] set default null value for input arguments

### DIFF
--- a/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/types/generateGraphQLInputObjectTypeSpec.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/types/generateGraphQLInputObjectTypeSpec.kt
@@ -19,6 +19,7 @@ package com.expediagroup.graphql.plugin.generator.types
 import com.expediagroup.graphql.plugin.generator.GraphQLClientGeneratorContext
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
+import com.squareup.kotlinpoet.ParameterSpec
 import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeSpec
 import graphql.language.InputObjectTypeDefinition
@@ -46,7 +47,12 @@ internal fun generateGraphQLInputObjectTypeSpec(context: GraphQLClientGeneratorC
 
         val inputPropertySpec = inputPropertySpecBuilder.build()
         inputObjectTypeSpecBuilder.addProperty(inputPropertySpec)
-        constructorBuilder.addParameter(inputPropertySpec.name, inputPropertySpec.type)
+
+        val inputParameterSpec = ParameterSpec.builder(inputPropertySpec.name, inputPropertySpec.type)
+        if (inputPropertySpec.type.isNullable) {
+            inputParameterSpec.defaultValue("null")
+        }
+        constructorBuilder.addParameter(inputParameterSpec.build())
     }
     inputObjectTypeSpecBuilder.primaryConstructor(constructorBuilder.build())
 

--- a/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/types/generateVariableTypeSpec.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/types/generateVariableTypeSpec.kt
@@ -19,6 +19,7 @@ package com.expediagroup.graphql.plugin.generator.types
 import com.expediagroup.graphql.plugin.generator.GraphQLClientGeneratorContext
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
+import com.squareup.kotlinpoet.ParameterSpec
 import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeSpec
 import graphql.language.VariableDefinition
@@ -34,7 +35,11 @@ internal fun generateVariableTypeSpec(context: GraphQLClientGeneratorContext, va
     variableDefinitions.forEach { variableDef ->
         val kotlinTypeName = generateTypeName(context, variableDef.type)
 
-        constructorSpec.addParameter(variableDef.name, kotlinTypeName)
+        val parameterBuilder = ParameterSpec.builder(variableDef.name, kotlinTypeName)
+        if (kotlinTypeName.isNullable) {
+            parameterBuilder.defaultValue("null")
+        }
+        constructorSpec.addParameter(parameterBuilder.build())
         variableTypeSpec.addProperty(
             PropertySpec.builder(variableDef.name, kotlinTypeName)
                 .initializer(variableDef.name)

--- a/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateVariableTypeSpecIT.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateVariableTypeSpecIT.kt
@@ -49,7 +49,7 @@ class GenerateVariableTypeSpecIT {
                       requestBuilder)
 
                   data class Variables(
-                    val criteria: TestQueryWithVariables.SimpleArgumentInput?
+                    val criteria: TestQueryWithVariables.SimpleArgumentInput? = null
                   )
 
                   /**
@@ -59,15 +59,15 @@ class GenerateVariableTypeSpecIT {
                     /**
                      * Maximum value for test criteria
                      */
-                    val max: Float?,
+                    val max: Float? = null,
                     /**
                      * Minimum value for test criteria
                      */
-                    val min: Float?,
+                    val min: Float? = null,
                     /**
                      * New value to be set
                      */
-                    val newName: String?
+                    val newName: String? = null
                   )
 
                   data class Result(


### PR DESCRIPTION
### :pencil: Description

When generating client we can set default `null` value to the optional nullable input arguments.

### :link: Related Issues

Related: https://github.com/ExpediaGroup/graphql-kotlin/issues/781