### PR TITLE
Support default Kotlin values

### DIFF
--- a/docs/schema-generator/execution/optional-undefined-arguments.md
+++ b/docs/schema-generator/execution/optional-undefined-arguments.md
@@ -7,7 +7,7 @@ In the GraphQL world, input types can be optional which means that the client ca
 
 * Not specify a value at all
 * Send null explicitly
-* Send the non-null type
+* Send a non-null value
 
 This is in contrast with the JVM world where objects can either have some specific value or don't have any value (i.e.
 are `null`). As a result, when using default serialization logic it is not possible to distinguish between missing/unspecified
@@ -15,9 +15,9 @@ value and explicit `null` value.
 
 ## Using OptionalInput wrapper
 
-`OptionalInput` sealed class is a convenient wrapper that provides easy distinction between unspecified, `null` and non-null
-value. If target argument is not specified in the request it will be represented as `Undefined` object, otherwise actual
-value will be wrapped in `Defined` class.
+`OptionalInput` is a convenient sealed class wrapper that provides distinction between undefined, null, and non-null
+values. If the argument is not specified in the request it will be represented as a `OptionalInput.Undefined` object, otherwise the
+value will be wrapped in `OptionalInput.Defined` class.
 
 ```kotlin
 fun optionalInput(input: OptionalInput<String>): String = when (input) {
@@ -28,14 +28,14 @@ fun optionalInput(input: OptionalInput<String>): String = when (input) {
 
 ```graphql
 query OptionalInputQuery {
-  undefined: optionalInput
-  null: optionalInput(value: null)
-  foo: optionalInput(value: "foo")
+  undefined: optionalInput # input was not specified
+  null: optionalInput(value: null) # input value: null
+  foo: optionalInput(value: "foo") # input value: foo
 }
 ```
 
-> NOTE: Regardless whether generic type of `OptionalInput` is specified as nullable or not it will always result in nullable
-> value in `Defined` class.
+> NOTE: Regardless whether the generic type of `OptionalInput` is specified as nullable or not it will always result in nullable
+> value in `Defined` class, i.e. `OptionalInput<String>` will appear as nullable `String` in the GraphQL schema and in the wrapped value
 
 ## Using DataFetchingEnvironment
 
@@ -47,9 +47,9 @@ fun optionalInput(value: String?): String? = value
 
 ```graphql
 query OptionalInputQuery {
-  undefined: optionalInput
-  null: optionalInput(value: null)
-  foo: optionalInput(value: "foo")
+  undefined: optionalInput # null
+  null: optionalInput(value: null) # null
+  foo: optionalInput(value: "foo") # foo
 }
 ```
 
@@ -67,3 +67,7 @@ fun optionalInput(value: String?, dataFetchingEnvironment: DataFetchingEnvironme
         "The value was undefined"
     }
 ```
