### PR TITLE
Fix issue with GraphQLName on properties

### DIFF
--- a/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/query/NestedQueries.kt
+++ b/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/query/NestedQueries.kt
@@ -17,6 +17,7 @@
 package com.expediagroup.graphql.examples.query
 
 import com.expediagroup.graphql.annotations.GraphQLDescription
+import com.expediagroup.graphql.annotations.GraphQLName
 import com.expediagroup.graphql.spring.operations.Query
 import com.fasterxml.jackson.annotation.JsonIgnore
 import graphql.schema.DataFetcher
@@ -38,6 +39,7 @@ class NestedQueries(private val coffeeBean: CoffeeBean) : Query {
 
 data class NestedAnimal(
     val id: Int,
+    @GraphQLName("animalType")
     val type: String
 ) {
     @JsonIgnore

--- a/examples/spring/src/test/kotlin/com/expediagroup/graphql/examples/query/NestedQueriesIT.kt
+++ b/examples/spring/src/test/kotlin/com/expediagroup/graphql/examples/query/NestedQueriesIT.kt
@@ -42,14 +42,14 @@ class NestedQueriesIT(@Autowired private val testClient: WebTestClient) {
             .uri(GRAPHQL_ENDPOINT)
             .accept(APPLICATION_JSON)
             .contentType(GRAPHQL_MEDIA_TYPE)
-            .bodyValue("query { $query { details { veryDetailedFunction }, id, type } }")
+            .bodyValue("query { $query { details { veryDetailedFunction }, id, animalType } }")
             .exchange()
             .expectStatus().isOk
             .verifyOnlyDataExists(query)
             .jsonPath("$DATA_JSON_PATH.$query.details").exists()
             .jsonPath("$DATA_JSON_PATH.$query.details.veryDetailedFunction").isEqualTo("Details(1)")
             .jsonPath("$DATA_JSON_PATH.$query.id").isEqualTo("1")
-            .jsonPath("$DATA_JSON_PATH.$query.type").isEqualTo("cat")
+            .jsonPath("$DATA_JSON_PATH.$query.animalType").isEqualTo("cat")
     }
 
     @Test

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/generateProperty.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/generateProperty.kt
@@ -33,9 +33,11 @@ internal fun generateProperty(generator: SchemaGenerator, prop: KProperty<*>, pa
     val propertyType = generateGraphQLType(generator, type = prop.returnType)
         .safeCast<GraphQLOutputType>()
 
+    val propertyName = prop.getPropertyName(parentClass)
+
     val fieldBuilder = GraphQLFieldDefinition.newFieldDefinition()
         .description(prop.getPropertyDescription(parentClass))
-        .name(prop.getPropertyName(parentClass))
+        .name(propertyName)
         .type(propertyType)
 
     prop.getPropertyDeprecationReason(parentClass)?.let {
@@ -50,7 +52,7 @@ internal fun generateProperty(generator: SchemaGenerator, prop: KProperty<*>, pa
     val field = fieldBuilder.build()
 
     val parentType = parentClass.getSimpleName()
-    val coordinates = FieldCoordinates.coordinates(parentType, prop.name)
+    val coordinates = FieldCoordinates.coordinates(parentType, propertyName)
     val dataFetcherFactory = generator.config.dataFetcherFactoryProvider.propertyDataFetcherFactory(kClass = parentClass, kProperty = prop)
     generator.codeRegistry.dataFetcher(coordinates, dataFetcherFactory)
 

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/GeneratePropertyTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/GeneratePropertyTest.kt
@@ -19,6 +19,7 @@ package com.expediagroup.graphql.generator.types
 import com.expediagroup.graphql.SchemaGeneratorConfig
 import com.expediagroup.graphql.annotations.GraphQLDescription
 import com.expediagroup.graphql.annotations.GraphQLDirective
+import com.expediagroup.graphql.annotations.GraphQLName
 import com.expediagroup.graphql.directives.KotlinDirectiveWiringFactory
 import com.expediagroup.graphql.directives.KotlinSchemaDirectiveWiring
 import com.expediagroup.graphql.execution.KotlinDataFetcherFactoryProvider
@@ -42,6 +43,7 @@ import io.mockk.spyk
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -54,7 +56,7 @@ class GeneratePropertyTest : TypeTestHelper() {
     private class ClassWithProperties {
         @GraphQLDescription("It's not a lie")
         @PropertyDirective("trust me")
-        lateinit var cake: String
+        val cake: String = "chocolate"
 
         @Deprecated("Only cake")
         lateinit var dessert: String
@@ -63,6 +65,9 @@ class GeneratePropertyTest : TypeTestHelper() {
         lateinit var healthyFood: String
 
         var nullableCake: String? = null
+
+        @GraphQLName("pie")
+        val renameMe: String = "apple"
     }
 
     private data class DataClassWithProperties(
@@ -84,6 +89,20 @@ class GeneratePropertyTest : TypeTestHelper() {
         val result = generateProperty(generator, prop, ClassWithProperties::class)
 
         assertEquals("cake", result.name)
+        val registry = generator.codeRegistry.build()
+        val coordinates = FieldCoordinates.coordinates("ClassWithProperties", "cake")
+        assertNotNull(registry.getDataFetcher(coordinates, result))
+    }
+
+    @Test
+    fun `Test naming override`() {
+        val prop = ClassWithProperties::renameMe
+        val result = generateProperty(generator, prop, ClassWithProperties::class)
+
+        assertEquals("pie", result.name)
+        val registry = generator.codeRegistry.build()
+        val coordinates = FieldCoordinates.coordinates("ClassWithProperties", "pie")
+        assertNotNull(registry.getDataFetcher(coordinates, result))
     }
 
     @Test


### PR DESCRIPTION
### :pencil: Description
Allow properties to have `@GraphQLName` to change the name of the type in the schema and queries

![Screen Shot 2020-09-03 at 11 24 08 PM](https://user-images.githubusercontent.com/2446877/92206670-bc21c680-ee3c-11ea-9ab8-3832b88fc279.png)

### :link: Related Issues
Fixes https://github.com/ExpediaGroup/graphql-kotlin/issues/866