### PR TITLE
[client] fix generation of duplicate classes

### DIFF
--- a/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/types/generateTypeName.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/types/generateTypeName.kt
@@ -22,6 +22,7 @@ import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FLOAT
 import com.squareup.kotlinpoet.INT
 import com.squareup.kotlinpoet.LIST
+import com.squareup.kotlinpoet.ParameterizedTypeName
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.STRING
 import com.squareup.kotlinpoet.TypeName
@@ -111,7 +112,7 @@ internal fun generateCustomClassName(context: GraphQLClientGeneratorContext, gra
             else -> throw RuntimeException("should never happen")
         }
         val className = ClassName(context.packageName, "${context.rootType}.${typeSpec.name}")
-        context.classNameCache[overriddenName]?.add(className)
+        context.classNameCache[graphQLTypeName]?.add(className)
         className
     }
 }
@@ -150,8 +151,7 @@ private fun isCachedTypeApplicable(context: GraphQLClientGeneratorContext, graph
 
 private fun verifySelectionSet(context: GraphQLClientGeneratorContext, graphQLTypeName: String, selectionSet: SelectionSet): Boolean {
     val selectedFields = calculateSelectedFields(context, graphQLTypeName, selectionSet)
-    val typeSpec = context.typeSpecs[graphQLTypeName]
-    val properties = typeSpec?.propertySpecs?.map { it.name }?.toMutableSet() ?: mutableSetOf()
+    val properties = calculateGeneratedTypeProperties(context, graphQLTypeName)
     if (context.objectsWithTypeNameSelection.contains(graphQLTypeName)) {
         properties.add("__typename")
     }
@@ -161,15 +161,16 @@ private fun verifySelectionSet(context: GraphQLClientGeneratorContext, graphQLTy
 private fun calculateSelectedFields(
     context: GraphQLClientGeneratorContext,
     targetType: String,
-    selectionSet: SelectionSet
+    selectionSet: SelectionSet,
+    path: String = ""
 ): Set<String> {
     val result = mutableSetOf<String>()
     selectionSet.selections.forEach { selection ->
         when (selection) {
             is Field -> {
-                result.add(selection.name)
+                result.add(path + selection.name)
                 if (selection.selectionSet != null) {
-                    result.addAll(calculateSelectedFields(context, targetType, selection.selectionSet))
+                    result.addAll(calculateSelectedFields(context, targetType, selection.selectionSet, "$path${selection.name}."))
                 }
             }
             is InlineFragment -> if (selection.typeCondition.name == targetType) {
@@ -186,4 +187,25 @@ private fun calculateSelectedFields(
         }
     }
     return result
+}
+
+private fun calculateGeneratedTypeProperties(context: GraphQLClientGeneratorContext, graphQLTypeName: String, path: String = ""): MutableSet<String> {
+    val props = mutableSetOf<String>()
+
+    val typeSpec = context.typeSpecs[graphQLTypeName]
+    for (property in typeSpec?.propertySpecs ?: emptyList()) {
+        props.add(path + property.name)
+        when (val propertyType = property.type) {
+            is ParameterizedTypeName -> {
+                val genericType = propertyType.typeArguments.firstOrNull() as? ClassName
+                val genericTypeName = genericType?.simpleNameWithoutWrapper() ?: ""
+                props.addAll(calculateGeneratedTypeProperties(context, genericTypeName, "$path${property.name}."))
+            }
+            is ClassName -> {
+                val fieldTypeName = propertyType.simpleNameWithoutWrapper()
+                props.addAll(calculateGeneratedTypeProperties(context, fieldTypeName, "$path${property.name}."))
+            }
+        }
+    }
+    return props
 }

--- a/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLClientIT.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLClientIT.kt
@@ -368,4 +368,354 @@ class GenerateGraphQLClientIT {
         assertEquals(1, fileSpecs.size)
         assertEquals(expectedQueryFileSpec, fileSpecs[0].toString().trim())
     }
+
+    @Test
+    fun `verifies types are reused with same selection set`() {
+        val expected =
+            """
+                package com.expediagroup.graphql.plugin.generator.integration
+
+                import com.expediagroup.graphql.client.GraphQLClient
+                import com.expediagroup.graphql.client.execute
+                import com.expediagroup.graphql.types.GraphQLResponse
+                import kotlin.Int
+                import kotlin.String
+
+                const val REUSED_TYPES_QUERY: String =
+                    "query ReusedTypesQuery {\n  first: complexObjectQuery {\n    id\n    name\n  }\n  second: complexObjectQuery {\n    id\n    name\n    details {\n      id\n      value\n    }\n  }\n  third: complexObjectQuery {\n    id\n    name\n    details {\n      id\n    }\n  }\n  fourth: complexObjectQuery {\n    id\n    name\n  }\n  fifth: complexObjectQuery {\n    id\n    name\n    details {\n      id\n      value\n    }\n  }\n}"
+
+                class ReusedTypesQuery(
+                  private val graphQLClient: GraphQLClient
+                ) {
+                  suspend fun execute(): GraphQLResponse<ReusedTypesQuery.Result> =
+                      graphQLClient.execute(REUSED_TYPES_QUERY, "ReusedTypesQuery", null)
+
+                  /**
+                   * Multi line description of a complex type.
+                   * This is a second line of the paragraph.
+                   * This is final line of the description.
+                   */
+                  data class ComplexObject(
+                    /**
+                     * Some unique identifier
+                     */
+                    val id: Int,
+                    /**
+                     * Some object name
+                     */
+                    val name: String
+                  )
+
+                  /**
+                   * Inner type object description
+                   */
+                  data class DetailsObject(
+                    /**
+                     * Unique identifier
+                     */
+                    val id: Int,
+                    /**
+                     * Actual detail value
+                     */
+                    val value: String
+                  )
+
+                  /**
+                   * Multi line description of a complex type.
+                   * This is a second line of the paragraph.
+                   * This is final line of the description.
+                   */
+                  data class ComplexObject2(
+                    /**
+                     * Some unique identifier
+                     */
+                    val id: Int,
+                    /**
+                     * Some object name
+                     */
+                    val name: String,
+                    /**
+                     * Some additional details
+                     */
+                    val details: ReusedTypesQuery.DetailsObject
+                  )
+
+                  /**
+                   * Inner type object description
+                   */
+                  data class DetailsObject2(
+                    /**
+                     * Unique identifier
+                     */
+                    val id: Int
+                  )
+
+                  /**
+                   * Multi line description of a complex type.
+                   * This is a second line of the paragraph.
+                   * This is final line of the description.
+                   */
+                  data class ComplexObject3(
+                    /**
+                     * Some unique identifier
+                     */
+                    val id: Int,
+                    /**
+                     * Some object name
+                     */
+                    val name: String,
+                    /**
+                     * Some additional details
+                     */
+                    val details: ReusedTypesQuery.DetailsObject2
+                  )
+
+                  data class Result(
+                    /**
+                     * Query returning an object that references another object
+                     */
+                    val first: ReusedTypesQuery.ComplexObject,
+                    /**
+                     * Query returning an object that references another object
+                     */
+                    val second: ReusedTypesQuery.ComplexObject2,
+                    /**
+                     * Query returning an object that references another object
+                     */
+                    val third: ReusedTypesQuery.ComplexObject3,
+                    /**
+                     * Query returning an object that references another object
+                     */
+                    val fourth: ReusedTypesQuery.ComplexObject,
+                    /**
+                     * Query returning an object that references another object
+                     */
+                    val fifth: ReusedTypesQuery.ComplexObject2
+                  )
+                }
+            """.trimIndent()
+        val reusedTypesQuery =
+            """
+                query ReusedTypesQuery {
+                  first: complexObjectQuery {
+                    id
+                    name
+                  }
+                  second: complexObjectQuery {
+                    id
+                    name
+                    details {
+                      id
+                      value
+                    }
+                  }
+                  third: complexObjectQuery {
+                    id
+                    name
+                    details {
+                      id
+                    }
+                  }
+                  fourth: complexObjectQuery {
+                    id
+                    name
+                  }
+                  fifth: complexObjectQuery {
+                    id
+                    name
+                    details {
+                      id
+                      value
+                    }
+                  }
+                }
+            """.trimIndent()
+        verifyGeneratedFileSpecContents(reusedTypesQuery, expected)
+    }
+
+    @Test
+    fun `verifies list types are reused with same selection set`() {
+        val expected =
+            """
+                package com.expediagroup.graphql.plugin.generator.integration
+
+                import com.expediagroup.graphql.client.GraphQLClient
+                import com.expediagroup.graphql.client.execute
+                import com.expediagroup.graphql.types.GraphQLResponse
+                import kotlin.Int
+                import kotlin.String
+                import kotlin.collections.List
+
+                const val REUSED_LIST_TYPES_QUERY: String =
+                    "query ReusedListTypesQuery {\n  first: listQuery {\n    id\n    name\n  }\n  second: listQuery {\n    name\n  }\n  third: listQuery {\n    id\n    name\n  }\n  firstComplex: complexObjectQuery {\n    id\n    name\n    basicList {\n      id\n      name\n    }\n  }\n  secondComplex: complexObjectQuery {\n    id\n    name\n    basicList {\n      id\n      name\n    }\n  }\n  thirdComplex: complexObjectQuery {\n    id\n    name\n    basicList {\n      name\n    }\n  }\n  fourthComplex: complexObjectQuery {\n    id\n    basicList {\n      id\n    }\n  }\n}"
+
+                class ReusedListTypesQuery(
+                  private val graphQLClient: GraphQLClient
+                ) {
+                  suspend fun execute(): GraphQLResponse<ReusedListTypesQuery.Result> =
+                      graphQLClient.execute(REUSED_LIST_TYPES_QUERY, "ReusedListTypesQuery", null)
+
+                  /**
+                   * Some basic description
+                   */
+                  data class BasicObject(
+                    val id: Int,
+                    /**
+                     * Object name
+                     */
+                    val name: String
+                  )
+
+                  /**
+                   * Some basic description
+                   */
+                  data class BasicObject2(
+                    /**
+                     * Object name
+                     */
+                    val name: String
+                  )
+
+                  /**
+                   * Multi line description of a complex type.
+                   * This is a second line of the paragraph.
+                   * This is final line of the description.
+                   */
+                  data class ComplexObject(
+                    /**
+                     * Some unique identifier
+                     */
+                    val id: Int,
+                    /**
+                     * Some object name
+                     */
+                    val name: String,
+                    /**
+                     * List of objects
+                     */
+                    val basicList: List<ReusedListTypesQuery.BasicObject>
+                  )
+
+                  /**
+                   * Multi line description of a complex type.
+                   * This is a second line of the paragraph.
+                   * This is final line of the description.
+                   */
+                  data class ComplexObject2(
+                    /**
+                     * Some unique identifier
+                     */
+                    val id: Int,
+                    /**
+                     * Some object name
+                     */
+                    val name: String,
+                    /**
+                     * List of objects
+                     */
+                    val basicList: List<ReusedListTypesQuery.BasicObject2>
+                  )
+
+                  /**
+                   * Some basic description
+                   */
+                  data class BasicObject3(
+                    val id: Int
+                  )
+
+                  /**
+                   * Multi line description of a complex type.
+                   * This is a second line of the paragraph.
+                   * This is final line of the description.
+                   */
+                  data class ComplexObject3(
+                    /**
+                     * Some unique identifier
+                     */
+                    val id: Int,
+                    /**
+                     * List of objects
+                     */
+                    val basicList: List<ReusedListTypesQuery.BasicObject3>
+                  )
+
+                  data class Result(
+                    /**
+                     * Query returning list of simple objects
+                     */
+                    val first: List<ReusedListTypesQuery.BasicObject>,
+                    /**
+                     * Query returning list of simple objects
+                     */
+                    val second: List<ReusedListTypesQuery.BasicObject2>,
+                    /**
+                     * Query returning list of simple objects
+                     */
+                    val third: List<ReusedListTypesQuery.BasicObject>,
+                    /**
+                     * Query returning an object that references another object
+                     */
+                    val firstComplex: ReusedListTypesQuery.ComplexObject,
+                    /**
+                     * Query returning an object that references another object
+                     */
+                    val secondComplex: ReusedListTypesQuery.ComplexObject,
+                    /**
+                     * Query returning an object that references another object
+                     */
+                    val thirdComplex: ReusedListTypesQuery.ComplexObject2,
+                    /**
+                     * Query returning an object that references another object
+                     */
+                    val fourthComplex: ReusedListTypesQuery.ComplexObject3
+                  )
+                }
+            """.trimIndent()
+        val reusedTypesQuery =
+            """
+                query ReusedListTypesQuery {
+                  first: listQuery {
+                    id
+                    name
+                  }
+                  second: listQuery {
+                    name
+                  }
+                  third: listQuery {
+                    id
+                    name
+                  }
+                  firstComplex: complexObjectQuery {
+                    id
+                    name
+                    basicList {
+                      id
+                      name
+                    }
+                  }
+                  secondComplex: complexObjectQuery {
+                    id
+                    name
+                    basicList {
+                      id
+                      name
+                    }
+                  }
+                  thirdComplex: complexObjectQuery {
+                    id
+                    name
+                    basicList {
+                      name
+                    }
+                  }
+                  fourthComplex: complexObjectQuery {
+                    id
+                    basicList {
+                      id
+                    }
+                  }
+                }
+            """.trimIndent()
+        verifyGeneratedFileSpecContents(reusedTypesQuery, expected)
+    }
 }

--- a/plugins/graphql-kotlin-plugin-core/src/test/resources/testSchema.graphql
+++ b/plugins/graphql-kotlin-plugin-core/src/test/resources/testSchema.graphql
@@ -49,6 +49,8 @@ type ComplexObject {
   Second line of the description
   """
   optional: String
+  "List of objects"
+  basicList: [BasicObject!]!
 }
 "Inner type object description"
 type DetailsObject {


### PR DESCRIPTION
### :pencil: Description

We were incorrectly using simple class name for the type lookup as all classes are wrapped in some root type (i.e. `Query.MyClass`) whereas GraphQL type name was just the actual type. We were also incorrectly comparing selection sets as we were not unwrapping selection sets of the children fields.

### :link: Related Issues
Fixes: https://github.com/ExpediaGroup/graphql-kotlin/issues/864