### PR TITLE
[client] Remove duplicate header

### DIFF
--- a/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/introspectSchema.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/introspectSchema.kt
@@ -25,7 +25,6 @@ import io.ktor.client.engine.cio.CIO
 import io.ktor.client.engine.cio.endpoint
 import io.ktor.client.features.ClientRequestException
 import io.ktor.client.features.json.JsonFeature
-import io.ktor.client.request.accept
 import io.ktor.client.request.header
 import io.ktor.client.request.post
 import io.ktor.client.request.url
@@ -51,7 +50,6 @@ suspend fun introspectSchema(endpoint: String, httpHeaders: Map<String, Any> = e
         client.post<Map<String, Any?>> {
             url(endpoint)
             contentType(ContentType.Application.Json)
-            accept(ContentType.Application.Json)
             httpHeaders.forEach { (name, value) ->
                 header(name, value)
             }


### PR DESCRIPTION
### :pencil: Description
It looks like the application/json accept header is set by `install(feature = JsonFeature)` on line 48 as well as `accept(ContentType.Application.Json)` on line 54. This causes a duplicate Accept header during the introspection query Gradle task. 

Spring handles the duplicate Accept header, but Jersey returns an 400 Bad Request when receiving the header.`Accept: application/json;application/json`

### :link: Related Issues
I have not created an issue.