### PR TITLE
fixes typo and adds tests for subscription (context)

### DIFF
--- a/examples/spring/src/test/kotlin/com/expediagroup/graphql/examples/subscriptions/SimpleSubscriptionIT.kt
+++ b/examples/spring/src/test/kotlin/com/expediagroup/graphql/examples/subscriptions/SimpleSubscriptionIT.kt
@@ -120,8 +120,6 @@ class SimpleSubscriptionIT(@LocalServerPort private var port: Int) {
             .verify()
     }
 
-
-
     private fun subscribe(query: String, id: String, initPayload: Any? = null): TestPublisher<String> {
         val output = TestPublisher.create<String>()
 

--- a/examples/spring/src/test/kotlin/com/expediagroup/graphql/examples/subscriptions/SimpleSubscriptionIT.kt
+++ b/examples/spring/src/test/kotlin/com/expediagroup/graphql/examples/subscriptions/SimpleSubscriptionIT.kt
@@ -94,24 +94,53 @@ class SimpleSubscriptionIT(@LocalServerPort private var port: Int) {
             .verify()
     }
 
-    private fun subscribe(query: String, id: String): TestPublisher<String> {
+    @Test
+    fun `verify subscriptionContext query without connectionParams`() {
+        val query = "subscriptionContext"
+        val subscription = subscribe(query, "5")
+
+        StepVerifier.create(subscription)
+            .expectNext("{\"data\":{\"$query\":\"none\"}}")
+            .expectNext("{\"data\":{\"$query\":\"value 2\"}}")
+            .expectNext("{\"data\":{\"$query\":\"value3\"}}")
+            .expectComplete()
+            .verify()
+    }
+
+    @Test
+    fun `verify subscriptionContext query with connectionParams read by MySubscriptionHooks`() {
+        val query = "subscriptionContext"
+        val subscription = subscribe(query, "5", mapOf("Authorization" to "mytoken"))
+
+        StepVerifier.create(subscription)
+            .expectNext("{\"data\":{\"$query\":\"mytoken\"}}")
+            .expectNext("{\"data\":{\"$query\":\"value 2\"}}")
+            .expectNext("{\"data\":{\"$query\":\"value3\"}}")
+            .expectComplete()
+            .verify()
+    }
+
+
+
+    private fun subscribe(query: String, id: String, initPayload: Any? = null): TestPublisher<String> {
         val output = TestPublisher.create<String>()
 
         val client = ReactorNettyWebSocketClient()
         val uri = URI.create("ws://localhost:$port$SUBSCRIPTION_ENDPOINT")
 
-        client.execute(uri) { session -> executeSubscription(session, query, id, output) }.subscribe()
+        client.execute(uri) { session -> executeSubscription(session, initPayload, query, id, output) }.subscribe()
 
         return output
     }
 
     private fun executeSubscription(
         session: WebSocketSession,
+        initPayload: Any?,
         query: String,
         id: String,
         output: TestPublisher<String>
     ): Mono<Void> {
-        val initMessage = getInitMessage(id)
+        val initMessage = getInitMessage(id, initPayload)
         val startMessage = getStartMessage(query, id)
         val firstMessage = session.textMessage(initMessage).toMono()
             .concatWith(session.textMessage(startMessage).toMono())
@@ -133,7 +162,7 @@ class SimpleSubscriptionIT(@LocalServerPort private var port: Int) {
     }
 
     private fun SubscriptionOperationMessage.toJson() = objectMapper.writeValueAsString(this)
-    private fun getInitMessage(id: String) = SubscriptionOperationMessage(GQL_CONNECTION_INIT.type, id).toJson()
+    private fun getInitMessage(id: String, payload: Any?) = SubscriptionOperationMessage(GQL_CONNECTION_INIT.type, id = id, payload = payload).toJson()
     private fun getStartMessage(query: String, id: String): String {
         val request = GraphQLRequest("subscription { $query }")
         return SubscriptionOperationMessage(GQL_START.type, id = id, payload = request).toJson()

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/execution/ContextWebFilter.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/execution/ContextWebFilter.kt
@@ -32,7 +32,7 @@ import reactor.core.publisher.Mono
  * [org.springframework.core.Ordered] value used for the [ContextWebFilter] order in which it will be applied to the incoming requests.
  * Smaller value take higher precedence.
  */
-const val GRAPHQL_CONTEXT_FILTER_ODER = 0
+const val GRAPHQL_CONTEXT_FILTER_ORDER = 0
 
 /**
  * Default web filter that populates GraphQL context in the reactor subscriber context.
@@ -61,7 +61,7 @@ open class ContextWebFilter<out T : GraphQLContext>(config: GraphQLConfiguration
             chain.filter(exchange)
         }
 
-    override fun getOrder(): Int = GRAPHQL_CONTEXT_FILTER_ODER
+    override fun getOrder(): Int = GRAPHQL_CONTEXT_FILTER_ORDER
 
     open fun isApplicable(path: String): Boolean {
         val parsedPath = PathContainer.parsePath(path)

--- a/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/context/GraphQLContextFactoryIT.kt
+++ b/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/context/GraphQLContextFactoryIT.kt
@@ -17,7 +17,7 @@
 package com.expediagroup.graphql.spring.context
 
 import com.expediagroup.graphql.execution.GraphQLContext
-import com.expediagroup.graphql.spring.execution.GRAPHQL_CONTEXT_FILTER_ODER
+import com.expediagroup.graphql.spring.execution.GRAPHQL_CONTEXT_FILTER_ORDER
 import com.expediagroup.graphql.spring.execution.GraphQLContextFactory
 import com.expediagroup.graphql.spring.operations.Query
 import com.expediagroup.graphql.types.GraphQLRequest
@@ -78,7 +78,7 @@ class GraphQLContextFactoryIT(@Autowired private val testClient: WebTestClient) 
         }
 
         @Bean
-        @Order(GRAPHQL_CONTEXT_FILTER_ODER - 1)
+        @Order(GRAPHQL_CONTEXT_FILTER_ORDER - 1)
         fun customWebFilter(): WebFilter = WebFilter { exchange, chain ->
             val headerValue = exchange.request.headers.getFirst("X-First-Header") ?: "DEFAULT_FIRST"
             chain.filter(exchange).subscriberContext { it.put("firstFilterValue", headerValue) }


### PR DESCRIPTION
### :pencil: Description
Small typo in the subscription code constant and adds an example unit test

### :link: Related Issues
N\A