### PR TITLE
[plugins] allow renaming of the downloaded/introspected schema

### DIFF
--- a/docs/plugins/gradle-plugin.md
+++ b/docs/plugins/gradle-plugin.md
@@ -172,7 +172,8 @@ and could be used as an alternative to `graphqlIntrospectSchema` to generate inp
 | -------- | ---- | -------- | ----------- |
 | `endpoint` | String | yes | Target GraphQL server SDL endpoint that will be used to download schema.<br/>**Command line property is**: `endpoint`. |
 | `headers` | Map<String, Any> | | Optional HTTP headers to be specified on a SDL request. |
-| `timeoutConfig` | TimeoutConfig | | Timeout configuration(in milliseconds) to download schema from SDL endpoint before we cancel the request.<br/>**Default value are:** connect timeout = 5_000, read timeout = 15_000.<br/>|
+| `outputFile` | File | | Target GraphQL schema file to be generated.<br/>**Default value is:** `${project.buildDir}/schema.graphql` |
+| `timeoutConfig` | TimeoutConfig | | Timeout configuration(in milliseconds) to download schema from SDL endpoint before we cancel the request.<br/>**Default value are:**<br/>connect timeout = 5_000<br/>read timeout = 15_000.<br/>|
 
 ### graphqlGenerateClient
 
@@ -228,7 +229,8 @@ should be used to generate input for the subsequent `graphqlGenerateClient` task
 | -------- | ---- | -------- | ----------- |
 | `endpoint` | String | yes | Target GraphQL server endpoint that will be used to execute introspection queries.<br/>**Command line property is**: `endpoint`. |
 | `headers` | Map<String, Any> | | Optional HTTP headers to be specified on an introspection query. |
-| `timeoutConfig` | TimeoutConfig | | Timeout configuration(in milliseconds) to download schema from SDL endpoint before we cancel the request.<br/>**Default value are:** connect timeout = 5_000, read timeout = 15_000.<br/>|
+| `outputFile` | File | | Target GraphQL schema file to be generated.<br/>**Default value is:** `${project.buildDir}/schema.graphql` |
+| `timeoutConfig` | TimeoutConfig | | Timeout configuration(in milliseconds) to download schema from SDL endpoint before we cancel the request.<br/>**Default value are:**<br/>connect timeout = 5_000</br>read timeout = 15_000.<br/>|
 
 ## Examples
 

--- a/docs/plugins/maven-plugin.md
+++ b/docs/plugins/maven-plugin.md
@@ -17,9 +17,9 @@ GraphQL endpoints are often public and as such many servers might disable intros
 Since GraphQL schema is needed to generate type safe clients, as alternative GraphQL servers might expose private
 endpoints (e.g. accessible only from within network, etc) that could be used to download schema in Schema Definition
 Language (SDL) directly. This Mojo attempts to download schema from the specified `graphql.endpoint`, validates the
-result whether it is a valid schema and saves it locally as `schema.graphql` under build directory. In general, this
-goal provides limited functionality by itself and instead should be used to generate input for the subsequent
-`generate-client` goal.
+result whether it is a valid schema and saves it locally in a specified target file (defaults to `schema.graphql` under
+build directory). In general, this goal provides limited functionality by itself and instead should be used to generate
+input for the subsequent `generate-client` goal.
 
 **Attributes**
 
@@ -31,7 +31,8 @@ goal provides limited functionality by itself and instead should be used to gene
 | -------- | ---- | -------- | ----------- |
 | `endpoint` | String | yes | Target GraphQL server SDL endpoint that will be used to download schema.<br/>**User property is**: `graphql.endpoint`. |
 | `headers` | Map<String, Any> | | Optional HTTP headers to be specified on a SDL request.
