### PR TITLE
[build] exclude unnecessary plugin dependencies

### DIFF
--- a/plugins/graphql-kotlin-plugin-core/build.gradle.kts
+++ b/plugins/graphql-kotlin-plugin-core/build.gradle.kts
@@ -7,8 +7,14 @@ val wireMockVersion: String by project
 
 dependencies {
     api(project(path = ":graphql-kotlin-ktor-client"))
-    api(project(path = ":graphql-kotlin-spring-client"))
-    api("com.graphql-java:graphql-java:$graphQLJavaVersion")
+    api(project(path = ":graphql-kotlin-spring-client")) {
+        exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-reactor")
+        exclude(group = "org.springframework")
+        exclude(group = "org.springframework.boot")
+    }
+    api("com.graphql-java:graphql-java:$graphQLJavaVersion") {
+        exclude(group = "com.graphql-java", module = "java-dataloader")
+    }
     api("com.squareup:kotlinpoet:$kotlinPoetVersion")
     implementation("io.ktor:ktor-client-cio:$ktorVersion")
     implementation("io.ktor:ktor-client-json:$ktorVersion")

--- a/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/GraphQLClientGenerator.kt
+++ b/plugins/graphql-kotlin-plugin-core/src/main/kotlin/com/expediagroup/graphql/plugin/generator/GraphQLClientGenerator.kt
@@ -39,7 +39,6 @@ import graphql.language.OperationDefinition
 import graphql.parser.Parser
 import graphql.schema.idl.TypeDefinitionRegistry
 import io.ktor.client.request.HttpRequestBuilder
-import org.springframework.web.reactive.function.client.WebClient
 import java.io.File
 
 private const val LIBRARY_PACKAGE = "com.expediagroup.graphql.client"
@@ -143,7 +142,7 @@ class GraphQLClientGenerator(
                     val webClientRequestCustomizer: ParameterSpec = ParameterSpec.builder(
                         "requestBuilder",
                         LambdaTypeName.get(
-                            WebClient.RequestBodyUriSpec::class.asTypeName(),
+                            ClassName("org.springframework.web.reactive.function.client", "WebClient", "RequestBodyUriSpec"),
                             emptyList(),
                             Unit::class.asTypeName()
                         )


### PR DESCRIPTION
### :pencil: Description

`graphql-kotlin-plugin-core` was transitively pulling in the full dependencies for Spring, Netty and data-loader which are not required for its functionality.

This change eliminates 25 build dependencies:
- before: https://scans.gradle.com/s/bjgr6gnkaf3i6/build-dependencies
- after: https://scans.gradle.com/s/ojywargwsvkpk/build-dependencies

### :link: Related Issues

Resolves: https://github.com/ExpediaGroup/graphql-kotlin/issues/930