### PR TITLE
Ensure artifact is published to maven before maven integration tests

### DIFF
--- a/plugins/graphql-kotlin-maven-plugin/build.gradle.kts
+++ b/plugins/graphql-kotlin-maven-plugin/build.gradle.kts
@@ -86,6 +86,11 @@ tasks {
         mustRunAfter("startWireMock")
     }
     val integrationTest by register("integrationTest") {
+        dependsOn(":graphql-kotlin-types:publishToMavenLocal")
+        dependsOn(":graphql-kotlin-client:publishToMavenLocal")
+        dependsOn(":graphql-kotlin-ktor-client:publishToMavenLocal")
+        dependsOn(":graphql-kotlin-spring-client:publishToMavenLocal")
+        dependsOn(":graphql-kotlin-plugin-core:publishToMavenLocal")
         dependsOn("publishToMavenLocal")
         dependsOn(startWireMock.path)
         finalizedBy(stopWireMock.path)

--- a/plugins/graphql-kotlin-maven-plugin/build.gradle.kts
+++ b/plugins/graphql-kotlin-maven-plugin/build.gradle.kts
@@ -86,6 +86,7 @@ tasks {
         mustRunAfter("startWireMock")
     }
     val integrationTest by register("integrationTest") {
+        dependsOn(publishToMavenLocal)
         dependsOn(startWireMock.path)
         finalizedBy(stopWireMock.path)
         timeout.set(Duration.ofSeconds(500))

--- a/plugins/graphql-kotlin-maven-plugin/build.gradle.kts
+++ b/plugins/graphql-kotlin-maven-plugin/build.gradle.kts
@@ -86,7 +86,7 @@ tasks {
         mustRunAfter("startWireMock")
     }
     val integrationTest by register("integrationTest") {
-        dependsOn(publishToMavenLocal)
+        dependsOn("publishToMavenLocal")
         dependsOn(startWireMock.path)
         finalizedBy(stopWireMock.path)
         timeout.set(Duration.ofSeconds(500))


### PR DESCRIPTION
### :pencil: Description
Prevents a failure from maven on a fresh checkout that the maven plugin is not available in maven local for the plugin integration tests. Occurs on `./gradlew build` when the maven local repository is empty.

```
[INFO] [ERROR] Failed to execute goal com.expediagroup:graphql-kotlin-maven-plugin:4.0.0-SNAPSHOT:introspect-schema (default) on project graphql-kotlin-introspect-schema-mojo-timeout-test: Execution default of goal com.expediagroup:graphql-kotlin-maven-plugin:4.0.0-SNAPSHOT:introspect-schema failed: Timed out waiting for 100 ms -> [Help 1]
```
