### PR TITLE
[2.x.x] Include java getters for ignore checks

### DIFF
--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/extensions/kPropertyExtensions.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/extensions/kPropertyExtensions.kt
@@ -33,6 +33,7 @@ internal fun KProperty<*>.isPropertyGraphQLID(parentClass: KClass<*>): Boolean =
 internal fun KProperty<*>.isPropertyGraphQLIgnored(parentClass: KClass<*>): Boolean = when {
     this.isGraphQLIgnored() -> true
     getConstructorParameter(parentClass)?.isGraphQLIgnored().isTrue() -> true
+    this.getter.isGraphQLIgnored() -> true
     else -> false
 }
 

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/extensions/KPropertyExtensionsKtTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/extensions/KPropertyExtensionsKtTest.kt
@@ -45,6 +45,9 @@ internal class KPropertyExtensionsKtTest {
         @GraphQLName("nameOnConstructor")
         val constructorAnnotation: String,
 
+        @get:GraphQLIgnore
+        val getterAnnotation: String,
+
         val noAnnotations: String
     )
 
@@ -59,6 +62,7 @@ internal class KPropertyExtensionsKtTest {
     fun isPropertyGraphQLIgnored() {
         assertTrue(MyDataClass::propertyAnnotation.isPropertyGraphQLIgnored(MyDataClass::class))
         assertTrue(MyDataClass::constructorAnnotation.isPropertyGraphQLIgnored(MyDataClass::class))
+        assertTrue(MyDataClass::getterAnnotation.isPropertyGraphQLIgnored(MyDataClass::class))
         assertFalse(MyDataClass::noAnnotations.isPropertyGraphQLIgnored(MyDataClass::class))
     }
 


### PR DESCRIPTION
### :pencil: Description
Copy logic from `3.x.x` branch

Update the property generator code to check the getters for the `@GraphQLIgnore` annotation. This means that any Kotlin property can use both `@GraphQLIgnore` and `@get:GraphQLIgnore`, but it also solve the issue with directive arguments that the generated JVM code only has annotation on the argument getters.

### :link: Related Issues
https://github.com/ExpediaGroup/graphql-kotlin/pull/763