### PR TITLE
move operation marker interfaces from spring-server to types

### DIFF
--- a/examples/federation/base-app/src/main/kotlin/com/expediagroup/graphql/examples/query/NestedQuery.kt
+++ b/examples/federation/base-app/src/main/kotlin/com/expediagroup/graphql/examples/query/NestedQuery.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Expedia, Inc
+ * Copyright 2020 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package com.expediagroup.graphql.examples.query
 
-import com.expediagroup.graphql.spring.operations.Query
+import com.expediagroup.graphql.server.operations.Query
 import org.springframework.stereotype.Component
 import kotlin.random.Random
 

--- a/examples/federation/base-app/src/main/kotlin/com/expediagroup/graphql/examples/query/SimpleQuery.kt
+++ b/examples/federation/base-app/src/main/kotlin/com/expediagroup/graphql/examples/query/SimpleQuery.kt
@@ -17,7 +17,7 @@
 package com.expediagroup.graphql.examples.query
 
 import com.expediagroup.graphql.annotations.GraphQLDescription
-import com.expediagroup.graphql.spring.operations.Query
+import com.expediagroup.graphql.server.operations.Query
 import org.springframework.stereotype.Component
 
 @Suppress("FunctionOnlyReturningConstant")

--- a/examples/federation/base-app/src/main/kotlin/com/expediagroup/graphql/examples/query/WidgetQuery.kt
+++ b/examples/federation/base-app/src/main/kotlin/com/expediagroup/graphql/examples/query/WidgetQuery.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Expedia, Inc
+ * Copyright 2020 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 package com.expediagroup.graphql.examples.query
 
 import com.expediagroup.graphql.annotations.GraphQLDescription
-import com.expediagroup.graphql.spring.operations.Query
+import com.expediagroup.graphql.server.operations.Query
 import com.expediagroup.graphql.examples.model.Widget
 import org.springframework.stereotype.Component
 

--- a/examples/federation/extend-app/src/main/kotlin/com/expediagroup/graphql/examples/query/SimpleQuery.kt
+++ b/examples/federation/extend-app/src/main/kotlin/com/expediagroup/graphql/examples/query/SimpleQuery.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Expedia, Inc
+ * Copyright 2020 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package com.expediagroup.graphql.examples.query
 
-import com.expediagroup.graphql.spring.operations.Query
+import com.expediagroup.graphql.server.operations.Query
 import org.springframework.stereotype.Component
 
 @Suppress("FunctionOnlyReturningConstant")

--- a/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/mutation/OptionalInputMutation.kt
+++ b/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/mutation/OptionalInputMutation.kt
@@ -16,7 +16,7 @@
 
 package com.expediagroup.graphql.examples.mutation
 
-import com.expediagroup.graphql.spring.operations.Mutation
+import com.expediagroup.graphql.server.operations.Mutation
 import graphql.schema.DataFetchingEnvironment
 import org.springframework.stereotype.Component
 

--- a/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/mutation/SimpleMutation.kt
+++ b/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/mutation/SimpleMutation.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Expedia, Inc
+ * Copyright 2020 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 package com.expediagroup.graphql.examples.mutation
 
 import com.expediagroup.graphql.annotations.GraphQLDescription
