### PR TITLE
[plugin] support query file directory in Gradle extension

### DIFF
--- a/docs/plugins/gradle-plugin.md
+++ b/docs/plugins/gradle-plugin.md
@@ -102,7 +102,9 @@ graphql {
     headers = mapOf("X-Custom-Header" to "Custom-Header-Value")
     // Target package name to be used for generated classes.
     packageName = "com.example.generated"
-    // Optional list of query files to be processed, if not specified will default to all query files under src/main/resources.
+    // Custom directory containing query files, defaults to src/main/resources
+    queryFileDirectory = "${project.projectDir}/src/main/resources/queries"
+    // Optional list of query files to be processed, takes precedence over queryFileDirectory
     queryFiles = listOf(file("${project.projectDir}/src/main/resources/queries/MyQuery.graphql"))
     // GraphQL server SDL endpoint that will be used to download schema. Alternatively you can run introspection query against `endpoint`.
     sdlEndpoint = "http://localhost:8080/sdl"
@@ -134,7 +136,9 @@ graphql {
         headers = ["X-Custom-Header" : "My-Custom-Header-Value"]
         // Target package name to be used for generated classes.
         packageName = "com.example.generated"
-        // Optional list of query files to be processed, if not specified will default to all query files under src/main/resources.
+        // Custom directory containing query files, defaults to src/main/resources
+        queryFileDirectory = "${project.projectDir}/src/main/resources/queries"
+        // Optional list of query files to be processed, takes precedence over queryFileDirectory
         queryFiles = [file("${project.projectDir}/src/main/resources/queries/MyQuery.graphql")]
         // GraphQL server SDL endpoint that will be used to download schema. Alternatively you can run introspection query against `endpoint`.
         sdlEndpoint = "http://localhost:8080/sdl"

--- a/plugins/graphql-kotlin-gradle-plugin/README.md
+++ b/plugins/graphql-kotlin-gradle-plugin/README.md
@@ -39,7 +39,9 @@ graphql {
     headers = mapOf("X-Custom-Header" to "Custom-Header-Value")
     // Target package name to be used for generated classes.
     packageName = "com.example.generated"
-    // Optional list of query files to be processed, if not specified will default to all query files under src/main/resources.
+    // Custom directory containing query files, defaults to src/main/resources
+    queryFileDirectory = "${project.projectDir}/src/main/resources/queries"
+    // Optional list of query files to be processed, takes precedence over queryFileDirectory
     queryFiles = listOf(file("${project.projectDir}/src/main/resources/queries/MyQuery.graphql"))
     // GraphQL server SDL endpoint that will be used to download schema. Alternatively you can run introspection query against `endpoint`.
     sdlEndpoint = "http://localhost:8080/sdl"

--- a/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePlugin.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePlugin.kt
@@ -61,6 +61,10 @@ class GraphQLGradlePlugin : Plugin<Project> {
                     generateClientTask.packageName.convention(project.provider { extension.clientExtension.packageName })
                     generateClientTask.allowDeprecatedFields.convention(project.provider { extension.clientExtension.allowDeprecatedFields })
                     generateClientTask.converters.convention(extension.clientExtension.converters)
+                    val queryFileDirectory = extension.clientExtension.queryFileDirectory
+                    if (queryFileDirectory != null) {
+                        generateClientTask.queryFileDirectory.convention(queryFileDirectory)
+                    }
                     generateClientTask.queryFiles.setFrom(extension.clientExtension.queryFiles)
                     generateClientTask.clientType.convention(extension.clientExtension.clientType)
 

--- a/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLPluginExtension.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLPluginExtension.kt
@@ -57,6 +57,8 @@ open class GraphQLPluginClientExtension {
     var converters: Map<String, ScalarConverterMapping> = emptyMap()
     /** List of query files to be processed. */
     var queryFiles: List<File> = emptyList()
+    /** Directory containing GraphQL query files. */
+    var queryFileDirectory: String? = null
     /** Type of GraphQL client implementation to generate. */
     var clientType: GraphQLClientType = GraphQLClientType.DEFAULT
 


### PR DESCRIPTION
### :pencil: Description

Adds ability to specify custom query file directory (previously we had to explicitly provide a list of query files).

```kotlin
graphql {
  client {
    endpoint = "http://localhost:8080/graphql"
    package = "com.example"
    queryFileDirectory = "${project.projectDir}/src/main/resources/queries"
  }
}
```

### :link: Related Issues

Resolves https://github.com/ExpediaGroup/graphql-kotlin/issues/886