### PR TITLE
[3.x.x] backport fixes for client concurrency and custom scalars bug

### DIFF
--- a/graphql-kotlin-client/src/main/kotlin/com/expediagroup/graphql/client/GraphQLClient.kt
+++ b/graphql-kotlin-client/src/main/kotlin/com/expediagroup/graphql/client/GraphQLClient.kt
@@ -36,6 +36,7 @@ import io.ktor.http.contentType
 import io.ktor.util.KtorExperimentalAPI
 import java.io.Closeable
 import java.net.URL
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * A lightweight typesafe GraphQL HTTP client.
@@ -48,7 +49,7 @@ open class GraphQLClient<in T : HttpClientEngineConfig>(
     configuration: HttpClientConfig<T>.() -> Unit = {}
 ) : Closeable {
 
-    private val typeCache = mutableMapOf<Class<*>, JavaType>()
+    private val typeCache = ConcurrentHashMap<Class<*>, JavaType>()
 
     init {
         mapper.enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE)

--- a/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/types/generateTypeName.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/types/generateTypeName.kt
@@ -203,7 +203,10 @@ private fun calculateGeneratedTypeProperties(context: GraphQLClientGeneratorCont
             }
             is ClassName -> {
                 val fieldTypeName = propertyType.simpleNameWithoutWrapper()
-                props.addAll(calculateGeneratedTypeProperties(context, fieldTypeName, "$path${property.name}."))
+                // we need to check whether generated type is a custom scalar
+                if (context.scalarTypeToConverterMapping[fieldTypeName] == null) {
+                    props.addAll(calculateGeneratedTypeProperties(context, fieldTypeName, "$path${property.name}."))
+                }
             }
         }
     }


### PR DESCRIPTION
### :pencil: Description

3.x.x backports:
* https://github.com/ExpediaGroup/graphql-kotlin/pull/913
* https://github.com/ExpediaGroup/graphql-kotlin/pull/916

### :link: Related Issues

Fixes: https://github.com/ExpediaGroup/graphql-kotlin/issues/903