-import com.expediagroup.graphql.spring.operations.Mutation
+import com.expediagroup.graphql.server.operations.Mutation
 import org.springframework.stereotype.Component
 
 /**

--- a/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/mutation/WidgetMutation.kt
+++ b/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/mutation/WidgetMutation.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Expedia, Inc
+ * Copyright 2020 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package com.expediagroup.graphql.examples.mutation
 
 import com.expediagroup.graphql.annotations.GraphQLDescription
 import com.expediagroup.graphql.examples.model.Widget
-import com.expediagroup.graphql.spring.operations.Mutation
+import com.expediagroup.graphql.server.operations.Mutation
 import org.springframework.stereotype.Component
 
 /**

--- a/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/query/AsyncQuery.kt
+++ b/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/query/AsyncQuery.kt
@@ -17,7 +17,7 @@
 package com.expediagroup.graphql.examples.query
 
 import com.expediagroup.graphql.annotations.GraphQLDescription
-import com.expediagroup.graphql.spring.operations.Query
+import com.expediagroup.graphql.server.operations.Query
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.time.delay
 import org.springframework.stereotype.Component

--- a/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/query/ContextualQuery.kt
+++ b/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/query/ContextualQuery.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Expedia, Inc
+ * Copyright 2020 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ package com.expediagroup.graphql.examples.query
 import com.expediagroup.graphql.annotations.GraphQLDescription
 import com.expediagroup.graphql.examples.context.MyGraphQLContext
 import com.expediagroup.graphql.examples.model.ContextualResponse
-import com.expediagroup.graphql.spring.operations.Query
+import com.expediagroup.graphql.server.operations.Query
 import org.springframework.stereotype.Component
 
 /**

--- a/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/query/CoroutineQuery.kt
+++ b/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/query/CoroutineQuery.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Expedia, Inc
+ * Copyright 2020 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 package com.expediagroup.graphql.examples.query
 
 import com.expediagroup.graphql.annotations.GraphQLDescription
-import com.expediagroup.graphql.spring.operations.Query
+import com.expediagroup.graphql.server.operations.Query
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay

--- a/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/query/CustomDirectiveQuery.kt
+++ b/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/query/CustomDirectiveQuery.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Expedia, Inc
+ * Copyright 2020 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import com.expediagroup.graphql.annotations.GraphQLDescription
 import com.expediagroup.graphql.examples.directives.LowercaseDirective
 import com.expediagroup.graphql.examples.directives.SpecificValueOnly
 import com.expediagroup.graphql.examples.directives.StringEval
-import com.expediagroup.graphql.spring.operations.Query
+import com.expediagroup.graphql.server.operations.Query
 import org.springframework.stereotype.Component
 
 @Component

--- a/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/query/DataAndErrorsQuery.kt
+++ b/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/query/DataAndErrorsQuery.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Expedia, Inc
+ * Copyright 2020 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@
 
 package com.expediagroup.graphql.examples.query
 
+import com.expediagroup.graphql.server.operations.Query
 import com.expediagroup.graphql.spring.exception.SimpleKotlinGraphQLError
-import com.expediagroup.graphql.spring.operations.Query
 import graphql.execution.DataFetcherResult
 import graphql.execution.ResultPath
 import graphql.language.SourceLocation

--- a/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/query/DataLoaderQuery.kt
+++ b/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/query/DataLoaderQuery.kt
@@ -1,9 +1,25 @@
+/*
+ * Copyright 2020 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.expediagroup.graphql.examples.query
 
 import com.expediagroup.graphql.annotations.GraphQLDescription
 import com.expediagroup.graphql.examples.model.Company
 import com.expediagroup.graphql.examples.model.Employee
-import com.expediagroup.graphql.spring.operations.Query
+import com.expediagroup.graphql.server.operations.Query
 import graphql.schema.DataFetcher
 import graphql.schema.DataFetchingEnvironment
 import org.springframework.beans.factory.BeanFactory

--- a/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/query/EnvironmentQuery.kt
+++ b/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/query/EnvironmentQuery.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Expedia, Inc
+ * Copyright 2020 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package com.expediagroup.graphql.examples.query
 
-import com.expediagroup.graphql.spring.operations.Query
+import com.expediagroup.graphql.server.operations.Query
 import graphql.schema.DataFetchingEnvironment
 import org.springframework.stereotype.Component
 

--- a/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/query/NestedQueries.kt
+++ b/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/query/NestedQueries.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Expedia, Inc
+ * Copyright 2020 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package com.expediagroup.graphql.examples.query
 
 import com.expediagroup.graphql.annotations.GraphQLDescription
 import com.expediagroup.graphql.annotations.GraphQLName
-import com.expediagroup.graphql.spring.operations.Query
+import com.expediagroup.graphql.server.operations.Query
 import com.fasterxml.jackson.annotation.JsonIgnore
 import graphql.schema.DataFetcher
 import graphql.schema.DataFetchingEnvironment

--- a/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/query/PolymorphicQuery.kt
+++ b/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/query/PolymorphicQuery.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Expedia, Inc
+ * Copyright 2020 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import com.expediagroup.graphql.examples.model.Dog
 import com.expediagroup.graphql.examples.model.Fruit
 import com.expediagroup.graphql.examples.model.LeftHand
 import com.expediagroup.graphql.examples.model.RightHand
-import com.expediagroup.graphql.spring.operations.Query
+import com.expediagroup.graphql.server.operations.Query
 import org.springframework.stereotype.Component
 
 /**

--- a/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/query/PrivateInterfaceQuery.kt
+++ b/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/query/PrivateInterfaceQuery.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Expedia, Inc
+ * Copyright 2020 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package com.expediagroup.graphql.examples.query
 
 import com.expediagroup.graphql.annotations.GraphQLDescription
 import com.expediagroup.graphql.examples.model.HidesInheritance
-import com.expediagroup.graphql.spring.operations.Query
+import com.expediagroup.graphql.server.operations.Query
 import org.springframework.stereotype.Component
 
 @Component

--- a/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/query/RecursiveQuery.kt
+++ b/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/query/RecursiveQuery.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Expedia, Inc
+ * Copyright 2020 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package com.expediagroup.graphql.examples.query
 
 import com.expediagroup.graphql.annotations.GraphQLDescription
 import com.expediagroup.graphql.examples.model.Node
-import com.expediagroup.graphql.spring.operations.Query
+import com.expediagroup.graphql.server.operations.Query
 import org.springframework.stereotype.Component
 
 @Component

--- a/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/query/ScalarQuery.kt
+++ b/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/query/ScalarQuery.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Expedia, Inc
+ * Copyright 2020 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,8 @@
 package com.expediagroup.graphql.examples.query
 
 import com.expediagroup.graphql.annotations.GraphQLDescription
-import com.expediagroup.graphql.spring.operations.Mutation
-import com.expediagroup.graphql.spring.operations.Query
+import com.expediagroup.graphql.server.operations.Mutation
+import com.expediagroup.graphql.server.operations.Query
 import com.expediagroup.graphql.scalars.ID
 import org.springframework.stereotype.Component
 import java.math.BigDecimal

--- a/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/query/SimpleQuery.kt
+++ b/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/query/SimpleQuery.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Expedia, Inc
+ * Copyright 2020 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ package com.expediagroup.graphql.examples.query
 import com.expediagroup.graphql.annotations.GraphQLDescription
 import com.expediagroup.graphql.annotations.GraphQLIgnore
 import com.expediagroup.graphql.examples.model.Selection
-import com.expediagroup.graphql.spring.operations.Query
+import com.expediagroup.graphql.server.operations.Query
 import org.springframework.stereotype.Component
 import java.util.Random
 

--- a/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/query/SpringAwareQuery.kt
+++ b/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/query/SpringAwareQuery.kt
@@ -1,9 +1,25 @@
+/*
+ * Copyright 2020 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.expediagroup.graphql.examples.query
 
 import com.expediagroup.graphql.annotations.GraphQLDescription
 import com.expediagroup.graphql.annotations.GraphQLIgnore
 import com.expediagroup.graphql.examples.model.Widget
-import com.expediagroup.graphql.spring.operations.Query
+import com.expediagroup.graphql.server.operations.Query
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 import org.springframework.stereotype.Service

--- a/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/query/StressQuery.kt
+++ b/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/query/StressQuery.kt
@@ -19,7 +19,7 @@
 package com.expediagroup.graphql.examples.query
 
 import com.expediagroup.graphql.examples.directives.TrackTimesInvoked
-import com.expediagroup.graphql.spring.operations.Query
+import com.expediagroup.graphql.server.operations.Query
 import io.netty.util.internal.ThreadLocalRandom
 import org.springframework.stereotype.Component
 import java.util.UUID

--- a/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/query/SubQueries.kt
+++ b/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/query/SubQueries.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Expedia, Inc
+ * Copyright 2020 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package com.expediagroup.graphql.examples.query
 
 import com.expediagroup.graphql.annotations.GraphQLDescription
 import com.expediagroup.graphql.annotations.GraphQLIgnore
-import com.expediagroup.graphql.spring.operations.Query
+import com.expediagroup.graphql.server.operations.Query
 import org.springframework.beans.factory.BeanFactory
 import org.springframework.beans.factory.BeanFactoryAware
 import org.springframework.beans.factory.getBean

--- a/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/query/TopLevelBeanFactoryQuery.kt
+++ b/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/query/TopLevelBeanFactoryQuery.kt
@@ -17,7 +17,7 @@
 package com.expediagroup.graphql.examples.query
 
 import com.expediagroup.graphql.annotations.GraphQLIgnore
-import com.expediagroup.graphql.spring.operations.Query
+import com.expediagroup.graphql.server.operations.Query
 import org.springframework.beans.factory.BeanFactory
 import org.springframework.beans.factory.BeanFactoryAware
 import org.springframework.beans.factory.annotation.Autowired

--- a/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/query/ValidatedQuery.kt
+++ b/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/query/ValidatedQuery.kt
@@ -16,7 +16,7 @@
 
 package com.expediagroup.graphql.examples.query
 
-import com.expediagroup.graphql.spring.operations.Query
+import com.expediagroup.graphql.server.operations.Query
 import org.springframework.stereotype.Component
 import org.springframework.validation.annotation.Validated
 import javax.validation.Valid

--- a/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/subscriptions/SimpleSubscription.kt
+++ b/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/subscriptions/SimpleSubscription.kt
@@ -18,8 +18,8 @@ package com.expediagroup.graphql.examples.subscriptions
 
 import com.expediagroup.graphql.annotations.GraphQLDescription
 import com.expediagroup.graphql.examples.context.MyGraphQLContext
+import com.expediagroup.graphql.server.operations.Subscription
 import com.expediagroup.graphql.spring.exception.SimpleKotlinGraphQLError
-import com.expediagroup.graphql.spring.operations.Subscription
 import graphql.execution.DataFetcherResult
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.reactive.asPublisher

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/FederatedSchemaAutoConfiguration.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/FederatedSchemaAutoConfiguration.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Expedia, Inc
+ * Copyright 2020 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,9 +24,9 @@ import com.expediagroup.graphql.federation.FederatedSchemaGeneratorHooks
 import com.expediagroup.graphql.federation.execution.FederatedTypeResolver
 import com.expediagroup.graphql.federation.toFederatedSchema
 import com.expediagroup.graphql.spring.extensions.toTopLevelObjects
-import com.expediagroup.graphql.spring.operations.Mutation
-import com.expediagroup.graphql.spring.operations.Query
-import com.expediagroup.graphql.spring.operations.Subscription
+import com.expediagroup.graphql.server.operations.Mutation
+import com.expediagroup.graphql.server.operations.Query
+import com.expediagroup.graphql.server.operations.Subscription
 import graphql.schema.GraphQLSchema
 import org.slf4j.LoggerFactory
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/NonFederatedSchemaAutoConfiguration.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/NonFederatedSchemaAutoConfiguration.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Expedia, Inc
+ * Copyright 2020 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,9 +23,9 @@ import com.expediagroup.graphql.extensions.print
 import com.expediagroup.graphql.hooks.NoopSchemaGeneratorHooks
 import com.expediagroup.graphql.hooks.SchemaGeneratorHooks
 import com.expediagroup.graphql.spring.extensions.toTopLevelObjects
-import com.expediagroup.graphql.spring.operations.Mutation
-import com.expediagroup.graphql.spring.operations.Query
-import com.expediagroup.graphql.spring.operations.Subscription
+import com.expediagroup.graphql.server.operations.Mutation
+import com.expediagroup.graphql.server.operations.Query
+import com.expediagroup.graphql.server.operations.Subscription
 import com.expediagroup.graphql.toSchema
 import graphql.schema.GraphQLSchema
 import org.slf4j.LoggerFactory

--- a/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/SubscriptionAutoConfiguration.kt
+++ b/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/spring/SubscriptionAutoConfiguration.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Expedia, Inc
+ * Copyright 2020 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ import com.expediagroup.graphql.spring.execution.SimpleSubscriptionHandler
 import com.expediagroup.graphql.spring.execution.SimpleSubscriptionHooks
 import com.expediagroup.graphql.spring.execution.SubscriptionHandler
 import com.expediagroup.graphql.spring.execution.SubscriptionWebSocketHandler
-import com.expediagroup.graphql.spring.operations.Subscription
+import com.expediagroup.graphql.server.operations.Subscription
 import com.fasterxml.jackson.databind.ObjectMapper
 import graphql.GraphQL
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean

--- a/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/FederationConfigurationTest.kt
+++ b/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/FederationConfigurationTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Expedia, Inc
+ * Copyright 2020 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ import com.expediagroup.graphql.federation.directives.FieldSet
 import com.expediagroup.graphql.federation.directives.KeyDirective
 import com.expediagroup.graphql.spring.execution.GraphQLContextFactory
 import com.expediagroup.graphql.spring.execution.QueryHandler
-import com.expediagroup.graphql.spring.operations.Query
+import com.expediagroup.graphql.server.operations.Query
 import com.expediagroup.graphql.toSchema
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper

--- a/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/SchemaConfigurationTest.kt
+++ b/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/SchemaConfigurationTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Expedia, Inc
+ * Copyright 2020 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import com.expediagroup.graphql.spring.execution.ContextWebFilter
 import com.expediagroup.graphql.spring.execution.DataLoaderRegistryFactory
 import com.expediagroup.graphql.spring.execution.GraphQLContextFactory
 import com.expediagroup.graphql.spring.execution.QueryHandler
-import com.expediagroup.graphql.spring.operations.Query
+import com.expediagroup.graphql.server.operations.Query
 import com.expediagroup.graphql.toSchema
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper

--- a/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/SubscriptionConfigurationTest.kt
+++ b/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/SubscriptionConfigurationTest.kt
@@ -19,8 +19,8 @@ package com.expediagroup.graphql.spring
 import com.expediagroup.graphql.SchemaGeneratorConfig
 import com.expediagroup.graphql.spring.execution.QueryHandler
 import com.expediagroup.graphql.spring.execution.SubscriptionHandler
-import com.expediagroup.graphql.spring.operations.Query
-import com.expediagroup.graphql.spring.operations.Subscription
+import com.expediagroup.graphql.server.operations.Query
+import com.expediagroup.graphql.server.operations.Subscription
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import graphql.GraphQL

--- a/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/context/GraphQLContextFactoryIT.kt
+++ b/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/context/GraphQLContextFactoryIT.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Expedia, Inc
+ * Copyright 2020 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ package com.expediagroup.graphql.spring.context
 import com.expediagroup.graphql.execution.GraphQLContext
 import com.expediagroup.graphql.spring.execution.GRAPHQL_CONTEXT_FILTER_ORDER
 import com.expediagroup.graphql.spring.execution.GraphQLContextFactory
-import com.expediagroup.graphql.spring.operations.Query
+import com.expediagroup.graphql.server.operations.Query
 import com.expediagroup.graphql.types.GraphQLRequest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.reactor.ReactorContext

--- a/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/execution/DataFetcherIT.kt
+++ b/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/execution/DataFetcherIT.kt
@@ -16,7 +16,7 @@
 package com.expediagroup.graphql.spring.execution
 
 import com.expediagroup.graphql.hooks.SchemaGeneratorHooks
-import com.expediagroup.graphql.spring.operations.Query
+import com.expediagroup.graphql.server.operations.Query
 import com.expediagroup.graphql.types.GraphQLRequest
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import graphql.language.StringValue

--- a/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/execution/IntrospectionIT.kt
+++ b/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/execution/IntrospectionIT.kt
@@ -15,7 +15,7 @@
  */
 package com.expediagroup.graphql.spring.execution
 
