### PR TITLE
fix documentation

### DIFF
--- a/website/versioned_docs/version-3.4.2/client/client-customization.md
+++ b/website/versioned_docs/version-3.4.2/client/client-customization.md
@@ -1,5 +1,5 @@
 ---
-id: version-3.4.1-client-customization
+id: version-3.4.2-client-customization
 title: Client Customization
 original_id: client-customization
 ---

--- a/website/versioned_docs/version-3.4.2/client/client-features.md
+++ b/website/versioned_docs/version-3.4.2/client/client-features.md
@@ -1,5 +1,5 @@
 ---
-id: version-3.4.1-client-features
+id: version-3.4.2-client-features
 title: Client Features
 original_id: client-features
 ---

--- a/website/versioned_docs/version-3.4.2/client/client-overview.md
+++ b/website/versioned_docs/version-3.4.2/client/client-overview.md
@@ -1,5 +1,5 @@
 ---
-id: version-3.4.1-client-overview
+id: version-3.4.2-client-overview
 title: Client Overview
 original_id: client-overview
 ---

--- a/website/versioned_docs/version-3.4.2/contributors/release-proc.md
+++ b/website/versioned_docs/version-3.4.2/contributors/release-proc.md
@@ -1,5 +1,5 @@
 ---
-id: version-3.4.1-release-proc
+id: version-3.4.2-release-proc
 title: Releasing a new version
 original_id: release-proc
 ---

--- a/website/versioned_docs/version-3.4.2/federated/apollo-federation.md
+++ b/website/versioned_docs/version-3.4.2/federated/apollo-federation.md
@@ -1,5 +1,5 @@
 ---
-id: version-3.4.1-apollo-federation
+id: version-3.4.2-apollo-federation
 title: Apollo Federation
 original_id: apollo-federation
 ---

--- a/website/versioned_docs/version-3.4.2/federated/federated-directives.md
+++ b/website/versioned_docs/version-3.4.2/federated/federated-directives.md
@@ -1,5 +1,5 @@
 ---
-id: version-3.4.1-federated-directives
+id: version-3.4.2-federated-directives
 title: Federated Directives
 original_id: federated-directives
 ---

--- a/website/versioned_docs/version-3.4.2/federated/federated-schemas.md
+++ b/website/versioned_docs/version-3.4.2/federated/federated-schemas.md
@@ -1,5 +1,5 @@
 ---
-id: version-3.4.1-federated-schemas
+id: version-3.4.2-federated-schemas
 title: Federated Schemas
 original_id: federated-schemas
 ---

--- a/website/versioned_docs/version-3.4.2/federated/type-resolution.md
+++ b/website/versioned_docs/version-3.4.2/federated/type-resolution.md
@@ -1,5 +1,5 @@
 ---
-id: version-3.4.1-type-resolution
+id: version-3.4.2-type-resolution
 title: Federated Type Resolution
 original_id: type-resolution
 ---

--- a/website/versioned_docs/version-3.4.2/plugins/gradle-plugin.md
+++ b/website/versioned_docs/version-3.4.2/plugins/gradle-plugin.md
@@ -1,5 +1,5 @@
 ---
-id: version-3.4.1-gradle-plugin
+id: version-3.4.2-gradle-plugin
 title: Gradle Plugin
 original_id: gradle-plugin
 ---

--- a/website/versioned_docs/version-3.4.2/plugins/maven-plugin.md
+++ b/website/versioned_docs/version-3.4.2/plugins/maven-plugin.md
@@ -1,5 +1,5 @@
 ---
-id: version-3.4.1-maven-plugin
+id: version-3.4.2-maven-plugin
 title: Maven Plugin
 original_id: maven-plugin
 ---

--- a/website/versioned_docs/version-3.4.2/schema-generator/customizing-schemas/advanced-features.md
+++ b/website/versioned_docs/version-3.4.2/schema-generator/customizing-schemas/advanced-features.md
@@ -1,5 +1,5 @@
 ---
-id: version-3.4.1-advanced-features
+id: version-3.4.2-advanced-features
 title: Advanced Features
 original_id: advanced-features
 ---

