### PR TITLE
Include reflection as a dependency for all subprojects

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -182,6 +182,7 @@ subprojects {
 
     dependencies {
         implementation(kotlin("stdlib", kotlinVersion))
+        implementation(kotlin("reflect", kotlinVersion))
         implementation("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:$kotlinCoroutinesVersion")
         testImplementation(kotlin("test", kotlinVersion))
         testImplementation(kotlin("test-junit5", kotlinVersion))

--- a/graphql-kotlin-schema-generator/build.gradle.kts
+++ b/graphql-kotlin-schema-generator/build.gradle.kts
@@ -3,7 +3,6 @@ description = "Code-only GraphQL schema generation for Kotlin"
 val classGraphVersion: String by project
 val graphQLJavaVersion: String by project
 val jacksonVersion: String by project
-val kotlinVersion: String by project
 val kotlinCoroutinesVersion: String by project
 val rxjavaVersion: String by project
 val junitVersion: String by project
@@ -12,7 +11,6 @@ dependencies {
     api("com.graphql-java:graphql-java:$graphQLJavaVersion")
     api("org.jetbrains.kotlinx:kotlinx-coroutines-reactive:$kotlinCoroutinesVersion")
     api("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion")
-    implementation(kotlin("reflect", kotlinVersion))
     implementation("io.github.classgraph:classgraph:$classGraphVersion")
     testImplementation("io.reactivex.rxjava3:rxjava:$rxjavaVersion")
     testImplementation("org.junit.jupiter:junit-jupiter-params:$junitVersion")

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/state/ClassScanner.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/state/ClassScanner.kt
@@ -32,7 +32,7 @@ internal class ClassScanner(supportedPackages: List<String>) : Closeable {
     @Suppress("Detekt.SpreadOperator")
     private val scanResult = ClassGraph()
         .enableAllInfo()
-        .whitelistPackages(*supportedPackages.toTypedArray())
+        .acceptPackages(*supportedPackages.toTypedArray())
         .scan()
 
     /**


### PR DESCRIPTION
We are getting compile errors in the different builds. We need to include the reflection dependency in the different sub libraries and in the test deps for the th plugin
```
> Task :graphql-kotlin-gradle-plugin:compileTestKotlin
w: Runtime JAR files in the classpath should have the same version. These files were found in the classpath:
    /home/runner/.gradle/wrapper/dists/gradle-6.3-bin/8tpu6egwsccjzp10c1jckl0rx/gradle-6.3/lib/kotlin-stdlib-1.3.70.jar (version 1.3)
    /home/runner/.gradle/wrapper/dists/gradle-6.3-bin/8tpu6egwsccjzp10c1jckl0rx/gradle-6.3/lib/kotlin-stdlib-common-1.3.70.jar (version 1.3)
    /home/runner/.gradle/wrapper/dists/gradle-6.3-bin/8tpu6egwsccjzp10c1jckl0rx/gradle-6.3/lib/kotlin-stdlib-jdk8-1.3.70.jar (version 1.3)
    /home/runner/.gradle/wrapper/dists/gradle-6.3-bin/8tpu6egwsccjzp10c1jckl0rx/gradle-6.3/lib/kotlin-stdlib-jdk7-1.3.70.jar (version 1.3)
    /home/runner/.gradle/wrapper/dists/gradle-6.3-bin/8tpu6egwsccjzp10c1jckl0rx/gradle-6.3/lib/kotlin-reflect-1.3.70.jar (version 1.3)
    /home/runner/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jdk8/1.3.72/916d54b9eb6442b615e6f1488978f551c0674720/kotlin-stdlib-jdk8-1.3.72.jar (version 1.3)
    /home/runner/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jdk7/1.3.72/3adfc2f4ea4243e01204be8081fe63bde6b12815/kotlin-stdlib-jdk7-1.3.72.jar (version 1.3)
    /home/runner/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-reflect/1.3.61/2e07c9a84c9e118efb70eede7e579fd663932122/kotlin-reflect-1.3.61.jar (version 1.3)
    /home/runner/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib/1.4.0/63e75298e93d4ae0b299bb869cf0c627196f8843/kotlin-stdlib-1.4.0.jar (version 1.4)
    /home/runner/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-common/1.4.0/1c752cce0ead8d504ccc88a4fed6471fd83ab0dd/kotlin-stdlib-common-1.4.0.jar (version 1.4)
w: Consider providing an explicit dependency on kotlin-reflect 1.4 to prevent strange errors
w: Some runtime JAR files in the classpath have an incompatible version. Consider removing them from the classpath
```

### :link: Related Issues
https://github.com/ExpediaGroup/graphql-kotlin/runs/1046998832