-import com.expediagroup.graphql.spring.operations.Query
+import com.expediagroup.graphql.server.operations.Query
 import com.expediagroup.graphql.types.GraphQLRequest
 import graphql.introspection.IntrospectionQuery
 import org.junit.jupiter.api.Test

--- a/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/execution/SpringDataFetcherIT.kt
+++ b/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/execution/SpringDataFetcherIT.kt
@@ -16,7 +16,7 @@
 package com.expediagroup.graphql.spring.execution
 
 import com.expediagroup.graphql.annotations.GraphQLIgnore
-import com.expediagroup.graphql.spring.operations.Query
+import com.expediagroup.graphql.server.operations.Query
 import com.expediagroup.graphql.types.GraphQLRequest
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired

--- a/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/execution/SubscriptionWebSocketHandlerIT.kt
+++ b/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/execution/SubscriptionWebSocketHandlerIT.kt
@@ -20,8 +20,8 @@ import com.expediagroup.graphql.execution.GraphQLContext
 import com.expediagroup.graphql.spring.model.SubscriptionOperationMessage
 import com.expediagroup.graphql.spring.model.SubscriptionOperationMessage.ClientMessages
 import com.expediagroup.graphql.spring.model.SubscriptionOperationMessage.ServerMessages
-import com.expediagroup.graphql.spring.operations.Query
-import com.expediagroup.graphql.spring.operations.Subscription
+import com.expediagroup.graphql.server.operations.Query
+import com.expediagroup.graphql.server.operations.Subscription
 import com.expediagroup.graphql.types.GraphQLRequest
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue

