### PR TITLE
[client] update ScalarConverter to accept any objects

### DIFF
--- a/clients/graphql-kotlin-client/src/main/kotlin/com/expediagroup/graphql/client/converter/ScalarConverter.kt
+++ b/clients/graphql-kotlin-client/src/main/kotlin/com/expediagroup/graphql/client/converter/ScalarConverter.kt
@@ -22,12 +22,12 @@ package com.expediagroup.graphql.client.converter
 interface ScalarConverter<T> {
 
     /**
-     * Deserialize raw JSON String value to a typesafe value.
+     * Deserialize raw JSON value to a typesafe value.
      */
-    fun toScalar(rawValue: String): T
+    fun toScalar(rawValue: Any): T
 
     /**
-     * Serialize typesafe scalar value to a raw JSON string.
+     * Serialize typesafe scalar value to a raw JSON value.
      */
-    fun toJson(value: T): String
+    fun toJson(value: T): Any
 }

--- a/docs/client/client-customization.md
+++ b/docs/client/client-customization.md
@@ -150,13 +150,13 @@ val customObjectMapper = jacksonObjectMapper()
 val client = GraphQLClient(url = URL("http://localhost:8080/graphql"), mapper = customObjectMapper)
 ```
 
-## Deprecated Field Usage
+## Deprecated Field Usage
 
 Build plugins will automatically fail generation of a client if any of the specified query files are referencing
 deprecated fields. This ensures that your clients have to explicitly opt-in into deprecated usage by specifying
 `allowDeprecatedFields` configuration option.
 
-## Custom GraphQL Scalars
+## Custom GraphQL Scalars
 
 By default, custom GraphQL scalars are serialized and [type-aliased](https://kotlinlang.org/docs/reference/type-aliases.html)
 to a String. GraphQL Kotlin plugins also support custom serialization based on provided configuration.
@@ -171,8 +171,8 @@ import com.expediagroup.graphql.client.converter.ScalarConverter
 import java.util.UUID
 
 class UUIDScalarConverter : ScalarConverter<UUID> {
-    override fun toScalar(rawValue: String): UUID = UUID.fromString(rawValue)
-    override fun toJson(value: UUID): String = value.toString()
+    override fun toScalar(rawValue: Any): UUID = UUID.fromString(rawValue.toString())
+    override fun toJson(value: UUID): Any = value.toString()
 }
 ```
 
