### PR TITLE
[client 3.x.x] update ScalarConverter included in 3.x.x to accept any objects (#819)

### DIFF
--- a/docs/client/client-customization.md
+++ b/docs/client/client-customization.md
@@ -104,7 +104,7 @@ import com.expediagroup.graphql.client.converter.ScalarConverter
 import java.util.UUID
 
 class UUIDScalarConverter : ScalarConverter<UUID> {
-    override fun toScalar(rawValue: Any ): UUID = UUID.fromString(rawValue)
+    override fun toScalar(rawValue: Any): UUID = UUID.fromString(rawValue.toString())
     override fun toJson(value: UUID): Any = value.toString()
 }
 ```

--- a/docs/client/client-customization.md
+++ b/docs/client/client-customization.md
@@ -83,13 +83,13 @@ val customObjectMapper = jacksonObjectMapper()
 val client = GraphQLClient(url = URL("http://localhost:8080/graphql"), mapper = customObjectMapper)
 ```
 
-## Deprecated Field Usage
+## Deprecated Field Usage
 
 Build plugins will automatically fail generation of a client if any of the specified query files are referencing
 deprecated fields. This ensures that your clients have to explicitly opt-in into deprecated usage by specifying
 `allowDeprecatedFields` configuration option.
 
-## Custom GraphQL Scalars
+## Custom GraphQL Scalars
 
 By default, custom GraphQL scalars are serialized and [type-aliased](https://kotlinlang.org/docs/reference/type-aliases.html)
 to a String. GraphQL Kotlin plugins also support custom serialization based on provided configuration.
@@ -104,8 +104,8 @@ import com.expediagroup.graphql.client.converter.ScalarConverter
 import java.util.UUID
 
 class UUIDScalarConverter : ScalarConverter<UUID> {
-    override fun toScalar(rawValue: String): UUID = UUID.fromString(rawValue)
-    override fun toJson(value: UUID): String = value.toString()
+    override fun toScalar(rawValue: Any ): UUID = UUID.fromString(rawValue)
+    override fun toJson(value: UUID): Any = value.toString()
 }
 ```
 

--- a/docs/plugins/gradle-plugin.md
+++ b/docs/plugins/gradle-plugin.md
@@ -228,8 +228,8 @@ import com.expediagroup.graphql.client.converter.ScalarConverter
 import java.util.UUID
 
 class UUIDScalarConverter : ScalarConverter<UUID> {
-    override fun toScalar(rawValue: String): UUID = UUID.fromString(rawValue)
-    override fun toJson(value: UUID): String = value.toString()
+    override fun toScalar(rawValue: Any): UUID = UUID.fromString(rawValue.toString())
+    override fun toJson(value: UUID): Any = value.toString()
 }
 ```
 

--- a/docs/plugins/maven-plugin.md
+++ b/docs/plugins/maven-plugin.md
@@ -273,8 +273,8 @@ import com.expediagroup.graphql.client.converter.ScalarConverter
 import java.util.UUID
 
 class UUIDScalarConverter : ScalarConverter<UUID> {
-    override fun toScalar(rawValue: String): UUID = UUID.fromString(rawValue)
-    override fun toJson(value: UUID): String = value.toString()
+    override fun toScalar(rawValue: Any): UUID = UUID.fromString(rawValue.toString())
+    override fun toJson(value: UUID): Any = value.toString()
 }
 ```
 

--- a/examples/client/gradle-client/src/main/kotlin/com/expediagroup/graphql/examples/client/UUIDScalarConverter.kt
+++ b/examples/client/gradle-client/src/main/kotlin/com/expediagroup/graphql/examples/client/UUIDScalarConverter.kt
@@ -4,6 +4,6 @@ import com.expediagroup.graphql.client.converter.ScalarConverter
 import java.util.UUID
 
 class UUIDScalarConverter : ScalarConverter<UUID> {
-    override fun toScalar(rawValue: String): UUID = UUID.fromString(rawValue)
-    override fun toJson(value: UUID): String = value.toString()
+    override fun toScalar(rawValue: Any): UUID = UUID.fromString(rawValue.toString())
+    override fun toJson(value: UUID): Any = value.toString()
 }

--- a/examples/client/maven-client/src/main/kotlin/com/expediagroup/graphql/examples/client/UUIDScalarConverter.kt
+++ b/examples/client/maven-client/src/main/kotlin/com/expediagroup/graphql/examples/client/UUIDScalarConverter.kt
@@ -4,6 +4,6 @@ import com.expediagroup.graphql.client.converter.ScalarConverter
 import java.util.UUID
 
 class UUIDScalarConverter : ScalarConverter<UUID> {
-    override fun toScalar(rawValue: String): UUID = UUID.fromString(rawValue)
-    override fun toJson(value: UUID): String = value.toString()
+    override fun toScalar(rawValue: Any): UUID = UUID.fromString(rawValue.toString())
+    override fun toJson(value: UUID): Any = value.toString()
 }

--- a/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/hooks/CustomSchemaGeneratorHooks.kt
+++ b/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/hooks/CustomSchemaGeneratorHooks.kt
@@ -20,6 +20,9 @@ import com.expediagroup.graphql.directives.KotlinDirectiveWiringFactory
 import com.expediagroup.graphql.hooks.SchemaGeneratorHooks
 import graphql.language.StringValue
 import graphql.schema.Coercing
+import graphql.schema.CoercingParseValueException
+import graphql.schema.CoercingParseLiteralException
+import graphql.schema.CoercingSerializeException
 import graphql.schema.GraphQLScalarType
 import graphql.schema.GraphQLType
 import org.springframework.beans.factory.BeanFactoryAware

--- a/graphql-kotlin-client/src/main/kotlin/com/expediagroup/graphql/client/converter/ScalarConverter.kt
+++ b/graphql-kotlin-client/src/main/kotlin/com/expediagroup/graphql/client/converter/ScalarConverter.kt
@@ -22,12 +22,12 @@ package com.expediagroup.graphql.client.converter
 interface ScalarConverter<T> {
 
     /**
-     * Deserialize raw JSON String value to a typesafe value.
+     * Deserialize raw JSON value to a typesafe value.
      */
-    fun toScalar(rawValue: String): T
+    fun toScalar(rawValue: Any): T
 
     /**
-     * Serialize typesafe scalar value to a raw JSON string.
+     * Serialize typesafe scalar value to a raw JSON value.
      */
-    fun toJson(value: T): String
+    fun toJson(value: T): Any
 }

--- a/plugins/graphql-kotlin-gradle-plugin/src/test/resources/mocks/UUIDScalarConverter.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/test/resources/mocks/UUIDScalarConverter.kt
@@ -4,6 +4,6 @@ import com.expediagroup.graphql.client.converter.ScalarConverter
 import java.util.UUID
 
 class UUIDScalarConverter : ScalarConverter<UUID> {
-    override fun toScalar(rawValue: String): UUID = UUID.fromString(rawValue)
-    override fun toJson(value: UUID): String = value.toString()
+    override fun toScalar(rawValue: Any): UUID = UUID.fromString(rawValue.toString())
+    override fun toJson(value: UUID): Any = value.toString()
 }

--- a/plugins/graphql-kotlin-maven-plugin/src/integration/complete-setup/src/main/kotlin/com/example/UUIDScalarConverter.kt
+++ b/plugins/graphql-kotlin-maven-plugin/src/integration/complete-setup/src/main/kotlin/com/example/UUIDScalarConverter.kt
@@ -4,6 +4,6 @@ import com.expediagroup.graphql.client.converter.ScalarConverter
 import java.util.UUID
 
 class UUIDScalarConverter : ScalarConverter<UUID> {
-    override fun toScalar(rawValue: Any): UUID = UUID.fromString(rawValue)
-    override fun toJson(value: UUID): String = value.toString()
+    override fun toScalar(rawValue: Any): UUID = UUID.fromString(rawValue.toString())
+    override fun toJson(value: UUID): Any = value.toString()
 }

--- a/plugins/graphql-kotlin-maven-plugin/src/integration/complete-setup/src/main/kotlin/com/example/UUIDScalarConverter.kt
+++ b/plugins/graphql-kotlin-maven-plugin/src/integration/complete-setup/src/main/kotlin/com/example/UUIDScalarConverter.kt
@@ -4,6 +4,6 @@ import com.expediagroup.graphql.client.converter.ScalarConverter
 import java.util.UUID
 
 class UUIDScalarConverter : ScalarConverter<UUID> {
-    override fun toScalar(rawValue: String): UUID = UUID.fromString(rawValue)
+    override fun toScalar(rawValue: Any): UUID = UUID.fromString(rawValue)
     override fun toJson(value: UUID): String = value.toString()
 }

--- a/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/types/generateGraphQLCustomScalarTypeSpec.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/types/generateGraphQLCustomScalarTypeSpec.kt
@@ -71,7 +71,7 @@ internal fun generateGraphQLCustomScalarTypeSpec(context: GraphQLClientGenerator
                 FunSpec.builder("create")
                     .addAnnotation(JsonCreator::class.java)
                     .jvmStatic()
-                    .addParameter("rawValue", String::class)
+                    .addParameter("rawValue", Any::class)
                     .addStatement("return %L(%N.toScalar(rawValue))", customScalarName, converter)
                     .build()
             )

--- a/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLCustomScalarTypeSpecIT.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLCustomScalarTypeSpecIT.kt
@@ -63,7 +63,7 @@ class GenerateGraphQLCustomScalarTypeSpecIT {
 
                       @JsonCreator
                       @JvmStatic
-                      fun create(rawValue: String) = UUID(converter.toScalar(rawValue))
+                      fun create(rawValue: Any) = UUID(converter.toScalar(rawValue))
                     }
                   }
 

--- a/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLCustomScalarTypeSpecIT.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLCustomScalarTypeSpecIT.kt
@@ -35,6 +35,7 @@ class GenerateGraphQLCustomScalarTypeSpecIT {
                 import com.fasterxml.jackson.annotation.JsonCreator
                 import com.fasterxml.jackson.annotation.JsonValue
                 import io.ktor.client.request.HttpRequestBuilder
+                import kotlin.Any
                 import kotlin.String
                 import kotlin.Unit
                 import kotlin.jvm.JvmStatic
@@ -117,6 +118,7 @@ class GenerateGraphQLCustomScalarTypeSpecIT {
                 import com.fasterxml.jackson.annotation.JsonCreator
                 import com.fasterxml.jackson.annotation.JsonValue
                 import io.ktor.client.request.HttpRequestBuilder
+                import kotlin.Any
                 import kotlin.Int
                 import kotlin.String
                 import kotlin.Unit
@@ -146,7 +148,7 @@ class GenerateGraphQLCustomScalarTypeSpecIT {
 
                       @JsonCreator
                       @JvmStatic
-                      fun create(rawValue: String) = UUID(converter.toScalar(rawValue))
+                      fun create(rawValue: Any) = UUID(converter.toScalar(rawValue))
                     }
                   }
 

--- a/website/versioned_docs/version-3.5.0/client/client-customization.md
+++ b/website/versioned_docs/version-3.5.0/client/client-customization.md
@@ -105,8 +105,8 @@ import com.expediagroup.graphql.client.converter.ScalarConverter
 import java.util.UUID
 
 class UUIDScalarConverter : ScalarConverter<UUID> {
-    override fun toScalar(rawValue: String): UUID = UUID.fromString(rawValue)
-    override fun toJson(value: UUID): String = value.toString()
+    override fun toScalar(rawValue: Any): UUID = UUID.fromString(rawValue.toString())
+    override fun toJson(value: UUID): Any = value.toString()
 }
 ```
 

--- a/website/versioned_docs/version-3.5.0/plugins/gradle-plugin.md
+++ b/website/versioned_docs/version-3.5.0/plugins/gradle-plugin.md
@@ -229,8 +229,8 @@ import com.expediagroup.graphql.client.converter.ScalarConverter
 import java.util.UUID
 
 class UUIDScalarConverter : ScalarConverter<UUID> {
-    override fun toScalar(rawValue: String): UUID = UUID.fromString(rawValue)
-    override fun toJson(value: UUID): String = value.toString()
+    override fun toScalar(rawValue: Any): UUID = UUID.fromString(rawValue.toString())
+    override fun toJson(value: UUID): Any = value.toString()
 }
 ```
 

--- a/website/versioned_docs/version-3.5.0/plugins/maven-plugin.md
+++ b/website/versioned_docs/version-3.5.0/plugins/maven-plugin.md
@@ -274,8 +274,8 @@ import com.expediagroup.graphql.client.converter.ScalarConverter
 import java.util.UUID
 
 class UUIDScalarConverter : ScalarConverter<UUID> {
-    override fun toScalar(rawValue: String): UUID = UUID.fromString(rawValue)
-    override fun toJson(value: UUID): String = value.toString()
+    override fun toScalar(rawValue: Any): UUID = UUID.fromString(rawValue.toString())
+    override fun toJson(value: UUID): Any = value.toString()
 }
 ```
 


### PR DESCRIPTION
### :pencil: Description
ScalarConverter included in 3.x.x still accepts only String.

### :link: Related Issues
#819 