### PR TITLE
[plugins] create sdl-generator module that can generate graphql schema

### DIFF
--- a/docs/plugins/hooks-provider.md
+++ b/docs/plugins/hooks-provider.md
@@ -1,0 +1,91 @@
+---
+id: hooks-provider
+title: Schema Generator Hooks Provider
+---
+
+GraphQL Kotlin plugins can generate GraphQL schema as your build artifact directly from your source code. Plugins will scan
+your classpath for classes implementing `graphql-kotlin-types` marker `Query`, `Mutation` and `Subscription` interfaces
+and then generate corresponding GraphQL schema using `graphql-kotlin-schema-generator`. By default, plugins will generate
+the schema using `NoopSchemaGeneratorHooks`. If your project uses custom hooks or needs to generate the federated GraphQL
+schema, you will need to provide an instance of `SchemaGeneratorHooksProvider` that will be used to create an instance of
+your custom hooks.
+
+`SchemaGeneratorHooksProvider` is a service provider interface that exposes a single `hooks` method to generate an instance
+of `SchemaGeneratorHooks` that will be used to generate your schema. By utilizing Java [ServiceLoader](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/ServiceLoader.html)
+we can dynamically load your custom provider from the classpath. Service provider can be provided as part of your project
+sources, included inside of one of your project dependencies or through explicitly provided artifact. Since we need to be
+able to deterministically choose a single hooks provider, generation of schema will fail if there are multiple providers
+on the classpath.
+
+## Creating Custom Hooks Service Provider
+
+### Add dependency on graphql-kotlin-sdl-generator
+
+`SchemaGeneratorHooksProvider` interface is defined in `graphql-kotlin-sdl-generator` module.
+
+<!--DOCUSAURUS_CODE_TABS-->
+<!--Gradle-->
+
+```kotlin
+// build.gradle.kts
+implementation("com.expediagroup", "graphql-kotlin-sdl-generator", latestVersion)
+```
+
+<!--Maven-->
+
+```xml
+<dependency>
+    <groupId>com.expediagroup</groupId>
+    <artifactId>graphql-kotlin-sdl-generator</artifactId>
+    <version>${latestVersion}</version>
+</dependency>
+```
+
+<!--END_DOCUSAURUS_CODE_TABS-->
+
+### Create new SchemaGeneratorHooksProvider implementation
+
+Service provider implementation has to implement `SchemaGeneratorHooksProvider` interface that provides a way to instantiate
+schema generator hooks that will be used to generate the GraphQL schema.
+
+```kotlin
+package com.example
+
+class MyCustomSchemaGeneratorHooksProvider : SchemaGeneratorHooksProvider {
+    override fun hooks(): SchemaGeneratorHooks = MyCustomHooks()
+}
+```
+
+### Create provider configuration file
+
+Service loader provider configuration file should be created under JAR `/META-INF/services` directory (e.g. `src/main/resources/META-INF/services`
+in default project structure). Name of the provider configuration should be fully qualified service provider interface name, i.e.
+`com.expediagroup.graphql.plugin.schema.hooks.SchemaGeneratorHooksProvider` and contain single entry - a fully qualified
+name of the service provider implementation.
+
+Using the example service provider implementation from the above, our project structure should look like
+
+```
+my-project
+|- src
+  |- main
+    |- kotlin
+      |- com
+        |- example
+          |- MyCustomSchemaGeneratorHooksProvider.kt
+    |- resources
+      |- META-INF
+        |- services
+          |- com.expediagroup.graphql.plugin.schema.hooks.SchemaGeneratorHooksProvider
+```
+
+Our service provider configuration file should have following content
+
+```text
+com.example.MyCustomSchemaGeneratorHooksProvider
+```
+
+## Limitations
+
+We don't support Java 9 module mechanism for declaring `ServiceLoader` implementations. As a workaround, you have to define
+your service providers in the provider configuration file under `META-INF/services`.

--- a/docs/plugins/hooks-provider.md
+++ b/docs/plugins/hooks-provider.md
@@ -19,16 +19,16 @@ on the classpath.
 
 ## Creating Custom Hooks Service Provider
 
-### Add dependency on graphql-kotlin-sdl-generator
+### Add dependency on graphql-kotlin-hooks-provider
 
-`SchemaGeneratorHooksProvider` interface is defined in `graphql-kotlin-sdl-generator` module.
+`SchemaGeneratorHooksProvider` interface is defined in `graphql-kotlin-hooks-provider` module.
 
 <!--DOCUSAURUS_CODE_TABS-->
 <!--Gradle-->
 
 ```kotlin
 // build.gradle.kts
-implementation("com.expediagroup", "graphql-kotlin-sdl-generator", latestVersion)
+implementation("com.expediagroup", "graphql-kotlin-hooks-provider", latestVersion)
 ```
 
 <!--Maven-->