--- a/website/versioned_docs/version-3.4.2/schema-generator/customizing-schemas/deprecating-schema.md
+++ b/website/versioned_docs/version-3.4.2/schema-generator/customizing-schemas/deprecating-schema.md
@@ -1,5 +1,5 @@
 ---
-id: version-3.4.1-deprecating-schema
+id: version-3.4.2-deprecating-schema
 title: Deprecating Schema
 original_id: deprecating-schema
 ---

--- a/website/versioned_docs/version-3.4.2/schema-generator/customizing-schemas/directives.md
+++ b/website/versioned_docs/version-3.4.2/schema-generator/customizing-schemas/directives.md
@@ -1,5 +1,5 @@
 ---
-id: version-3.4.1-directives
+id: version-3.4.2-directives
 title: Directives
 original_id: directives
 ---

--- a/website/versioned_docs/version-3.4.2/schema-generator/customizing-schemas/documenting-fields.md
+++ b/website/versioned_docs/version-3.4.2/schema-generator/customizing-schemas/documenting-fields.md
@@ -1,5 +1,5 @@
 ---
-id: version-3.4.1-documenting-fields
+id: version-3.4.2-documenting-fields
 title: Documenting Schema
 original_id: documenting-fields
 ---

--- a/website/versioned_docs/version-3.4.2/schema-generator/customizing-schemas/excluding-fields.md
+++ b/website/versioned_docs/version-3.4.2/schema-generator/customizing-schemas/excluding-fields.md
@@ -1,5 +1,5 @@
 ---
-id: version-3.4.1-excluding-fields
+id: version-3.4.2-excluding-fields
 title: Excluding Fields
 original_id: excluding-fields
 ---

--- a/website/versioned_docs/version-3.4.2/schema-generator/customizing-schemas/generator-config.md
+++ b/website/versioned_docs/version-3.4.2/schema-generator/customizing-schemas/generator-config.md
@@ -1,5 +1,5 @@
 ---
-id: version-3.4.1-generator-config
+id: version-3.4.2-generator-config
 title: Generator Configuration
 original_id: generator-config
 ---

--- a/website/versioned_docs/version-3.4.2/schema-generator/customizing-schemas/renaming-fields.md
+++ b/website/versioned_docs/version-3.4.2/schema-generator/customizing-schemas/renaming-fields.md
@@ -1,5 +1,5 @@
 ---
-id: version-3.4.1-renaming-fields
+id: version-3.4.2-renaming-fields
 title: Renaming Fields
 original_id: renaming-fields
 ---

--- a/website/versioned_docs/version-3.4.2/schema-generator/execution/async-models.md
+++ b/website/versioned_docs/version-3.4.2/schema-generator/execution/async-models.md
@@ -1,5 +1,5 @@
 ---
-id: version-3.4.1-async-models
+id: version-3.4.2-async-models
 title: Async Models
 original_id: async-models
 ---

--- a/website/versioned_docs/version-3.4.2/schema-generator/execution/contextual-data.md
+++ b/website/versioned_docs/version-3.4.2/schema-generator/execution/contextual-data.md
@@ -1,5 +1,5 @@
 ---
-id: version-3.4.1-contextual-data
+id: version-3.4.2-contextual-data
 title: Contextual Data
 original_id: contextual-data
 ---

--- a/website/versioned_docs/version-3.4.2/schema-generator/execution/data-fetching-environment.md
+++ b/website/versioned_docs/version-3.4.2/schema-generator/execution/data-fetching-environment.md
@@ -1,5 +1,5 @@
 ---
-id: version-3.4.1-data-fetching-environment
+id: version-3.4.2-data-fetching-environment
 title: Data Fetching Environment
 original_id: data-fetching-environment
 ---

--- a/website/versioned_docs/version-3.4.2/schema-generator/execution/exceptions.md
+++ b/website/versioned_docs/version-3.4.2/schema-generator/execution/exceptions.md
@@ -1,5 +1,5 @@
 ---
