### PR TITLE
[client] Throw error on non-successful HTTP responses

### DIFF
--- a/clients/graphql-kotlin-spring-client/src/main/kotlin/com/expediagroup/graphql/client/GraphQLWebClient.kt
+++ b/clients/graphql-kotlin-spring-client/src/main/kotlin/com/expediagroup/graphql/client/GraphQLWebClient.kt
@@ -21,13 +21,12 @@ import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.JavaType
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import kotlinx.coroutines.reactive.awaitSingle
 import org.springframework.http.MediaType
 import org.springframework.http.codec.json.Jackson2JsonDecoder
 import org.springframework.http.codec.json.Jackson2JsonEncoder
 import org.springframework.web.reactive.function.client.ExchangeStrategies
 import org.springframework.web.reactive.function.client.WebClient
-import org.springframework.web.reactive.function.client.awaitBody
-import org.springframework.web.reactive.function.client.awaitExchange
 
 /**
  * A lightweight typesafe GraphQL HTTP client using Spring WebClient engine.
@@ -81,8 +80,9 @@ open class GraphQLWebClient(
             .accept(MediaType.APPLICATION_JSON)
             .contentType(MediaType.APPLICATION_JSON)
             .bodyValue(graphQLRequest)
-            .awaitExchange()
-            .awaitBody<String>()
+            .retrieve()
+            .bodyToMono(String::class.java)
+            .awaitSingle()
 
         @Suppress("BlockingMethodInNonBlockingContext")
         return mapper.readValue(rawResult, parameterizedType(resultType))


### PR DESCRIPTION
Currently GraphQLWebClient throws NoSuchElementException for non-200 with
empty body response (i.e 401 Unauthorized) instead of propagating the error.

This change makes use of WebClient.retrieve to throw exception on
non-sucessful HTTP responses to keep inline with KtorClient.

GraphQL always uses HTTP status 200 so other status like 4xx or 5xx should
be treated as failure and it does not need to unmarshal response body.
