### PR TITLE
[server] update default GraphQLContext

### DIFF
--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/execution/GraphQLContext.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/execution/GraphQLContext.kt
@@ -16,6 +16,9 @@
 
 package com.expediagroup.graphql.execution
 
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ConcurrentMap
+
 /**
  * Marker interface to indicate that the implementing class should be considered
  * as the GraphQL context. This means the implementing class will not appear in the schema.
@@ -23,6 +26,9 @@ package com.expediagroup.graphql.execution
 interface GraphQLContext
 
 /**
- * Can be used as a default [GraphQLContext] if there is none provided.
+ * Default [GraphQLContext] that can be used if there is none provided. Exposes generic concurrent hash map
+ * that can be populated with custom data.
  */
-class EmptyGraphQLContext : GraphQLContext
+class DefaultGraphQLContext : GraphQLContext {
+    val contents: ConcurrentMap<Any, Any> = ConcurrentHashMap()
+}

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/GraphQLExecutionConfiguration.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/GraphQLExecutionConfiguration.kt
@@ -20,7 +20,7 @@ import com.expediagroup.graphql.execution.KotlinDataFetcherFactoryProvider
 import com.expediagroup.graphql.spring.exception.KotlinDataFetcherExceptionHandler
 import com.expediagroup.graphql.spring.execution.ContextWebFilter
 import com.expediagroup.graphql.spring.execution.DataLoaderRegistryFactory
-import com.expediagroup.graphql.spring.execution.EmptyContextFactory
+import com.expediagroup.graphql.spring.execution.DefaultContextFactory
 import com.expediagroup.graphql.spring.execution.EmptyDataLoaderRegistryFactory
 import com.expediagroup.graphql.spring.execution.GraphQLContextFactory
 import com.expediagroup.graphql.spring.execution.SpringKotlinDataFetcherFactoryProvider
@@ -58,7 +58,7 @@ class GraphQLExecutionConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    fun graphQLContextFactory(): GraphQLContextFactory<*> = EmptyContextFactory
+    fun graphQLContextFactory(): GraphQLContextFactory<*> = DefaultContextFactory
 
     @Bean
     @ConditionalOnMissingBean

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/execution/GraphQLContextFactory.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/execution/GraphQLContextFactory.kt
@@ -16,7 +16,7 @@
 
 package com.expediagroup.graphql.spring.execution
 
-import com.expediagroup.graphql.execution.EmptyGraphQLContext
+import com.expediagroup.graphql.execution.DefaultGraphQLContext
 import com.expediagroup.graphql.execution.GraphQLContext
 import org.springframework.http.server.reactive.ServerHttpRequest
 import org.springframework.http.server.reactive.ServerHttpResponse
@@ -38,9 +38,9 @@ interface GraphQLContextFactory<out T : GraphQLContext> {
 }
 
 /**
- * Default context factory that generates empty GraphQL context.
+ * Default context factory that generates GraphQL context with empty concurrent map that can store any elements.
  */
-internal object EmptyContextFactory : GraphQLContextFactory<EmptyGraphQLContext> {
+internal object DefaultContextFactory : GraphQLContextFactory<DefaultGraphQLContext> {
 
-    override suspend fun generateContext(request: ServerHttpRequest, response: ServerHttpResponse) = EmptyGraphQLContext()
+    override suspend fun generateContext(request: ServerHttpRequest, response: ServerHttpResponse) = DefaultGraphQLContext()
 }

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/extensions/requestExtensions.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/extensions/requestExtensions.kt
@@ -16,9 +16,9 @@
 
 package com.expediagroup.graphql.spring.extensions
 
+import com.expediagroup.graphql.execution.DefaultGraphQLContext
 import com.expediagroup.graphql.types.GraphQLRequest
 import graphql.ExecutionInput
-import graphql.GraphQLContext
 import org.dataloader.DataLoaderRegistry
 
 /**
@@ -29,6 +29,6 @@ fun GraphQLRequest.toExecutionInput(graphQLContext: Any? = null, dataLoaderRegis
         .query(this.query)
         .operationName(this.operationName)
         .variables(this.variables ?: emptyMap())
-        .context(graphQLContext ?: GraphQLContext.newContext().build())
+        .context(graphQLContext ?: DefaultGraphQLContext())
         .dataLoaderRegistry(dataLoaderRegistry ?: DataLoaderRegistry())
         .build()

--- a/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/context/ContextWebFilterTest.kt
+++ b/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/context/ContextWebFilterTest.kt
@@ -16,7 +16,7 @@
 
 package com.expediagroup.graphql.spring.context
 
-import com.expediagroup.graphql.execution.EmptyGraphQLContext
+import com.expediagroup.graphql.execution.DefaultGraphQLContext
 import com.expediagroup.graphql.spring.GraphQLConfigurationProperties
 import com.expediagroup.graphql.spring.execution.ContextWebFilter
 import com.expediagroup.graphql.spring.execution.GRAPHQL_CONTEXT_KEY
@@ -55,7 +55,7 @@ class ContextWebFilterTest {
         }
 
         val simpleFactory: GraphQLContextFactory<*> = mockk {
-            coEvery { generateContext(any(), any()) } returns EmptyGraphQLContext()
+            coEvery { generateContext(any(), any()) } returns DefaultGraphQLContext()
         }
 
         val contextFilter = ContextWebFilter(GraphQLConfigurationProperties(packages = listOf("com.expediagroup.graphql")), simpleFactory)
@@ -63,7 +63,7 @@ class ContextWebFilterTest {
             .verifyComplete()
 
         assertNotNull(generatedContext)
-        val graphQLContext = generatedContext?.getOrDefault<EmptyGraphQLContext>(GRAPHQL_CONTEXT_KEY, null)
+        val graphQLContext = generatedContext?.getOrDefault<DefaultGraphQLContext>(GRAPHQL_CONTEXT_KEY, null)
         assertNotNull(graphQLContext)
     }
 
@@ -91,7 +91,7 @@ class ContextWebFilterTest {
         }
 
         val simpleFactory: GraphQLContextFactory<*> = mockk {
-            coEvery { generateContext(any(), any()) } returns EmptyGraphQLContext()
+            coEvery { generateContext(any(), any()) } returns DefaultGraphQLContext()
         }
 
         val contextFilter = ContextWebFilter(GraphQLConfigurationProperties(packages = listOf("com.expediagroup.graphql")), simpleFactory)

--- a/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/extensions/RequestExtensionsKtTest.kt
+++ b/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/extensions/RequestExtensionsKtTest.kt
@@ -16,8 +16,8 @@
 
 package com.expediagroup.graphql.spring.extensions
 
+import com.expediagroup.graphql.execution.GraphQLContext
 import com.expediagroup.graphql.types.GraphQLRequest
-import graphql.GraphQLContext
 import io.mockk.mockk
 import org.dataloader.DataLoaderRegistry
 import org.junit.jupiter.api.Test


### PR DESCRIPTION
### :pencil: Description

Some time ago we updated our `GraphQLContext` parameter handling logic from requiring explicit `@GraphQLContext` parameter annotation to requiring context classes to implement our marker interface but we never updated our fallback logic. By default, `spring-server` created `EmptyGraphQLContext` context factory with a fallback to `graphql-java` `GraphQLContext` that could never be specified as function parameter as it (obviously) did not implement our interface.

Updating default generated `GraphQLContext` to more usable `DefaultGraphQLContext` that holds concurrent hash map of arbitrary elements (similar to `graphql-java` default).

### :link: Related Issues

Issue found in https://github.com/ExpediaGroup/graphql-kotlin/issues/945