### PR TITLE
[client] update GraphQLWebClient to correctly apply codecs

### DIFF
--- a/clients/graphql-kotlin-spring-client/src/main/kotlin/com/expediagroup/graphql/client/GraphQLWebClient.kt
+++ b/clients/graphql-kotlin-spring-client/src/main/kotlin/com/expediagroup/graphql/client/GraphQLWebClient.kt
@@ -25,7 +25,6 @@ import kotlinx.coroutines.reactive.awaitSingle
 import org.springframework.http.MediaType
 import org.springframework.http.codec.json.Jackson2JsonDecoder
 import org.springframework.http.codec.json.Jackson2JsonEncoder
-import org.springframework.web.reactive.function.client.ExchangeStrategies
 import org.springframework.web.reactive.function.client.WebClient
 
 /**
@@ -42,16 +41,13 @@ open class GraphQLWebClient(
     init {
         mapper.enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE)
 
-        val strategies = ExchangeStrategies
-            .builder()
-            .codecs { configurer ->
-                configurer.defaultCodecs().jackson2JsonEncoder(Jackson2JsonEncoder(mapper, MediaType.APPLICATION_JSON))
-                configurer.defaultCodecs().jackson2JsonDecoder(Jackson2JsonDecoder(mapper, MediaType.APPLICATION_JSON))
-            }.build()
-        builder.exchangeStrategies(strategies)
+        builder.codecs { codecConfigurer ->
+            codecConfigurer.defaultCodecs().jackson2JsonEncoder(Jackson2JsonEncoder(mapper, MediaType.APPLICATION_JSON))
+            codecConfigurer.defaultCodecs().jackson2JsonDecoder(Jackson2JsonDecoder(mapper, MediaType.APPLICATION_JSON))
+        }
     }
 
-    private val client = builder.baseUrl(url).build()
+    private val client: WebClient = builder.baseUrl(url).build()
 
     /**
      * Executes specified GraphQL query or mutation.


### PR DESCRIPTION
### :pencil: Description

Apply default codecs for JSON encoder/decoder without overwriting whole exchange strategies.

### :link: Related Issues

Resolves: https://github.com/ExpediaGroup/graphql-kotlin/issues/899