### PR TITLE
[client] update parameterizedType cache to use concurrent hash map

### DIFF
--- a/clients/graphql-kotlin-ktor-client/src/main/kotlin/com/expediagroup/graphql/client/GraphQLKtorClient.kt
+++ b/clients/graphql-kotlin-ktor-client/src/main/kotlin/com/expediagroup/graphql/client/GraphQLKtorClient.kt
@@ -36,6 +36,7 @@ import io.ktor.http.contentType
 import io.ktor.util.KtorExperimentalAPI
 import java.io.Closeable
 import java.net.URL
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * A lightweight typesafe GraphQL HTTP client using Ktor HTTP client engine.
@@ -48,7 +49,7 @@ open class GraphQLKtorClient<in T : HttpClientEngineConfig>(
     configuration: HttpClientConfig<T>.() -> Unit = {}
 ) : GraphQLClient, Closeable {
 
-    private val typeCache = mutableMapOf<Class<*>, JavaType>()
+    private val typeCache = ConcurrentHashMap<Class<*>, JavaType>()
 
     init {
         mapper.enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE)

--- a/clients/graphql-kotlin-spring-client/src/main/kotlin/com/expediagroup/graphql/client/GraphQLWebClient.kt
+++ b/clients/graphql-kotlin-spring-client/src/main/kotlin/com/expediagroup/graphql/client/GraphQLWebClient.kt
@@ -26,6 +26,7 @@ import org.springframework.http.MediaType
 import org.springframework.http.codec.json.Jackson2JsonDecoder
 import org.springframework.http.codec.json.Jackson2JsonEncoder
 import org.springframework.web.reactive.function.client.WebClient
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * A lightweight typesafe GraphQL HTTP client using Spring WebClient engine.
@@ -36,7 +37,7 @@ open class GraphQLWebClient(
     builder: WebClient.Builder = WebClient.builder()
 ) : GraphQLClient {
 
-    private val typeCache = mutableMapOf<Class<*>, JavaType>()
+    private val typeCache = ConcurrentHashMap<Class<*>, JavaType>()
 
     init {
         mapper.enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE)


### PR DESCRIPTION
### :pencil: Description

When client was used in multithreaded environment it was possible to encounter `ConcurrentModificationException` when multiple threads attempted to compute parameterized type.

### :link: Related Issues

None