### PR TITLE
Add new hook to override the isValidAdditionalType check

### DIFF
--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/SchemaGenerator.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/SchemaGenerator.kt
@@ -19,7 +19,6 @@ package com.expediagroup.graphql.generator
 import com.expediagroup.graphql.SchemaGeneratorConfig
 import com.expediagroup.graphql.TopLevelObject
 import com.expediagroup.graphql.exceptions.InvalidPackagesException
-import com.expediagroup.graphql.generator.extensions.isValidAdditionalType
 import com.expediagroup.graphql.generator.state.AdditionalType
 import com.expediagroup.graphql.generator.state.ClassScanner
 import com.expediagroup.graphql.generator.state.TypesCache
@@ -98,12 +97,12 @@ open class SchemaGenerator(internal val config: SchemaGeneratorConfig) : Closeab
     /**
      * Add all types with the following annotation to the schema.
      *
-     * This is helpful for things like federation or combining external schemas
+     * This is helpful for things like federation or combining external schemas.
      */
     protected fun addAdditionalTypesWithAnnotation(annotation: KClass<*>, inputType: Boolean = false) {
-        classScanner.getClassesWithAnnotation(annotation).forEach {
-            if (it.isValidAdditionalType(inputType)) {
-                additionalTypes.add(AdditionalType(it.createType(), inputType))
+        classScanner.getClassesWithAnnotation(annotation).forEach { kClass ->
+            if (config.hooks.isValidAdditionalType(kClass, inputType)) {
+                additionalTypes.add(AdditionalType(kClass.createType(), inputType))
             }
         }
     }

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/extensions/kClassExtensions.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/extensions/kClassExtensions.kt
@@ -67,8 +67,10 @@ internal fun KClass<*>.isUnion(): Boolean =
  * Do not add interfaces as additional types if it expects all the types
  * to be input types. The isInteface() check works for both
  * GraphQL Interfaces and GraphQL Unions
+ *
+ * Also do not add any classes that are marked as @GraphQLIgnore
  */
-internal fun KClass<*>.isValidAdditionalType(inputType: Boolean): Boolean = !(inputType && this.isInterface())
+internal fun KClass<*>.isValidAdditionalType(inputType: Boolean): Boolean = !(inputType && this.isInterface()) && !this.isGraphQLIgnored()
 
 internal fun KClass<*>.isEnum(): Boolean = this.isSubclassOf(Enum::class)
 

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/generateInputProperty.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/generateInputProperty.kt
@@ -16,6 +16,7 @@
 
 package com.expediagroup.graphql.generator.types
 
+import com.expediagroup.graphql.extensions.unwrapType
 import com.expediagroup.graphql.generator.SchemaGenerator
 import com.expediagroup.graphql.generator.extensions.getPropertyDescription
 import com.expediagroup.graphql.generator.extensions.getPropertyName
@@ -27,7 +28,11 @@ import kotlin.reflect.KProperty
 
 internal fun generateInputProperty(generator: SchemaGenerator, prop: KProperty<*>, parentClass: KClass<*>): GraphQLInputObjectField {
     val builder = GraphQLInputObjectField.newInputObjectField()
-    val graphQLInputType = generateGraphQLType(generator = generator, type = prop.returnType, inputType = true).safeCast<GraphQLInputType>()
+
+    // Verfiy that the unwrapped GraphQL type is a valid input type
+    val graphQLInputType = generateGraphQLType(generator = generator, type = prop.returnType, inputType = true)
+        .unwrapType()
+        .safeCast<GraphQLInputType>()
 
     builder.description(prop.getPropertyDescription(parentClass))
     builder.name(prop.getPropertyName(parentClass))

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/generateInterface.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/generateInterface.kt
@@ -16,7 +16,6 @@
 
 package com.expediagroup.graphql.generator.types
 
-import com.expediagroup.graphql.generator.state.AdditionalType
 import com.expediagroup.graphql.extensions.unwrapType
 import com.expediagroup.graphql.generator.SchemaGenerator
 import com.expediagroup.graphql.generator.extensions.getGraphQLDescription
@@ -24,8 +23,8 @@ import com.expediagroup.graphql.generator.extensions.getSimpleName
 import com.expediagroup.graphql.generator.extensions.getValidFunctions
 import com.expediagroup.graphql.generator.extensions.getValidProperties
 import com.expediagroup.graphql.generator.extensions.getValidSuperclasses
-import com.expediagroup.graphql.generator.extensions.isGraphQLIgnored
 import com.expediagroup.graphql.generator.extensions.safeCast
+import com.expediagroup.graphql.generator.state.AdditionalType
 import graphql.TypeResolutionEnvironment
 import graphql.schema.GraphQLInterfaceType
 import graphql.schema.GraphQLTypeReference
@@ -58,7 +57,7 @@ internal fun generateInterface(generator: SchemaGenerator, kClass: KClass<*>): G
         .forEach { builder.field(generateFunction(generator, it, kClass.getSimpleName(), null, abstract = true)) }
 
     generator.classScanner.getSubTypesOf(kClass)
-        .filter { it.isGraphQLIgnored().not() }
+        .filter { generator.config.hooks.isValidAdditionalType(it, inputType = false) }
         .forEach { generator.additionalTypes.add(AdditionalType(it.createType(), inputType = false)) }
 
     val interfaceType = builder.build()

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/hooks/SchemaGeneratorHooks.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/hooks/SchemaGeneratorHooks.kt
@@ -24,6 +24,7 @@ import com.expediagroup.graphql.exceptions.EmptyObjectTypeException
 import com.expediagroup.graphql.exceptions.EmptyQueryTypeException
 import com.expediagroup.graphql.exceptions.EmptySubscriptionTypeException
 import com.expediagroup.graphql.generator.extensions.isSubclassOf
+import com.expediagroup.graphql.generator.extensions.isValidAdditionalType
 import graphql.schema.FieldCoordinates
 import graphql.schema.GraphQLCodeRegistry
 import graphql.schema.GraphQLFieldDefinition
@@ -101,6 +102,14 @@ interface SchemaGeneratorHooks {
      * NOTE: You will most likely need to also override the [willResolveMonad] hook to allow for your custom type to be generated.
      */
     fun isValidSubscriptionReturnType(kClass: KClass<*>, function: KFunction<*>): Boolean = function.returnType.isSubclassOf(Publisher::class)
+
+    /**
+     * Allow for custom logic when adding additional types to filter out specific classes
+     * or classes with other annotations or metadata.
+     *
+     * The default logic just filters out interfaces if inputType is true.
+     */
+    fun isValidAdditionalType(kClass: KClass<*>, inputType: Boolean): Boolean = kClass.isValidAdditionalType(inputType)
 
     /**
      * Called after `willGenerateGraphQLType` and before `didGenerateGraphQLType`.

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/PolymorphicTests.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/PolymorphicTests.kt
@@ -35,7 +35,7 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
-internal class PolymorphicTests {
+class PolymorphicTests {
 
     @Test
     fun `Schema generator creates union types from marked up interface`() {

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/extensions/KClassExtensionsTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/extensions/KClassExtensionsTest.kt
@@ -92,6 +92,9 @@ open class KClassExtensionsTest {
     @GraphQLIgnore
     interface IgnoredSecondLevelInterface : SomeInterface
 
+    @GraphQLIgnore
+    class IgnoredClass(val value: String)
+
     internal class ClassWithSecondLevelInterface : IgnoredSecondLevelInterface {
         override val someField: String = "hello"
 
@@ -348,5 +351,11 @@ open class KClassExtensionsTest {
         // Invalid cases
         assertFalse(SomeInterface::class.isValidAdditionalType(true))
         assertFalse(TestUnion::class.isValidAdditionalType(true))
+        assertFalse(IgnoredInterface::class.isValidAdditionalType(true))
+        assertFalse(IgnoredInterface::class.isValidAdditionalType(false))
+        assertFalse(IgnoredSecondLevelInterface::class.isValidAdditionalType(true))
+        assertFalse(IgnoredSecondLevelInterface::class.isValidAdditionalType(false))
+        assertFalse(IgnoredClass::class.isValidAdditionalType(true))
+        assertFalse(IgnoredClass::class.isValidAdditionalType(false))
     }
 }


### PR DESCRIPTION
### :pencil: Description
Add new hooks setting that will allow you to override the `isValidAdditionalType` check in the `addAdditionalTypesWithAnnotation` method and when adding additional types from the `generateInterface` implementations.

### :link: Related Issues
https://github.com/ExpediaGroup/graphql-kotlin/issues/818