### PR TITLE
[plugin] improve client generation exception handling

### DIFF
--- a/plugins/graphql-kotlin-plugin-core/build.gradle.kts
+++ b/plugins/graphql-kotlin-plugin-core/build.gradle.kts
@@ -23,12 +23,12 @@ tasks {
                 limit {
                     counter = "INSTRUCTION"
                     value = "COVEREDRATIO"
-                    minimum = "0.85".toBigDecimal()
+                    minimum = "0.90".toBigDecimal()
                 }
                 limit {
                     counter = "BRANCH"
                     value = "COVEREDRATIO"
-                    minimum = "0.65".toBigDecimal()
+                    minimum = "0.75".toBigDecimal()
                 }
             }
         }

--- a/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/GraphQLClientGenerator.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/GraphQLClientGenerator.kt
@@ -16,6 +16,7 @@
 
 package com.expediagroup.graphql.plugin.generator
 
+import com.expediagroup.graphql.plugin.generator.exceptions.MultipleOperationsInFileException
 import com.expediagroup.graphql.plugin.generator.types.generateGraphQLObjectTypeSpec
 import com.expediagroup.graphql.plugin.generator.types.generateVariableTypeSpec
 import com.squareup.kotlinpoet.ClassName
@@ -81,7 +82,7 @@ class GraphQLClientGenerator(
 
         val operationDefinitions = queryDocument.definitions.filterIsInstance(OperationDefinition::class.java)
         if (operationDefinitions.size > 1) {
-            throw RuntimeException("GraphQL client does not support query files with multiple operations")
+            throw MultipleOperationsInFileException
         }
 
         val fileSpec = FileSpec.builder(packageName = config.packageName, fileName = queryFile.nameWithoutExtension.capitalize())

--- a/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/exceptions/DeprecatedFieldsSelectedException.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/exceptions/DeprecatedFieldsSelectedException.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2020 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.plugin.generator.exceptions
+
+/**
+ * Exception thrown when query specifies deprecated fields but client configuration does not allow it.
+ */
+internal class DeprecatedFieldsSelectedException(field: String, type: String) :
+    RuntimeException("query specifies deprecated field - $field in $type, update your query or update your configuration to allow usage of deprecated fields")

--- a/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/exceptions/DeprecatedFieldsSelectedException.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/exceptions/DeprecatedFieldsSelectedException.kt
@@ -20,4 +20,4 @@ package com.expediagroup.graphql.plugin.generator.exceptions
  * Exception thrown when query specifies deprecated fields but client configuration does not allow it.
  */
 internal class DeprecatedFieldsSelectedException(field: String, type: String) :
-    RuntimeException("query specifies deprecated field - $field in $type, update your query or update your configuration to allow usage of deprecated fields")
+    RuntimeException("Operation specifies deprecated field - $field in $type. Update your operation or update your configuration to allow usage of deprecated fields")

--- a/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/exceptions/InvalidFragmentException.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/exceptions/InvalidFragmentException.kt
@@ -20,4 +20,4 @@ package com.expediagroup.graphql.plugin.generator.exceptions
  * Exception thrown when query file specifies invalid fragment.
  */
 internal class InvalidFragmentException(fragmentName: String, targetType: String) :
-    RuntimeException("invalid fragment - $fragmentName fragment not found or does not reference valid $targetType type")
+    RuntimeException("Invalid fragment, $fragmentName fragment not found or does not reference valid $targetType type")

--- a/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/exceptions/InvalidFragmentException.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/exceptions/InvalidFragmentException.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2020 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.plugin.generator.exceptions
+
+/**
+ * Exception thrown when query file specifies invalid fragment.
+ */
+internal class InvalidFragmentException(fragmentName: String, targetType: String) :
+    RuntimeException("invalid fragment - $fragmentName fragment not found or does not reference valid $targetType type")

--- a/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/exceptions/InvalidPolymorphicQueryException.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/exceptions/InvalidPolymorphicQueryException.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2020 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.plugin.generator.exceptions
+
+/**
+ * Exception thrown when query contains invalid polymorphic selection sets.
+ */
+internal class InvalidPolymorphicQueryException(message: String) : RuntimeException(message)

--- a/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/exceptions/InvalidSelectionSetException.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/exceptions/InvalidSelectionSetException.kt
@@ -19,4 +19,4 @@ package com.expediagroup.graphql.plugin.generator.exceptions
 /**
  * Exception thrown when specified query file contains invalid selection set.
  */
-internal class InvalidSelectionSetException(message: String) : RuntimeException(message)
+internal class InvalidSelectionSetException(typeDefinitionName : String, typeName : String) : RuntimeException("Invalid selection set for $typeName - cannot select empty $typeDefinitionName")

--- a/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/exceptions/InvalidSelectionSetException.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/exceptions/InvalidSelectionSetException.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2020 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.plugin.generator.exceptions
+
+/**
+ * Exception thrown when specified query file contains invalid selection set.
+ */
+internal class InvalidSelectionSetException(message: String) : RuntimeException(message)

--- a/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/exceptions/MultipleOperationsInFileException.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/exceptions/MultipleOperationsInFileException.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2020 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.plugin.generator.exceptions
+
+/**
+ * Exception thrown when attempting to generate a client from a query file containing multiple operations.
+ */
+internal object MultipleOperationsInFileException : RuntimeException("GraphQL client does not support query files with multiple operations")

--- a/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/exceptions/UnknownFieldSelectedException.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/exceptions/UnknownFieldSelectedException.kt
@@ -17,7 +17,7 @@
 package com.expediagroup.graphql.plugin.generator.exceptions
 
 /**
- * Exception thrown when specified query file contains invalid selection set.
+ * Exception thrown when specified query file references unknown fields.
  */
-internal class InvalidSelectionSetException(typeDefinitionName: String, typeName: String) :
-    RuntimeException("Invalid selection set for $typeName - cannot select empty $typeDefinitionName")
+internal class UnknownFieldSelectedException(fieldName: String, typeDefinitionName: String) :
+    RuntimeException("Invalid selection set for $typeDefinitionName - unknown $fieldName field selected")

--- a/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/exceptions/UnknownGraphQLTypeException.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/exceptions/UnknownGraphQLTypeException.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2020 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.plugin.generator.exceptions
+
+import graphql.language.Node
+
+/**
+ * This exception should never be thrown. It is used to enforce type safety of type name generation operations. Exception
+ * is used to mark unreachable code execution branches that ensures non null response from all valid branches.
+ */
+internal class UnknownGraphQLTypeException(graphQLType: Node<*>) :
+    RuntimeException("client generation failure - attempting to generate code for unsupported GraphQL type $graphQLType")

--- a/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/exceptions/UnknownGraphQLTypeException.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/exceptions/UnknownGraphQLTypeException.kt
@@ -23,4 +23,4 @@ import graphql.language.Node
  * is used to mark unreachable code execution branches that ensures non null response from all valid branches.
  */
 internal class UnknownGraphQLTypeException(graphQLType: Node<*>) :
-    RuntimeException("client generation failure - attempting to generate code for unsupported GraphQL type $graphQLType")
+    RuntimeException("Client generation failure - attempting to generate code for unsupported GraphQL type $graphQLType")

--- a/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/extensions/DocumentExtensions.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/extensions/DocumentExtensions.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2020 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.plugin.generator.extensions
+
+import com.expediagroup.graphql.plugin.generator.exceptions.InvalidFragmentException
+import graphql.language.Document
+import graphql.language.FragmentDefinition
+
+internal fun Document.findFragmentDefinition(targetFragment: String, targetType: String): FragmentDefinition =
+    this.getDefinitionsOfType(FragmentDefinition::class.java)
+        .find { it.name == targetFragment && it.typeCondition.name == targetType } ?: throw InvalidFragmentException(targetFragment, targetType)

--- a/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/types/generateGraphQLInterfaceTypeSpec.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/types/generateGraphQLInterfaceTypeSpec.kt
@@ -35,7 +35,7 @@ internal fun generateGraphQLInterfaceTypeSpec(
     interfaceNameOverride: String? = null
 ): TypeSpec {
     if (selectionSet == null || selectionSet.selections.isEmpty()) {
-        throw InvalidSelectionSetException("invalid interface selection set - cannot select empty ${interfaceDefinition.name} interface ")
+        throw InvalidSelectionSetException(interfaceDefinition.name, "interface")
     }
 
     val interfaceName = interfaceNameOverride ?: interfaceDefinition.name

--- a/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/types/generateGraphQLInterfaceTypeSpec.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/types/generateGraphQLInterfaceTypeSpec.kt
@@ -17,6 +17,7 @@
 package com.expediagroup.graphql.plugin.generator.types
 
 import com.expediagroup.graphql.plugin.generator.GraphQLClientGeneratorContext
+import com.expediagroup.graphql.plugin.generator.exceptions.InvalidSelectionSetException
 import com.squareup.kotlinpoet.TypeSpec
 import graphql.language.InterfaceTypeDefinition
 import graphql.language.SelectionSet
@@ -34,7 +35,7 @@ internal fun generateGraphQLInterfaceTypeSpec(
     interfaceNameOverride: String? = null
 ): TypeSpec {
     if (selectionSet == null || selectionSet.selections.isEmpty()) {
-        throw RuntimeException("cannot select empty interface")
+        throw InvalidSelectionSetException("invalid interface selection set - cannot select empty ${interfaceDefinition.name} interface ")
     }
 
     val interfaceName = interfaceNameOverride ?: interfaceDefinition.name

--- a/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/types/generateGraphQLObjectTypeSpec.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/types/generateGraphQLObjectTypeSpec.kt
@@ -36,7 +36,7 @@ internal fun generateGraphQLObjectTypeSpec(
     objectNameOverride: String? = null
 ): TypeSpec {
     if (selectionSet == null || selectionSet.selections.isEmpty()) {
-        throw InvalidSelectionSetException("invalid object selection set - cannot select empty ${objectDefinition.name} object ")
+        throw InvalidSelectionSetException(objectDefinition.name, "object")
     }
 
     val typeName = objectNameOverride ?: objectDefinition.name

--- a/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/types/generateGraphQLObjectTypeSpec.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/types/generateGraphQLObjectTypeSpec.kt
@@ -17,10 +17,11 @@
 package com.expediagroup.graphql.plugin.generator.types
 
 import com.expediagroup.graphql.plugin.generator.GraphQLClientGeneratorContext
+import com.expediagroup.graphql.plugin.generator.exceptions.InvalidSelectionSetException
+import com.expediagroup.graphql.plugin.generator.extensions.findFragmentDefinition
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.TypeSpec
-import graphql.language.FragmentDefinition
 import graphql.language.FragmentSpread
 import graphql.language.ObjectTypeDefinition
 import graphql.language.SelectionSet
@@ -35,7 +36,7 @@ internal fun generateGraphQLObjectTypeSpec(
     objectNameOverride: String? = null
 ): TypeSpec {
     if (selectionSet == null || selectionSet.selections.isEmpty()) {
-        throw RuntimeException("cannot select empty objects")
+        throw InvalidSelectionSetException("invalid object selection set - cannot select empty ${objectDefinition.name} object ")
     }
 
     val typeName = objectNameOverride ?: objectDefinition.name
@@ -59,8 +60,7 @@ internal fun generateGraphQLObjectTypeSpec(
     selectionSet.getSelectionsOfType(FragmentSpread::class.java)
         .forEach { fragment ->
             val fragmentDefinition = context.queryDocument
-                .getDefinitionsOfType(FragmentDefinition::class.java)
-                .find { it.name == fragment.name } ?: throw RuntimeException("fragment not found")
+                .findFragmentDefinition(fragment.name, objectDefinition.name)
             generatePropertySpecs(
                 context = context,
                 objectName = objectDefinition.name,

--- a/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/types/generateGraphQLUnionTypeSpec.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/types/generateGraphQLUnionTypeSpec.kt
@@ -17,6 +17,7 @@
 package com.expediagroup.graphql.plugin.generator.types
 
 import com.expediagroup.graphql.plugin.generator.GraphQLClientGeneratorContext
+import com.expediagroup.graphql.plugin.generator.exceptions.InvalidSelectionSetException
 import com.squareup.kotlinpoet.TypeSpec
 import graphql.language.SelectionSet
 import graphql.language.TypeName
@@ -35,7 +36,7 @@ internal fun generateGraphQLUnionTypeSpec(
     unionNameOverride: String? = null
 ): TypeSpec {
     if (selectionSet == null || selectionSet.selections.isEmpty()) {
-        throw RuntimeException("cannot select empty union")
+        throw InvalidSelectionSetException("invalid union selection set - cannot select empty ${unionDefinition.name} union ")
     }
 
     val unionName = unionNameOverride ?: unionDefinition.name

--- a/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/types/generateGraphQLUnionTypeSpec.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/types/generateGraphQLUnionTypeSpec.kt
@@ -36,7 +36,7 @@ internal fun generateGraphQLUnionTypeSpec(
     unionNameOverride: String? = null
 ): TypeSpec {
     if (selectionSet == null || selectionSet.selections.isEmpty()) {
-        throw InvalidSelectionSetException("invalid union selection set - cannot select empty ${unionDefinition.name} union ")
+        throw InvalidSelectionSetException(unionDefinition.name, "union")
     }
 
     val unionName = unionNameOverride ?: unionDefinition.name

--- a/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/types/generateInterfaceTypeSpec.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/types/generateInterfaceTypeSpec.kt
@@ -60,7 +60,7 @@ internal fun generateInterfaceTypeSpec(
     if (kdoc != null) {
         interfaceTypeSpec.addKdoc(kdoc)
     }
-    
+
     val namedFragments = selectionSet.getSelectionsOfType(FragmentSpread::class.java).map { fragment ->
         // polymorphic selection set can contain selection set against interface or concrete types
         context.queryDocument.getDefinitionsOfType(FragmentDefinition::class.java)

--- a/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/types/generateInterfaceTypeSpec.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/types/generateInterfaceTypeSpec.kt
@@ -17,6 +17,8 @@
 package com.expediagroup.graphql.plugin.generator.types
 
 import com.expediagroup.graphql.plugin.generator.GraphQLClientGeneratorContext
+import com.expediagroup.graphql.plugin.generator.exceptions.InvalidFragmentException
+import com.expediagroup.graphql.plugin.generator.exceptions.InvalidPolymorphicQueryException
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.squareup.kotlinpoet.AnnotationSpec
@@ -58,9 +60,11 @@ internal fun generateInterfaceTypeSpec(
     if (kdoc != null) {
         interfaceTypeSpec.addKdoc(kdoc)
     }
-
+    
     val namedFragments = selectionSet.getSelectionsOfType(FragmentSpread::class.java).map { fragment ->
-        context.queryDocument.getDefinitionsOfType(FragmentDefinition::class.java).find { it.name == fragment.name } ?: throw RuntimeException("fragment ${fragment.name} not found")
+        // polymorphic selection set can contain selection set against interface or concrete types
+        context.queryDocument.getDefinitionsOfType(FragmentDefinition::class.java)
+            .find { it.name == fragment.name } ?: throw InvalidFragmentException(fragment.name, interfaceName)
     }.associateBy { it.typeCondition.name }
 
     // find super selection set that contains
@@ -108,7 +112,7 @@ internal fun generateInterfaceTypeSpec(
     // check if all implementations are selected
     val notImplemented = implementations.minus(implementationSelections.keys)
     if (notImplemented.isNotEmpty()) {
-        throw RuntimeException("query does not specify all polymorphic implementations - $interfaceName field selection is missing $notImplemented")
+        throw InvalidPolymorphicQueryException("query does not specify all polymorphic implementations - $interfaceName field selection is missing $notImplemented")
     }
 
     // generate implementations with final selection set
@@ -116,7 +120,7 @@ internal fun generateInterfaceTypeSpec(
     implementationSelections.forEach { implementationName, (typeCondition, selections) ->
         val distinctSelections = selections.filterIsInstance(Field::class.java).distinctBy { if (it.alias != null) it.alias else it.name }
         if (!verifyTypeNameIsSelected(distinctSelections)) {
-            throw RuntimeException("invalid selection set - $implementationName implementation of $interfaceName is missing __typename field in its selection set")
+            throw InvalidPolymorphicQueryException("invalid polymorphic selection set - $implementationName implementation of $interfaceName is missing __typename field in its selection set")
         }
         val implementationClassName = generateTypeName(context, typeCondition, SelectionSet.newSelectionSet(distinctSelections).build()) as ClassName
         val simpleName = implementationClassName.simpleName.substringAfter('.')

--- a/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/types/generatePropertySpecs.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/types/generatePropertySpecs.kt
@@ -47,7 +47,7 @@ internal fun generatePropertySpecs(
     }
     .map { selectedField ->
         val fieldDefinition = fieldDefinitions.find { it.name == selectedField.name }
-            ?: throw InvalidSelectionSetException("unable to find corresponding field definition of ${selectedField.name} in $objectName")
+            ?: throw InvalidSelectionSetException(selectedField.name, objectName)
 
         val nullable = fieldDefinition.type !is NonNullType
         val kotlinFieldType = generateTypeName(context, fieldDefinition.type, selectedField.selectionSet)

--- a/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLClientIT.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLClientIT.kt
@@ -19,6 +19,7 @@ package com.expediagroup.graphql.plugin.generator.types
 import com.expediagroup.graphql.plugin.generator.GraphQLClientGenerator
 import com.expediagroup.graphql.plugin.generator.GraphQLClientGeneratorConfig
 import com.expediagroup.graphql.plugin.generator.GraphQLClientType
+import com.expediagroup.graphql.plugin.generator.exceptions.DeprecatedFieldsSelectedException
 import com.expediagroup.graphql.plugin.generator.testSchema
 import com.expediagroup.graphql.plugin.generator.verifyGeneratedFileSpecContents
 import org.junit.jupiter.api.Test
@@ -188,7 +189,7 @@ class GenerateGraphQLClientIT {
                   deprecatedQuery
                 }
             """.trimIndent()
-        assertThrows<RuntimeException> {
+        assertThrows<DeprecatedFieldsSelectedException> {
             verifyGeneratedFileSpecContents(invalidQuery, "will throw exception")
         }
     }

--- a/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLInterfaceTypeSpecIT.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLInterfaceTypeSpecIT.kt
@@ -16,8 +16,11 @@
 
 package com.expediagroup.graphql.plugin.generator.types
 
+import com.expediagroup.graphql.plugin.generator.exceptions.InvalidPolymorphicQueryException
+import com.expediagroup.graphql.plugin.generator.exceptions.InvalidSelectionSetException
 import com.expediagroup.graphql.plugin.generator.verifyGeneratedFileSpecContents
 import graphql.language.SelectionSet
+import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -265,8 +268,14 @@ class GenerateGraphQLInterfaceTypeSpecIT {
 
     @Test
     fun `verify interface generation will throw exception if empty selection set is specified`() {
-        assertThrows<RuntimeException> {
-            generateGraphQLInterfaceTypeSpec(mockk(), mockk(), SelectionSet.newSelectionSet().build())
+        assertThrows<InvalidSelectionSetException> {
+            generateGraphQLInterfaceTypeSpec(
+                mockk(),
+                mockk {
+                    every { name } returns "junit_interface"
+                },
+                SelectionSet.newSelectionSet().build()
+            )
         }
     }
 
@@ -287,7 +296,7 @@ class GenerateGraphQLInterfaceTypeSpecIT {
                   }
                 }
             """.trimIndent()
-        assertThrows<RuntimeException> {
+        assertThrows<InvalidPolymorphicQueryException> {
             verifyGeneratedFileSpecContents(invalidQuery, "will throw exception")
         }
     }
@@ -307,7 +316,7 @@ class GenerateGraphQLInterfaceTypeSpecIT {
                   }
                 }
             """.trimIndent()
-        assertThrows<RuntimeException> {
+        assertThrows<InvalidPolymorphicQueryException> {
             verifyGeneratedFileSpecContents(invalidQuery, "will throw exception")
         }
     }

--- a/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLUnionTypeSpecIT.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLUnionTypeSpecIT.kt
@@ -16,8 +16,11 @@
 
 package com.expediagroup.graphql.plugin.generator.types
 
+import com.expediagroup.graphql.plugin.generator.exceptions.InvalidPolymorphicQueryException
+import com.expediagroup.graphql.plugin.generator.exceptions.InvalidSelectionSetException
 import com.expediagroup.graphql.plugin.generator.verifyGeneratedFileSpecContents
 import graphql.language.SelectionSet
+import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -241,7 +244,7 @@ class GenerateGraphQLUnionTypeSpecIT {
                   }
                 }
             """.trimIndent()
-        assertThrows<RuntimeException> {
+        assertThrows<InvalidPolymorphicQueryException> {
             verifyGeneratedFileSpecContents(invalidQuery, "should throw exception")
         }
     }
@@ -264,15 +267,21 @@ class GenerateGraphQLUnionTypeSpecIT {
                   }
                 }
             """.trimIndent()
-        assertThrows<RuntimeException> {
+        assertThrows<InvalidPolymorphicQueryException> {
             verifyGeneratedFileSpecContents(invalidQuery, "should throw exception")
         }
     }
 
     @Test
     fun `verify union type generation will throw exception if we pass empty selection set`() {
-        assertThrows<RuntimeException> {
-            generateGraphQLUnionTypeSpec(mockk(), mockk(), SelectionSet.newSelectionSet().build())
+        assertThrows<InvalidSelectionSetException> {
+            generateGraphQLUnionTypeSpec(
+                mockk(),
+                mockk {
+                    every { name } returns "junit_union"
+                },
+                SelectionSet.newSelectionSet().build()
+            )
         }
     }
 


### PR DESCRIPTION
### :pencil: Description

Changes
* use typed exceptions instead of generic `RuntimeException`
* validate whether fragments are valid

### :link: Related Issues

Related: https://github.com/ExpediaGroup/graphql-kotlin/issues/903