### PR TITLE
feat: catching field name collision on schema generation

### DIFF
--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/exceptions/ConflictingFieldsException.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/exceptions/ConflictingFieldsException.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2020 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.exceptions
+
+/**
+ * Thrown when the schema being generated has two functions or attributes with the same field name
+ * in a GraphQLType. Field name must be unique in each GraphQLType.
+ */
+class ConflictingFieldsException(type: String, field: String) :
+    GraphQLKotlinException("Conflicting field names in schema generation [type : $type, field name: $field]")

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/generateMutation.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/generateMutation.kt
@@ -17,6 +17,7 @@
 package com.expediagroup.graphql.generator.types
 
 import com.expediagroup.graphql.TopLevelObject
+import com.expediagroup.graphql.exceptions.ConflictingFieldsException
 import com.expediagroup.graphql.exceptions.InvalidMutationTypeException
 import com.expediagroup.graphql.generator.SchemaGenerator
 import com.expediagroup.graphql.generator.extensions.getValidFunctions
@@ -46,6 +47,9 @@ internal fun generateMutations(generator: SchemaGenerator, mutations: List<TopLe
             .forEach {
                 val function = generateFunction(generator, it, generator.config.topLevelNames.mutation, mutation.obj)
                 val functionFromHook = generator.config.hooks.didGenerateMutationField(mutation.kClass, it, function)
+                if (mutationBuilder.hasField(functionFromHook.name)) {
+                    throw ConflictingFieldsException("Mutation(class: ${mutation.kClass})", it.name)
+                }
                 mutationBuilder.field(functionFromHook)
             }
     }

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/generateQuery.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/generateQuery.kt
@@ -17,6 +17,7 @@
 package com.expediagroup.graphql.generator.types
 
 import com.expediagroup.graphql.TopLevelObject
+import com.expediagroup.graphql.exceptions.ConflictingFieldsException
 import com.expediagroup.graphql.exceptions.InvalidQueryTypeException
 import com.expediagroup.graphql.generator.SchemaGenerator
 import com.expediagroup.graphql.generator.extensions.getValidFunctions
@@ -41,6 +42,9 @@ internal fun generateQueries(generator: SchemaGenerator, queries: List<TopLevelO
             .forEach {
                 val function = generateFunction(generator, it, generator.config.topLevelNames.query, query.obj)
                 val functionFromHook = generator.config.hooks.didGenerateQueryField(query.kClass, it, function)
+                if (queryBuilder.hasField(functionFromHook.name)) {
+                    throw ConflictingFieldsException("Query(class: ${query.kClass})", it.name)
+                }
                 queryBuilder.field(functionFromHook)
             }
     }

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/generateSubscription.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/types/generateSubscription.kt
@@ -17,6 +17,7 @@
 package com.expediagroup.graphql.generator.types
 
 import com.expediagroup.graphql.TopLevelObject
+import com.expediagroup.graphql.exceptions.ConflictingFieldsException
 import com.expediagroup.graphql.exceptions.InvalidSubscriptionTypeException
 import com.expediagroup.graphql.generator.SchemaGenerator
 import com.expediagroup.graphql.generator.extensions.getValidFunctions
@@ -51,6 +52,9 @@ internal fun generateSubscriptions(generator: SchemaGenerator, subscriptions: Li
 
                 val function = generateFunction(generator, it, generator.config.topLevelNames.subscription, subscription.obj)
                 val functionFromHook = generator.config.hooks.didGenerateSubscriptionField(kClass, it, function)
+                if (subscriptionBuilder.hasField(functionFromHook.name)) {
+                    throw ConflictingFieldsException("Subscription(class: ${subscription.kClass})", it.name)
+                }
                 subscriptionBuilder.field(functionFromHook)
             }
     }

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/GenerateQueryTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/GenerateQueryTest.kt
@@ -19,6 +19,7 @@ package com.expediagroup.graphql.generator.types
 import com.expediagroup.graphql.TopLevelObject
 import com.expediagroup.graphql.annotations.GraphQLDescription
 import com.expediagroup.graphql.annotations.GraphQLIgnore
+import com.expediagroup.graphql.exceptions.ConflictingFieldsException
 import com.expediagroup.graphql.exceptions.EmptyQueryTypeException
 import com.expediagroup.graphql.exceptions.InvalidQueryTypeException
 import com.expediagroup.graphql.generator.extensions.isTrue
@@ -52,6 +53,10 @@ internal class GenerateQueryTest : TypeTestHelper() {
     @SimpleDirective
     class QueryObject {
         @GraphQLDescription("A GraphQL query method")
+        fun query(value: Int) = value
+    }
+
+    class QueryObjectWithSameFun {
         fun query(value: Int) = value
     }
 
@@ -108,5 +113,13 @@ internal class GenerateQueryTest : TypeTestHelper() {
         val result = generateQueries(generator, queries)
         assertEquals(expected = 1, actual = result.directives.size)
         assertEquals(expected = "simpleDirective", actual = result.directives.first().name)
+    }
+
+    @Test
+    fun `verify builder fails if plural queries the have same field names`() {
+        val queries = listOf(TopLevelObject(QueryObject()), TopLevelObject(QueryObjectWithSameFun()))
+        assertThrows<ConflictingFieldsException> {
+            generateQueries(generator, queries)
+        }
     }
 }

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/GenerateSubscriptionTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/GenerateSubscriptionTest.kt
@@ -19,6 +19,7 @@ package com.expediagroup.graphql.generator.types
 import com.expediagroup.graphql.TopLevelNames
 import com.expediagroup.graphql.TopLevelObject
 import com.expediagroup.graphql.annotations.GraphQLDirective
+import com.expediagroup.graphql.exceptions.ConflictingFieldsException
 import com.expediagroup.graphql.exceptions.EmptySubscriptionTypeException
 import com.expediagroup.graphql.exceptions.InvalidSubscriptionTypeException
 import com.expediagroup.graphql.generator.extensions.getTypeOfFirstArgument
@@ -160,6 +161,14 @@ class GenerateSubscriptionTest : TypeTestHelper() {
         assertEquals("mySubscriptionDirective", result.directives.first().name)
     }
 
+    @Test
+    fun `verify builder fails if plural subscriptions have the same field names`() {
+        val subscriptions = listOf(TopLevelObject(MyPublicTestSubscription()), TopLevelObject(MyPublicTestSubscriptionWithSameFun()))
+        assertThrows<ConflictingFieldsException> {
+            generateSubscriptions(generator, subscriptions)
+        }
+    }
+
     @MySubscriptionDirective
     @MyInterfaceDirective
     class MyPublicTestSubscription {
@@ -168,6 +177,10 @@ class GenerateSubscriptionTest : TypeTestHelper() {
         fun flowabelCounter(): Flowable<Int> = Flowable.just(1)
 
         fun filterMe(): Publisher<Int> = Flowable.just(2)
+    }
+
+    class MyPublicTestSubscriptionWithSameFun {
+        fun counter(): Publisher<Int> = Flowable.just(1)
     }
 
     class MyInvalidSubscriptionClass {


### PR DESCRIPTION
### :pencil: Description

Since Operation types (mutation, mutation, subscription) can be implemented in plural classes, there are chances to make mistake by implementing plural operation classes with same function name. 
This PR catches such grammar errors on schema generation.

### :link: Related Issues

Resolves https://github.com/ExpediaGroup/graphql-kotlin/issues/921