--- a/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/instrumentation/InstrumentationIT.kt
+++ b/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/instrumentation/InstrumentationIT.kt
@@ -1,7 +1,23 @@
+/*
+ * Copyright 2020 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.expediagroup.graphql.spring.instrumentation
 
 import com.expediagroup.graphql.spring.DEFAULT_INSTRUMENTATION_ORDER
-import com.expediagroup.graphql.spring.operations.Query
+import com.expediagroup.graphql.server.operations.Query
 import com.expediagroup.graphql.types.GraphQLRequest
 import graphql.ExecutionResult
 import graphql.ExecutionResultImpl

--- a/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/routes/RouteConfigurationIT.kt
+++ b/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/routes/RouteConfigurationIT.kt
@@ -22,7 +22,7 @@ import com.expediagroup.graphql.spring.REQUEST_PARAM_QUERY
 import com.expediagroup.graphql.spring.REQUEST_PARAM_VARIABLES
 import com.expediagroup.graphql.spring.execution.GraphQLContextFactory
 import com.expediagroup.graphql.spring.graphQLMediaType
-import com.expediagroup.graphql.spring.operations.Query
+import com.expediagroup.graphql.server.operations.Query
 import com.expediagroup.graphql.types.GraphQLRequest
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.junit.jupiter.api.Test

--- a/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/routes/SubscriptionRoutesConfigurationIT.kt
+++ b/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/spring/routes/SubscriptionRoutesConfigurationIT.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Expedia, Inc
+ * Copyright 2020 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,8 +20,8 @@ import com.expediagroup.graphql.spring.REQUEST_PARAM_QUERY
 import com.expediagroup.graphql.spring.model.SubscriptionOperationMessage
 import com.expediagroup.graphql.spring.model.SubscriptionOperationMessage.ClientMessages
 import com.expediagroup.graphql.spring.model.SubscriptionOperationMessage.ServerMessages
-import com.expediagroup.graphql.spring.operations.Query
-import com.expediagroup.graphql.spring.operations.Subscription
+import com.expediagroup.graphql.server.operations.Query
+import com.expediagroup.graphql.server.operations.Subscription
 import com.expediagroup.graphql.types.GraphQLRequest
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue

--- a/graphql-kotlin-types/src/main/kotlin/com/expediagroup/graphql/server/operations/Mutation.kt
+++ b/graphql-kotlin-types/src/main/kotlin/com/expediagroup/graphql/server/operations/Mutation.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.expediagroup.graphql.spring.operations
+package com.expediagroup.graphql.server.operations
 
 /**
  * Marker interface to indicate what classes should be used for GraphQL mutations.

--- a/graphql-kotlin-types/src/main/kotlin/com/expediagroup/graphql/server/operations/Query.kt
+++ b/graphql-kotlin-types/src/main/kotlin/com/expediagroup/graphql/server/operations/Query.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.expediagroup.graphql.spring.operations
+package com.expediagroup.graphql.server.operations
 
 /**
  * Marker interface to indicate what classes should be used for GraphQL queries.

--- a/graphql-kotlin-types/src/main/kotlin/com/expediagroup/graphql/server/operations/Subscription.kt
+++ b/graphql-kotlin-types/src/main/kotlin/com/expediagroup/graphql/server/operations/Subscription.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.expediagroup.graphql.spring.operations
+package com.expediagroup.graphql.server.operations
 
 /**
  * Marker interface to indicate what classes should be used for GraphQL subscriptions.


### PR DESCRIPTION
### :pencil: Description

Those generic marker interfaces can be used by different server implementations and are also needed by plugins to be able to generate SDL.

### :link: Related Issues

https://github.com/ExpediaGroup/graphql-kotlin/pull/982