### PR TITLE
[build] officially start targeting 4.0.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group = com.expediagroup
-version = 3.0.0-SNAPSHOT
+version = 4.0.0-SNAPSHOT
 
 # build config
 org.gradle.caching=true


### PR DESCRIPTION
Just bumps the version in `gradle.properties` that is used for CI. Release builds use version from tags anyway.