### PR TITLE
fix(spring-server): adding credentials by default

### DIFF
--- a/graphql-kotlin-spring-server/src/main/resources/graphql-playground.html
+++ b/graphql-kotlin-spring-server/src/main/resources/graphql-playground.html
@@ -50,6 +50,7 @@
 </div>
 <script>window.addEventListener('load', function (event) {
     GraphQLPlayground.init(document.getElementById('root'), {
+        settings: {'request.credentials': 'same-origin'},
         endpoint: '/${graphQLEndpoint}',
         subscriptionEndpoint: '/${subscriptionsEndpoint}'
     })


### PR DESCRIPTION
### :pencil: Description
Hello,

My brand uses a security context provided by cookies.
When opening the playground from a first party domain name (from the domain name having the graphql endpoints),
I want to have the auth cookie sent to the server without having to specify it in the "http headers" section of the playground

### :link: Related Issues
auth and graphql-kotlin jira tickets in my brand.