### PR TITLE
[plugins] update introspection query

### DIFF
--- a/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/introspectSchema.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/introspectSchema.kt
@@ -32,7 +32,8 @@ import io.ktor.http.contentType
 import io.ktor.util.KtorExperimentalAPI
 import kotlinx.coroutines.TimeoutCancellationException
 
-private const val INTROSPECTION_QUERY = """
+private const val INTROSPECTION_QUERY =
+    """
     query IntrospectionQuery {
       __schema {
         queryType { name }
@@ -120,7 +121,8 @@ private const val INTROSPECTION_QUERY = """
           }
         }
       }
-    }"""
+    }
+    """
 
 /**
  * Runs introspection query against specified GraphQL endpoint and returns underlying schema.

--- a/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/introspectSchema.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/introspectSchema.kt
@@ -17,7 +17,6 @@
 package com.expediagroup.graphql.plugin
 
 import com.expediagroup.graphql.plugin.config.TimeoutConfig
-import graphql.introspection.IntrospectionQuery
 import graphql.introspection.IntrospectionResultToSchema
 import graphql.schema.idl.SchemaPrinter
 import io.ktor.client.HttpClient
@@ -32,6 +31,96 @@ import io.ktor.http.ContentType
 import io.ktor.http.contentType
 import io.ktor.util.KtorExperimentalAPI
 import kotlinx.coroutines.TimeoutCancellationException
+
+private const val INTROSPECTION_QUERY = """
+    query IntrospectionQuery {
+      __schema {
+        queryType { name }
+        mutationType { name }
+        subscriptionType { name }
+        types {
+          ...FullType
+        }
+        directives {
+          name
+          description
+          locations
+          args {
+            ...InputValue
+          }
+        }
+      }
+    }
+    fragment FullType on __Type {
+      kind
+      name
+      description
+      fields(includeDeprecated: true) {
+        name
+        description
+        args {
+          ...InputValue
+        }
+        type {
+          ...TypeRef
+        }
+        isDeprecated
+        deprecationReason
+      }
+      inputFields {
+        ...InputValue
+      }
+      interfaces {
+        ...TypeRef
+      }
+      enumValues(includeDeprecated: true) {
+        name
+        description
+        isDeprecated
+        deprecationReason
+      }
+      possibleTypes {
+        ...TypeRef
+      }
+    }
+    fragment InputValue on __InputValue {
+      name
+      description
+      type { ...TypeRef }
+      defaultValue
+    }
+    fragment TypeRef on __Type {
+      kind
+      name
+      ofType {
+        kind
+        name
+        ofType {
+          kind
+          name
+          ofType {
+            kind
+            name
+            ofType {
+              kind
+              name
+              ofType {
+                kind
+                name
+                ofType {
+                  kind
+                  name
+                  ofType {
+                    kind
+                    name
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }"""
 
 /**
  * Runs introspection query against specified GraphQL endpoint and returns underlying schema.
@@ -54,7 +143,7 @@ suspend fun introspectSchema(endpoint: String, httpHeaders: Map<String, Any> = e
                 header(name, value)
             }
             body = mapOf(
-                "query" to IntrospectionQuery.INTROSPECTION_QUERY,
+                "query" to INTROSPECTION_QUERY,
                 "operationName" to "IntrospectionQuery"
             )
         }


### PR DESCRIPTION
### :pencil: Description

`graphql-java` version 16 updated their introspection query to support repeatable directives. Updated introspection query can only be executed against servers that are running latest version of `graphql-java`. Adding old version of the introspection query as we dont need repeatable directive info for generating the client code

### :link: Related Issues
