### PR TITLE
[build] specify timeouts for GH workflows

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -10,6 +10,7 @@ on:
       - 'website/**'
 
 jobs:
+  timeout-minutes: 30
   build:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/pr-check-docs.yml
+++ b/.github/workflows/pr-check-docs.yml
@@ -10,8 +10,8 @@ on:
       - 'website/**'
 
 jobs:
+  timeout-minutes: 10
   check-docs:
-
     runs-on: ubuntu-latest
     if: github.repository == 'ExpediaGroup/graphql-kotlin'
 

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -10,6 +10,7 @@ on:
       - 'website/**'
 
 jobs:
+  timeout-minutes: 30
   build:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/publish-latest-docs.yml
+++ b/.github/workflows/publish-latest-docs.yml
@@ -9,8 +9,8 @@ on:
       - 'website/**'
 
 jobs:
+  timeout-minutes: 10
   publish-docs:
-
     runs-on: ubuntu-latest
     if: github.repository == 'ExpediaGroup/graphql-kotlin'
 

--- a/.github/workflows/release-code.yml
+++ b/.github/workflows/release-code.yml
@@ -5,6 +5,7 @@ on:
     types: [published]
 
 jobs:
+  timeout-minutes: 60
   release-code:
     runs-on: ubuntu-latest
     if: github.repository == 'ExpediaGroup/graphql-kotlin'

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -5,6 +5,7 @@ on:
     types: [published]
 
 jobs:
+  timeout-minutes: 10
   release-docs:
     runs-on: ubuntu-latest
     if: github.repository == 'ExpediaGroup/graphql-kotlin'


### PR DESCRIPTION
### :pencil: Description

GH actions default to 6 hour timeout per workflow. Since steps occassionally get stuck, we end up manually cancelling and re-running those workflows.

Based on the https://github.com/ExpediaGroup/graphql-kotlin/actions our workflows average time

* PR check / CI - ~10-12 minutes -> adding timeout of 30 minutes
* PR check docs / Publish latest docs / Release docs  - ~1 min -> adding timeout of 10 minutes
* Release code - ~15 minutes -> adding timeout of 1h

### :link: Related Issues

N/A
