### PR TITLE
[plugin] fix client generation when selecting custom scalars

### DIFF
--- a/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/types/generateTypeName.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/types/generateTypeName.kt
@@ -203,7 +203,10 @@ private fun calculateGeneratedTypeProperties(context: GraphQLClientGeneratorCont
             }
             is ClassName -> {
                 val fieldTypeName = propertyType.simpleNameWithoutWrapper()
-                props.addAll(calculateGeneratedTypeProperties(context, fieldTypeName, "$path${property.name}."))
+                // we need to check whether generated type is a custom scalar
+                if (context.scalarTypeToConverterMapping[fieldTypeName] == null) {
+                    props.addAll(calculateGeneratedTypeProperties(context, fieldTypeName, "$path${property.name}."))
+                }
             }
         }
     }

--- a/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/GraphQLTestUtils.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/GraphQLTestUtils.kt
@@ -16,9 +16,11 @@
 
 package com.expediagroup.graphql.plugin.generator
 
+import com.expediagroup.graphql.client.converter.ScalarConverter
 import com.squareup.kotlinpoet.FileSpec
 import graphql.schema.idl.SchemaParser
 import graphql.schema.idl.TypeDefinitionRegistry
+import java.util.UUID
 import kotlin.test.assertEquals
 
 internal fun testSchema(): TypeDefinitionRegistry {
@@ -47,4 +49,9 @@ internal fun verifyGeneratedFileSpecContents(
 ) {
     val fileSpecs = generateTestFileSpec(query, graphQLConfig)
     assertEquals(expected, fileSpecs.first().toString().trim())
+}
+
+class UUIDScalarConverter : ScalarConverter<UUID> {
+    override fun toScalar(rawValue: Any): UUID = UUID.fromString(rawValue.toString())
+    override fun toJson(value: UUID): String = value.toString()
 }


### PR DESCRIPTION
### :pencil: Description

When custom scalars (with converters) were referenced multiple times from selection set (e.g. from a common fragment) we would attempt to unwrap the converted scalar type when comparing generated object properties and next selection set fields. This that even though it was the same selection we could still end up with multiple duplicate classes. Added explicit check to verify whether unwrapped property type is auto converted scalar type.

### :link: Related Issues

Resolves: https://github.com/ExpediaGroup/graphql-kotlin/issues/903



