### PR TITLE
[client] Remove duplicate accept header

### DIFF
--- a/clients/graphql-kotlin-ktor-client/src/main/kotlin/com/expediagroup/graphql/client/GraphQLKtorClient.kt
+++ b/clients/graphql-kotlin-ktor-client/src/main/kotlin/com/expediagroup/graphql/client/GraphQLKtorClient.kt
@@ -30,7 +30,6 @@ import io.ktor.client.engine.cio.CIOEngineConfig
 import io.ktor.client.features.json.JacksonSerializer
 import io.ktor.client.features.json.JsonFeature
 import io.ktor.client.request.HttpRequestBuilder
-import io.ktor.client.request.accept
 import io.ktor.client.request.post
 import io.ktor.http.ContentType
 import io.ktor.http.contentType

--- a/clients/graphql-kotlin-ktor-client/src/main/kotlin/com/expediagroup/graphql/client/GraphQLKtorClient.kt
+++ b/clients/graphql-kotlin-ktor-client/src/main/kotlin/com/expediagroup/graphql/client/GraphQLKtorClient.kt
@@ -82,7 +82,6 @@ open class GraphQLKtorClient<in T : HttpClientEngineConfig>(
 
         val rawResult = client.post<String>(url) {
             apply(requestBuilder)
-            accept(ContentType.Application.Json)
             contentType(ContentType.Application.Json)
             body = graphQLRequest
         }


### PR DESCRIPTION
### :pencil: Description
This header is already added with `install(JsonFeature) { }`

### :link: Related Issues
See https://github.com/ExpediaGroup/graphql-kotlin/pull/865
https://github.com/ExpediaGroup/graphql-kotlin/pull/867
