### PR TITLE
update to graphql java 16

### DIFF
--- a/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/exceptions/CustomDataFetcherExceptionHandler.kt
+++ b/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/exceptions/CustomDataFetcherExceptionHandler.kt
@@ -25,7 +25,7 @@ import graphql.GraphQLError
 import graphql.execution.DataFetcherExceptionHandler
 import graphql.execution.DataFetcherExceptionHandlerParameters
 import graphql.execution.DataFetcherExceptionHandlerResult
-import graphql.execution.ExecutionPath
+import graphql.execution.ResultPath
 import graphql.language.SourceLocation
 import org.slf4j.LoggerFactory
 
@@ -49,7 +49,7 @@ class CustomDataFetcherExceptionHandler : DataFetcherExceptionHandler {
 @JsonIgnoreProperties("exception")
 class ValidationDataFetchingGraphQLError(
     val constraintErrors: List<ConstraintError>,
-    path: ExecutionPath,
+    path: ResultPath,
     exception: Throwable,
     sourceLocation: SourceLocation
 ) : ExceptionWhileDataFetching(

--- a/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/query/DataAndErrorsQuery.kt
+++ b/examples/spring/src/main/kotlin/com/expediagroup/graphql/examples/query/DataAndErrorsQuery.kt
@@ -19,7 +19,7 @@ package com.expediagroup.graphql.examples.query
 import com.expediagroup.graphql.spring.exception.SimpleKotlinGraphQLError
 import com.expediagroup.graphql.spring.operations.Query
 import graphql.execution.DataFetcherResult
-import graphql.execution.ExecutionPath
+import graphql.execution.ResultPath
 import graphql.language.SourceLocation
 import org.springframework.stereotype.Component
 import java.util.concurrent.CompletableFuture
@@ -28,7 +28,7 @@ import java.util.concurrent.CompletableFuture
 class DataAndErrorsQuery : Query {
 
     fun returnDataAndErrors(): DataFetcherResult<String?> {
-        val error = SimpleKotlinGraphQLError(RuntimeException("data and errors"), listOf(SourceLocation(1, 1)), ExecutionPath.rootPath().toList())
+        val error = SimpleKotlinGraphQLError(RuntimeException("data and errors"), listOf(SourceLocation(1, 1)), ResultPath.rootPath().toList())
         return DataFetcherResult.newResult<String>()
             .data("Hello from data fetcher")
             .error(error)
@@ -36,7 +36,7 @@ class DataAndErrorsQuery : Query {
     }
 
     fun completableFutureDataAndErrors(): CompletableFuture<DataFetcherResult<String?>> {
-        val error = SimpleKotlinGraphQLError(RuntimeException("data and errors"), listOf(SourceLocation(1, 1)), ExecutionPath.rootPath().toList())
+        val error = SimpleKotlinGraphQLError(RuntimeException("data and errors"), listOf(SourceLocation(1, 1)), ResultPath.rootPath().toList())
         val dataFetcherResult = DataFetcherResult.newResult<String>()
             .data("Hello from data fetcher")
             .error(error)

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ kotlinVersion = 1.3.72
 kotlinCoroutinesVersion = 1.3.8
 
 classGraphVersion = 4.8.87
-graphQLJavaVersion = 15.0
+graphQLJavaVersion = 16.1
 jacksonVersion = 2.11.3
 kotlinPoetVersion = 1.6.0
 ktorVersion = 1.3.1

--- a/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/execution/ServiceQueryResolverTest.kt
+++ b/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/execution/ServiceQueryResolverTest.kt
@@ -73,7 +73,7 @@ scalar CustomScalar"""
 
 const val BASE_SERVICE_SDL =
 """
-type Query {
+type Query @extends {
   getSimpleNestedObject: [SelfReferenceObject]!
   hello(name: String!): String!
 }

--- a/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/federationDirectives.kt
+++ b/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/federation/federationDirectives.kt
@@ -31,6 +31,8 @@ internal fun getKeyDirective(diretiveValue: String): GraphQLDirective = mockk {
             every { value } returns diretiveValue
         }
     }
+    every { isNonRepeatable } returns true
+    every { isRepeatable } returns false
 }
 
 internal fun getRequiresDirective(directiveValue: String): GraphQLDirective = mockk {
@@ -40,6 +42,8 @@ internal fun getRequiresDirective(directiveValue: String): GraphQLDirective = mo
             every { value } returns directiveValue
         }
     }
+    every { isNonRepeatable } returns true
+    every { isRepeatable } returns false
 }
 
 internal val externalDirective = GraphQLDirective.newDirective().name(EXTERNAL_DIRECTIVE_NAME)

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/directives/DirectiveTests.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/directives/DirectiveTests.kt
@@ -95,7 +95,7 @@ class DirectiveTests {
 
         assertEquals("arenaming", directive.arguments[0].value)
         assertEquals("arg", directive.arguments[0].name)
-        assertEquals(GraphQLNonNull(Scalars.GraphQLString), directive.arguments[0].type)
+        assertTrue(GraphQLNonNull(Scalars.GraphQLString).isEqualTo(directive.arguments[0].type))
     }
 }
 

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/ToSchemaTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/ToSchemaTest.kt
@@ -31,7 +31,7 @@ import graphql.ExceptionWhileDataFetching
 import graphql.GraphQL
 import graphql.Scalars
 import graphql.execution.DataFetcherResult
-import graphql.execution.ExecutionPath
+import graphql.execution.ResultPath
 import graphql.introspection.IntrospectionQuery
 import graphql.language.SourceLocation
 import graphql.schema.GraphQLNonNull
@@ -553,7 +553,7 @@ class ToSchemaTest {
 
     class QueryWithDataFetcherResult {
         fun dataAndErrors(): DataFetcherResult<String> {
-            val error = ExceptionWhileDataFetching(ExecutionPath.rootPath(), RuntimeException(), SourceLocation(1, 1))
+            val error = ExceptionWhileDataFetching(ResultPath.rootPath(), RuntimeException(), SourceLocation(1, 1))
             return DataFetcherResult.newResult<String>().data("Hello").error(error).build()
         }
     }

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/GenerateObjectTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/GenerateObjectTest.kt
@@ -26,6 +26,7 @@ import graphql.schema.GraphQLObjectType
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 class GenerateObjectTest : TypeTestHelper() {
 
@@ -76,7 +77,7 @@ class GenerateObjectTest : TypeTestHelper() {
         assertEquals("objectDirective", directive.name)
         assertEquals("Don't worry", directive.arguments[0].value)
         assertEquals("arg", directive.arguments[0].name)
-        assertEquals(GraphQLNonNull(Scalars.GraphQLString), directive.arguments[0].type)
+        assertTrue(GraphQLNonNull(Scalars.GraphQLString).isEqualTo(directive.arguments[0].type))
         assertEquals(
             directive.validLocations()?.toSet(),
             setOf(Introspection.DirectiveLocation.OBJECT)

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/GeneratePropertyTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/types/GeneratePropertyTest.kt
@@ -157,7 +157,7 @@ class GeneratePropertyTest : TypeTestHelper() {
         assertEquals("propertyDirective", directive.name)
         assertEquals("trust me", directive.arguments[0].value)
         assertEquals("arg", directive.arguments[0].name)
-        assertEquals(GraphQLNonNull(Scalars.GraphQLString), directive.arguments[0].type)
+        assertTrue(GraphQLNonNull(Scalars.GraphQLString).isEqualTo(directive.arguments[0].type))
         assertEquals(
             directive.validLocations()?.toSet(),
             setOf(Introspection.DirectiveLocation.FIELD_DEFINITION)

--- a/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/exception/KotlinDataFetcherExceptionHandlerTest.kt
+++ b/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/exception/KotlinDataFetcherExceptionHandlerTest.kt
@@ -18,7 +18,7 @@ package com.expediagroup.graphql.spring.exception
 
 import graphql.execution.AbortExecutionException
 import graphql.execution.DataFetcherExceptionHandlerParameters
-import graphql.execution.ExecutionPath
+import graphql.execution.ResultPath
 import graphql.language.SourceLocation
 import io.mockk.every
 import io.mockk.mockk
@@ -34,7 +34,7 @@ class KotlinDataFetcherExceptionHandlerTest {
         val parameters: DataFetcherExceptionHandlerParameters = mockk {
             every { exception } returns AbortExecutionException("my exception")
             every { sourceLocation } returns SourceLocation(1, 1)
-            every { path } returns ExecutionPath.parse("/foo")
+            every { path } returns ResultPath.parse("/foo")
         }
 
         val handler = KotlinDataFetcherExceptionHandler()
@@ -52,7 +52,7 @@ class KotlinDataFetcherExceptionHandlerTest {
         val parameters: DataFetcherExceptionHandlerParameters = mockk {
             every { exception } returns Throwable("generic exception")
             every { sourceLocation } returns SourceLocation(1, 1)
-            every { path } returns ExecutionPath.parse("/foo")
+            every { path } returns ResultPath.parse("/foo")
         }
 
         val handler = KotlinDataFetcherExceptionHandler()

--- a/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/types/generateGraphQLEnumTypeSpec.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/types/generateGraphQLEnumTypeSpec.kt
@@ -37,7 +37,8 @@ internal fun generateGraphQLEnumTypeSpec(context: GraphQLClientGeneratorContext,
         enumValueDefinition.description?.content?.let { kdoc ->
             enumValueTypeSpecBuilder.addKdoc(kdoc)
         }
-        enumValueDefinition.getDirective(DeprecatedDirective.name)?.let { deprecatedDirective ->
+        val deprecatedDirective = enumValueDefinition.getDirectives(DeprecatedDirective.name).firstOrNull()
+        if (deprecatedDirective != null) {
             val deprecatedReason = deprecatedDirective.getArgument("reason")?.value as? StringValue
             val reason = deprecatedReason?.value ?: "no longer supported"
             enumValueTypeSpecBuilder.addAnnotation(

--- a/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/types/generatePropertySpecs.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/types/generatePropertySpecs.kt
@@ -57,7 +57,8 @@ internal fun generatePropertySpecs(
         if (!abstract) {
             propertySpecBuilder.initializer(fieldName)
         }
-        fieldDefinition.getDirective(DeprecatedDirective.name)?.let { deprecatedDirective ->
+        val deprecatedDirective = fieldDefinition.getDirectives(DeprecatedDirective.name).firstOrNull()
+        if (deprecatedDirective != null) {
             if (!context.allowDeprecated) {
                 throw DeprecatedFieldsSelectedException(selectedField.name, objectName)
             } else {


### PR DESCRIPTION
### :pencil: Description

Update to `graphql-java` v16 (see: https://github.com/graphql-java/graphql-java/releases/tag/v16.0 for details).

`graphql-java` added new validations that now fail schema generation if objects (e.g. query) doesn't have any fields. Unfortunately this complicates federation generation logic as it is possible to have federated service without any regular queries. As a workaround, we now add `_service` field during query generation to ensure that it will always have at least one single field. As a side effect we now have to add some additional String manipulations to generate valid federated SDL.

### :link: Related Issues

https://github.com/graphql-java/graphql-java/issues/2107