### PR TITLE
[plugin] Update Gradle extension to accept immutable lists

### DIFF
--- a/docs/plugins/gradle-plugin.md
+++ b/docs/plugins/gradle-plugin.md
@@ -5,6 +5,8 @@ title: Gradle Plugin
 
 GraphQL Kotlin Gradle Plugin provides functionality to introspect GraphQL schemas and generate a lightweight GraphQL HTTP client.
 
+> NOTE: This plugin is dependent on Kotlin compiler plugin as it generates Kotlin source code that needs to be compiled.
+
 ## Usage
 
 `graphql-kotlin-gradle-plugin` is published on Gradle [Plugin Portal](https://plugins.gradle.org/plugin/com.expediagroup.graphql).
@@ -93,15 +95,15 @@ graphql {
     // Type of GraphQL client implementation to generate.
     clientType = GraphQLClientType.DEFAULT
     // Custom GraphQL scalar to converter mapping containing information about corresponding Java type and converter that should be used to serialize/deserialize values.
-    converters["UUID"] = ScalarConverterMapping("java.util.UUID", "com.example.UUIDScalarConverter")
+    converters = mapOf("UUID" to ScalarConverterMapping("java.util.UUID", "com.example.UUIDScalarConverter"))
     // GraphQL server endpoint that will be used to for running introspection queries. Alternatively you can download schema directly from `sdlEndpoint`.
     endpoint = "http://localhost:8080/graphql"
     // Optional HTTP headers to be specified on an introspection query or SDL request.
-    headers["X-Custom-Header"] = "Custom-Header-Value"
+    headers = mapOf("X-Custom-Header" to "Custom-Header-Value")
     // Target package name to be used for generated classes.
     packageName = "com.example.generated"
     // Optional list of query files to be processed, if not specified will default to all query files under src/main/resources.
-    queryFiles = mutableListOf(file("${project.projectDir}/src/main/resources/queries/MyQuery.graphql"))
+    queryFiles = listOf(file("${project.projectDir}/src/main/resources/queries/MyQuery.graphql"))
     // GraphQL server SDL endpoint that will be used to download schema. Alternatively you can run introspection query against `endpoint`.
     sdlEndpoint = "http://localhost:8080/sdl"
     // Timeout configuration for introspection query/downloading SDL
@@ -125,11 +127,11 @@ graphql {
         // Type of GraphQL client implementation to generate.
         clientType = com.expediagroup.graphql.plugin.generator.GraphQLClientType.DEFAULT
         // Custom GraphQL scalar to converter mapping containing information about corresponding Java type and converter that should be used to serialize/deserialize values.
-        converters["UUID"] = new com.expediagroup.graphql.plugin.generator.ScalarConverterMapping("java.util.UUID", "com.example.UUIDScalarConverter")
+        converters = ["UUID" : new com.expediagroup.graphql.plugin.generator.ScalarConverterMapping("java.util.UUID", "com.example.UUIDScalarConverter")]
         // GraphQL server endpoint that will be used to for running introspection queries. Alternatively you can download schema directly from `sdlEndpoint`.
         endpoint = "http://localhost:8080/graphql"
         // Optional HTTP headers to be specified on an introspection query or SDL request.
-        headers["X-Custom-Header"] = "My-Custom-Header-Value"
+        headers = ["X-Custom-Header" : "My-Custom-Header-Value"]
         // Target package name to be used for generated classes.
         packageName = "com.example.generated"
         // Optional list of query files to be processed, if not specified will default to all query files under src/main/resources.
@@ -565,8 +567,8 @@ graphql {
     // optional configuration
     allowDeprecatedFields = true
     clientType = GraphQLClientType.KTOR
-    converters["UUID"] = ScalarConverterMapping("java.util.UUID", "com.example.UUIDScalarConverter")
-    headers["X-Custom-Header"] = "My-Custom-Header"
+    converters = mapOf("UUID" to ScalarConverterMapping("java.util.UUID", "com.example.UUIDScalarConverter"))
+    headers = mapOf("X-Custom-Header" to "My-Custom-Header")
     queryFiles = listOf(file("${project.projectDir}/src/main/resources/queries/MyQuery.graphql"))
     timeout {
         connect = 10_000
@@ -615,8 +617,8 @@ graphql {
         // optional configuration
         allowDeprecatedFields = true
         clientType = com.expediagroup.graphql.plugin.generator.GraphQLClientType.KTOR
-        converters["UUID"] = new com.expediagroup.graphql.plugin.generator.ScalarConverterMapping("java.util.UUID", "com.example.UUIDScalarConverter")
-        headers["X-Custom-Header"] = "My-Custom-Header"
+        converters = ["UUID" : new com.expediagroup.graphql.plugin.generator.ScalarConverterMapping("java.util.UUID", "com.example.UUIDScalarConverter")]
+        headers = ["X-Custom-Header" : "My-Custom-Header"]
         queryFiles = [file("${project.projectDir}/src/main/resources/queries/MyQuery.graphql")]
         timeout { t ->
             t.connect = 10_000

--- a/docs/plugins/maven-plugin.md
+++ b/docs/plugins/maven-plugin.md
@@ -5,6 +5,8 @@ title: Maven Plugin
 
 GraphQL Kotlin Maven Plugin provides functionality to introspect GraphQL schemas and generate a lightweight GraphQL HTTP client.
 
+> NOTE: This plugin is dependent on Kotlin compiler plugin as it generates Kotlin source code that needs to be compiled.
+
 ## Goals
 
 You can find detailed information about `graphql-kotlin-maven-plugin` and all its goals by running `mvn help:describe -Dplugin=com.expediagroup:graphql-kotlin-maven-plugin -Ddetail`.

--- a/plugins/graphql-kotlin-gradle-plugin/README.md
+++ b/plugins/graphql-kotlin-gradle-plugin/README.md
@@ -32,15 +32,15 @@ graphql {
     // Type of GraphQL client implementation to generate.
     clientType = GraphQLClientType.DEFAULT
     // Custom GraphQL scalar to converter mapping containing information about corresponding Java type and converter that should be used to serialize/deserialize values.
-    converters["UUID"] = ScalarConverterMapping("java.util.UUID", "com.example.UUIDScalarConverter")
+    converters = mapOf("UUID" to ScalarConverterMapping("java.util.UUID", "com.example.UUIDScalarConverter"))
     // GraphQL server endpoint that will be used to for running introspection queries. Alternatively you can download schema directly from `sdlEndpoint`.
     endpoint = "http://localhost:8080/graphql"
     // Optional HTTP headers to be specified on an introspection query or SDL request.
-    headers["X-Custom-Header"] = "Custom-Header-Value"
+    headers = mapOf("X-Custom-Header" to "Custom-Header-Value")
     // Target package name to be used for generated classes.
     packageName = "com.example.generated"
     // Optional list of query files to be processed, if not specified will default to all query files under src/main/resources.
-    queryFiles.add(file("${project.projectDir}/src/main/resources/queries/MyQuery.graphql"))
+    queryFiles = listOf(file("${project.projectDir}/src/main/resources/queries/MyQuery.graphql"))
     // GraphQL server SDL endpoint that will be used to download schema. Alternatively you can run introspection query against `endpoint`.
     sdlEndpoint = "http://localhost:8080/sdl"
     // Timeout configuration for introspection query/downloading SDL

--- a/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLPluginExtension.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLPluginExtension.kt
@@ -50,13 +50,13 @@ open class GraphQLPluginClientExtension {
     /** Target package name to be used for generated classes. */
     var packageName: String? = null
     /** Optional HTTP headers to be specified on an introspection query or SDL request. */
-    var headers: MutableMap<String, Any> = mutableMapOf()
+    var headers: Map<String, Any> = emptyMap()
     /** Boolean flag indicating whether or not selection of deprecated fields is allowed. */
     var allowDeprecatedFields: Boolean = false
     /** Custom GraphQL scalar to converter mapping containing information about corresponding Java type and converter that should be used to serialize/deserialize values. */
-    var converters: MutableMap<String, ScalarConverterMapping> = mutableMapOf()
+    var converters: Map<String, ScalarConverterMapping> = emptyMap()
     /** List of query files to be processed. */
-    var queryFiles: MutableList<File> = mutableListOf()
+    var queryFiles: List<File> = emptyList()
     /** Type of GraphQL client implementation to generate. */
     var clientType: GraphQLClientType = GraphQLClientType.DEFAULT
 

--- a/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/GraphQLGenerateClientTask.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/GraphQLGenerateClientTask.kt
@@ -22,7 +22,7 @@ import com.expediagroup.graphql.plugin.generator.GraphQLClientType
 import com.expediagroup.graphql.plugin.generator.ScalarConverterMapping
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileCollection
-import org.gradle.api.file.Directory
+import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
@@ -122,7 +122,7 @@ open class GraphQLGenerateClientTask : DefaultTask() {
     val clientType: Property<GraphQLClientType> = project.objects.property(GraphQLClientType::class.java)
 
     @OutputDirectory
-    val outputDirectory: Property<Directory> = project.objects.directoryProperty()
+    val outputDirectory: DirectoryProperty = project.objects.directoryProperty()
 
     init {
         group = "GraphQL"

--- a/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePluginIT.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePluginIT.kt
@@ -96,10 +96,12 @@ class GraphQLGradlePluginIT : GraphQLGradlePluginAbstractIT() {
 
                 // optional
                 allowDeprecatedFields = true
-                headers["$customHeaderName"] = "$customHeaderValue"
-                converters["UUID"] = ScalarConverterMapping("java.util.UUID", "com.example.UUIDScalarConverter")
-                queryFiles.add(file("${'$'}{project.projectDir}/src/main/resources/queries/JUnitQuery.graphql"))
-                queryFiles.add(file("${'$'}{project.projectDir}/src/main/resources/queries/DeprecatedQuery.graphql"))
+                headers = mapOf("$customHeaderName" to "$customHeaderValue")
+                converters = mapOf("UUID" to ScalarConverterMapping("java.util.UUID", "com.example.UUIDScalarConverter"))
+                queryFiles = listOf(
+                    file("${'$'}{project.projectDir}/src/main/resources/queries/JUnitQuery.graphql"),
+                    file("${'$'}{project.projectDir}/src/main/resources/queries/DeprecatedQuery.graphql")
+                )
               }
             }
             """.trimIndent()
@@ -223,8 +225,8 @@ class GraphQLGradlePluginIT : GraphQLGradlePluginAbstractIT() {
                     // optional configuration
                     allowDeprecatedFields = true
                     clientType = com.expediagroup.graphql.plugin.generator.GraphQLClientType.KTOR
-                    converters["UUID"] = new com.expediagroup.graphql.plugin.generator.ScalarConverterMapping("java.util.UUID", "com.example.UUIDScalarConverter")
-                    headers["X-Custom-Header"] = "My-Custom-Header-Value"
+                    converters = ["UUID" : new com.expediagroup.graphql.plugin.generator.ScalarConverterMapping("java.util.UUID", "com.example.UUIDScalarConverter")]
+                    headers = ["X-Custom-Header" : "My-Custom-Header-Value"]
                     queryFiles = [
                         file("$testProjectDirectory/src/main/resources/queries/JUnitQuery.graphql"),
                         file("$testProjectDirectory/src/main/resources/queries/DeprecatedQuery.graphql")


### PR DESCRIPTION
### :pencil: Description

In order to keep extension logic consistent, all extension configuration fields can be explicitly set. Fields with return type of a collection now only accept immutable collections and it is no longer possible to add elements directly to a field.

Previous configuration allowed both
```
graphql {
  client {
    // set new headers map
    headers = mutableMapOf("foo" to "bar")
    // add individual entries
    headers["foo"] = "bar"

    // set new list of query files
    queryFiles = mutableListOf(file("foo.graphql"))
    // add files individually
    queryFiles.add(file("foo.graphql"))
  }
}
```

Updated configuration only allows setting immutable collections
```
graphql {
  client {
    headers = mapOf("foo" to "bar")
    queryFiles = listOf(file("foo.graphql"))
  }
}
```

### :link: Related Issues

Resolves https://github.com/ExpediaGroup/graphql-kotlin/issues/906