-id: version-3.4.1-exceptions
+id: version-3.4.2-exceptions
 title: Exceptions and Partial Data
 original_id: exceptions
 ---

--- a/website/versioned_docs/version-3.4.2/schema-generator/execution/fetching-data.md
+++ b/website/versioned_docs/version-3.4.2/schema-generator/execution/fetching-data.md
@@ -1,5 +1,5 @@
 ---
-id: version-3.4.1-fetching-data
+id: version-3.4.2-fetching-data
 title: Fetching Data
 original_id: fetching-data
 ---

--- a/website/versioned_docs/version-3.4.2/schema-generator/execution/introspection.md
+++ b/website/versioned_docs/version-3.4.2/schema-generator/execution/introspection.md
@@ -1,5 +1,5 @@
 ---
-id: version-3.4.1-introspection
+id: version-3.4.2-introspection
 title: Introspection
 original_id: introspection
 ---

--- a/website/versioned_docs/version-3.4.2/schema-generator/execution/optional-undefined-arguments.md
+++ b/website/versioned_docs/version-3.4.2/schema-generator/execution/optional-undefined-arguments.md
@@ -1,5 +1,5 @@
 ---
-id: version-3.4.1-optional-undefined-arguments
+id: version-3.4.2-optional-undefined-arguments
 title: Optional Undefined Arguments
 original_id: optional-undefined-arguments
 ---

--- a/website/versioned_docs/version-3.4.2/schema-generator/execution/subscriptions.md
+++ b/website/versioned_docs/version-3.4.2/schema-generator/execution/subscriptions.md
@@ -1,5 +1,5 @@
 ---
-id: version-3.4.1-subscriptions
+id: version-3.4.2-subscriptions
 title: Subscriptions
 original_id: subscriptions
 ---

--- a/website/versioned_docs/version-3.4.2/schema-generator/schema-generator-getting-started.md
+++ b/website/versioned_docs/version-3.4.2/schema-generator/schema-generator-getting-started.md
@@ -1,5 +1,5 @@
 ---
-id: version-3.4.1-schema-generator-getting-started
+id: version-3.4.2-schema-generator-getting-started
 title: Getting Started with the Schema Generator
 original_id: schema-generator-getting-started
 ---

--- a/website/versioned_docs/version-3.4.2/schema-generator/writing-schemas/annotations.md
+++ b/website/versioned_docs/version-3.4.2/schema-generator/writing-schemas/annotations.md
@@ -1,5 +1,5 @@
 ---
-id: version-3.4.1-annotations
+id: version-3.4.2-annotations
 title: Annotations
 original_id: annotations
 ---

--- a/website/versioned_docs/version-3.4.2/schema-generator/writing-schemas/arguments.md
+++ b/website/versioned_docs/version-3.4.2/schema-generator/writing-schemas/arguments.md
@@ -1,5 +1,5 @@
 ---
-id: version-3.4.1-arguments
+id: version-3.4.2-arguments
 title: Arguments
 original_id: arguments
 ---

--- a/website/versioned_docs/version-3.4.2/schema-generator/writing-schemas/enums.md
+++ b/website/versioned_docs/version-3.4.2/schema-generator/writing-schemas/enums.md
@@ -1,5 +1,5 @@
 ---
-id: version-3.4.1-enums
+id: version-3.4.2-enums
 title: Enums
 original_id: enums
 ---

--- a/website/versioned_docs/version-3.4.2/schema-generator/writing-schemas/interfaces.md
+++ b/website/versioned_docs/version-3.4.2/schema-generator/writing-schemas/interfaces.md
@@ -1,5 +1,5 @@
 ---
-id: version-3.4.1-interfaces
+id: version-3.4.2-interfaces
 title: Interfaces
 original_id: interfaces
 ---

--- a/website/versioned_docs/version-3.4.2/schema-generator/writing-schemas/lists.md
+++ b/website/versioned_docs/version-3.4.2/schema-generator/writing-schemas/lists.md
@@ -1,5 +1,5 @@
 ---
-id: version-3.4.1-lists
+id: version-3.4.2-lists
 title: Lists
 original_id: lists
 ---

