### PR TITLE
[3.x.x][generator] Only add directives with valid locations

### DIFF
--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/generateArgument.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/generateArgument.kt
@@ -26,6 +26,7 @@ import com.expediagroup.graphql.generator.extensions.isInterface
 import com.expediagroup.graphql.generator.extensions.isListType
 import com.expediagroup.graphql.generator.extensions.isUnion
 import com.expediagroup.graphql.generator.extensions.safeCast
+import graphql.introspection.Introspection.DirectiveLocation
 import graphql.schema.GraphQLArgument
 import kotlin.reflect.KClass
 import kotlin.reflect.KParameter
@@ -49,7 +50,7 @@ internal fun generateArgument(generator: SchemaGenerator, parameter: KParameter)
         .description(parameter.getGraphQLDescription())
         .type(graphQLType.safeCast())
 
-    generateDirectives(generator, parameter).forEach {
+    generateDirectives(generator, parameter, DirectiveLocation.ARGUMENT_DEFINITION).forEach {
         builder.withDirective(it)
     }
 

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/generateDirective.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/generateDirective.kt
@@ -21,7 +21,7 @@ import com.expediagroup.graphql.generator.extensions.getPropertyAnnotations
 import com.expediagroup.graphql.generator.extensions.getSimpleName
 import com.expediagroup.graphql.generator.extensions.getValidProperties
 import com.expediagroup.graphql.generator.extensions.safeCast
-import graphql.introspection.Introspection
+import graphql.introspection.Introspection.DirectiveLocation
 import graphql.schema.GraphQLArgument
 import graphql.schema.GraphQLDirective
 import java.lang.reflect.Field
@@ -33,7 +33,7 @@ import com.expediagroup.graphql.annotations.GraphQLDirective as GraphQLDirective
 internal fun generateDirectives(
     generator: SchemaGenerator,
     element: KAnnotatedElement,
-    location: Introspection.DirectiveLocation,
+    location: DirectiveLocation,
     parentClass: KClass<*>? = null
 ): List<GraphQLDirective> {
     val annotations = when {
@@ -47,10 +47,10 @@ internal fun generateDirectives(
         .map { getDirective(generator, it) }
 }
 
-internal fun generateFieldDirectives(generator: SchemaGenerator, field: Field, location: Introspection.DirectiveLocation): List<GraphQLDirective> =
+internal fun generateEnumValueDirectives(generator: SchemaGenerator, field: Field): List<GraphQLDirective> =
     field.annotations
         .mapNotNull { it.getDirectiveInfo() }
-        .filter { it.directiveAnnotation.locations.contains(location) }
+        .filter { it.directiveAnnotation.locations.contains(DirectiveLocation.ENUM_VALUE) }
         .map { getDirective(generator, it) }
 
 private fun getDirective(generator: SchemaGenerator, directiveInfo: DirectiveInfo): GraphQLDirective {

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/generateDirective.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/generateDirective.kt
@@ -21,6 +21,7 @@ import com.expediagroup.graphql.generator.extensions.getPropertyAnnotations
 import com.expediagroup.graphql.generator.extensions.getSimpleName
 import com.expediagroup.graphql.generator.extensions.getValidProperties
 import com.expediagroup.graphql.generator.extensions.safeCast
+import graphql.introspection.Introspection
 import graphql.schema.GraphQLArgument
 import graphql.schema.GraphQLDirective
 import java.lang.reflect.Field
@@ -29,7 +30,12 @@ import kotlin.reflect.KClass
 import kotlin.reflect.KProperty
 import com.expediagroup.graphql.annotations.GraphQLDirective as GraphQLDirectiveAnnotation
 
-internal fun generateDirectives(generator: SchemaGenerator, element: KAnnotatedElement, parentClass: KClass<*>? = null): List<GraphQLDirective> {
+internal fun generateDirectives(
+    generator: SchemaGenerator,
+    element: KAnnotatedElement,
+    location: Introspection.DirectiveLocation,
+    parentClass: KClass<*>? = null
+): List<GraphQLDirective> {
     val annotations = when {
         element is KProperty<*> && parentClass != null -> element.getPropertyAnnotations(parentClass)
         else -> element.annotations
@@ -37,12 +43,14 @@ internal fun generateDirectives(generator: SchemaGenerator, element: KAnnotatedE
 
     return annotations
         .mapNotNull { it.getDirectiveInfo() }
+        .filter { it.directiveAnnotation.locations.contains(location) }
         .map { getDirective(generator, it) }
 }
 
-internal fun generateFieldDirectives(generator: SchemaGenerator, field: Field): List<GraphQLDirective> =
+internal fun generateFieldDirectives(generator: SchemaGenerator, field: Field, location: Introspection.DirectiveLocation): List<GraphQLDirective> =
     field.annotations
         .mapNotNull { it.getDirectiveInfo() }
+        .filter { it.directiveAnnotation.locations.contains(location) }
         .map { getDirective(generator, it) }
 
 private fun getDirective(generator: SchemaGenerator, directiveInfo: DirectiveInfo): GraphQLDirective {

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/generateEnum.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/generateEnum.kt
@@ -52,7 +52,7 @@ private fun getEnumValueDefinition(generator: SchemaGenerator, enum: Enum<*>, kC
     valueBuilder.name(name)
     valueBuilder.value(name)
 
-    generateFieldDirectives(generator, valueField, DirectiveLocation.ENUM_VALUE).forEach {
+    generateEnumValueDirectives(generator, valueField).forEach {
         valueBuilder.withDirective(it)
     }
 

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/generateEnum.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/generateEnum.kt
@@ -23,6 +23,7 @@ import com.expediagroup.graphql.generator.extensions.getGraphQLDescription
 import com.expediagroup.graphql.generator.extensions.getGraphQLName
 import com.expediagroup.graphql.generator.extensions.getSimpleName
 import com.expediagroup.graphql.generator.extensions.safeCast
+import graphql.introspection.Introspection.DirectiveLocation
 import graphql.schema.GraphQLEnumType
 import graphql.schema.GraphQLEnumValueDefinition
 import kotlin.reflect.KClass
@@ -33,7 +34,7 @@ internal fun generateEnum(generator: SchemaGenerator, kClass: KClass<out Enum<*>
     enumBuilder.name(kClass.getSimpleName())
     enumBuilder.description(kClass.getGraphQLDescription())
 
-    generateDirectives(generator, kClass).forEach {
+    generateDirectives(generator, kClass, DirectiveLocation.ENUM).forEach {
         enumBuilder.withDirective(it)
     }
 
@@ -51,7 +52,7 @@ private fun getEnumValueDefinition(generator: SchemaGenerator, enum: Enum<*>, kC
     valueBuilder.name(name)
     valueBuilder.value(name)
 
-    generateFieldDirectives(generator, valueField).forEach {
+    generateFieldDirectives(generator, valueField, DirectiveLocation.ENUM_VALUE).forEach {
         valueBuilder.withDirective(it)
     }
 

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/generateFunction.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/generateFunction.kt
@@ -24,6 +24,7 @@ import com.expediagroup.graphql.generator.extensions.getGraphQLDescription
 import com.expediagroup.graphql.generator.extensions.getValidArguments
 import com.expediagroup.graphql.generator.extensions.safeCast
 import com.expediagroup.graphql.generator.types.utils.getWrappedReturnType
+import graphql.introspection.Introspection.DirectiveLocation
 import graphql.schema.FieldCoordinates
 import graphql.schema.GraphQLFieldDefinition
 import graphql.schema.GraphQLOutputType
@@ -40,7 +41,7 @@ internal fun generateFunction(generator: SchemaGenerator, fn: KFunction<*>, pare
         builder.withDirective(deprecatedDirectiveWithReason(it))
     }
 
-    generateDirectives(generator, fn).forEach {
+    generateDirectives(generator, fn, DirectiveLocation.FIELD_DEFINITION).forEach {
         builder.withDirective(it)
     }
 

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/generateInputObject.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/generateInputObject.kt
@@ -21,6 +21,7 @@ import com.expediagroup.graphql.generator.extensions.getGraphQLDescription
 import com.expediagroup.graphql.generator.extensions.getSimpleName
 import com.expediagroup.graphql.generator.extensions.getValidProperties
 import com.expediagroup.graphql.generator.extensions.safeCast
+import graphql.introspection.Introspection.DirectiveLocation
 import graphql.schema.GraphQLInputObjectType
 import kotlin.reflect.KClass
 
@@ -30,7 +31,7 @@ internal fun generateInputObject(generator: SchemaGenerator, kClass: KClass<*>):
     builder.name(kClass.getSimpleName(isInputClass = true))
     builder.description(kClass.getGraphQLDescription())
 
-    generateDirectives(generator, kClass).forEach {
+    generateDirectives(generator, kClass, DirectiveLocation.INPUT_OBJECT).forEach {
         builder.withDirective(it)
     }
 

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/generateInputProperty.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/generateInputProperty.kt
@@ -20,6 +20,7 @@ import com.expediagroup.graphql.generator.SchemaGenerator
 import com.expediagroup.graphql.generator.extensions.getPropertyDescription
 import com.expediagroup.graphql.generator.extensions.getPropertyName
 import com.expediagroup.graphql.generator.extensions.safeCast
+import graphql.introspection.Introspection.DirectiveLocation
 import graphql.schema.GraphQLInputObjectField
 import graphql.schema.GraphQLInputType
 import kotlin.reflect.KClass
@@ -35,7 +36,7 @@ internal fun generateInputProperty(generator: SchemaGenerator, prop: KProperty<*
     builder.name(prop.getPropertyName(parentClass))
     builder.type(graphQLInputType)
 
-    generateDirectives(generator, prop, parentClass).forEach {
+    generateDirectives(generator, prop, DirectiveLocation.INPUT_FIELD_DEFINITION, parentClass).forEach {
         builder.withDirective(it)
     }
 

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/generateInterface.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/generateInterface.kt
@@ -26,6 +26,7 @@ import com.expediagroup.graphql.generator.extensions.getValidSuperclasses
 import com.expediagroup.graphql.generator.extensions.safeCast
 import com.expediagroup.graphql.generator.state.AdditionalType
 import graphql.TypeResolutionEnvironment
+import graphql.introspection.Introspection.DirectiveLocation
 import graphql.schema.GraphQLInterfaceType
 import graphql.schema.GraphQLTypeReference
 import kotlin.reflect.KClass
@@ -37,7 +38,7 @@ internal fun generateInterface(generator: SchemaGenerator, kClass: KClass<*>): G
     builder.name(kClass.getSimpleName())
     builder.description(kClass.getGraphQLDescription())
 
-    generateDirectives(generator, kClass).forEach {
+    generateDirectives(generator, kClass, DirectiveLocation.INTERFACE).forEach {
         builder.withDirective(it)
     }
 

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/generateMutation.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/generateMutation.kt
@@ -21,6 +21,7 @@ import com.expediagroup.graphql.exceptions.InvalidMutationTypeException
 import com.expediagroup.graphql.generator.SchemaGenerator
 import com.expediagroup.graphql.generator.extensions.getValidFunctions
 import com.expediagroup.graphql.generator.extensions.isNotPublic
+import graphql.introspection.Introspection.DirectiveLocation
 import graphql.schema.GraphQLObjectType
 
 internal fun generateMutations(generator: SchemaGenerator, mutations: List<TopLevelObject>): GraphQLObjectType? {
@@ -37,7 +38,7 @@ internal fun generateMutations(generator: SchemaGenerator, mutations: List<TopLe
             throw InvalidMutationTypeException(mutation.kClass)
         }
 
-        generateDirectives(generator, mutation.kClass).forEach {
+        generateDirectives(generator, mutation.kClass, DirectiveLocation.OBJECT).forEach {
             mutationBuilder.withDirective(it)
         }
 

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/generateObject.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/generateObject.kt
@@ -24,6 +24,7 @@ import com.expediagroup.graphql.generator.extensions.getValidFunctions
 import com.expediagroup.graphql.generator.extensions.getValidProperties
 import com.expediagroup.graphql.generator.extensions.getValidSuperclasses
 import com.expediagroup.graphql.generator.extensions.safeCast
+import graphql.introspection.Introspection.DirectiveLocation
 import graphql.schema.GraphQLInterfaceType
 import graphql.schema.GraphQLObjectType
 import graphql.schema.GraphQLTypeReference
@@ -37,7 +38,7 @@ internal fun generateObject(generator: SchemaGenerator, kClass: KClass<*>): Grap
     builder.name(name)
     builder.description(kClass.getGraphQLDescription())
 
-    generateDirectives(generator, kClass).forEach {
+    generateDirectives(generator, kClass, DirectiveLocation.OBJECT).forEach {
         builder.withDirective(it)
     }
 

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/generateProperty.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/generateProperty.kt
@@ -23,6 +23,7 @@ import com.expediagroup.graphql.generator.extensions.getPropertyDescription
 import com.expediagroup.graphql.generator.extensions.getPropertyName
 import com.expediagroup.graphql.generator.extensions.getSimpleName
 import com.expediagroup.graphql.generator.extensions.safeCast
+import graphql.introspection.Introspection.DirectiveLocation
 import graphql.schema.FieldCoordinates
 import graphql.schema.GraphQLFieldDefinition
 import graphql.schema.GraphQLOutputType
@@ -43,7 +44,7 @@ internal fun generateProperty(generator: SchemaGenerator, prop: KProperty<*>, pa
         fieldBuilder.withDirective(deprecatedDirectiveWithReason(it))
     }
 
-    generateDirectives(generator, prop, parentClass).forEach {
+    generateDirectives(generator, prop, DirectiveLocation.FIELD_DEFINITION, parentClass).forEach {
         fieldBuilder.withDirective(it)
     }
 

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/generateQuery.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/generateQuery.kt
@@ -21,6 +21,7 @@ import com.expediagroup.graphql.exceptions.InvalidQueryTypeException
 import com.expediagroup.graphql.generator.SchemaGenerator
 import com.expediagroup.graphql.generator.extensions.getValidFunctions
 import com.expediagroup.graphql.generator.extensions.isNotPublic
+import graphql.introspection.Introspection.DirectiveLocation
 import graphql.schema.GraphQLObjectType
 
 internal fun generateQueries(generator: SchemaGenerator, queries: List<TopLevelObject>): GraphQLObjectType {
@@ -32,7 +33,7 @@ internal fun generateQueries(generator: SchemaGenerator, queries: List<TopLevelO
             throw InvalidQueryTypeException(query.kClass)
         }
 
-        generateDirectives(generator, query.kClass).forEach {
+        generateDirectives(generator, query.kClass, DirectiveLocation.OBJECT).forEach {
             queryBuilder.withDirective(it)
         }
 

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/generateSubscription.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/generateSubscription.kt
@@ -21,6 +21,7 @@ import com.expediagroup.graphql.exceptions.InvalidSubscriptionTypeException
 import com.expediagroup.graphql.generator.SchemaGenerator
 import com.expediagroup.graphql.generator.extensions.getValidFunctions
 import com.expediagroup.graphql.generator.extensions.isNotPublic
+import graphql.introspection.Introspection.DirectiveLocation
 import graphql.schema.GraphQLObjectType
 
 internal fun generateSubscriptions(generator: SchemaGenerator, subscriptions: List<TopLevelObject>): GraphQLObjectType? {
@@ -36,6 +37,10 @@ internal fun generateSubscriptions(generator: SchemaGenerator, subscriptions: Li
 
         if (kClass.isNotPublic()) {
             throw InvalidSubscriptionTypeException(kClass)
+        }
+
+        generateDirectives(generator, subscription.kClass, DirectiveLocation.OBJECT).forEach {
+            subscriptionBuilder.withDirective(it)
         }
 
         kClass.getValidFunctions(generator.config.hooks)

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/generateUnion.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/generateUnion.kt
@@ -22,6 +22,7 @@ import com.expediagroup.graphql.generator.extensions.getGraphQLDescription
 import com.expediagroup.graphql.generator.extensions.getSimpleName
 import com.expediagroup.graphql.generator.extensions.safeCast
 import graphql.TypeResolutionEnvironment
+import graphql.introspection.Introspection.DirectiveLocation
 import graphql.schema.GraphQLObjectType
 import graphql.schema.GraphQLTypeReference
 import graphql.schema.GraphQLUnionType
@@ -33,7 +34,7 @@ internal fun generateUnion(generator: SchemaGenerator, kClass: KClass<*>): Graph
     builder.name(kClass.getSimpleName())
     builder.description(kClass.getGraphQLDescription())
 
-    generateDirectives(generator, kClass).forEach {
+    generateDirectives(generator, kClass, DirectiveLocation.UNION).forEach {
         builder.withDirective(it)
     }
 

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/GenerateDirectiveTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/GenerateDirectiveTest.kt
@@ -153,10 +153,10 @@ class GenerateDirectiveTest {
     }
 
     @Test
-    fun `directives are valid on fields (enum values)`() {
+    fun `directives are valid on enum values`() {
         val field = Type::class.java.getField("ONE")
 
-        val directives = generateFieldDirectives(basicGenerator, field, DirectiveLocation.ENUM_VALUE)
+        val directives = generateEnumValueDirectives(basicGenerator, field)
 
         assertEquals(2, directives.size)
         assertEquals("directiveWithString", directives.first().name)
@@ -167,7 +167,7 @@ class GenerateDirectiveTest {
     fun `directives are empty on an enum with no valid annotations`() {
         val field = Type::class.java.getField("TWO")
 
-        val directives = generateFieldDirectives(basicGenerator, field, DirectiveLocation.ENUM_VALUE)
+        val directives = generateEnumValueDirectives(basicGenerator, field)
 
         assertEquals(0, directives.size)
     }

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/GenerateEnumTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/GenerateEnumTest.kt
@@ -19,22 +19,25 @@ package com.expediagroup.graphql.generator.types
 import com.expediagroup.graphql.annotations.GraphQLDescription
 import com.expediagroup.graphql.annotations.GraphQLName
 import com.expediagroup.graphql.test.utils.CustomDirective
+import com.expediagroup.graphql.test.utils.InterfaceOnlyDirective
 import com.expediagroup.graphql.test.utils.SimpleDirective
-import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
 
 class GenerateEnumTest : TypeTestHelper() {
 
     @Suppress("Detekt.UnusedPrivateClass")
     @GraphQLDescription("MyTestEnum description")
     @SimpleDirective
+    @InterfaceOnlyDirective
     enum class MyTestEnum {
         @GraphQLDescription("enum 'ONE' description")
         @SimpleDirective
+        @InterfaceOnlyDirective
         ONE,
 
         @GraphQLDescription("enum 'TWO' description")
@@ -120,8 +123,10 @@ class GenerateEnumTest : TypeTestHelper() {
     @Test
     fun `Enum values can have a multiple directives`() {
         val gqlEnum = assertNotNull(generateEnum(generator, MyTestEnum::class))
-        assertEquals(1, gqlEnum.values.first().directives.size)
-        assertEquals("simpleDirective", gqlEnum.values.first().directives.first().name)
+
+        val enumValuesDirectives = assertNotNull(gqlEnum.values.find { it.name == "ONE" }?.directives)
+        assertEquals(1, enumValuesDirectives.size)
+        assertEquals("simpleDirective", enumValuesDirectives.first().name)
     }
 
     @Test

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/GenerateInputObjectTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/GenerateInputObjectTest.kt
@@ -18,15 +18,17 @@ package com.expediagroup.graphql.generator.types
 
 import com.expediagroup.graphql.annotations.GraphQLDescription
 import com.expediagroup.graphql.annotations.GraphQLName
+import com.expediagroup.graphql.test.utils.ObjectOnlyDirective
 import com.expediagroup.graphql.test.utils.SimpleDirective
-import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
+import org.junit.jupiter.api.Test
 
-internal class GenerateInputObjectTest : TypeTestHelper() {
+class GenerateInputObjectTest : TypeTestHelper() {
 
     @Suppress("Detekt.UnusedPrivateClass")
     @GraphQLDescription("The truth")
     @SimpleDirective
+    @ObjectOnlyDirective
     private class InputClass {
         @SimpleDirective
         val myField: String = "car"
@@ -65,7 +67,7 @@ internal class GenerateInputObjectTest : TypeTestHelper() {
     }
 
     @Test
-    fun `directives should be on input objects`() {
+    fun `directives with locations as INPUT_OBJECT should only be added`() {
         val result = generateInputObject(generator, InputClass::class)
         assertEquals(1, result.directives.size)
         assertEquals("simpleDirective", result.directives.first().name)

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/GenerateObjectTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/GenerateObjectTest.kt
@@ -19,13 +19,14 @@ package com.expediagroup.graphql.generator.types
 import com.expediagroup.graphql.annotations.GraphQLDescription
 import com.expediagroup.graphql.annotations.GraphQLDirective
 import com.expediagroup.graphql.annotations.GraphQLName
+import com.expediagroup.graphql.test.utils.InputObjectOnlyDirective
 import graphql.Scalars
 import graphql.introspection.Introspection
 import graphql.schema.GraphQLNonNull
 import graphql.schema.GraphQLObjectType
-import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import org.junit.jupiter.api.Test
 
 class GenerateObjectTest : TypeTestHelper() {
 
@@ -34,6 +35,7 @@ class GenerateObjectTest : TypeTestHelper() {
 
     @GraphQLDescription("The truth")
     @ObjectDirective("Don't worry")
+    @InputObjectOnlyDirective
     private class BeHappy
 
     @GraphQLName("BeHappyRenamed")
@@ -67,7 +69,7 @@ class GenerateObjectTest : TypeTestHelper() {
     }
 
     @Test
-    fun `Test custom directive`() {
+    fun `Objects should only have directives with OBJECT in their locations`() {
         val result = generateObject(generator, BeHappy::class) as? GraphQLObjectType
         assertNotNull(result)
         assertEquals(1, result.directives.size)

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/GenerateQueryTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/GenerateQueryTest.kt
@@ -23,16 +23,17 @@ import com.expediagroup.graphql.exceptions.EmptyQueryTypeException
 import com.expediagroup.graphql.exceptions.InvalidQueryTypeException
 import com.expediagroup.graphql.generator.extensions.isTrue
 import com.expediagroup.graphql.hooks.SchemaGeneratorHooks
+import com.expediagroup.graphql.test.utils.InterfaceOnlyDirective
 import com.expediagroup.graphql.test.utils.SimpleDirective
 import graphql.schema.GraphQLFieldDefinition
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 @Suppress("Detekt.NestedClassesVisibility")
 internal class GenerateQueryTest : TypeTestHelper() {
@@ -49,6 +50,7 @@ internal class GenerateQueryTest : TypeTestHelper() {
         fun echo(msg: String) = msg
     }
 
+    @InterfaceOnlyDirective
     @SimpleDirective
     class QueryObject {
         @GraphQLDescription("A GraphQL query method")
@@ -103,7 +105,7 @@ internal class GenerateQueryTest : TypeTestHelper() {
     }
 
     @Test
-    fun `query objects can have directives`() {
+    fun `query objects should only have directive with OBJECT as their location`() {
         val queries = listOf(TopLevelObject(QueryObject()))
         val result = generateQueries(generator, queries)
         assertEquals(expected = 1, actual = result.directives.size)

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/test/utils/differentLocationDirectives.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/test/utils/differentLocationDirectives.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.test.utils
+
+import com.expediagroup.graphql.annotations.GraphQLDirective
+import graphql.introspection.Introspection.DirectiveLocation
+
+@GraphQLDirective(locations = [DirectiveLocation.INTERFACE])
+annotation class InterfaceOnlyDirective
+
+@GraphQLDirective(locations = [DirectiveLocation.OBJECT])
+annotation class ObjectOnlyDirective
+
+@GraphQLDirective(locations = [DirectiveLocation.INPUT_OBJECT])
+annotation class InputObjectOnlyDirective


### PR DESCRIPTION
## :pencil: Description

When generating a schema you can have an annotation on any part of the schema, assuming you haven't set the Target, so if you are restricting the directive locations to only specific places they may still be added to the schema and then fail generation as they are added to invalid locations. While this could be viewed as a customer error, this is more of an issue with graphql-kotlin because we can have input and output objects with the same directives and things like the KeyDirective from federation are only valid on output. So in that case we shouldn't fail if someone uses the type as input elsewhere, it will still not be marked as a federation type for the input
