### PR TITLE
[build] deprioritize jcenter in favor of maven central

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,15 +23,15 @@ allprojects {
     buildscript {
         repositories {
             mavenLocal()
-            jcenter()
             mavenCentral()
+            jcenter()
         }
     }
 
     repositories {
         mavenLocal()
-        jcenter()
         mavenCentral()
+        jcenter()
     }
 
     apply(plugin = "de.marcphilipp.nexus-publish")


### PR DESCRIPTION
See:
* https://github.com/gradle/gradle/issues/15406
* https://blog.autsoft.hu/a-confusing-dependency/