### PR TITLE
Separate release docs and code 

### DIFF
--- a/.github/workflows/pr-check-docs.yml
+++ b/.github/workflows/pr-check-docs.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - master
+      - '*.x.x'
     paths:
       - 'docs/**'
       - 'website/**'

--- a/.github/workflows/publish-latest-docs.yml
+++ b/.github/workflows/publish-latest-docs.yml
@@ -1,4 +1,4 @@
-name: Publish Docs
+name: Publish Latest Docs
 
 on:
   push:

--- a/.github/workflows/release-code.yml
+++ b/.github/workflows/release-code.yml
@@ -1,0 +1,37 @@
+name: Release Code
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  release-code:
+    runs-on: ubuntu-latest
+    if: github.repository == 'ExpediaGroup/graphql-kotlin'
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: gradle/wrapper-validation-action@v1
+
+      - name: Set up Java 1.8
+        uses: actions/setup-java@v1
+        # dokka doesn't support Java 11
+        with:
+          java-version: 1.8
+
+      - name: Build library with Gradle
+        run: ./gradlew clean build
+
+      - name: Publish library with Gradle
+        run: |
+          NEW_VERSION=$(echo "${GITHUB_REF}" | cut -d "/" -f3)
+          echo "New version: ${NEW_VERSION}"
+          ./gradlew :initializeSonatypeStagingRepository publish :closeAndReleaseRepository publishPlugins -Pversion=${NEW_VERSION}
+        env:
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          GPG_SECRET: ${{ secrets.GPG_SECRET }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          PLUGIN_PORTAL_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
+          PLUGIN_PORTAL_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -1,41 +1,10 @@
-name: Release
+name: Release Docs
 
 on:
   release:
     types: [published]
 
 jobs:
-  release-code:
-    runs-on: ubuntu-latest
-    if: github.repository == 'ExpediaGroup/graphql-kotlin'
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: gradle/wrapper-validation-action@v1
-
-      - name: Set up Java 1.8
-        uses: actions/setup-java@v1
-        # dokka doesn't support Java 11
-        with:
-          java-version: 1.8
-
-      - name: Build library with Gradle
-        run: ./gradlew clean build
-
-      - name: Publish library with Gradle
-        run: |
-          NEW_VERSION=$(echo "${GITHUB_REF}" | cut -d "/" -f3)
-          echo "New version: ${NEW_VERSION}"
-          ./gradlew :initializeSonatypeStagingRepository publish :closeAndReleaseRepository publishPlugins -Pversion=${NEW_VERSION}
-        env:
-          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-          GPG_SECRET: ${{ secrets.GPG_SECRET }}
-          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-          PLUGIN_PORTAL_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
-          PLUGIN_PORTAL_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
-
   release-docs:
     runs-on: ubuntu-latest
     if: github.repository == 'ExpediaGroup/graphql-kotlin'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
 
-      - name: Build website
+      - name: Build website with version
         run: |
           NEW_VERSION=$(echo "${GITHUB_REF}" | cut -d "/" -f3)
           echo "New version: ${NEW_VERSION}"
@@ -64,18 +64,10 @@ jobs:
           npm run version $NEW_VERSION
           npm run build
 
-      - name: Deploy GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./website/build/graphql-kotlin
-          user_name: eg-oss-ci
-          user_email: oss@expediagroup.com
-
       - name: Commit new files
         run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
+          git config --local user.email "oss@expediagroup.com"
+          git config --local user.name "eg-oss-ci"
           git add website docs
           git commit -m "Add new docs version"
 
@@ -83,3 +75,11 @@ jobs:
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Deploy GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./website/build/graphql-kotlin
+          user_name: eg-oss-ci
+          user_email: oss@expediagroup.com


### PR DESCRIPTION
### :pencil: Description
Split the GH Actions for releasing docs and code so we can trigger them independently on failure. Also the push works now with the actions username but for consistency sake we can use the eg-osss user

### :link: Related Issues
https://github.com/ExpediaGroup/graphql-kotlin/commit/6c1c53fbe1a9476b59aa0c1f5a4f13169d98f348