-| `timeoutConfiguration` | TimeoutConfiguration | | Optional timeout configuration (in milliseconds) to download schema from SDL endpoint before we cancel the request.<br/>**Default values are:** connect timeout = 5000, read timeout = 15000.<br/> |
+| `timeoutConfiguration` | TimeoutConfiguration | | Optional timeout configuration (in milliseconds) to download schema from SDL endpoint before we cancel the request.<br/>**Default values are:**<br/>connect timeout = 5000<br/>read timeout = 15000.<br/> |
+| `schemaFile` | File | | Target schema file.<br/>**Default value is**: `${project.build.directory}/schema.graphql`<br/>**User property is**: `graphql.schemaFile`. |
 
 **Parameter Details**
 
@@ -66,7 +67,7 @@ Generate GraphQL client code based on the provided GraphQL schema and target que
 | `packageName` | String | yes | Target package name for generated code.<br/>**User property is**: `graphql.packageName`. |
 | `queryFileDirectory` | File | | Directory file containing GraphQL queries. Instead of specifying a directory you can also specify list of query file by using `queryFiles` property instead.<br/>**Default value is:** `src/main/resources`. |
 | `queryFiles` | List<File> | | List of query files to be processed. Instead of a list of files to be processed you can also specify `queryFileDirectory` directory containing all the files. If this property is specified it will take precedence over the corresponding directory property. |
-| `schemaFile` | String | yes | GraphQL schema file that will be used to generate client code.<br/>**User property is**: `graphql.schemaFile`. |
+| `schemaFile` | String | | GraphQL schema file that will be used to generate client code.<br/>**Default value is**: `${project.build.directory}/schema.graphql`<br/>**User property is**: `graphql.schemaFile`. |
 
 **Parameter Details**
 
@@ -106,7 +107,7 @@ Generate GraphQL test client code based on the provided GraphQL schema and targe
 | `packageName` | String | yes | Target package name for generated code.<br/>**User property is**: `graphql.packageName`. |
 | `queryFileDirectory` | File | | Directory file containing GraphQL queries. Instead of specifying a directory you can also specify list of query file by using `queryFiles` property instead.<br/>**Default value is:** `src/test/resources`. |
 | `queryFiles` | List<File> | | List of query files to be processed. Instead of a list of files to be processed you can also specify `queryFileDirectory` directory containing all the files. If this property is specified it will take precedence over the corresponding directory property. |
-| `schemaFile` | String | yes | GraphQL schema file that will be used to generate client code.<br/>**User property is**: `graphql.schemaFile`. |
+| `schemaFile` | String | | GraphQL schema file that will be used to generate client code.<br/>**Default value is**: `${project.build.directory}/schema.graphql`<br/>**User property is**: `graphql.schemaFile`. |
 
 **Parameter Details**
 
@@ -127,9 +128,9 @@ Generate GraphQL test client code based on the provided GraphQL schema and targe
 
 ### introspect-schema
 
-Executes GraphQL introspection query against specified `graphql.endpoint` and saves the underlying schema file as
-`schema.graphql` under build directory. In general, this goal provides limited functionality by itself and instead
-should be used to generate input for the subsequent `generate-client` goal.
+Executes GraphQL introspection query against specified `graphql.endpoint` and saves the result locally to a target file
+(defaults to `schema.graphql` under build directory). In general, this goal provides limited functionality by itself and
+instead should be used to generate input for the subsequent `generate-client` goal.
 
 **Attributes**
 
@@ -141,7 +142,8 @@ should be used to generate input for the subsequent `generate-client` goal.
 | -------- | ---- | -------- | ----------- |
 | `endpoint` | String | yes | Target GraphQL server endpoint that will be used to execute introspection queries.<br/>**User property is**: `graphql.endpoint`. |
 | `headers` | Map<String, Any> | | Optional HTTP headers to be specified on an introspection query. |
-| `timeoutConfiguration` | TimeoutConfiguration | | Optional timeout configuration(in milliseconds) to execute introspection query before we cancel the request.<br/>**Default values are:** connect timeout = 5000, read timeout = 15000.<br/> |
+| `timeoutConfiguration` | TimeoutConfiguration | | Optional timeout configuration (in milliseconds) to download schema from SDL endpoint before we cancel the request.<br/>**Default values are:**<br/>connect timeout = 5000<br/>read timeout = 15000.<br/> |
+| `schemaFile` | File | | Target schema file.<br/>**Default value is**: `${project.build.directory}/schema.graphql`<br/>**User property is**: `graphql.schemaFile`. |
 
 **Parameter Details**
 
