### PR TITLE
[build] revert Kotlin version to 1.3.72

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,8 +15,8 @@ org.gradle.jvmargs=-Xmx2g -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError
 
 # dependencies
 kotlinJvmVersion = 1.8
-kotlinVersion = 1.4.0
-kotlinCoroutinesVersion = 1.3.9
+kotlinVersion = 1.3.72
+kotlinCoroutinesVersion = 1.3.8
 
 classGraphVersion = 4.8.87
 graphQLJavaVersion = 15.0

--- a/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePluginAbstractIT.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePluginAbstractIT.kt
@@ -35,7 +35,7 @@ abstract class GraphQLGradlePluginAbstractIT {
     // unsure if there is a better way - correct values are set from Gradle build
     // when running directly from IDE you will need to manually update those to correct values
     private val gqlKotlinVersion = System.getProperty("graphQLKotlinVersion") ?: "4.0.0-SNAPSHOT"
-    private val kotlinVersion = System.getProperty("kotlinVersion") ?: "1.4.0"
+    private val kotlinVersion = System.getProperty("kotlinVersion") ?: "1.3.72"
     private val junitVersion = System.getProperty("junitVersion") ?: "5.6.2"
 
     val testSchema = loadResource("mocks/schema.graphql")

--- a/plugins/graphql-kotlin-maven-plugin/build.gradle.kts
+++ b/plugins/graphql-kotlin-maven-plugin/build.gradle.kts
@@ -34,7 +34,6 @@ dependencies {
     implementation("org.apache.maven:maven-plugin-api:$mavenPluginApiVersion")
     implementation("org.apache.maven:maven-project:$mavenProjectVersion")
     implementation("org.apache.maven.plugin-tools:maven-plugin-annotations:$mavenPluginAnnotationVersion")
-    testImplementation(project(path = ":graphql-kotlin-client"))
 }
 
 tasks {


### PR DESCRIPTION
### :pencil: Description

We are hitting some library and plugin issues with incompatibilities between Kotlin versions. Downgrading back to 1.3.72 for now, we will revisit update to 1.4 sometime in the future.

### :link: Related Issues

Update to 1.4 https://github.com/ExpediaGroup/graphql-kotlin/pull/844