### PR TITLE
[3.x.x] Add federation context and tracing support

### DIFF
--- a/docs/federated/federation-tracing.md
+++ b/docs/federated/federation-tracing.md
@@ -1,0 +1,15 @@
+---
+id: federation-tracing
+title: Federation Tracing
+---
+
+Support for Apollo Federation tracing is added to both the `graphql-kotlin-federation` and `graphql-kotlin-spring-server` packages by using the [apollographql/federation-jvm](https://github.com/apollographql/federation-jvm) library.
+
+### `FederationGraphQLContext`
+
+To best support tracing the context must implement a specific method to get the HTTP headers from the context. This is done by implementing the `FederationGraphQLContext` interface instead of just the `GraphQLContext` interface from `graphql-kotlin`.
+
+### `FederationGraphQLContextFactory`
+
+To make sure we return the correct `GraphQLContext` implementation, add the `FederationGraphQLContextFactory` class as a bean instead of the regular `GraphQLContextFactory`.
+This will then return a `FederationGraphQLContext` when we execute the different operations and will allow us to adding tracing information to the response.

--- a/docs/spring-server/spring-graphql-context.md
+++ b/docs/spring-server/spring-graphql-context.md
@@ -33,3 +33,5 @@ Once your application is configured to build your custom `MyGraphQLContext`, we 
 While executing the query, the corresponding GraphQL context will be read from the environment and automatically injected to the function input arguments.
 
 For more details see the [Contextual Data documentation](../schema-generator/execution/contextual-data).
+
+If you need [federation tracing support](../federated/federation-tracing.md) you must implement the separate `FederationGraphQLContext` and `FederationGraphQLContextFactory` interfaces.

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,6 +26,7 @@ ktorVersion = 1.3.1
 reactorVersion = 3.3.6.RELEASE
 reactorExtensionsVersion = 1.0.2.RELEASE
 springBootVersion = 2.2.6.RELEASE
+federationGraphQLJavaSupport = 0.5.0
 
 # test dependency versions
 junitVersion = 5.6.2

--- a/graphql-kotlin-federation/build.gradle.kts
+++ b/graphql-kotlin-federation/build.gradle.kts
@@ -1,9 +1,11 @@
 description = "Federated GraphQL schema generator"
 
 val junitVersion: String by project
+val federationGraphQLJavaSupport: String by project
 
 dependencies {
     api(project(path = ":graphql-kotlin-schema-generator"))
+    implementation("com.apollographql.federation:federation-graphql-java-support:$federationGraphQLJavaSupport")
     testImplementation("org.junit.jupiter:junit-jupiter-params:$junitVersion")
 }
 

--- a/graphql-kotlin-federation/build.gradle.kts
+++ b/graphql-kotlin-federation/build.gradle.kts
@@ -5,7 +5,7 @@ val federationGraphQLJavaSupport: String by project
 
 dependencies {
     api(project(path = ":graphql-kotlin-schema-generator"))
-    implementation("com.apollographql.federation:federation-graphql-java-support:$federationGraphQLJavaSupport")
+    api("com.apollographql.federation:federation-graphql-java-support:$federationGraphQLJavaSupport")
     testImplementation("org.junit.jupiter:junit-jupiter-params:$junitVersion")
 }
 

--- a/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/execution/FederationGraphQLContext.kt
+++ b/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/federation/execution/FederationGraphQLContext.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.federation.execution
+
+import com.apollographql.federation.graphqljava.tracing.HTTPRequestHeaders
+import com.expediagroup.graphql.execution.GraphQLContext
+
+/**
+ * Apollo federation needs access to the HTTP headers to inspect if the
+ * request came from the Apollo Gateway. That means we need a special interface
+ * for the federation context.
+ */
+interface FederationGraphQLContext : GraphQLContext, HTTPRequestHeaders
+
+/**
+ * Can be used as a default [FederationGraphQLContext] if there is none provided.
+ */
+class EmptyFederationGraphQLContext : FederationGraphQLContext {
+    override fun getHTTPRequestHeader(caseInsensitiveHeaderName: String): String? {
+        return null
+    }
+}

--- a/graphql-kotlin-spring-server/build.gradle.kts
+++ b/graphql-kotlin-spring-server/build.gradle.kts
@@ -18,7 +18,7 @@ dependencies {
     api("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:$kotlinCoroutinesVersion")
     api("io.projectreactor.kotlin:reactor-kotlin-extensions:$reactorExtensionsVersion")
     api("org.jetbrains.kotlinx:kotlinx-coroutines-reactor:$kotlinCoroutinesVersion")
-    implementation("com.apollographql.federation:federation-graphql-java-support:$federationGraphQLJavaSupport")
+    api("com.apollographql.federation:federation-graphql-java-support:$federationGraphQLJavaSupport")
     kapt("org.springframework.boot:spring-boot-configuration-processor:$springBootVersion")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:$kotlinCoroutinesVersion")
     testImplementation("org.springframework.boot:spring-boot-starter-test:$springBootVersion")

--- a/graphql-kotlin-spring-server/build.gradle.kts
+++ b/graphql-kotlin-spring-server/build.gradle.kts
@@ -9,6 +9,7 @@ val kotlinCoroutinesVersion: String by project
 val springBootVersion: String by project
 val reactorVersion: String by project
 val reactorExtensionsVersion: String by project
+val federationGraphQLJavaSupport: String by project
 
 dependencies {
     api(project(path = ":graphql-kotlin-types"))
@@ -17,6 +18,7 @@ dependencies {
     api("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:$kotlinCoroutinesVersion")
     api("io.projectreactor.kotlin:reactor-kotlin-extensions:$reactorExtensionsVersion")
     api("org.jetbrains.kotlinx:kotlinx-coroutines-reactor:$kotlinCoroutinesVersion")
+    implementation("com.apollographql.federation:federation-graphql-java-support:$federationGraphQLJavaSupport")
     kapt("org.springframework.boot:spring-boot-configuration-processor:$springBootVersion")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:$kotlinCoroutinesVersion")
     testImplementation("org.springframework.boot:spring-boot-starter-test:$springBootVersion")

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/FederatedSchemaAutoConfiguration.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/FederatedSchemaAutoConfiguration.kt
@@ -16,6 +16,7 @@
 
 package com.expediagroup.graphql.spring
 
+import com.apollographql.federation.graphqljava.tracing.FederatedTracingInstrumentation
 import com.expediagroup.graphql.TopLevelNames
 import com.expediagroup.graphql.execution.KotlinDataFetcherFactoryProvider
 import com.expediagroup.graphql.extensions.print
@@ -23,17 +24,19 @@ import com.expediagroup.graphql.federation.FederatedSchemaGeneratorConfig
 import com.expediagroup.graphql.federation.FederatedSchemaGeneratorHooks
 import com.expediagroup.graphql.federation.execution.FederatedTypeRegistry
 import com.expediagroup.graphql.federation.toFederatedSchema
+import com.expediagroup.graphql.spring.execution.EmptyFederationContextFactory
+import com.expediagroup.graphql.spring.execution.FederationGraphQLContextFactory
 import com.expediagroup.graphql.spring.extensions.toTopLevelObjects
 import com.expediagroup.graphql.spring.operations.Mutation
 import com.expediagroup.graphql.spring.operations.Query
 import com.expediagroup.graphql.spring.operations.Subscription
 import graphql.schema.GraphQLSchema
+import java.util.Optional
 import org.slf4j.LoggerFactory
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import java.util.Optional
 
 /**
  * SpringBoot autoconfiguration for generating Federated GraphQL schema.
@@ -86,4 +89,21 @@ class FederatedSchemaAutoConfiguration {
 
         return schema
     }
+
+    /**
+     * Instrumentation is automatically added to the schema if it is registered as a spring component.
+     * This registers the federaiton tracing intrumentation for federated services.
+     */
+    @Bean
+    fun federationTracing(): FederatedTracingInstrumentation {
+        return FederatedTracingInstrumentation()
+    }
+
+    /**
+     * Federation requires we use a different context for the tracing so we must use the
+     * specific interface factory.
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    fun graphQLContextFactory(): FederationGraphQLContextFactory<*> = EmptyFederationContextFactory
 }

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/FederatedSchemaAutoConfiguration.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/FederatedSchemaAutoConfiguration.kt
@@ -92,7 +92,7 @@ class FederatedSchemaAutoConfiguration {
 
     /**
      * Instrumentation is automatically added to the schema if it is registered as a spring component.
-     * This registers the federaiton tracing intrumentation for federated services.
+     * This registers the federation tracing instrumentation for federated services.
      */
     @Bean
     fun federationTracing(): FederatedTracingInstrumentation {

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/GraphQLAutoConfiguration.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/GraphQLAutoConfiguration.kt
@@ -21,7 +21,6 @@ import com.expediagroup.graphql.execution.SimpleKotlinDataFetcherFactoryProvider
 import com.expediagroup.graphql.spring.exception.KotlinDataFetcherExceptionHandler
 import com.expediagroup.graphql.spring.execution.ContextWebFilter
 import com.expediagroup.graphql.spring.execution.DataLoaderRegistryFactory
-import com.expediagroup.graphql.spring.execution.EmptyContextFactory
 import com.expediagroup.graphql.spring.execution.EmptyDataLoaderRegistryFactory
 import com.expediagroup.graphql.spring.execution.GraphQLContextFactory
 import com.expediagroup.graphql.spring.execution.QueryHandler

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/GraphQLAutoConfiguration.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/GraphQLAutoConfiguration.kt
@@ -115,6 +115,7 @@ class GraphQLAutoConfiguration {
         preparsedDocumentProvider.ifPresent {
             graphQL.preparsedDocumentProvider(it)
         }
+
         return graphQL.build()
     }
 
@@ -128,10 +129,6 @@ class GraphQLAutoConfiguration {
         graphql: GraphQL,
         dataLoaderRegistryFactory: DataLoaderRegistryFactory
     ): QueryHandler = SimpleQueryHandler(graphql, dataLoaderRegistryFactory)
-
-    @Bean
-    @ConditionalOnMissingBean
-    fun graphQLContextFactory(): GraphQLContextFactory<*> = EmptyContextFactory
 
     @Bean
     @ConditionalOnMissingBean

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/SchemaAutoConfiguration.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/SchemaAutoConfiguration.kt
@@ -22,18 +22,20 @@ import com.expediagroup.graphql.execution.KotlinDataFetcherFactoryProvider
 import com.expediagroup.graphql.extensions.print
 import com.expediagroup.graphql.hooks.NoopSchemaGeneratorHooks
 import com.expediagroup.graphql.hooks.SchemaGeneratorHooks
+import com.expediagroup.graphql.spring.execution.EmptyContextFactory
+import com.expediagroup.graphql.spring.execution.GraphQLContextFactory
 import com.expediagroup.graphql.spring.extensions.toTopLevelObjects
 import com.expediagroup.graphql.spring.operations.Mutation
 import com.expediagroup.graphql.spring.operations.Query
 import com.expediagroup.graphql.spring.operations.Subscription
 import com.expediagroup.graphql.toSchema
 import graphql.schema.GraphQLSchema
+import java.util.Optional
 import org.slf4j.LoggerFactory
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import java.util.Optional
 
 /**
  * SpringBoot autoconfiguration for generating GraphQL schema.
@@ -81,4 +83,8 @@ class SchemaAutoConfiguration {
 
         return schema
     }
+
+    @Bean
+    @ConditionalOnMissingBean
+    fun graphQLContextFactory(): GraphQLContextFactory<*> = EmptyContextFactory
 }

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/execution/GraphQLContextFactory.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/execution/GraphQLContextFactory.kt
@@ -18,6 +18,8 @@ package com.expediagroup.graphql.spring.execution
 
 import com.expediagroup.graphql.execution.EmptyGraphQLContext
 import com.expediagroup.graphql.execution.GraphQLContext
+import com.expediagroup.graphql.federation.execution.EmptyFederationGraphQLContext
+import com.expediagroup.graphql.federation.execution.FederationGraphQLContext
 import org.springframework.http.server.reactive.ServerHttpRequest
 import org.springframework.http.server.reactive.ServerHttpResponse
 
@@ -38,9 +40,22 @@ interface GraphQLContextFactory<out T : GraphQLContext> {
 }
 
 /**
+ * Factory that generates Federation GraphQL context.
+ */
+interface FederationGraphQLContextFactory<out T : FederationGraphQLContext> : GraphQLContextFactory<T>
+
+/**
  * Default context factory that generates empty GraphQL context.
  */
 internal object EmptyContextFactory : GraphQLContextFactory<EmptyGraphQLContext> {
 
     override suspend fun generateContext(request: ServerHttpRequest, response: ServerHttpResponse) = EmptyGraphQLContext()
+}
+
+/**
+ * Default federation context factory that generates empty GraphQL context.
+ */
+internal object EmptyFederationContextFactory : FederationGraphQLContextFactory<FederationGraphQLContext> {
+
+    override suspend fun generateContext(request: ServerHttpRequest, response: ServerHttpResponse) = EmptyFederationGraphQLContext()
 }

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/execution/QueryHandler.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/execution/QueryHandler.kt
@@ -23,10 +23,10 @@ import com.expediagroup.graphql.spring.extensions.toGraphQLResponse
 import com.expediagroup.graphql.types.GraphQLRequest
 import com.expediagroup.graphql.types.GraphQLResponse
 import graphql.GraphQL
+import kotlin.coroutines.coroutineContext
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.future.await
 import kotlinx.coroutines.reactor.ReactorContext
-import kotlin.coroutines.coroutineContext
 
 /**
  * GraphQL query handler.

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -54,7 +54,8 @@
       "federated/apollo-federation",
       "federated/federated-schemas",
       "federated/federated-directives",
-      "federated/type-resolution"
+      "federated/type-resolution",
+      "federated/federation-tracing"
     ],
     "Spring Server": [
       "spring-server/spring-overview",


### PR DESCRIPTION
### :pencil: Description
For federation we need to send back tracing metrics to get usage reporting. We can use Apollo's library: https://github.com/apollographql/federation-jvm

This adds a new `FederationGraphQLContext` and a `FederationGraphQLContextFactory` that are conditionally added if federation is enabled. Since they implement the base interfaces we already had we don't need to change the code in `ContextWebFilter` or the spring execution to use them differently. It will just be on federation users to implement the `FederationGraphQLContextFactory` now instead of the `GraphQLContextFactory` if they want tracing support.


### :link: Related Issues
Resolves https://github.com/ExpediaGroup/graphql-kotlin/issues/418