### PR TITLE
[server] add support for flow subscriptions

### DIFF
--- a/docs/schema-generator/execution/subscriptions.md
+++ b/docs/schema-generator/execution/subscriptions.md
@@ -26,6 +26,11 @@ toSchema(
 )
 ```
 
+### Flow Support
+
+`graphql-kotlin` provides support for Kotlin `Flow` through `FlowSubscriptionExecutionStrategy` that automatically converts
+`Flow` to a `Publisher`.
+
 ### Subscription Hooks
 
 #### `didGenerateSubscriptionType`

--- a/docs/spring-server/subscriptions.md
+++ b/docs/spring-server/subscriptions.md
@@ -4,7 +4,12 @@ title: Subscriptions
 ---
 
 ## Schema
-To see more details of how to implement subscriptions in your schema, see [executing subscriptions](../execution/subscriptions).
+To see more details of how to implement subscriptions in your schema, see [executing subscriptions](../schema-generator/execution/subscriptions).
+
+## Flow Support
+
+`graphql-kotlin-spring-server` provides automatic support for Kotlin `Flow` through `FlowSubscriptionExecutionStrategy`
+that supports existing `Publisher`s and relies on Kotlin reactive-streams interop to convert `Flow` to a `Publisher`.
 
 ## `graphql-ws` subprotocol
 ### Overview

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/GraphQLSchemaConfiguration.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/GraphQLSchemaConfiguration.kt
@@ -16,6 +16,7 @@
 
 package com.expediagroup.graphql.spring
 
+import com.expediagroup.graphql.execution.FlowSubscriptionExecutionStrategy
 import com.expediagroup.graphql.spring.execution.DataLoaderRegistryFactory
 import com.expediagroup.graphql.spring.execution.QueryHandler
 import com.expediagroup.graphql.spring.execution.SimpleQueryHandler
@@ -24,7 +25,6 @@ import graphql.execution.AsyncExecutionStrategy
 import graphql.execution.AsyncSerialExecutionStrategy
 import graphql.execution.DataFetcherExceptionHandler
 import graphql.execution.ExecutionIdProvider
-import graphql.execution.SubscriptionExecutionStrategy
 import graphql.execution.instrumentation.ChainedInstrumentation
 import graphql.execution.instrumentation.Instrumentation
 import graphql.execution.preparsed.PreparsedDocumentProvider
@@ -69,7 +69,7 @@ class GraphQLSchemaConfiguration {
         val graphQL = GraphQL.newGraphQL(schema)
             .queryExecutionStrategy(AsyncExecutionStrategy(dataFetcherExceptionHandler))
             .mutationExecutionStrategy(AsyncSerialExecutionStrategy(dataFetcherExceptionHandler))
-            .subscriptionExecutionStrategy(SubscriptionExecutionStrategy(dataFetcherExceptionHandler))
+            .subscriptionExecutionStrategy(FlowSubscriptionExecutionStrategy(dataFetcherExceptionHandler))
 
         instrumentations.ifPresent { unordered ->
             if (unordered.size == 1) {


### PR DESCRIPTION
### :pencil: Description

`FlowSubscriptionExecutionStrategy` was available in the schema-generator library but we never integrated it with the spring-server. Since all our subscription handlers are based on the publisher API, I also updated flow subscription strategy to return publisher as well. This is a breaking for the existing flow subscription strategy users but without this change we would need to rewrite all our subscription handling logic to support flow natively (which we should do eventually when/if we move away from `graphql-java` based execution).

Explicit casts are required due to the type erasure and also Java reliance on site-variance vs Kotlin declaration-variance.

### :link: Related Issues

https://github.com/ExpediaGroup/graphql-kotlin/issues/358
https://github.com/ExpediaGroup/graphql-kotlin/discussions/970