+
+## Kotlin Default Values
+
+If you don't need logic for when the client specified a value, you can still use [Kotlin default values](../writing-schemas/arguments.md)

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/execution/FunctionDataFetcherTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/execution/FunctionDataFetcherTest.kt
@@ -31,12 +31,18 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
-internal class FunctionDataFetcherTest {
+class FunctionDataFetcherTest {
 
-    internal class MyContext(val value: String) : GraphQLContext
+    class MyContext(val value: String) : GraphQLContext
 
-    internal class MyClass {
-        fun print(string: String) = string
+    interface MyInterface {
+        fun print(string: String): String
+    }
+
+    class MyClass : MyInterface {
+        override fun print(string: String) = string
+
+        fun printDefault(string: String? = "hello") = string
 
         fun printArray(items: Array<String>) = items.joinToString(separator = ":")
 
@@ -58,10 +64,15 @@ internal class FunctionDataFetcherTest {
 
         @GraphQLName("myCustomField")
         fun renamedFields(@GraphQLName("myCustomArgument") arg: MyInputClass) = "You sent ${arg.field1}"
+
+        fun optionalWrapper(input: OptionalInput<String>): String = when (input) {
+            is OptionalInput.Undefined -> "input was UNDEFINED"
+            is OptionalInput.Defined -> "input was ${input.value}"
+        }
     }
 
     @GraphQLName("MyInputClassRenamed")
-    internal data class MyInputClass(
+    data class MyInputClass(
         @JsonProperty("jacksonField")
         @GraphQLName("jacksonField")
         val field1: String
@@ -70,49 +81,105 @@ internal class FunctionDataFetcherTest {
     @Test
     fun `null target and null source returns null`() {
         val dataFetcher = FunctionDataFetcher(target = null, fn = MyClass::print)
-        val mockEnvironmet: DataFetchingEnvironment = mockk()
-        every { mockEnvironmet.getSource<Any>() } returns null
+        val mockEnvironmet: DataFetchingEnvironment = mockk {
+            every { getSource<Any>() } returns null
+        }
         assertNull(dataFetcher.get(mockEnvironmet))
     }
 
     @Test
     fun `null target and valid source returns the value`() {
         val dataFetcher = FunctionDataFetcher(target = null, fn = MyClass::print)
-        val mockEnvironmet: DataFetchingEnvironment = mockk()
-        every { mockEnvironmet.getSource<Any>() } returns MyClass()
-        every { mockEnvironmet.arguments } returns mapOf("string" to "hello")
+        val mockEnvironmet: DataFetchingEnvironment = mockk {
+            every { getSource<Any>() } returns MyClass()
+            every { arguments } returns mapOf("string" to "hello")
+            every { containsArgument("string") } returns true
+        }
         assertEquals(expected = "hello", actual = dataFetcher.get(mockEnvironmet))
     }
 
     @Test
     fun `valid target and null source returns the value`() {
         val dataFetcher = FunctionDataFetcher(target = MyClass(), fn = MyClass::print)
-        val mockEnvironmet: DataFetchingEnvironment = mockk()
-        every { mockEnvironmet.arguments } returns mapOf("string" to "hello")
+        val mockEnvironmet: DataFetchingEnvironment = mockk {
+            every { arguments } returns mapOf("string" to "hello")
+            every { containsArgument("string") } returns true
+        }
         assertEquals(expected = "hello", actual = dataFetcher.get(mockEnvironmet))
     }
 
     @Test
     fun `valid target with context class`() {
         val dataFetcher = FunctionDataFetcher(target = MyClass(), fn = MyClass::contextClass)
-        val mockEnvironmet: DataFetchingEnvironment = mockk()
-        every { mockEnvironmet.getContext<MyContext>() } returns MyContext("foo")
+        val mockEnvironmet: DataFetchingEnvironment = mockk {
+            every { getContext<MyContext>() } returns MyContext("foo")
+            every { arguments } returns emptyMap()
+            every { containsArgument(any()) } returns false
+        }
         assertEquals(expected = "foo", actual = dataFetcher.get(mockEnvironmet))
+    }
+
+    @Test
+    fun `target is different than the function instance`() {
+        val dataFetcher = FunctionDataFetcher(target = MyClass(), fn = MyInterface::print)
+        val mockEnvironmet: DataFetchingEnvironment = mockk {
+            every { getSource<Any>() } returns MyClass()
+            every { arguments } returns mapOf("string" to "hello")
+            every { containsArgument("string") } returns true
+        }
+        assertEquals(expected = "hello", actual = dataFetcher.get(mockEnvironmet))
+    }
+
+    @Test
+    fun `default values are used when arument is not present`() {
+        val dataFetcher = FunctionDataFetcher(target = null, fn = MyClass::printDefault)
+        val mockEnvironmet: DataFetchingEnvironment = mockk {
+            every { getSource<Any>() } returns MyClass()
+            every { arguments } returns emptyMap()
+            every { containsArgument(any()) } returns false
+        }
+        assertEquals(expected = "hello", actual = dataFetcher.get(mockEnvironmet))
+    }
+
+    @Test
+    fun `default values are overriden when arument is passed in`() {
+        val dataFetcher = FunctionDataFetcher(target = null, fn = MyClass::printDefault)
+        val mockEnvironmet: DataFetchingEnvironment = mockk {
+            every { getSource<Any>() } returns MyClass()
+            every { arguments } returns mapOf("string" to "foo")
+            every { containsArgument("string") } returns true
+        }
+        assertEquals(expected = "foo", actual = dataFetcher.get(mockEnvironmet))
+    }
+
+    @Test
+    fun `default values are overriden when arument is passed as null`() {
+        val dataFetcher = FunctionDataFetcher(target = null, fn = MyClass::printDefault)
+        val mockEnvironmet: DataFetchingEnvironment = mockk {
+            every { getSource<Any>() } returns MyClass()
+            every { arguments } returns mapOf("string" to null)
+            every { containsArgument("string") } returns true
+        }
+        assertNull(dataFetcher.get(mockEnvironmet))
     }
 
     @Test
     fun `array inputs can be converted by the object mapper`() {
         val dataFetcher = FunctionDataFetcher(target = MyClass(), fn = MyClass::printArray)
-        val mockEnvironmet: DataFetchingEnvironment = mockk()
-        every { mockEnvironmet.arguments } returns mapOf("items" to arrayOf("foo", "bar"))
+        val mockEnvironmet: DataFetchingEnvironment = mockk {
+            every { arguments } returns mapOf("items" to arrayOf("foo", "bar"))
+            every { containsArgument("items") } returns true
+        }
         assertEquals(expected = "foo:bar", actual = dataFetcher.get(mockEnvironmet))
     }
 
     @Test
     fun `list can be converted by the object mapper`() {
         val dataFetcher = FunctionDataFetcher(target = MyClass(), fn = MyClass::printList)
-        val mockEnvironmet: DataFetchingEnvironment = mockk()
-        every { mockEnvironmet.arguments } returns mapOf("items" to listOf("foo", "bar"))
+        val mockEnvironmet: DataFetchingEnvironment = mockk {
+            every { arguments } returns mapOf("items" to listOf("foo", "bar"))
+            every { containsArgument("items") } returns true
+        }
 
         assertEquals(expected = "foo:bar", actual = dataFetcher.get(mockEnvironmet))
     }
@@ -120,9 +187,12 @@ internal class FunctionDataFetcherTest {
     @Test
     fun `dataFetchingEnvironement is passed as an argument`() {
         val dataFetcher = FunctionDataFetcher(target = MyClass(), fn = MyClass::dataFetchingEnvironment)
-        val mockEnvironmet: DataFetchingEnvironment = mockk()
-        every { mockEnvironmet.field } returns mockk {
-            every { name } returns "fooBarBaz"
+        val mockEnvironmet: DataFetchingEnvironment = mockk {
+            every { arguments } returns emptyMap()
+            every { containsArgument(any()) } returns false
+            every { field } returns mockk {
+                every { name } returns "fooBarBaz"
+            }
         }
         assertEquals(expected = "fooBarBaz", actual = dataFetcher.get(mockEnvironmet))
     }
@@ -130,8 +200,10 @@ internal class FunctionDataFetcherTest {
     @Test
     fun `suspend functions return value wrapped in CompletableFuture`() {
         val dataFetcher = FunctionDataFetcher(target = MyClass(), fn = MyClass::suspendPrint)
-        val mockEnvironmet: DataFetchingEnvironment = mockk()
-        every { mockEnvironmet.arguments } returns mapOf("string" to "hello")
+        val mockEnvironmet: DataFetchingEnvironment = mockk {
+            every { arguments } returns mapOf("string" to "hello")
+            every { containsArgument("string") } returns true
+        }
 
         val result = dataFetcher.get(mockEnvironmet)
 
@@ -142,7 +214,10 @@ internal class FunctionDataFetcherTest {
     @Test
     fun `throwException function propagates the original exception`() {
         val dataFetcher = FunctionDataFetcher(target = MyClass(), fn = MyClass::throwException)
-        val mockEnvironmet: DataFetchingEnvironment = mockk()
+        val mockEnvironmet: DataFetchingEnvironment = mockk {
+            every { arguments } returns emptyMap()
+            every { containsArgument(any()) } returns false
+        }
 
         try {
             dataFetcher.get(mockEnvironmet)
@@ -155,7 +230,10 @@ internal class FunctionDataFetcherTest {
     @Test
     fun `suspendThrow throws exception when resolved`() {
         val dataFetcher = FunctionDataFetcher(target = MyClass(), fn = MyClass::suspendThrow)
-        val mockEnvironmet: DataFetchingEnvironment = mockk()
+        val mockEnvironmet: DataFetchingEnvironment = mockk {
+            every { arguments } returns emptyMap()
+            every { containsArgument(any()) } returns false
+        }
 
         try {
             val result = dataFetcher.get(mockEnvironmet)
@@ -172,9 +250,30 @@ internal class FunctionDataFetcherTest {
     @Test
     fun `renamed fields can be converted by the object mapper`() {
         val dataFetcher = FunctionDataFetcher(target = MyClass(), fn = MyClass::renamedFields)
-        val mockEnvironmet: DataFetchingEnvironment = mockk()
-        val arguments = mapOf("myCustomArgument" to mapOf("jacksonField" to "foo"))
-        every { mockEnvironmet.arguments } returns arguments
+        val mockEnvironmet: DataFetchingEnvironment = mockk {
+            every { arguments } returns mapOf("myCustomArgument" to mapOf("jacksonField" to "foo"))
+            every { containsArgument("myCustomArgument") } returns true
+        }
         assertEquals(expected = "You sent foo", actual = dataFetcher.get(mockEnvironmet))
+    }
+
+    @Test
+    fun `optional inputs return the value when arguments are passed`() {
+        val dataFetcher = FunctionDataFetcher(target = MyClass(), fn = MyClass::optionalWrapper)
+        val mockEnvironmet: DataFetchingEnvironment = mockk {
+            every { arguments } returns mapOf("input" to "hello")
+            every { containsArgument("input") } returns true
+        }
+        assertEquals(expected = "input was hello", actual = dataFetcher.get(mockEnvironmet))
+    }
+
+    @Test
+    fun `optional inputs return undefined when arguments are empty`() {
+        val dataFetcher = FunctionDataFetcher(target = MyClass(), fn = MyClass::optionalWrapper)
+        val mockEnvironmet: DataFetchingEnvironment = mockk {
+            every { arguments } returns emptyMap()
+            every { containsArgument(any()) } returns false
+        }
+        assertEquals(expected = "input was UNDEFINED", actual = dataFetcher.get(mockEnvironmet))
     }
 }

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/test/integration/OptionalInputTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/test/integration/OptionalInputTest.kt
@@ -13,10 +13,12 @@ import java.util.stream.Stream
 import kotlin.test.assertEquals
 
 class OptionalInputTest {
+
     private val schema = toSchema(
         queries = listOf(TopLevelObject(OptionalInputQuery())),
         config = testSchemaConfig
     )
+
     private val graphQL = GraphQL.newGraphQL(schema).build()
 
     @DisplayName("verify optional arguments can be correctly deserialized")

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/execution/SpringDataFetcher.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/execution/SpringDataFetcher.kt
@@ -40,14 +40,15 @@ open class SpringDataFetcher(
 ) : FunctionDataFetcher(target, fn, objectMapper) {
 
     @ExperimentalStdlibApi
-    override fun mapParameterToValue(param: KParameter, environment: DataFetchingEnvironment): Any? = if (param.hasAnnotation<Autowired>()) {
-        val qualifier = param.findAnnotation<Qualifier>()?.value
-        if (qualifier != null) {
-            applicationContext.getBean(qualifier)
+    override fun mapParameterToValue(param: KParameter, environment: DataFetchingEnvironment): Pair<KParameter, Any?>? =
+        if (param.hasAnnotation<Autowired>()) {
+            val qualifier = param.findAnnotation<Qualifier>()?.value
+            if (qualifier != null) {
+                param to applicationContext.getBean(qualifier)
+            } else {
+                param to applicationContext.getBean(param.type.javaType as Class<*>)
+            }
         } else {
-            applicationContext.getBean(param.type.javaType as Class<*>)
+            super.mapParameterToValue(param, environment)
         }
-    } else {
-        super.mapParameterToValue(param, environment)
-    }
 }


### PR DESCRIPTION
### :pencil: Description
Add support for Kotlin default values. By calling functions with the `callBy` methods instead we can pass a map of `KParameters`. Then if one of the params is optional and it is not sent a value from GraphQL input we can exclude that parameter from the map, which mean the default value will be used.

Kotlin
```kotlin
fun print(message: String? = "hello"): String? = message
```

GraphQL
```graphql
query PrintMessages {
    first: print(message = "foo") # foo
    second: print(message = null) # null
    third: print # hello
}
```

This info will not be [conveyed in the schema](https://graphql.org/learn/schema/#arguments), but it simplifies the logic needed for optional arguments. If you still need to have logic for the default values I recommend using the `OptionalInput` wrapper, since you will still not be able to determine the difference when the client didn't pass a value or it passed in the same value as the default.

This is a breaking change because we are changing the function signature that is open for `FunctionDataFetcher`

### :link: Related Issues
Fixes https://github.com/ExpediaGroup/graphql-kotlin/issues/53