### PR TITLE
[plugin] fix generation of self referencing types

### DIFF
--- a/plugins/graphql-kotlin-plugin-core/README.md
+++ b/plugins/graphql-kotlin-plugin-core/README.md
@@ -27,10 +27,6 @@ using [square/kotlinpoet](https://github.com/square/kotlinpoet) library.
 
 ## Code Generation Limitations
 
-* Currently only Ktor Http Client is supported. Additional clients (e.g. Spring WebClient) might be supported in the future.
 * Due to the custom logic required for deserialization of polymorphic types and default enum values only Jackson is currently supported.
 * Only a single operation per GraphQL query file is supported.
 * Subscriptions are currently NOT supported.
-* Nested queries have limited support as same object will be used for ALL nested results. This means that you have to
-  explicitly ask for data from ALL nested levels + the NULL/empty child following it (that may skip recursive field selection
-  as it will be NULL)

--- a/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/GraphQLClientGeneratorContext.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/GraphQLClientGeneratorContext.kt
@@ -38,5 +38,6 @@ data class GraphQLClientGeneratorContext(
     val classNameCache: MutableMap<String, MutableList<ClassName>> = mutableMapOf()
     val typeSpecs: MutableMap<String, TypeSpec> = mutableMapOf()
     val typeAliases: MutableMap<String, TypeAliasSpec> = mutableMapOf()
-    val objectsWithTypeNameSelection: MutableSet<String> = mutableSetOf()
+
+    val typeToSelectionSetMap: MutableMap<String, Set<String>> = mutableMapOf()
 }

--- a/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/extensions/DocumentExtensions.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/extensions/DocumentExtensions.kt
@@ -16,10 +16,12 @@
 
 package com.expediagroup.graphql.plugin.generator.extensions
 
+import com.expediagroup.graphql.plugin.generator.GraphQLClientGeneratorContext
 import com.expediagroup.graphql.plugin.generator.exceptions.InvalidFragmentException
 import graphql.language.Document
 import graphql.language.FragmentDefinition
 
-internal fun Document.findFragmentDefinition(targetFragment: String, targetType: String): FragmentDefinition =
+internal fun Document.findFragmentDefinition(context: GraphQLClientGeneratorContext, targetFragment: String, targetType: String): FragmentDefinition =
     this.getDefinitionsOfType(FragmentDefinition::class.java)
-        .find { it.name == targetFragment && it.typeCondition.name == targetType } ?: throw InvalidFragmentException(targetFragment, targetType)
+        .find { it.name == targetFragment && context.graphQLSchema.getType(it.typeCondition.name).isPresent }
+        ?: throw InvalidFragmentException(targetFragment, targetType)

--- a/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/types/generateGraphQLObjectTypeSpec.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/types/generateGraphQLObjectTypeSpec.kt
@@ -60,7 +60,7 @@ internal fun generateGraphQLObjectTypeSpec(
     selectionSet.getSelectionsOfType(FragmentSpread::class.java)
         .forEach { fragment ->
             val fragmentDefinition = context.queryDocument
-                .findFragmentDefinition(fragment.name, objectDefinition.name)
+                .findFragmentDefinition(context, fragment.name, objectDefinition.name)
             generatePropertySpecs(
                 context = context,
                 objectName = objectDefinition.name,

--- a/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/types/generateInterfaceTypeSpec.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/types/generateInterfaceTypeSpec.kt
@@ -135,7 +135,6 @@ internal fun generateInterfaceTypeSpec(
         val unwrappedClassName = implementationClassName.copy(nullable = false)
         // we point to original implementation name as that will be value from the __typename
         jsonSubTypesCodeBlock.add("com.fasterxml.jackson.annotation.JsonSubTypes.Type(value = %T::class, name=%S)", unwrappedClassName, implementationName)
-        context.objectsWithTypeNameSelection.add(implementationName)
     }
 
     // add jackson annotations to handle deserialization

--- a/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/types/generatePropertySpecs.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/types/generatePropertySpecs.kt
@@ -38,13 +38,7 @@ internal fun generatePropertySpecs(
     fieldDefinitions: List<FieldDefinition>,
     abstract: Boolean = false
 ): List<PropertySpec> = selectionSet.getSelectionsOfType(Field::class.java)
-    .filterNot {
-        val typeNameSelected = it.name == "__typename"
-        if (typeNameSelected) {
-            context.objectsWithTypeNameSelection.add(objectName)
-        }
-        typeNameSelected
-    }
+    .filterNot { it.name == "__typename" }
     .map { selectedField ->
         val fieldDefinition = fieldDefinitions.find { it.name == selectedField.name }
             ?: throw InvalidSelectionSetException(selectedField.name, objectName)

--- a/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/types/generateTypeName.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/types/generateTypeName.kt
@@ -24,7 +24,6 @@ import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FLOAT
 import com.squareup.kotlinpoet.INT
 import com.squareup.kotlinpoet.LIST
-import com.squareup.kotlinpoet.ParameterizedTypeName
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.STRING
 import com.squareup.kotlinpoet.TypeName
@@ -78,11 +77,15 @@ internal fun generateCustomClassName(context: GraphQLClientGeneratorContext, gra
 
     return if (cachedTypeNames == null || cachedTypeNames.isEmpty()) {
         // build new custom type
-        val className = if (graphQLTypeDefinition is ScalarTypeDefinition && context.scalarTypeToConverterMapping[graphQLTypeName] == null) {
+        if (graphQLTypeDefinition is ScalarTypeDefinition && context.scalarTypeToConverterMapping[graphQLTypeName] == null) {
             val typeAlias = generateGraphQLCustomScalarTypeAlias(context, graphQLTypeDefinition)
-            ClassName(context.packageName, typeAlias.name)
+            val className = ClassName(context.packageName, typeAlias.name)
+            context.classNameCache[graphQLTypeName] = mutableListOf(className)
+            className
         } else {
-            val typeSpec = when (graphQLTypeDefinition) {
+            val className = generateClassName(context, graphQLTypeDefinition, selectionSet)
+            // generate corresponding type spec
+            when (graphQLTypeDefinition) {
                 is ObjectTypeDefinition -> generateGraphQLObjectTypeSpec(context, graphQLTypeDefinition, selectionSet)
                 is InputObjectTypeDefinition -> generateGraphQLInputObjectTypeSpec(context, graphQLTypeDefinition)
                 is EnumTypeDefinition -> generateGraphQLEnumTypeSpec(context, graphQLTypeDefinition)
@@ -92,10 +95,8 @@ internal fun generateCustomClassName(context: GraphQLClientGeneratorContext, gra
                 // should never happen as above list covers all graphql types
                 else -> throw UnknownGraphQLTypeException(graphQLType)
             }
-            ClassName(context.packageName, "${context.rootType}.${typeSpec.name}")
+            className
         }
-        context.classNameCache[graphQLTypeName] = mutableListOf(className)
-        className
     } else if (selectionSet == null) {
         cachedTypeNames.first()
     } else {
@@ -108,58 +109,57 @@ internal fun generateCustomClassName(context: GraphQLClientGeneratorContext, gra
 
         // if different selection set we need to generate custom type
         val overriddenName = "$graphQLTypeName${cachedTypeNames.size + 1}"
-        val typeSpec = when (graphQLTypeDefinition) {
+        val className = generateClassName(context, graphQLTypeDefinition, selectionSet, overriddenName)
+
+        // generate new type spec
+        when (graphQLTypeDefinition) {
             is ObjectTypeDefinition -> generateGraphQLObjectTypeSpec(context, graphQLTypeDefinition, selectionSet, overriddenName)
             is InterfaceTypeDefinition -> generateGraphQLInterfaceTypeSpec(context, graphQLTypeDefinition, selectionSet, overriddenName)
             is UnionTypeDefinition -> generateGraphQLUnionTypeSpec(context, graphQLTypeDefinition, selectionSet, overriddenName)
             // should never happen as we can only generate different object, interface or union type
             else -> throw UnknownGraphQLTypeException(graphQLType)
         }
-        val className = ClassName(context.packageName, "${context.rootType}.${typeSpec.name}")
-        context.classNameCache[graphQLTypeName]?.add(className)
         className
     }
+}
+
+/**
+ * Generate custom [ClassName] reference to a Kotlin class representing GraphQL complex type (object, input object, enum, interface, union or custom scalar) and caches the value.
+ */
+internal fun generateClassName(
+    context: GraphQLClientGeneratorContext,
+    graphQLType: NamedNode<*>,
+    selectionSet: SelectionSet? = null,
+    nameOverride: String? = null
+): ClassName {
+    val typeName = nameOverride ?: graphQLType.name
+    val className = ClassName(context.packageName, "${context.rootType}.$typeName")
+    val classNames = context.classNameCache.getOrDefault(graphQLType.name, mutableListOf())
+    classNames.add(className)
+    context.classNameCache[graphQLType.name] = classNames
+
+    if (selectionSet != null) {
+        val selectedFields = calculateSelectedFields(context, typeName, selectionSet)
+        context.typeToSelectionSetMap[typeName] = selectedFields
+    }
+
+    return className
 }
 
 private fun ClassName.simpleNameWithoutWrapper() = this.simpleName.substringAfter(".")
 
 private fun isCachedTypeApplicable(context: GraphQLClientGeneratorContext, graphQLTypeName: String, graphQLTypeDefinition: TypeDefinition<*>, selectionSet: SelectionSet): Boolean =
     when (graphQLTypeDefinition) {
-        is UnionTypeDefinition -> {
-            val unionImplementations = graphQLTypeDefinition.memberTypes.filterIsInstance(graphql.language.TypeName::class.java).map { it.name }
-            var result = true
-            for (unionImplementation in unionImplementations) {
-                result = result && verifySelectionSet(context, unionImplementation, selectionSet)
-                if (!result) {
-                    break
-                }
-            }
-            result
-        }
-        is InterfaceTypeDefinition -> {
-            var result = verifySelectionSet(context, graphQLTypeName, selectionSet)
-            if (result) {
-                val implementations = context.graphQLSchema.getImplementationsOf(graphQLTypeDefinition).map { it.name }
-                for (implementation in implementations) {
-                    result = result && verifySelectionSet(context, implementation, selectionSet)
-                    if (!result) {
-                        break
-                    }
-                }
-            }
-            result
-        }
+        is UnionTypeDefinition -> verifySelectionSet(context, graphQLTypeName, selectionSet)
+        is InterfaceTypeDefinition -> verifySelectionSet(context, graphQLTypeName, selectionSet)
         is ObjectTypeDefinition -> verifySelectionSet(context, graphQLTypeName, selectionSet)
         else -> true
     }
 
 private fun verifySelectionSet(context: GraphQLClientGeneratorContext, graphQLTypeName: String, selectionSet: SelectionSet): Boolean {
     val selectedFields = calculateSelectedFields(context, graphQLTypeName, selectionSet)
-    val properties = calculateGeneratedTypeProperties(context, graphQLTypeName)
-    if (context.objectsWithTypeNameSelection.contains(graphQLTypeName)) {
-        properties.add("__typename")
-    }
-    return selectedFields == properties
+    val cachedTypeFields = context.typeToSelectionSetMap[graphQLTypeName]
+    return selectedFields == cachedTypeFields
 }
 
 private fun calculateSelectedFields(
@@ -177,39 +177,26 @@ private fun calculateSelectedFields(
                     result.addAll(calculateSelectedFields(context, targetType, selection.selectionSet, "$path${selection.name}."))
                 }
             }
-            is InlineFragment -> if (selection.typeCondition.name == targetType) {
-                result.addAll(calculateSelectedFields(context, targetType, selection.selectionSet))
+            is InlineFragment -> {
+                val targetFragmentType = selection.typeCondition.name
+                val fragmentPathPrefix = if (targetFragmentType == targetType) {
+                    path
+                } else {
+                    "$path$targetFragmentType."
+                }
+                result.addAll(calculateSelectedFields(context, targetType, selection.selectionSet, fragmentPathPrefix))
             }
             is FragmentSpread -> {
-                val fragmentDefinition = context.queryDocument
-                    .findFragmentDefinition(selection.name, targetType)
-                result.addAll(calculateSelectedFields(context, targetType, fragmentDefinition.selectionSet))
+                val fragmentDefinition = context.queryDocument.findFragmentDefinition(context, selection.name, targetType)
+                val targetFragmentType = fragmentDefinition.typeCondition.name
+                val fragmentPathPrefix = if (targetFragmentType == targetType) {
+                    path
+                } else {
+                    "$path$targetFragmentType."
+                }
+                result.addAll(calculateSelectedFields(context, targetType, fragmentDefinition.selectionSet, fragmentPathPrefix))
             }
         }
     }
     return result
-}
-
-private fun calculateGeneratedTypeProperties(context: GraphQLClientGeneratorContext, graphQLTypeName: String, path: String = ""): MutableSet<String> {
-    val props = mutableSetOf<String>()
-
-    val typeSpec = context.typeSpecs[graphQLTypeName]
-    for (property in typeSpec?.propertySpecs ?: emptyList()) {
-        props.add(path + property.name)
-        when (val propertyType = property.type) {
-            is ParameterizedTypeName -> {
-                val genericType = propertyType.typeArguments.firstOrNull() as? ClassName
-                val genericTypeName = genericType?.simpleNameWithoutWrapper() ?: ""
-                props.addAll(calculateGeneratedTypeProperties(context, genericTypeName, "$path${property.name}."))
-            }
-            is ClassName -> {
-                val fieldTypeName = propertyType.simpleNameWithoutWrapper()
-                // we need to check whether generated type is a custom scalar
-                if (context.scalarTypeToConverterMapping[fieldTypeName] == null) {
-                    props.addAll(calculateGeneratedTypeProperties(context, fieldTypeName, "$path${property.name}."))
-                }
-            }
-        }
-    }
-    return props
 }

--- a/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLInputObjectTypeSpecIT.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLInputObjectTypeSpecIT.kt
@@ -59,4 +59,67 @@ class GenerateGraphQLInputObjectTypeSpecIT {
             """.trimIndent()
         verifyGeneratedFileSpecContents(query, expected)
     }
+
+    @Test
+    fun `verify generation of self referencing input object`() {
+        val expected =
+            """
+                package com.expediagroup.graphql.plugin.generator.integration
+
+                import com.expediagroup.graphql.client.GraphQLClient
+                import com.expediagroup.graphql.client.execute
+                import com.expediagroup.graphql.types.GraphQLResponse
+                import kotlin.Boolean
+                import kotlin.Float
+                import kotlin.String
+
+                const val INPUT_OBJECT_TEST_QUERY: String =
+                    "query InputObjectTestQuery(${'$'}{'${'$'}'}input: ComplexArgumentInput) {\n  complexInputObjectQuery(criteria: ${'$'}{'${'$'}'}input)\n}"
+
+                class InputObjectTestQuery(
+                  private val graphQLClient: GraphQLClient
+                ) {
+                  suspend fun execute(variables: InputObjectTestQuery.Variables):
+                      GraphQLResponse<InputObjectTestQuery.Result> = graphQLClient.execute(INPUT_OBJECT_TEST_QUERY,
+                      "InputObjectTestQuery", variables)
+
+                  data class Variables(
+                    val input: InputObjectTestQuery.ComplexArgumentInput? = null
+                  )
+
+                  /**
+                   * Self referencing input object
+                   */
+                  data class ComplexArgumentInput(
+                    /**
+                     * Maximum value for test criteria
+                     */
+                    val max: Float? = null,
+                    /**
+                     * Minimum value for test criteria
+                     */
+                    val min: Float? = null,
+                    /**
+                     * Next criteria
+                     */
+                    val next: InputObjectTestQuery.ComplexArgumentInput? = null
+                  )
+
+                  data class Result(
+                    /**
+                     * Query that accepts self referencing input object
+                     */
+                    val complexInputObjectQuery: Boolean
+                  )
+                }
+            """.trimIndent()
+
+        val query =
+            """
+            query InputObjectTestQuery(${'$'}input: ComplexArgumentInput) {
+              complexInputObjectQuery(criteria: ${'$'}input)
+            }
+            """.trimIndent()
+        verifyGeneratedFileSpecContents(query, expected)
+    }
 }

--- a/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLObjectTypeSpecIT.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/test/kotlin/com/expediagroup/graphql/plugin/generator/types/GenerateGraphQLObjectTypeSpecIT.kt
@@ -302,7 +302,7 @@ class GenerateGraphQLObjectTypeSpecIT {
     }
 
     @Test
-    fun `verify we can generate nested objects`() {
+    fun `verify we can generate self referencing objects`() {
         val expected =
             """
                 package com.expediagroup.graphql.plugin.generator.integration
@@ -315,13 +315,59 @@ class GenerateGraphQLObjectTypeSpecIT {
                 import kotlin.collections.List
 
                 const val NESTED_QUERY: String =
-                    "query NestedQuery {\n  nestedObjectQuery {\n    id\n    name\n    children {\n      id\n      name\n    }\n  }\n}"
+                    "query NestedQuery {\n  nestedObjectQuery {\n    id\n    name\n    children {\n      name\n      children {\n        id\n        name\n        children {\n          id\n          name\n        }\n      }\n    }\n  }\n}"
 
                 class NestedQuery(
                   private val graphQLClient: GraphQLClient
                 ) {
                   suspend fun execute(): GraphQLResponse<NestedQuery.Result> = graphQLClient.execute(NESTED_QUERY,
                       "NestedQuery", null)
+
+                  /**
+                   * Example of an object self-referencing itself
+                   */
+                  data class NestedObject4(
+                    /**
+                     * Unique identifier
+                     */
+                    val id: Int,
+                    /**
+                     * Name of the object
+                     */
+                    val name: String
+                  )
+
+                  /**
+                   * Example of an object self-referencing itself
+                   */
+                  data class NestedObject3(
+                    /**
+                     * Unique identifier
+                     */
+                    val id: Int,
+                    /**
+                     * Name of the object
+                     */
+                    val name: String,
+                    /**
+                     * Children elements
+                     */
+                    val children: List<NestedQuery.NestedObject4>
+                  )
+
+                  /**
+                   * Example of an object self-referencing itself
+                   */
+                  data class NestedObject2(
+                    /**
+                     * Name of the object
+                     */
+                    val name: String,
+                    /**
+                     * Children elements
+                     */
+                    val children: List<NestedQuery.NestedObject3>
+                  )
 
                   /**
                    * Example of an object self-referencing itself
@@ -338,7 +384,7 @@ class GenerateGraphQLObjectTypeSpecIT {
                     /**
                      * Children elements
                      */
-                    val children: List<NestedQuery.NestedObject>
+                    val children: List<NestedQuery.NestedObject2>
                   )
 
                   data class Result(
@@ -356,8 +402,15 @@ class GenerateGraphQLObjectTypeSpecIT {
                     id
                     name
                     children {
-                      id
                       name
+                      children {
+                        id
+                        name
+                        children {
+                          id
+                          name
+                        }
+                      }
                     }
                   }
                 }

--- a/plugins/graphql-kotlin-plugin-core/src/test/resources/testSchema.graphql
+++ b/plugins/graphql-kotlin-plugin-core/src/test/resources/testSchema.graphql
@@ -86,6 +86,8 @@ type NestedObject {
 type Query {
   "Query returning an object that references another object"
   complexObjectQuery: ComplexObject!
+  "Query that accepts self referencing input object"
+  complexInputObjectQuery(criteria: ComplexArgumentInput!): Boolean!
   "Deprecated query that should not be used anymore"
   deprecatedQuery: String! @deprecated(reason : "old query should not be used")
   "Query that returns enum value"
@@ -146,4 +148,13 @@ input SimpleArgumentInput {
   min: Float
   "New value to be set"
   newName: String
+}
+"Self referencing input object"
+input ComplexArgumentInput {
+  "Maximum value for test criteria"
+  max: Float
+  "Minimum value for test criteria"
+  min: Float
+  "Next criteria"
+  next: ComplexArgumentInput
 }


### PR DESCRIPTION
### :pencil: Description

Fixes logic to generate the self-referencing types. We were caching both generated `TypeSpecs` (class implementation) and `ClassNames` (class references) but we were doing so in wrong order. We rely on `ClassNames` and its selection set to determine whether the underlying type was already generated but we populated `ClassName` AFTER generating the type. This meant that if a type had a self-reference it would trigger generation of outer type first and then attempt to generate its own self reference but since `ClassName` was not yet generated it would generate the child type with the same name and then overwrite it with the generated parent. This lead to incorrect classes being generated as shown in original (invalid) `verify we can generate nested objects` test (note: that single type was generated even though child has different selection set). As a side effect it was also not possible to generate self-referencing input objects as such attempt would lead to infinite recursion and stack overflow.

Updated logic to first generate (and cache) target `ClassName`, store its selection set and then generate (and cache) the underlying `TypeSpec`. By storing the selection set of the generated `ClassName` we can also simplify the logic that compares different selection sets.

### :link: Related Issues

Resolves: https://github.com/ExpediaGroup/graphql-kotlin/issues/941