### PR TITLE
Start each subscription with init message

### DIFF
--- a/examples/spring/src/test/kotlin/com/expediagroup/graphql/examples/subscriptions/SimpleSubscriptionIT.kt
+++ b/examples/spring/src/test/kotlin/com/expediagroup/graphql/examples/subscriptions/SimpleSubscriptionIT.kt
@@ -25,7 +25,6 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import java.net.URI
-import kotlin.random.Random
 import org.junit.jupiter.api.Test
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration
 import org.springframework.boot.test.context.SpringBootTest
@@ -96,24 +95,24 @@ class SimpleSubscriptionIT(@LocalServerPort private var port: Int) {
     }
 
     private fun subscribe(query: String, id: String): TestPublisher<String> {
-        val message = getStartMessage(query, id)
         val output = TestPublisher.create<String>()
 
         val client = ReactorNettyWebSocketClient()
         val uri = URI.create("ws://localhost:$port$SUBSCRIPTION_ENDPOINT")
 
-        client.execute(uri) { session -> executeSubscription(session, message, output) }.subscribe()
+        client.execute(uri) { session -> executeSubscription(session, query, id, output) }.subscribe()
 
         return output
     }
 
     private fun executeSubscription(
         session: WebSocketSession,
-        startMessage: String,
+        query: String,
+        id: String,
         output: TestPublisher<String>
     ): Mono<Void> {
-        val messageId = Random.nextInt().toString()
-        val initMessage = getInitMessage(messageId)
+        val initMessage = getInitMessage(id)
+        val startMessage = getStartMessage(query, id)
         val firstMessage = session.textMessage(initMessage).toMono()
             .concatWith(session.textMessage(startMessage).toMono())
 


### PR DESCRIPTION
### :pencil: Description
Update the unit test to send an INIT message for each subscription

![Screen Shot 2020-09-25 at 2 37 42 PM](https://user-images.githubusercontent.com/2446877/94318179-c5361d00-ff3c-11ea-9b8d-9a53db9daacc.png)


### :link: Related Issues
