### PR TITLE
Add separate configuration for SDL route

### DIFF
--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/GraphQLAutoConfiguration.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/GraphQLAutoConfiguration.kt
@@ -25,8 +25,9 @@ import org.springframework.context.annotation.Import
  */
 @Configuration
 @Import(
-    RoutesConfiguration::class,
+    GraphQLRoutesConfiguration::class,
     SubscriptionAutoConfiguration::class,
-    PlaygroundAutoConfiguration::class
+    PlaygroundRouteConfiguration::class,
+    SdlRouteConfiguration::class
 )
 class GraphQLAutoConfiguration

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/PlaygroundRouteConfiguration.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/PlaygroundRouteConfiguration.kt
@@ -26,11 +26,11 @@ import org.springframework.web.reactive.function.server.coRouter
 import org.springframework.web.reactive.function.server.html
 
 /**
- * SpringBoot auto configuration for generating Playground Service.
+ * Configuration for exposing the GraphQL Playground on a specific HTTP path
  */
 @ConditionalOnProperty(value = ["graphql.playground.enabled"], havingValue = "true", matchIfMissing = true)
 @Configuration
-class PlaygroundAutoConfiguration(
+class PlaygroundRouteConfiguration(
     private val config: GraphQLConfigurationProperties,
     @Value("classpath:/graphql-playground.html") private val playgroundHtml: Resource
 ) {

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/SdlRouteConfiguration.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/SdlRouteConfiguration.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.spring
+
+import com.expediagroup.graphql.extensions.print
+import graphql.schema.GraphQLSchema
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Import
+import org.springframework.http.MediaType
+import org.springframework.web.reactive.function.server.bodyValueAndAwait
+import org.springframework.web.reactive.function.server.coRouter
+
+/**
+ * Configuration to expose the SDL of the schema on on specific HTTP path
+ */
+@Configuration
+@Import(GraphQLSchemaConfiguration::class)
+class SdlRouteConfiguration(
+    private val config: GraphQLConfigurationProperties,
+    schema: GraphQLSchema
+) {
+
+    private val sdl = schema.print()
+
+    @Bean
+    @ConditionalOnProperty(value = ["graphql.sdl.enabled"], havingValue = "true", matchIfMissing = true)
+    fun sdlRoute() = coRouter {
+        GET(config.sdl.endpoint) {
+            ok().contentType(MediaType.TEXT_PLAIN).bodyValueAndAwait(sdl)
+        }
+    }
+}

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/SubscriptionAutoConfiguration.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/SubscriptionAutoConfiguration.kt
@@ -36,7 +36,7 @@ import org.springframework.web.reactive.socket.server.support.WebSocketHandlerAd
 
 /**
  * This value is needed so that this url handler is run without a drastically different order
- * to the graphql routes in [RoutesConfiguration]. If we use [org.springframework.core.Ordered] to set as extreme
+ * to the graphql routes in [GraphQLRoutesConfiguration]. If we use [org.springframework.core.Ordered] to set as extreme
  * high or low, then the requests are not handled properly.
  *
  * Hopefully we can eventually move the url handler to the same router DSL.


### PR DESCRIPTION
### :pencil: Description
Create a separate bean for the `/sdl` route so we don't need to pass the schema bean to the `GraphQLRoutesConfiguraiton`. This also makes it clear the beans that can be enabled and disabled from the classes

### :link: Related Issues