--- a/website/versioned_docs/version-3.4.2/schema-generator/writing-schemas/nested-arguments.md
+++ b/website/versioned_docs/version-3.4.2/schema-generator/writing-schemas/nested-arguments.md
@@ -1,5 +1,5 @@
 ---
-id: version-3.4.1-nested-arguments
+id: version-3.4.2-nested-arguments
 title: Nested Arguments
 original_id: nested-arguments
 ---

--- a/website/versioned_docs/version-3.4.2/schema-generator/writing-schemas/nullability.md
+++ b/website/versioned_docs/version-3.4.2/schema-generator/writing-schemas/nullability.md
@@ -1,5 +1,5 @@
 ---
-id: version-3.4.1-nullability
+id: version-3.4.2-nullability
 title: Nullability
 original_id: nullability
 ---

--- a/website/versioned_docs/version-3.4.2/schema-generator/writing-schemas/scalars.md
+++ b/website/versioned_docs/version-3.4.2/schema-generator/writing-schemas/scalars.md
@@ -1,5 +1,5 @@
 ---
-id: version-3.4.1-scalars
+id: version-3.4.2-scalars
 title: Scalars
 original_id: scalars
 ---

--- a/website/versioned_docs/version-3.4.2/schema-generator/writing-schemas/unions.md
+++ b/website/versioned_docs/version-3.4.2/schema-generator/writing-schemas/unions.md
@@ -1,5 +1,5 @@
 ---
-id: version-3.4.1-unions
+id: version-3.4.2-unions
 title: Unions
 original_id: unions
 ---

--- a/website/versioned_docs/version-3.4.2/spring-server/http-request-response.md
+++ b/website/versioned_docs/version-3.4.2/spring-server/http-request-response.md
@@ -1,5 +1,5 @@
 ---
-id: version-3.4.1-http-request-response
+id: version-3.4.2-http-request-response
 title: Access the HTTP Request-Response
 original_id: http-request-response
 ---

--- a/website/versioned_docs/version-3.4.2/spring-server/spring-beans.md
+++ b/website/versioned_docs/version-3.4.2/spring-server/spring-beans.md
@@ -1,5 +1,5 @@
 ---
-id: version-3.4.1-spring-beans
+id: version-3.4.2-spring-beans
 title: Automatically Created Beans
 original_id: spring-beans
 ---

--- a/website/versioned_docs/version-3.4.2/spring-server/spring-graphql-context.md
+++ b/website/versioned_docs/version-3.4.2/spring-server/spring-graphql-context.md
@@ -1,5 +1,5 @@
 ---
-id: version-3.4.1-spring-graphql-context
+id: version-3.4.2-spring-graphql-context
 title: Generating GraphQL Context
 original_id: spring-graphql-context
 ---

--- a/website/versioned_docs/version-3.4.2/spring-server/spring-overview.md
+++ b/website/versioned_docs/version-3.4.2/spring-server/spring-overview.md
@@ -1,5 +1,5 @@
 ---
-id: version-3.4.1-spring-overview
+id: version-3.4.2-spring-overview
 title: Spring Server Overview
 original_id: spring-overview
 ---

--- a/website/versioned_docs/version-3.4.2/spring-server/spring-properties.md
+++ b/website/versioned_docs/version-3.4.2/spring-server/spring-properties.md
@@ -1,5 +1,5 @@
 ---
-id: version-3.4.1-spring-properties
+id: version-3.4.2-spring-properties
 title: Configuration Properties
 original_id: spring-properties
 ---

--- a/website/versioned_docs/version-3.4.2/spring-server/subscriptions.md
+++ b/website/versioned_docs/version-3.4.2/spring-server/subscriptions.md
@@ -1,5 +1,5 @@
 ---
-id: version-3.4.1-subscriptions
+id: version-3.4.2-subscriptions
 title: Subscriptions
 original_id: subscriptions
 ---


### PR DESCRIPTION
Looks like renaming version broke the documentation - regenerated version 3.4.2 and you can see the diff in generated page IDs