### PR TITLE
[generator] additional test for nested optional input values

### DIFF
--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/execution/OptionalInput.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/execution/OptionalInput.kt
@@ -36,12 +36,16 @@ sealed class OptionalInput<out T> {
     /**
      * Represents missing/undefined value.
      */
-    object Undefined : OptionalInput<Nothing>()
+    object Undefined : OptionalInput<Nothing>() {
+        override fun toString() = "UNDEFINED"
+    }
 
     /**
      * Wrapper holding explicitly specified value including NULL.
      */
-    class Defined<out U> @JsonCreator constructor(@JsonValue val value: U?) : OptionalInput<U>()
+    class Defined<out U> @JsonCreator constructor(@JsonValue val value: U?) : OptionalInput<U>() {
+        override fun toString(): String = "Defined(value=$value)"
+    }
 }
 
 /**

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/test/integration/OptionalInputTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/test/integration/OptionalInputTest.kt
@@ -44,7 +44,13 @@ class OptionalInputTest {
             Arguments.of("{ inputWithOptionalScalarValues(input: { required: \"ABC\" optional: 1 }) }", "argument scalar value: 1"),
             Arguments.of("{ inputWithOptionalValues(input: { required: \"ABC\" }) }", "argument with optional object was not specified"),
             Arguments.of("{ inputWithOptionalValues(input: { required: \"ABC\" optional: null }) }", "argument object value: null"),
-            Arguments.of("{ inputWithOptionalValues(input: { required: \"ABC\" optional: { id: 1, name: \"XYZ\" } }) }", "argument object value: SimpleArgument(id=1, name=XYZ)")
+            Arguments.of("{ inputWithOptionalValues(input: { required: \"ABC\" optional: { id: 1, name: \"XYZ\" } }) }", "argument object value: SimpleArgument(id=1, name=XYZ)"),
+            /* ktlint-disable */
+            Arguments.of(
+                "{ inputWithNestedOptionalValues(input: { optional: { nestedOptionalScalar: \"ABC\", nestedOptionalInt: null } } )}",
+                "HasNestedOptionalArguments(optional=Defined(value=DeeplyNestedArguments(nestedOptional=UNDEFINED, nestedOptionalScalar=Defined(value=ABC), nestedOptionalInt=Defined(value=null))), optionalScalar=UNDEFINED)"
+            )
+            /* ktlint-enable */
         )
     }
 }
@@ -62,6 +68,17 @@ data class HasOptionalScalarArguments(
 data class HasOptionalArguments(
     val required: String,
     val optional: OptionalInput<SimpleArgument>
+)
+
+data class HasNestedOptionalArguments(
+    val optional: OptionalInput<DeeplyNestedArguments> = OptionalInput.Undefined,
+    val optionalScalar: OptionalInput<Int> = OptionalInput.Undefined
+)
+
+data class DeeplyNestedArguments(
+    val nestedOptional: OptionalInput<SimpleArgument> = OptionalInput.Undefined,
+    val nestedOptionalScalar: OptionalInput<String> = OptionalInput.Undefined,
+    val nestedOptionalInt: OptionalInput<Int> = OptionalInput.Undefined
 )
 
 class OptionalInputQuery {
@@ -84,4 +101,6 @@ class OptionalInputQuery {
         is OptionalInput.Undefined -> "argument with optional object was not specified"
         is OptionalInput.Defined<SimpleArgument> -> "argument object value: ${input.optional.value}"
     }
+
+    fun inputWithNestedOptionalValues(input: HasNestedOptionalArguments): String = input.toString()
 }


### PR DESCRIPTION
### :pencil: Description

Additional unit test that verifies deserialization of nested optional input arguments. Added a convenient `toString` on the `OptionalInput.Undefined` and `OptionalInput.Defined`.

### :link: Related Issues

See https://github.com/ExpediaGroup/graphql-kotlin/issues/954 for details