### PR TITLE
[generator] Simplify generateSchema signature

### DIFF
--- a/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/FederatedSchemaGenerator.kt
+++ b/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/FederatedSchemaGenerator.kt
@@ -19,8 +19,8 @@ package com.expediagroup.graphql.federation
 import com.expediagroup.graphql.TopLevelObject
 import com.expediagroup.graphql.federation.directives.ExtendsDirective
 import com.expediagroup.graphql.generator.SchemaGenerator
+import com.expediagroup.graphql.generator.state.AdditionalType
 import graphql.schema.GraphQLSchema
-import kotlin.reflect.KType
 
 /**
  * Generates federated GraphQL schemas based on the specified configuration.
@@ -35,10 +35,9 @@ open class FederatedSchemaGenerator(generatorConfig: FederatedSchemaGeneratorCon
         queries: List<TopLevelObject>,
         mutations: List<TopLevelObject>,
         subscriptions: List<TopLevelObject>,
-        additionalTypes: Set<KType>,
-        additionalInputTypes: Set<KType>
+        additionalTypes: Set<AdditionalType>
     ): GraphQLSchema {
         addAdditionalTypesWithAnnotation(ExtendsDirective::class, inputType = false)
-        return super.generateSchema(queries, mutations, subscriptions, additionalTypes, additionalInputTypes)
+        return super.generateSchema(queries, mutations, subscriptions, additionalTypes)
     }
 }

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/SchemaGenerator.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/SchemaGenerator.kt
@@ -36,7 +36,6 @@ import graphql.schema.visibility.NoIntrospectionGraphqlFieldVisibility
 import java.io.Closeable
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.reflect.KClass
-import kotlin.reflect.KType
 import kotlin.reflect.full.createType
 
 /**
@@ -72,12 +71,10 @@ open class SchemaGenerator(internal val config: SchemaGeneratorConfig) : Closeab
         queries: List<TopLevelObject>,
         mutations: List<TopLevelObject> = emptyList(),
         subscriptions: List<TopLevelObject> = emptyList(),
-        additionalTypes: Set<KType> = emptySet(),
-        additionalInputTypes: Set<KType> = emptySet()
+        additionalTypes: Set<AdditionalType> = emptySet()
     ): GraphQLSchema {
 
-        this.additionalTypes.addAll(additionalTypes.map { AdditionalType(it, inputType = false) })
-        this.additionalTypes.addAll(additionalInputTypes.map { AdditionalType(it, inputType = true) })
+        this.additionalTypes.addAll(additionalTypes)
 
         val builder = GraphQLSchema.newSchema()
         builder.query(generateQueries(this, queries))

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/state/AdditionalType.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/state/AdditionalType.kt
@@ -23,7 +23,7 @@ import kotlin.reflect.KType
  * and that can also be picked up at generation time by including all the
  * interface implementations that may not be used in the code.
  */
-internal data class AdditionalType(
+data class AdditionalType(
     val kType: KType,
     val inputType: Boolean = false
 )


### PR DESCRIPTION
### :pencil: Description
Simplify SchemaGenerator#generateSchema signature to just 1 set of additionalTypes

The generateSchema has to arguments: additionalTypes and additionalInputTypes. If we change the signature and use the new public class AdditionalType we can make this into one argument

### :link: Related Issues
[#818](https://github.com/ExpediaGroup/graphql-kotlin/issues/818)