@@ -189,6 +189,4 @@ graphql {
 }
 ```
 
-See [Gradle](../plugins/gradle-plugin.md)
-and [Maven](../plugins/maven-plugin.md)
-plugin documentation for additional details.
+See [Gradle](../plugins/gradle-plugin.md) and [Maven](../plugins/maven-plugin.md) plugin documentation for additional details.

--- a/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/hooks/CustomSchemaGeneratorHooks.kt
+++ b/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/hooks/CustomSchemaGeneratorHooks.kt
@@ -18,12 +18,17 @@ package com.expediagroup.graphql.examples.hooks
 
 import com.expediagroup.graphql.directives.KotlinDirectiveWiringFactory
 import com.expediagroup.graphql.hooks.SchemaGeneratorHooks
+import graphql.Scalars
 import graphql.language.StringValue
 import graphql.schema.Coercing
+import graphql.schema.CoercingParseLiteralException
+import graphql.schema.CoercingParseValueException
+import graphql.schema.CoercingSerializeException
 import graphql.schema.GraphQLScalarType
 import graphql.schema.GraphQLType
 import org.springframework.beans.factory.BeanFactoryAware
 import reactor.core.publisher.Mono
+import java.math.BigDecimal
 import java.util.UUID
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
@@ -39,6 +44,7 @@ class CustomSchemaGeneratorHooks(override val wiringFactory: KotlinDirectiveWiri
      */
     override fun willGenerateGraphQLType(type: KType): GraphQLType? = when (type.classifier) {
         UUID::class -> graphqlUUIDType
+        BigDecimal::class -> Scalars.GraphQLBigDecimal
         else -> null
     }
 
@@ -68,16 +74,24 @@ internal val graphqlUUIDType = GraphQLScalarType.newScalar()
     .build()
 
 private object UUIDCoercing : Coercing<UUID, String> {
-    override fun parseValue(input: Any?): UUID = UUID.fromString(
-        serialize(
-            input
-        )
-    )
-
-    override fun parseLiteral(input: Any?): UUID? {
-        val uuidString = (input as? StringValue)?.value
-        return UUID.fromString(uuidString)
+    override fun parseValue(input: Any): UUID = runCatching {
+        UUID.fromString(serialize(input))
+    }.getOrElse {
+        throw CoercingParseValueException("Expected valid UUID but was $input")
     }
 
-    override fun serialize(dataFetcherResult: Any?): String = dataFetcherResult.toString()
+    override fun parseLiteral(input: Any): UUID? {
+        val uuidString = (input as? StringValue)?.value
+        return runCatching {
+            UUID.fromString(uuidString)
+        }.getOrElse {
+            throw CoercingParseLiteralException("Expected valid UUID literal but was $uuidString")
+        }
+    }
+
+    override fun serialize(dataFetcherResult: Any): String = runCatching {
+        dataFetcherResult.toString()
+    }.getOrElse {
+        throw CoercingSerializeException("Data fetcher result $dataFetcherResult cannot be serialized to a String")
+    }
 }

--- a/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/query/ScalarQuery.kt
+++ b/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/query/ScalarQuery.kt
@@ -21,7 +21,9 @@ import com.expediagroup.graphql.spring.operations.Mutation
 import com.expediagroup.graphql.spring.operations.Query
 import com.expediagroup.graphql.scalars.ID
 import org.springframework.stereotype.Component
+import java.math.BigDecimal
 import java.util.UUID
+import kotlin.random.Random
 
 /**
  * Simple query that exposes custom scalar.
@@ -39,6 +41,9 @@ class ScalarQuery : Query {
 
     @GraphQLDescription("generates random GraphQL ID")
     fun generateRandomId() = ID(UUID.randomUUID().toString())
+
+    @GraphQLDescription("generates random BigDecimal")
+    fun generateRandomBigDecimal(): BigDecimal = BigDecimal(Random.nextLong())
 }
 
 @Component

--- a/plugins/graphql-kotlin-gradle-plugin/src/test/resources/mocks/UUIDScalarConverter.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/test/resources/mocks/UUIDScalarConverter.kt
@@ -4,6 +4,6 @@ import com.expediagroup.graphql.client.converter.ScalarConverter
 import java.util.UUID
 
 class UUIDScalarConverter : ScalarConverter<UUID> {
-    override fun toScalar(rawValue: String): UUID = UUID.fromString(rawValue)
-    override fun toJson(value: UUID): String = value.toString()
+    override fun toScalar(rawValue: Any): UUID = UUID.fromString(rawValue.toString())
+    override fun toJson(value: UUID): Any = value.toString()
 }

--- a/plugins/graphql-kotlin-maven-plugin/src/integration/complete-setup/src/main/kotlin/com/example/UUIDScalarConverter.kt
+++ b/plugins/graphql-kotlin-maven-plugin/src/integration/complete-setup/src/main/kotlin/com/example/UUIDScalarConverter.kt
@@ -4,6 +4,6 @@ import com.expediagroup.graphql.client.converter.ScalarConverter
 import java.util.UUID
 
 class UUIDScalarConverter : ScalarConverter<UUID> {
-    override fun toScalar(rawValue: String): UUID = UUID.fromString(rawValue)
-    override fun toJson(value: UUID): String = value.toString()
+    override fun toScalar(rawValue: Any): UUID = UUID.fromString(rawValue.toString())
+    override fun toJson(value: UUID): Any = value.toString()
 }

--- a/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/types/generateGraphQLCustomScalarTypeSpec.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/types/generateGraphQLCustomScalarTypeSpec.kt
@@ -71,7 +71,7 @@ internal fun generateGraphQLCustomScalarTypeSpec(context: GraphQLClientGenerator
                 FunSpec.builder("create")
                     .addAnnotation(JsonCreator::class.java)
                     .jvmStatic()
-                    .addParameter("rawValue", String::class)
+                    .addParameter("rawValue", Any::class)
                     .addStatement("return %L(%N.toScalar(rawValue))", customScalarName, converter)
                     .build()
             )

--- a/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLCustomScalarTypeSpecIT.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLCustomScalarTypeSpecIT.kt
@@ -36,6 +36,7 @@ class GenerateGraphQLCustomScalarTypeSpecIT {
                 import com.fasterxml.jackson.annotation.JsonCreator
                 import com.fasterxml.jackson.annotation.JsonValue
                 import kotlin.Any
+                import kotlin.String
                 import kotlin.jvm.JvmStatic
 
                 const val CUSTOM_SCALAR_TEST_QUERY: String =

--- a/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLCustomScalarTypeSpecIT.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLCustomScalarTypeSpecIT.kt
@@ -35,7 +35,7 @@ class GenerateGraphQLCustomScalarTypeSpecIT {
                 import com.expediagroup.graphql.types.GraphQLResponse
                 import com.fasterxml.jackson.annotation.JsonCreator
                 import com.fasterxml.jackson.annotation.JsonValue
-                import kotlin.String
+                import kotlin.Any
                 import kotlin.jvm.JvmStatic
 
                 const val CUSTOM_SCALAR_TEST_QUERY: String =
@@ -61,7 +61,7 @@ class GenerateGraphQLCustomScalarTypeSpecIT {
 
                       @JsonCreator
                       @JvmStatic
-                      fun create(rawValue: String) = UUID(converter.toScalar(rawValue))
+                      fun create(rawValue: Any) = UUID(converter.toScalar(rawValue))
                     }
                   }
 


### PR DESCRIPTION
### :pencil: Description

Custom GraphQL scalars can be serialized as any of the other built-in scalars (i.e. int, float, etc). Changed method signatures to accept `Any` when converting to scalar, and produce `Any` when generating JSON value.

### :link: Related Issues

Resolves https://github.com/ExpediaGroup/graphql-kotlin/issues/816