@@ -400,7 +402,6 @@ This generated schema is subsequently used to generate GraphQL client code based
             <configuration>
                 <endpoint>http://localhost:8080/graphql</endpoint>
                 <packageName>com.example.generated</packageName>
-                <schemaFile>${project.build.directory}/schema.graphql</schemaFile>
             </configuration>
         </execution>
     </executions>
@@ -430,8 +431,8 @@ the GraphQL client code based on the provided query.
             <configuration>
                 <endpoint>http://localhost:8080/sdl</endpoint>
                 <packageName>com.example.generated</packageName>
-                <schemaFile>${project.build.directory}/schema.graphql</schemaFile>
                 <!-- optional configuration below -->
+                <schemaFile>${project.build.directory}/mySchema.graphql</schemaFile>
                 <allowDeprecatedFields>true</allowDeprecatedFields>
                 <converters>
                     <!-- custom scalar UUID type -->

--- a/plugins/graphql-kotlin-gradle-plugin/README.md
+++ b/plugins/graphql-kotlin-gradle-plugin/README.md
@@ -75,7 +75,8 @@ and could be used as an alternative to `graphqlIntrospectSchema` to generate inp
 | -------- | ---- | -------- | ----------- |
 | `endpoint` | String | yes | Target GraphQL server SDL endpoint that will be used to download schema.<br/>**Command line property is**: `endpoint`. |
 | `headers` | Map<String, Any> | | Optional HTTP headers to be specified on a SDL request. |
-| `timeoutConfig` | TimeoutConfig | | Optional timeout configuration(in milliseconds) to download schema from SDL endpoint before we cancel the request.<br/>**Default value are:** connect timeout = 5_000, read timeout = 15_000.<br/>|
+| `outputFile` | File | | Target GraphQL schema file to be generated.<br/>**Default value is:** `${project.buildDir}/schema.graphql` |
+| `timeoutConfig` | TimeoutConfig | | Optional timeout configuration(in milliseconds) to download schema from SDL endpoint before we cancel the request.<br/>**Default value are:**<br/>connect timeout = 5_000<br/>read timeout = 15_000.<br/>|
 
 ### graphqlGenerateClient
 
@@ -131,7 +132,8 @@ should be used to generate input for the subsequent `graphqlGenerateClient` task
 | -------- | ---- | -------- | ----------- |
 | `endpoint` | String | yes | Target GraphQL server endpoint that will be used to execute introspection queries.<br/>**Command line property is**: `endpoint`. |
 | `headers` | Map<String, Any> | | Optional HTTP headers to be specified on an introspection query. |
-| `timeoutConfig` | TimeoutConfig | | Optional timeout configuration(in milliseconds) to execute introspection query before we cancel the request.<br/>**Default value are:** connect timeout = 5_000, read timeout = 15_000.<br/>|
+| `outputFile` | File | | Target GraphQL schema file to be generated.<br/>**Default value is:** `${project.buildDir}/schema.graphql` |
+| `timeoutConfig` | TimeoutConfig | | Optional timeout configuration(in milliseconds) to execute introspection query before we cancel the request.<br/>**Default value are:**<br/>connect timeout = 5_000</br>>read timeout = 15_000.<br/>|
 
 ## Documentation
 

--- a/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/GraphQLDownloadSDLTask.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/GraphQLDownloadSDLTask.kt
@@ -20,10 +20,9 @@ import com.expediagroup.graphql.plugin.config.TimeoutConfig
 import com.expediagroup.graphql.plugin.downloadSchema
 import kotlinx.coroutines.runBlocking
 import org.gradle.api.DefaultTask
