### PR TITLE
[client] open up GraphQL client

### DIFF
--- a/docs/client/client-customization.md
+++ b/docs/client/client-customization.md
@@ -56,6 +56,22 @@ val result = helloWorldQuery.execute(variables = HelloWorldQuery.Variables(name 
 }
 ```
 
+### Custom GraphQL client
+
+`GraphQLClient` is an open class which means you can also extend it to provide custom `execute` logic.
+
+```kotlin
+class CustomGraphQLClient(url: URL) : GraphQLClient<CIOEngineConfig>(url = url, engineFactory = CIO) {
+
+    override suspend fun <T> execute(query: String, operationName: String?, variables: Any?, resultType: Class<T>, requestBuilder: HttpRequestBuilder.() -> Unit): GraphQLResponse<T> {
+        // custom init logic
+        val result = super.execute(query, operationName, variables, resultType, requestBuilder)
+        // custom finalize logic
+        return result
+    }
+}
+```
+
 ## Jackson Customization
 
 `GraphQLClient` relies on Jackson to handle polymorphic types and default enum values. You can specify your own custom

--- a/graphql-kotlin-client/src/main/kotlin/com/expediagroup/graphql/client/GraphQLClient.kt
+++ b/graphql-kotlin-client/src/main/kotlin/com/expediagroup/graphql/client/GraphQLClient.kt
@@ -42,7 +42,7 @@ import java.net.URL
  * A lightweight typesafe GraphQL HTTP client.
  */
 @KtorExperimentalAPI
-class GraphQLClient<in T : HttpClientEngineConfig>(
+open class GraphQLClient<in T : HttpClientEngineConfig>(
     private val url: URL,
     engineFactory: HttpClientEngineFactory<T>,
     private val mapper: ObjectMapper = jacksonObjectMapper(),
@@ -71,7 +71,7 @@ class GraphQLClient<in T : HttpClientEngineConfig>(
      * default serialization would attempt to serialize results back to Any object. As a workaround we get raw results as String which we then
      * manually deserialize using passed in result type Class information.
      */
-    suspend fun <T> execute(query: String, operationName: String? = null, variables: Any? = null, resultType: Class<T>, requestBuilder: HttpRequestBuilder.() -> Unit = {}): GraphQLResponse<T> {
+    open suspend fun <T> execute(query: String, operationName: String? = null, variables: Any? = null, resultType: Class<T>, requestBuilder: HttpRequestBuilder.() -> Unit = {}): GraphQLResponse<T> {
         // Variables are simple data classes which will be serialized as map.
         // By using map instead of typed object we can eliminate the need to explicitly convert variables to a map
         val graphQLRequest = mapOf(


### PR DESCRIPTION
### :pencil: Description

Makes `GraphQLClient` an open class so end users can override `execute` method to provide some additional custom logic as needed.

### :link: Related Issues

Resolves: https://github.com/ExpediaGroup/graphql-kotlin/issues/800