@@ -36,7 +36,7 @@ implementation("com.expediagroup", "graphql-kotlin-sdl-generator", latestVersion
 ```xml
 <dependency>
     <groupId>com.expediagroup</groupId>
-    <artifactId>graphql-kotlin-sdl-generator</artifactId>
+    <artifactId>graphql-kotlin-hooks-provider</artifactId>
     <version>${latestVersion}</version>
 </dependency>
 ```
@@ -60,7 +60,7 @@ class MyCustomSchemaGeneratorHooksProvider : SchemaGeneratorHooksProvider {
 
 Service loader provider configuration file should be created under JAR `/META-INF/services` directory (e.g. `src/main/resources/META-INF/services`
 in default project structure). Name of the provider configuration should be fully qualified service provider interface name, i.e.
-`com.expediagroup.graphql.plugin.schema.hooks.SchemaGeneratorHooksProvider` and contain single entry - a fully qualified
+`SchemaGeneratorHooksProvider` and contain single entry - a fully qualified
 name of the service provider implementation.
 
 Using the example service provider implementation from the above, our project structure should look like
@@ -76,7 +76,7 @@ my-project
     |- resources
       |- META-INF
         |- services
-          |- com.expediagroup.graphql.plugin.schema.hooks.SchemaGeneratorHooksProvider
+          |- SchemaGeneratorHooksProvider
 ```
 
 Our service provider configuration file should have following content

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,6 +25,7 @@ kotlinPoetVersion = 1.6.0
 ktorVersion = 1.3.1
 reactorVersion = 3.3.10.RELEASE
 reactorExtensionsVersion = 1.0.2.RELEASE
+slf4jVersion = 1.7.30
 springBootVersion = 2.3.4.RELEASE
 springVersion = 5.2.9.RELEASE
 

--- a/plugins/schema/graphql-kotlin-federated-hooks-provider/README.md
+++ b/plugins/schema/graphql-kotlin-federated-hooks-provider/README.md
@@ -1,4 +1,4 @@
 # GraphQL Kotlin Federated Hooks Provider
 
 This module provides default implementation of `SchemaGeneratorHooksProvider` that can be used to generate federated GraphQL
-schema in SDL format.
+schema in SDL format. This provider creates a default instance of `FederatedSchemaGeneratorHooks`.

--- a/plugins/schema/graphql-kotlin-federated-hooks-provider/README.md
+++ b/plugins/schema/graphql-kotlin-federated-hooks-provider/README.md
@@ -1,0 +1,4 @@
+# GraphQL Kotlin Federated Hooks Provider
+
+This module provides default implementation of `SchemaGeneratorHooksProvider` that can be used to generate federated GraphQL
+schema in SDL format.

--- a/plugins/schema/graphql-kotlin-federated-hooks-provider/build.gradle.kts
+++ b/plugins/schema/graphql-kotlin-federated-hooks-provider/build.gradle.kts
@@ -1,0 +1,6 @@
+description = "Default federated GraphQL schema generator hooks provider"
+
+dependencies {
+    implementation(project(":graphql-kotlin-federation"))
+    implementation(project(":graphql-kotlin-sdl-generator"))
+}

--- a/plugins/schema/graphql-kotlin-federated-hooks-provider/build.gradle.kts
+++ b/plugins/schema/graphql-kotlin-federated-hooks-provider/build.gradle.kts
@@ -2,5 +2,5 @@ description = "Default federated GraphQL schema generator hooks provider"
 
 dependencies {
     implementation(project(":graphql-kotlin-federation"))
-    implementation(project(":graphql-kotlin-sdl-generator"))
+    implementation(project(":graphql-kotlin-hooks-provider"))
 }

--- a/plugins/schema/graphql-kotlin-federated-hooks-provider/src/main/kotlin/com/expediagroup/graphql/plugin/schema/hooks/FederatedSchemaGeneratorHooksProvider.kt
+++ b/plugins/schema/graphql-kotlin-federated-hooks-provider/src/main/kotlin/com/expediagroup/graphql/plugin/schema/hooks/FederatedSchemaGeneratorHooksProvider.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.plugin.schema.hooks
+
+import com.expediagroup.graphql.federation.FederatedSchemaGeneratorHooks
+import com.expediagroup.graphql.hooks.SchemaGeneratorHooks
+
+/**
+ * Default hooks provider to generate federated GraphQL schema in SDL format.
+ */
+class FederatedSchemaGeneratorHooksProvider : SchemaGeneratorHooksProvider {
+
+    /**
+     * Create a new instance of a FederatedSchemaGeneratorHooks that will be used to generate GraphQL schema in SDL format.
+     */
+    override fun hooks(): SchemaGeneratorHooks = FederatedSchemaGeneratorHooks(emptyList())
+}

--- a/plugins/schema/graphql-kotlin-federated-hooks-provider/src/main/resources/META-INF/services/com.expediagroup.graphql.plugin.schema.hooks.SchemaGeneratorHooksProvider
+++ b/plugins/schema/graphql-kotlin-federated-hooks-provider/src/main/resources/META-INF/services/com.expediagroup.graphql.plugin.schema.hooks.SchemaGeneratorHooksProvider
@@ -1,0 +1,1 @@
+com.expediagroup.graphql.plugin.schema.hooks.FederatedSchemaGeneratorHooksProvider

--- a/plugins/schema/graphql-kotlin-hooks-provider/README.md
+++ b/plugins/schema/graphql-kotlin-hooks-provider/README.md
@@ -1,0 +1,66 @@
+# GraphQL Kotlin Hooks Provider
+
+This module provides `SchemaGeneratorHooksProvider` Service Provider Interface that is used by the GraphQL Kotlin Plugins
+to obtain an instance of `SchemaGeneratorHooks` that will be used to generate GraphQL schema.
+
+```kotlin
+interface SchemaGeneratorHooksProvider {
+
+    /**
+     * Create a new instance of a SchemaGeneratorHooks that will be used to generate GraphQL schema in SDL format.
+     */
+    fun hooks(): SchemaGeneratorHooks
+}
+```
+
+## Creating Custom Hooks Provider
+
+SDL generator utilizes Java [ServiceLoader](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/ServiceLoader.html)
+to load available service providers from the classpath.
+
+### Create new SchemaGeneratorHooksProvider implementation
+
+Service provider implementation has to implement `SchemaGeneratorHooksProvider` interface that provides a way to instantiate
+schema generator hooks that will be used to generate the GraphQL schema.
+
+```kotlin
+package com.example
+
+class MyCustomSchemaGeneratorHooksProvider : SchemaGeneratorHooksProvider {
+    override fun hooks(): SchemaGeneratorHooks = MyCustomHooks()
+}
+```
+
+### Create provider configuration file
+
+Service loader provider configuration file should be created under JAR `/META-INF/services` directory (e.g. `src/main/resources/META-INF/services`
+in default project structure). Name of the provider configuration should be fully qualified service provider interface name, i.e.
+`SchemaGeneratorHooksProvider` and contain single entry - a fully qualified
+name of the service provider implementation.
+
+Using the example service provider implementation from the above, our project structure should look like
+
+```
+my-project
+|- src
+  |- main
+    |- kotlin
+      |- com
+        |- example
+          |- MyCustomSchemaGeneratorHooksProvider.kt
+    |- resources
+      |- META-INF
+        |- services
+          |- SchemaGeneratorHooksProvider
+```
+
+Our service provider configuration file should have following content
+
+```text
+com.example.MyCustomSchemaGeneratorHooksProvider
+```
+
+## Limitations
+
+We don't support Java 9 module mechanism for declaring `ServiceLoader` implementations. As a workaround, you have to define
+your service providers in the provider configuration file under `META-INF/services`.

--- a/plugins/schema/graphql-kotlin-hooks-provider/build.gradle.kts
+++ b/plugins/schema/graphql-kotlin-hooks-provider/build.gradle.kts
@@ -1,0 +1,5 @@
+description = "Module containing SchemaGeneratorHooksProvider Service Provider Interface (SPI)"
+
+dependencies {
+    implementation(project(":graphql-kotlin-schema-generator"))
+}

--- a/plugins/schema/graphql-kotlin-hooks-provider/src/main/kotlin/com/expediagroup/graphql/plugin/schema/hooks/SchemaGeneratorHooksProvider.kt
+++ b/plugins/schema/graphql-kotlin-hooks-provider/src/main/kotlin/com/expediagroup/graphql/plugin/schema/hooks/SchemaGeneratorHooksProvider.kt
@@ -22,7 +22,7 @@ import com.expediagroup.graphql.hooks.SchemaGeneratorHooks
  * Service provider interface that is used by the graphql-kotlin plugins to generate GraphQL schema in SDL format.
  *
  * Providers should be packaged in a JAR that contains provider configuration file under `src/main/resources/META-INF/services`. Provider file should be named
- * the same as implementing interface - `com.expediagroup.graphql.plugin.schema.hooks.SchemaGeneratorHooksProvider`.
+ * the same as implementing interface - `SchemaGeneratorHooksProvider`.
  * Provider configuration file should contain only single entry - fully qualified name of provider implementation.
  *
  * **See Also**: [ServiceLoader documentation](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/ServiceLoader.html)

--- a/plugins/schema/graphql-kotlin-sdl-generator/README.md
+++ b/plugins/schema/graphql-kotlin-sdl-generator/README.md
@@ -1,62 +1,13 @@
 # Graphql Kotlin SDL Generator
 
 GraphQL schema generator that invokes `graphql-kotlin-schema-generator` to generate GraphQL schema in Schema Definition
-Language (SDL) format. Utilizes Java [ServiceLoader](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/ServiceLoader.html)
+Language (SDL) format.
+
+Generator scans classpath for classes implementing `graphql-kotlin-types` `Query`, `Mutation` and `Subscription` marker
+interfaces. Since schema generation accepts an instance of `SchemaGeneratorHooks`, generator utilizes Java [ServiceLoader](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/ServiceLoader.html)
 mechanism to dynamically load available `SchemaGeneratorHooksProvider` service providers from the classpath.
 
 `SchemaGeneratorHooksProvider` provides an instance of `SchemaGeneratorHooks` that will be used to generate the schema.
 If no provider is available on the classpath, SDL generator will default to use `NoopSchemaGeneratorHooks`. Since we need
-to be able to deterministically choose a hooks provider, generation of schema will fail if there are multiple providers
+to be able to deterministically choose a single hooks provider, generation of schema will fail if there are multiple providers
 on the classpath.
-
-## Creating Custom Hooks Provider
-
-SDL generator utilizes Java [ServiceLoader](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/ServiceLoader.html)
-to load available service providers from the classpath.
-
-### Create new SchemaGeneratorHooksProvider implementation
-
-Service provider implementation has to implement `SchemaGeneratorHooksProvider` interface that provides a way to instantiate
-schema generator hooks that will be used to generate the GraphQL schema.
-
-```kotlin
-package com.example
-
-class MyCustomSchemaGeneratorHooksProvider : SchemaGeneratorHooksProvider {
-    override fun hooks(): SchemaGeneratorHooks = MyCustomHooks()
-}
-```
-
-### Create provider configuration file
-
-Service loader provider configuration file should be created under JAR `/META-INF/services` directory (e.g. `src/main/resources/META-INF/services`
-in default project structure). Name of the provider configuration should be fully qualified service provider interface name, i.e.
-`com.expediagroup.graphql.plugin.schema.hooks.SchemaGeneratorHooksProvider` and contain single entry - a fully qualified
-name of the service provider implementation.
-
-Using the example service provider implementation from the above, our project structure should look like
-
-```
-my-project
-|- src
-  |- main
-    |- kotlin
-      |- com
-        |- example
-          |- MyCustomSchemaGeneratorHooksProvider.kt
-    |- resources
-      |- META-INF
-        |- services
-          |- com.expediagroup.graphql.plugin.schema.hooks.SchemaGeneratorHooksProvider
-```
-
-Our service provider configuration file should have following content
-
-```text
-com.example.MyCustomSchemaGeneratorHooksProvider
-```
-
-## Limitations
-
-We don't support Java 9 module mechanism for declaring `ServiceLoader` implementations. As a workaround, you have to define
-your service providers in the provider configuration file under `META-INF/services`.

--- a/plugins/schema/graphql-kotlin-sdl-generator/README.md
+++ b/plugins/schema/graphql-kotlin-sdl-generator/README.md
@@ -1,0 +1,62 @@
+# Graphql Kotlin SDL Generator
+
+GraphQL schema generator that invokes `graphql-kotlin-schema-generator` to generate GraphQL schema in Schema Definition
+Language (SDL) format. Utilizes Java [ServiceLoader](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/ServiceLoader.html)
+mechanism to dynamically load available `SchemaGeneratorHooksProvider` service providers from the classpath.
+
+`SchemaGeneratorHooksProvider` provides an instance of `SchemaGeneratorHooks` that will be used to generate the schema.
+If no provider is available on the classpath, SDL generator will default to use `NoopSchemaGeneratorHooks`. Since we need
+to be able to deterministically choose a hooks provider, generation of schema will fail if there are multiple providers
+on the classpath.
+
+## Creating Custom Hooks Provider
+
+SDL generator utilizes Java [ServiceLoader](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/ServiceLoader.html)
+to load available service providers from the classpath.
+
+### Create new SchemaGeneratorHooksProvider implementation
+
+Service provider implementation has to implement `SchemaGeneratorHooksProvider` interface that provides a way to instantiate
+schema generator hooks that will be used to generate the GraphQL schema.
+
+```kotlin
+package com.example
+
+class MyCustomSchemaGeneratorHooksProvider : SchemaGeneratorHooksProvider {
+    override fun hooks(): SchemaGeneratorHooks = MyCustomHooks()
+}
+```
+
+### Create provider configuration file
+
+Service loader provider configuration file should be created under JAR `/META-INF/services` directory (e.g. `src/main/resources/META-INF/services`
+in default project structure). Name of the provider configuration should be fully qualified service provider interface name, i.e.
+`com.expediagroup.graphql.plugin.schema.hooks.SchemaGeneratorHooksProvider` and contain single entry - a fully qualified
+name of the service provider implementation.
+
+Using the example service provider implementation from the above, our project structure should look like
+
+```
+my-project
+|- src
+  |- main
+    |- kotlin
+      |- com
+        |- example
+          |- MyCustomSchemaGeneratorHooksProvider.kt
+    |- resources
+      |- META-INF
+        |- services
+          |- com.expediagroup.graphql.plugin.schema.hooks.SchemaGeneratorHooksProvider
+```
+
+Our service provider configuration file should have following content
+
+```text
+com.example.MyCustomSchemaGeneratorHooksProvider
+```
+
+## Limitations
+
+We don't support Java 9 module mechanism for declaring `ServiceLoader` implementations. As a workaround, you have to define
+your service providers in the provider configuration file under `META-INF/services`.

--- a/plugins/schema/graphql-kotlin-sdl-generator/build.gradle.kts
+++ b/plugins/schema/graphql-kotlin-sdl-generator/build.gradle.kts
@@ -5,6 +5,7 @@ val slf4jVersion: String by project
 
 dependencies {
     implementation(project(path = ":graphql-kotlin-types"))
+    implementation(project(path = ":graphql-kotlin-hooks-provider"))
     implementation(project(path = ":graphql-kotlin-schema-generator"))
     implementation(project(path = ":graphql-kotlin-federation"))
     implementation("io.github.classgraph:classgraph:$classGraphVersion")

--- a/plugins/schema/graphql-kotlin-sdl-generator/build.gradle.kts
+++ b/plugins/schema/graphql-kotlin-sdl-generator/build.gradle.kts
@@ -1,0 +1,63 @@
+description = "GraphQL Kotlin SDL generator that can be used to generate GraphQL schema from source files."
+
+val classGraphVersion: String by project
+val slf4jVersion: String by project
+
+dependencies {
+    implementation(project(path = ":graphql-kotlin-types"))
+    implementation(project(path = ":graphql-kotlin-schema-generator"))
+    implementation(project(path = ":graphql-kotlin-federation"))
+    implementation("io.github.classgraph:classgraph:$classGraphVersion")
+    implementation("org.slf4j:slf4j-api:$slf4jVersion")
+    testImplementation(project(path = ":graphql-kotlin-spring-server"))
+}
+
+sourceSets {
+    create("integrationTest") {
+        withConvention(org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet::class) {
+            kotlin.srcDir("src/integrationTest/kotlin")
+            resources.srcDir("src/integrationTest/resources")
+            compileClasspath += sourceSets["main"].output + sourceSets["test"].compileClasspath
+            runtimeClasspath += output + compileClasspath + sourceSets["test"].runtimeClasspath
+        }
+    }
+}
+
+tasks {
+    val integrationTest by registering(Test::class) {
+        description = "Runs the integration tests"
+        group = "verification"
+
+        testClassesDirs = sourceSets["integrationTest"].output.classesDirs
+        classpath = sourceSets["integrationTest"].runtimeClasspath
+        mustRunAfter("test")
+        finalizedBy("jacocoTestReport")
+        useJUnitPlatform()
+    }
+
+    jacocoTestReport {
+        // we need to explicitly add integrationTest coverage info
+        executionData.setFrom(fileTree(buildDir).include("/jacoco/*.exec"))
+    }
+    jacocoTestCoverageVerification {
+        // we need to explicitly add integrationTest coverage info
+        executionData.setFrom(fileTree(buildDir).include("/jacoco/*.exec"))
+        violationRules {
+            rule {
+                limit {
+                    counter = "INSTRUCTION"
+                    value = "COVEREDRATIO"
+                    minimum = "0.85".toBigDecimal()
+                }
+                limit {
+                    counter = "BRANCH"
+                    value = "COVEREDRATIO"
+                    minimum = "0.80".toBigDecimal()
+                }
+            }
+        }
+    }
+    check {
+        dependsOn("integrationTest")
+    }
+}

--- a/plugins/schema/graphql-kotlin-sdl-generator/src/integrationTest/kotlin/com/expediagroup/graphql/plugin/schema/GenerateCustomSDLTest.kt
+++ b/plugins/schema/graphql-kotlin-sdl-generator/src/integrationTest/kotlin/com/expediagroup/graphql/plugin/schema/GenerateCustomSDLTest.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2021 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.plugin.schema
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class GenerateCustomSDLTest {
+
+    @Test
+    fun `verify we can generate SDL using custom hooks provider`() {
+        val expectedSchema =
+            """
+                schema {
+                  query: Query
+                }
+
+                "Directs the executor to include this field or fragment only when the `if` argument is true"
+                directive @include(
+                    "Included when true."
+                    if: Boolean!
+                  ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+                "Directs the executor to skip this field or fragment when the `if`'argument is true."
+                directive @skip(
+                    "Skipped when true."
+                    if: Boolean!
+                  ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+                "Marks the field or enum value as deprecated"
+                directive @deprecated(
+                    "The reason for the deprecation"
+                    reason: String = "No longer supported"
+                  ) on FIELD_DEFINITION | ENUM_VALUE
+
+                "Exposes a URL that specifies the behaviour of this scalar."
+                directive @specifiedBy(
+                    "The URL that specifies the behaviour of this scalar."
+                    url: String!
+                  ) on SCALAR
+
+                "Marks target field as external meaning it will be resolved by federated schema"
+                directive @external on FIELD_DEFINITION
+
+                "Specifies required input field set from the base type for a resolver"
+                directive @requires(fields: _FieldSet) on FIELD_DEFINITION
+
+                "Specifies the base type field set that will be selectable by the gateway"
+                directive @provides(fields: _FieldSet) on FIELD_DEFINITION
+
+                "Space separated list of primary keys needed to access federated object"
+                directive @key(fields: _FieldSet) on OBJECT | INTERFACE
+
+                "Marks target object as extending part of the federated schema"
+                directive @extends on OBJECT | INTERFACE
+
+                type Query @extends {
+                  _service: _Service
+                  helloWorld(name: String): String!
+                  randomUUID: UUID!
+                }
+
+                type _Service {
+                  sdl: String!
+                }
+
+                "Custom scalar representing UUID"
+                scalar UUID
+
+                "Federation type representing set of fields"
+                scalar _FieldSet
+            """.trimIndent()
+        val generatedSchema = generateSDL(listOf("com.expediagroup.test"))
+
+        assertEquals(expectedSchema, generatedSchema.trim())
+    }
+}

--- a/plugins/schema/graphql-kotlin-sdl-generator/src/integrationTest/kotlin/com/expediagroup/test/FederatedGraphQLServer.kt
+++ b/plugins/schema/graphql-kotlin-sdl-generator/src/integrationTest/kotlin/com/expediagroup/test/FederatedGraphQLServer.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2021 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.test
+
+import com.expediagroup.graphql.federation.FederatedSchemaGeneratorHooks
+import com.expediagroup.test.hooks.CustomFederatedHooks
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+import org.springframework.context.annotation.Bean
+
+@SpringBootApplication
+open class FederatedGraphQLServer {
+
+    @Bean
+    open fun federatedSchemaGeneratorHooks(): FederatedSchemaGeneratorHooks = CustomFederatedHooks()
+}
+
+fun main(args: Array<String>) {
+    runApplication<FederatedGraphQLServer>(*args)
+}

--- a/plugins/schema/graphql-kotlin-sdl-generator/src/integrationTest/kotlin/com/expediagroup/test/SimpleQuery.kt
+++ b/plugins/schema/graphql-kotlin-sdl-generator/src/integrationTest/kotlin/com/expediagroup/test/SimpleQuery.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2021 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.test
+
+import com.expediagroup.graphql.server.operations.Query
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+@Component
+open class SimpleQuery : Query {
+
+    fun helloWorld(name: String? = null) = if (name != null) {
+        "Hello, $name!!!"
+    } else {
+        "Hello, World!!!"
+    }
+
+    fun randomUUID(): UUID = UUID.randomUUID()
+}

--- a/plugins/schema/graphql-kotlin-sdl-generator/src/integrationTest/kotlin/com/expediagroup/test/hooks/CustomFederatedHooks.kt
+++ b/plugins/schema/graphql-kotlin-sdl-generator/src/integrationTest/kotlin/com/expediagroup/test/hooks/CustomFederatedHooks.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2021 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.test.hooks
+
+import com.expediagroup.graphql.federation.FederatedSchemaGeneratorHooks
+import graphql.language.StringValue
+import graphql.schema.Coercing
+import graphql.schema.GraphQLScalarType
+import graphql.schema.GraphQLType
+import java.util.UUID
+import kotlin.reflect.KType
+
+private val graphqlUUIDType = GraphQLScalarType.newScalar()
+    .name("UUID")
+    .description("Custom scalar representing UUID")
+    .coercing(object : Coercing<UUID, String> {
+        override fun parseValue(input: Any?): UUID = UUID.fromString(
+            serialize(input)
+        )
+
+        override fun parseLiteral(input: Any?): UUID? {
+            val uuidString = (input as? StringValue)?.value
+            return UUID.fromString(uuidString)
+        }
+
+        override fun serialize(dataFetcherResult: Any?): String = dataFetcherResult.toString()
+    })
+    .build()
+
+class CustomFederatedHooks : FederatedSchemaGeneratorHooks(emptyList()) {
+
+    override fun willGenerateGraphQLType(type: KType): GraphQLType? = when (type.classifier) {
+        UUID::class -> graphqlUUIDType
+        else -> super.willGenerateGraphQLType(type)
+    }
+}

--- a/plugins/schema/graphql-kotlin-sdl-generator/src/integrationTest/kotlin/com/expediagroup/test/hooks/TestSchemaGeneratorHooksProvider.kt
+++ b/plugins/schema/graphql-kotlin-sdl-generator/src/integrationTest/kotlin/com/expediagroup/test/hooks/TestSchemaGeneratorHooksProvider.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2021 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.test.hooks
+
+import com.expediagroup.graphql.hooks.SchemaGeneratorHooks
+import com.expediagroup.graphql.plugin.schema.hooks.SchemaGeneratorHooksProvider
+
+class TestSchemaGeneratorHooksProvider : SchemaGeneratorHooksProvider {
+
+    override fun hooks(): SchemaGeneratorHooks = CustomFederatedHooks()
+}

--- a/plugins/schema/graphql-kotlin-sdl-generator/src/integrationTest/resources/META-INF/services/com.expediagroup.graphql.plugin.schema.hooks.SchemaGeneratorHooksProvider
+++ b/plugins/schema/graphql-kotlin-sdl-generator/src/integrationTest/resources/META-INF/services/com.expediagroup.graphql.plugin.schema.hooks.SchemaGeneratorHooksProvider
@@ -1,0 +1,1 @@
+com.expediagroup.test.hooks.TestSchemaGeneratorHooksProvider

--- a/plugins/schema/graphql-kotlin-sdl-generator/src/integrationTest/resources/application.yml
+++ b/plugins/schema/graphql-kotlin-sdl-generator/src/integrationTest/resources/application.yml
@@ -1,0 +1,5 @@
+graphql:
+  packages:
+    - "com.expediagroup.test"
+  federation:
+    enabled: true

--- a/plugins/schema/graphql-kotlin-sdl-generator/src/main/kotlin/com/expediagroup/graphql/plugin/schema/GenerateSDL.kt
+++ b/plugins/schema/graphql-kotlin-sdl-generator/src/main/kotlin/com/expediagroup/graphql/plugin/schema/GenerateSDL.kt
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2021 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.plugin.schema
+
+import com.expediagroup.graphql.SchemaGeneratorConfig
+import com.expediagroup.graphql.TopLevelObject
+import com.expediagroup.graphql.extensions.print
+import com.expediagroup.graphql.federation.FederatedSchemaGeneratorConfig
+import com.expediagroup.graphql.federation.FederatedSchemaGeneratorHooks
+import com.expediagroup.graphql.federation.toFederatedSchema
+import com.expediagroup.graphql.hooks.NoopSchemaGeneratorHooks
+import com.expediagroup.graphql.server.operations.Mutation
+import com.expediagroup.graphql.server.operations.Query
+import com.expediagroup.graphql.server.operations.Subscription
+import com.expediagroup.graphql.plugin.schema.hooks.SchemaGeneratorHooksProvider
+import com.expediagroup.graphql.toSchema
+import io.github.classgraph.ClassGraph
+import io.github.classgraph.ScanResult
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import java.util.ServiceLoader
+import kotlin.RuntimeException
+
+private val logger: Logger = LoggerFactory.getLogger("generateSDL")
+
+/**
+ * Generates GraphQL schema in SDL format.
+ *
+ * Relies on a `ServiceLoader` mechanism to dynamically load an instance of a `SchemaGeneratorHooksProvider` from the classpath.
+ */
+fun generateSDL(supportedPackages: List<String>): String {
+    val hooksProviders = ServiceLoader.load(SchemaGeneratorHooksProvider::class.java).toList()
+    val hooks = when {
+        hooksProviders.isEmpty() -> {
+            logger.warn("No SchemaGeneratorHooksProvider were found, defaulting to NoopSchemaGeneratorHooks")
+            NoopSchemaGeneratorHooks
+        }
+        hooksProviders.size > 1 -> {
+            throw RuntimeException("Cannot generate SDL as multiple SchemaGeneratorHooksProviders were found on the classpath")
+        }
+        else -> {
+            val provider = hooksProviders.first()
+            logger.debug("SchemaGeneratorHooksProvider found, ${provider.javaClass.simpleName} will be used to generate the hooks")
+            provider.hooks()
+        }
+    }
+    val scanResult = ClassGraph()
+        .enableAllInfo()
+        .acceptPackages(*supportedPackages.toTypedArray())
+        .scan()
+
+    val queries = findTopLevelObjects(scanResult, Query::class.java)
+    val mutations = findTopLevelObjects(scanResult, Mutation::class.java)
+    val subscriptions = findTopLevelObjects(scanResult, Subscription::class.java)
+
+    // TODO support top level name overrides?
+    val schema = if (hooks is FederatedSchemaGeneratorHooks) {
+        logger.debug("Generating federated schema using hooks = ${hooks.javaClass.simpleName}")
+        logger.debug("  query classes = ${queries.map { it.kClass }}")
+        logger.debug("  mutation classes = ${mutations.map { it.kClass }}")
+        logger.debug("  subscription classes = ${subscriptions.map { it.kClass }}")
+        val config = FederatedSchemaGeneratorConfig(
+            supportedPackages = supportedPackages,
+            hooks = hooks
+        )
+        toFederatedSchema(
+            config = config,
+            queries = queries,
+            mutations = mutations,
+            subscriptions = subscriptions
+        )
+    } else {
+        logger.debug("Generating schema using hooks = ${hooks.javaClass.simpleName}")
+        logger.debug("  query classes = ${queries.map { it.kClass }}")
+        logger.debug("  mutation classes = ${mutations.map { it.kClass }}")
+        logger.debug("  subscription classes = ${subscriptions.map { it.kClass }}")
+        val config = SchemaGeneratorConfig(
+            supportedPackages = supportedPackages,
+            hooks = hooks
+        )
+        toSchema(
+            config = config,
+            queries = queries,
+            mutations = mutations,
+            subscriptions = subscriptions
+        )
+    }
+
+    scanResult.close()
+    return schema.print()
+}
+
+private fun findTopLevelObjects(scanResult: ScanResult, markupClass: Class<*>): List<TopLevelObject> =
+    scanResult.getClassesImplementing(markupClass.name)
+        .map { it.loadClass() }
+        .map { TopLevelObject(null, it.kotlin) }

--- a/plugins/schema/graphql-kotlin-sdl-generator/src/main/kotlin/com/expediagroup/graphql/plugin/schema/hooks/SchemaGeneratorHooksProvider.kt
+++ b/plugins/schema/graphql-kotlin-sdl-generator/src/main/kotlin/com/expediagroup/graphql/plugin/schema/hooks/SchemaGeneratorHooksProvider.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.plugin.schema.hooks
+
+import com.expediagroup.graphql.hooks.SchemaGeneratorHooks
+
+/**
+ * Service provider interface that is used by the graphql-kotlin plugins to generate GraphQL schema in SDL format.
+ *
+ * Providers should be packaged in a JAR that contains provider configuration file under `src/main/resources/META-INF/services`. Provider file should be named
+ * the same as implementing interface - `com.expediagroup.graphql.plugin.schema.hooks.SchemaGeneratorHooksProvider`.
+ * Provider configuration file should contain only single entry - fully qualified name of provider implementation.
+ *
+ * **See Also**: [ServiceLoader documentation](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/ServiceLoader.html)
+ */
+interface SchemaGeneratorHooksProvider {
+
+    /**
+     * Create a new instance of a SchemaGeneratorHooks that will be used to generate GraphQL schema in SDL format.
+     */
+    fun hooks(): SchemaGeneratorHooks
+}

--- a/plugins/schema/graphql-kotlin-sdl-generator/src/test/kotlin/com/expediagroup/graphql/plugin/schema/GenerateSDLTest.kt
+++ b/plugins/schema/graphql-kotlin-sdl-generator/src/test/kotlin/com/expediagroup/graphql/plugin/schema/GenerateSDLTest.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2021 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.plugin.schema
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import kotlin.test.assertEquals
+
+class GenerateSDLTest {
+
+    @Test
+    fun `verify we can generate SDL using default hooks provider`() {
+        val expectedSchema =
+            """
+                schema {
+                  query: Query
+                }
+
+                "Directs the executor to include this field or fragment only when the `if` argument is true"
+                directive @include(
+                    "Included when true."
+                    if: Boolean!
+                  ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+                "Directs the executor to skip this field or fragment when the `if`'argument is true."
+                directive @skip(
+                    "Skipped when true."
+                    if: Boolean!
+                  ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+                "Marks the field or enum value as deprecated"
+                directive @deprecated(
+                    "The reason for the deprecation"
+                    reason: String = "No longer supported"
+                  ) on FIELD_DEFINITION | ENUM_VALUE
+
+                "Exposes a URL that specifies the behaviour of this scalar."
+                directive @specifiedBy(
+                    "The URL that specifies the behaviour of this scalar."
+                    url: String!
+                  ) on SCALAR
+
+                type Query {
+                  helloWorld(name: String): String!
+                }
+            """.trimIndent()
+        val generatedSchema = generateSDL(listOf("com.expediagroup.test"))
+
+        assertEquals(expectedSchema, generatedSchema.trim())
+    }
+
+    @Test
+    fun `verify that generation of SDL will fail if no queries are found`() {
+        val exception = assertThrows<RuntimeException> {
+            generateSDL(listOf("com.expediagroup.graphql.plugin.schema"))
+        }
+        assertEquals("Invalid query object type - no valid queries are available.", exception.message)
+    }
+}

--- a/plugins/schema/graphql-kotlin-sdl-generator/src/test/kotlin/com/expediagroup/test/SimpleGraphQLServer.kt
+++ b/plugins/schema/graphql-kotlin-sdl-generator/src/test/kotlin/com/expediagroup/test/SimpleGraphQLServer.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2021 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.test
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+
+@SpringBootApplication
+open class SimpleGraphQLServer
+
+fun main(args: Array<String>) {
+    runApplication<SimpleGraphQLServer>(*args)
+}

--- a/plugins/schema/graphql-kotlin-sdl-generator/src/test/kotlin/com/expediagroup/test/SimpleQuery.kt
+++ b/plugins/schema/graphql-kotlin-sdl-generator/src/test/kotlin/com/expediagroup/test/SimpleQuery.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2021 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.test
+
+import com.expediagroup.graphql.server.operations.Query
+import org.springframework.stereotype.Component
+
+@Component
+class SimpleQuery : Query {
+
+    fun helloWorld(name: String? = null) = if (name != null) {
+        "Hello, $name!!!"
+    } else {
+        "Hello, World!!!"
+    }
+}

--- a/plugins/schema/graphql-kotlin-sdl-generator/src/test/resources/application.yml
+++ b/plugins/schema/graphql-kotlin-sdl-generator/src/test/resources/application.yml
@@ -1,0 +1,3 @@
+graphql:
+  packages:
+    - "com.expediagroup.test"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -43,8 +43,10 @@ include(":graphql-kotlin-plugin-core")
 include(":graphql-kotlin-gradle-plugin")
 include(":graphql-kotlin-maven-plugin")
 include(":graphql-kotlin-sdl-generator")
+include(":graphql-kotlin-hooks-provider")
 include(":graphql-kotlin-federated-hooks-provider")
 
+// project mappings so we don't need to create projects that group subprojects
 project(":graphql-kotlin-client").projectDir = file("clients/graphql-kotlin-client")
 project(":graphql-kotlin-ktor-client").projectDir = file("clients/graphql-kotlin-ktor-client")
 project(":graphql-kotlin-spring-client").projectDir = file("clients/graphql-kotlin-spring-client")
@@ -53,4 +55,5 @@ project(":graphql-kotlin-plugin-core").projectDir = file("plugins/graphql-kotlin
 project(":graphql-kotlin-gradle-plugin").projectDir = file("plugins/graphql-kotlin-gradle-plugin")
 project(":graphql-kotlin-maven-plugin").projectDir = file("plugins/graphql-kotlin-maven-plugin")
 project(":graphql-kotlin-sdl-generator").projectDir = file("plugins/schema/graphql-kotlin-sdl-generator")
+project(":graphql-kotlin-hooks-provider").projectDir = file("plugins/schema/graphql-kotlin-hooks-provider")
 project(":graphql-kotlin-federated-hooks-provider").projectDir = file("plugins/schema/graphql-kotlin-federated-hooks-provider")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -29,13 +29,21 @@ rootProject.name = "graphql-kotlin"
 include(":graphql-kotlin-types")
 include(":graphql-kotlin-schema-generator")
 include(":graphql-kotlin-federation")
+
+// servers
 include(":graphql-kotlin-spring-server")
+
+// clients
 include(":graphql-kotlin-client")
 include(":graphql-kotlin-ktor-client")
 include(":graphql-kotlin-spring-client")
+
+// plugins
 include(":graphql-kotlin-plugin-core")
 include(":graphql-kotlin-gradle-plugin")
 include(":graphql-kotlin-maven-plugin")
+include(":graphql-kotlin-sdl-generator")
+include(":graphql-kotlin-federated-hooks-provider")
 
 project(":graphql-kotlin-client").projectDir = file("clients/graphql-kotlin-client")
 project(":graphql-kotlin-ktor-client").projectDir = file("clients/graphql-kotlin-ktor-client")
@@ -44,3 +52,5 @@ project(":graphql-kotlin-spring-client").projectDir = file("clients/graphql-kotl
 project(":graphql-kotlin-plugin-core").projectDir = file("plugins/graphql-kotlin-plugin-core")
 project(":graphql-kotlin-gradle-plugin").projectDir = file("plugins/graphql-kotlin-gradle-plugin")
 project(":graphql-kotlin-maven-plugin").projectDir = file("plugins/graphql-kotlin-maven-plugin")
+project(":graphql-kotlin-sdl-generator").projectDir = file("plugins/schema/graphql-kotlin-sdl-generator")
+project(":graphql-kotlin-federated-hooks-provider").projectDir = file("plugins/schema/graphql-kotlin-federated-hooks-provider")

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -73,7 +73,8 @@
     ],
     "Build Plugins": [
       "plugins/gradle-plugin",
-      "plugins/maven-plugin"
+      "plugins/maven-plugin",
+      "plugins/hooks-provider"
     ],
     "Contributors": [
       "contributors/release-proc"


### PR DESCRIPTION
### :pencil: Description

`graphql-kotlin-sdl-generator` module can be used to generate GraphQL schema build artifact directly from your source code. Module scans the classpath for classes implementing `graphql-kotlin-types` marker interfaces (`Query`, `Mutation` and `Subscription`) and then uses that information to generate a schema using `graphql-kotlin-schema-generator`. By default, this module will generate the schema using `NoopSchemaGeneratorHooks`. If your project uses custom hooks or needs to generate the federated GraphQL schema, you will need to provide an instance of `SchemaGeneratorHooksProvider` that will be used to create an instance of your custom hooks.

`SchemaGeneratorHooksProvider` is a service provider interface that exposes a single `hooks` method to generate an instance of `SchemaGeneratorHooks` that will be used to generate your schema. By utilizing Java [ServiceLoader](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/ServiceLoader.html) we can dynamically load custom providers directly from the classpath. Service provider can be provided as part of target project sources, included inside of one of the project dependencies or through explicitly provided artifact. Since we need to be able to deterministically choose a single hooks provider, generation of schema will fail if there are multiple providers on the classpath.

### :link: Related Issues

Splitting up https://github.com/ExpediaGroup/graphql-kotlin/pull/982/files into smaller PRs