-import org.gradle.api.file.RegularFile
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
-import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
@@ -57,8 +56,11 @@ open class GraphQLDownloadSDLTask : DefaultTask() {
     @Input
     val timeoutConfig: Property<TimeoutConfig> = project.objects.property(TimeoutConfig::class.java)
 
+    /**
+     * Target GraphQL schema file to be generated.
+     */
     @OutputFile
-    val outputFile: Provider<RegularFile> = project.layout.buildDirectory.file("schema.graphql")
+    val outputFile: RegularFileProperty = project.objects.fileProperty()
 
     init {
         group = "GraphQL"
@@ -66,6 +68,7 @@ open class GraphQLDownloadSDLTask : DefaultTask() {
 
         headers.convention(emptyMap())
         timeoutConfig.convention(TimeoutConfig())
+        outputFile.convention(project.layout.buildDirectory.file("schema.graphql"))
     }
 
     /**
@@ -77,7 +80,7 @@ open class GraphQLDownloadSDLTask : DefaultTask() {
         logger.debug("starting download SDL task against ${endpoint.get()}")
         runBlocking {
             val schema = downloadSchema(endpoint = endpoint.get(), httpHeaders = headers.get(), timeoutConfig = timeoutConfig.get())
-            val outputFile = outputFile.get().asFile
+            val outputFile = outputFile.asFile.get()
             outputFile.writeText(schema)
         }
         logger.debug("successfully downloaded SDL")

--- a/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/GraphQLIntrospectSchemaTask.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/GraphQLIntrospectSchemaTask.kt
@@ -20,10 +20,9 @@ import com.expediagroup.graphql.plugin.config.TimeoutConfig
 import com.expediagroup.graphql.plugin.introspectSchema
 import kotlinx.coroutines.runBlocking
 import org.gradle.api.DefaultTask
-import org.gradle.api.file.RegularFile
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
-import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
@@ -57,8 +56,11 @@ open class GraphQLIntrospectSchemaTask : DefaultTask() {
     @Input
     val timeoutConfig: Property<TimeoutConfig> = project.objects.property(TimeoutConfig::class.java)
 
+    /**
+     * Target GraphQL schema file to be generated.
+     */
     @OutputFile
-    val outputFile: Provider<RegularFile> = project.layout.buildDirectory.file("schema.graphql")
+    val outputFile: RegularFileProperty = project.objects.fileProperty()
 
     init {
         group = "GraphQL"
@@ -66,6 +68,7 @@ open class GraphQLIntrospectSchemaTask : DefaultTask() {
 
         headers.convention(emptyMap())
         timeoutConfig.convention(TimeoutConfig())
+        outputFile.convention(project.layout.buildDirectory.file("schema.graphql"))
     }
 
     /**
@@ -77,7 +80,8 @@ open class GraphQLIntrospectSchemaTask : DefaultTask() {
         logger.debug("starting introspection task against ${endpoint.get()}")
         runBlocking {
             val schema = introspectSchema(endpoint = endpoint.get(), httpHeaders = headers.get(), timeoutConfig = timeoutConfig.get())
-            outputFile.get().asFile.writeText(schema)
+            val outputFile = outputFile.asFile.get()
+            outputFile.writeText(schema)
         }
         logger.debug("successfully created GraphQL schema from introspection result")
     }

--- a/plugins/graphql-kotlin-maven-plugin/README.md
+++ b/plugins/graphql-kotlin-maven-plugin/README.md
@@ -23,8 +23,8 @@ Plugin should be configured as part of your `pom.xml` build file.
             <configuration>
                 <endpoint>http://localhost:8080/graphql</endpoint>
                 <packageName>com.example.generated</packageName>
-                <schemaFile>${project.build.directory}/schema.graphql</schemaFile>
                 <!-- optional configuration below -->
+                <schemaFile>${project.build.directory}/schema.graphql</schemaFile>
                 <allowDeprecatedFields>true</allowDeprecatedFields>
                 <clientType>DEFAULT</clientType>
                 <converters>
@@ -59,8 +59,9 @@ Plugin should be configured as part of your `pom.xml` build file.
 ### download-sdl
 
 This Mojo attempts to download schema from the specified `graphql.endpoint`, validates the result whether it is a valid
-schema and saves it locally as `schema.graphql` under build directory. In general, this goal provides limited functionality
-by itself and instead should be used to generate input for the subsequent `generate-client` goal.
+schema and saves it locally to a specified target schema file (defaults to `schema.graphql` under build directory). In
+general, this goal provides limited functionality by itself and instead should be used to generate input for the subsequent
+`generate-client` goal.
 
 **Attributes**
 
@@ -72,7 +73,8 @@ by itself and instead should be used to generate input for the subsequent `gener
 | -------- | ---- | -------- | ----------- |
 | `endpoint` | String | yes | Target GraphQL server SDL endpoint that will be used to download schema.<br/>**User property is**: `graphql.endpoint`. |
 | `headers` | Map<String, Any> | | Optional HTTP headers to be specified on a SDL request.
-| `timeoutConfiguration` | TimeoutConfiguration | | Optional timeout configuration (in milliseconds) to download schema from SDL endpoint before we cancel the request.<br/>**Default values are:** connect timeout = 5000, read timeout = 15000.<br/> |
+| `timeoutConfiguration` | TimeoutConfiguration | | Optional timeout configuration (in milliseconds) to download schema from SDL endpoint before we cancel the request.<br/>**Default values are:**<br/>connect timeout = 5000<br/>read timeout = 15000.<br/> |
+| `schemaFile` | File | | Target schema file.<br/>**Default value is**: `${project.build.directory}/schema.graphql`<br/>**User property is**: `graphql.schemaFile`. |
 
 **Parameter Details**
 
@@ -107,7 +109,7 @@ Generate GraphQL client code based on the provided GraphQL schema and target que
 | `packageName` | String | yes | Target package name for generated code.<br/>**User property is**: `graphql.packageName`. |
 | `queryFileDirectory` | File | | Directory file containing GraphQL queries. Instead of specifying a directory you can also specify list of query file by using `queryFiles` property instead.<br/>**Default value is:** `src/main/resources`. |
 | `queryFiles` | List<File> | | List of query files to be processed. Instead of a list of files to be processed you can also specify `queryFileDirectory` directory containing all the files. If this property is specified it will take precedence over the corresponding directory property. |
-| `schemaFile` | String | yes | GraphQL schema file that will be used to generate client code.<br/>**User property is**: `graphql.schemaFile`. |
+| `schemaFile` | String | | GraphQL schema file that will be used to generate client code.<br/>**Default value is**: `${project.build.directory}/schema.graphql`<br/>**User property is**: `graphql.schemaFile`. |
 
 **Parameter Details**
 
@@ -147,7 +149,7 @@ Generate GraphQL test client code based on the provided GraphQL schema and targe
 | `packageName` | String | yes | Target package name for generated code.<br/>**User property is**: `graphql.packageName`. |
 | `queryFileDirectory` | File | | Directory file containing GraphQL queries. Instead of specifying a directory you can also specify list of query file by using `queryFiles` property instead.<br/>**Default value is:** `src/test/resources`. |
 | `queryFiles` | List<File> | | List of query files to be processed. Instead of a list of files to be processed you can also specify `queryFileDirectory` directory containing all the files. If this property is specified it will take precedence over the corresponding directory property. |
-| `schemaFile` | String | yes | GraphQL schema file that will be used to generate client code.<br/>**User property is**: `graphql.schemaFile`. |
+| `schemaFile` | String | | GraphQL schema file that will be used to generate client code.<br/>**Default value is**: `${project.build.directory}/schema.graphql`<br/>**User property is**: `graphql.schemaFile`. |
 
 **Parameter Details**
 
@@ -168,9 +170,9 @@ Generate GraphQL test client code based on the provided GraphQL schema and targe
 
 ### introspect-schema
 
-Executes GraphQL introspection query against specified `graphql.endpoint` and saves the underlying schema file as
-`schema.graphql` under build directory. In general, this goal provides limited functionality by itself and instead
-should be used to generate input for the subsequent `generate-client` goal.
+Executes GraphQL introspection query against specified `graphql.endpoint` and saves the result to a specified target schema
+file (defaults to `schema.graphql` under build directory). In general, this goal provides limited functionality by itself
+and instead should be used to generate input for the subsequent `generate-client` goal.
 
 **Attributes**
 
@@ -182,7 +184,8 @@ should be used to generate input for the subsequent `generate-client` goal.
 | -------- | ---- | -------- | ----------- |
 | `endpoint` | String | yes | Target GraphQL server endpoint that will be used to execute introspection queries.<br/>**User property is**: `graphql.endpoint`. |
 | `headers` | Map<String, Any> | | Optional HTTP headers to be specified on an introspection query. |
-| `timeoutConfiguration` | TimeoutConfiguration | | Optional timeout configuration(in milliseconds) to execute introspection query before we cancel the request.<br/>**Default values are:** connect timeout = 5000, read timeout = 15000.<br/> |
+| `timeoutConfiguration` | TimeoutConfiguration | | Optional timeout configuration(in milliseconds) to execute introspection query before we cancel the request.<br/>**Default values are:**<br/>connect timeout = 5000<br/>read timeout = 15000.<br/> |
+| `schemaFile` | File | | Target schema file.<br/>**Default value is**: `${project.build.directory}/schema.graphql`<br/>**User property is**: `graphql.schemaFile`. |
 
 **Parameter Details**
 

--- a/plugins/graphql-kotlin-maven-plugin/src/integration/basic-setup/pom.xml
+++ b/plugins/graphql-kotlin-maven-plugin/src/integration/basic-setup/pom.xml
@@ -89,7 +89,6 @@
                         <configuration>
                             <endpoint>@graphql.endpoint@/graphql</endpoint>
                             <packageName>com.expediagroup.graphql.plugin.generated</packageName>
-                            <schemaFile>${project.build.directory}/schema.graphql</schemaFile>
                         </configuration>
                     </execution>
                 </executions>

--- a/plugins/graphql-kotlin-maven-plugin/src/integration/complete-setup/pom.xml
+++ b/plugins/graphql-kotlin-maven-plugin/src/integration/complete-setup/pom.xml
@@ -89,7 +89,7 @@
                         <configuration>
                             <endpoint>@graphql.endpoint@/sdlWithHeaders</endpoint>
                             <packageName>com.expediagroup.graphql.plugin.generated</packageName>
-                            <schemaFile>${project.build.directory}/schema.graphql</schemaFile>
+                            <schemaFile>${project.build.directory}/mySchema.graphql</schemaFile>
                             <!-- optional configuration below -->
                             <allowDeprecatedFields>true</allowDeprecatedFields>
                             <headers>

--- a/plugins/graphql-kotlin-maven-plugin/src/integration/complete-setup/src/test/kotlin/com/expediagroup/graphql/plugin/maven/GraphQLMavenPluginTest.kt
+++ b/plugins/graphql-kotlin-maven-plugin/src/integration/complete-setup/src/test/kotlin/com/expediagroup/graphql/plugin/maven/GraphQLMavenPluginTest.kt
@@ -33,7 +33,7 @@ class GraphQLMavenPluginTest {
     @Test
     fun `verify introspection query run and schema file was downloaded`() {
         val buildDirectory = System.getProperty("buildDirectory")
-        val schemaFile = File(buildDirectory, "schema.graphql")
+        val schemaFile = File(buildDirectory, "mySchema.graphql")
         assertTrue(schemaFile.exists(), "schema file was downloaded")
     }
 


### PR DESCRIPTION
### :pencil: Description

Simplifying Maven plugin configuration by allowing customizing the downloaded/introspected schema file name. Current logic did not allow renaming the default file (from `target/schema.graphql`) and required explicitly specifying the schema file for the client generation mojo. This was confusing as when `download-sdl`/`introspect-schema` mojo was used together with `generate-client` one we had to specify target schema always pointing to the default one. Updated logic so that specifying custom schema file name will now apply to all tasks. `generate-client` mojo was also updated to use default `target/schema.graphql` file if schema file is not specified.

In order to keep it consistent, Gradle `downloadSDL` and `introspectSchema` tasks were updated to allow specifying custom `outputFile`s from `build.gradle`.

### :link: Related Issues
