### PR TITLE
[client] move GraphQLKotlinClient implementations to specific packages

### DIFF
--- a/clients/graphql-kotlin-client/src/main/kotlin/GraphQLClient.kt
+++ b/clients/graphql-kotlin-client/src/main/kotlin/GraphQLClient.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Expedia, Inc
+ * Copyright 2021 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/clients/graphql-kotlin-client/src/main/kotlin/converter/ScalarConverter.kt
+++ b/clients/graphql-kotlin-client/src/main/kotlin/converter/ScalarConverter.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Expedia, Inc
+ * Copyright 2021 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/clients/graphql-kotlin-ktor-client/src/test/kotlin/GraphQLKtorClientTest.kt
+++ b/clients/graphql-kotlin-ktor-client/src/test/kotlin/GraphQLKtorClientTest.kt
@@ -1,5 +1,22 @@
-package com.expediagroup.graphql.client
+/*
+ * Copyright 2021 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
+package com.expediagroup.graphql.client.ktor
+
+import com.expediagroup.graphql.client.execute
 import com.expediagroup.graphql.types.GraphQLError
 import com.expediagroup.graphql.types.GraphQLResponse
 import com.expediagroup.graphql.types.SourceLocation

--- a/clients/graphql-kotlin-spring-client/src/main/kotlin/GraphQLWebClient.kt
+++ b/clients/graphql-kotlin-spring-client/src/main/kotlin/GraphQLWebClient.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Expedia, Inc
+ * Copyright 2021 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,55 +14,42 @@
  * limitations under the License.
  */
 
-package com.expediagroup.graphql.client
+package com.expediagroup.graphql.client.spring
 
+import com.expediagroup.graphql.client.GraphQLClient
 import com.expediagroup.graphql.types.GraphQLResponse
 import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.JavaType
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import io.ktor.client.HttpClient
-import io.ktor.client.HttpClientConfig
-import io.ktor.client.engine.HttpClientEngineConfig
-import io.ktor.client.engine.HttpClientEngineFactory
-import io.ktor.client.engine.cio.CIO
-import io.ktor.client.engine.cio.CIOEngineConfig
-import io.ktor.client.features.json.JacksonSerializer
-import io.ktor.client.features.json.JsonFeature
-import io.ktor.client.request.HttpRequestBuilder
-import io.ktor.client.request.post
-import io.ktor.http.ContentType
-import io.ktor.http.contentType
-import io.ktor.util.KtorExperimentalAPI
-import java.io.Closeable
-import java.net.URL
+import kotlinx.coroutines.reactive.awaitSingle
+import org.springframework.http.MediaType
+import org.springframework.http.codec.json.Jackson2JsonDecoder
+import org.springframework.http.codec.json.Jackson2JsonEncoder
+import org.springframework.web.reactive.function.client.WebClient
 import java.util.concurrent.ConcurrentHashMap
 
 /**
- * A lightweight typesafe GraphQL HTTP client using Ktor HTTP client engine.
+ * A lightweight typesafe GraphQL HTTP client using Spring WebClient engine.
  */
-@KtorExperimentalAPI
-open class GraphQLKtorClient<in T : HttpClientEngineConfig>(
-    private val url: URL,
-    engineFactory: HttpClientEngineFactory<T>,
+open class GraphQLWebClient(
+    url: String,
     private val mapper: ObjectMapper = jacksonObjectMapper(),
-    configuration: HttpClientConfig<T>.() -> Unit = {}
-) : GraphQLClient, Closeable {
+    builder: WebClient.Builder = WebClient.builder()
+) : GraphQLClient {
 
     private val typeCache = ConcurrentHashMap<Class<*>, JavaType>()
 
     init {
         mapper.enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE)
-    }
 
-    private val client = HttpClient(engineFactory = engineFactory) {
-        apply(configuration)
-
-        // install default JSON serializer
-        install(JsonFeature) {
-            serializer = JacksonSerializer(mapper)
+        builder.codecs { codecConfigurer ->
+            codecConfigurer.defaultCodecs().jackson2JsonEncoder(Jackson2JsonEncoder(mapper, MediaType.APPLICATION_JSON))
+            codecConfigurer.defaultCodecs().jackson2JsonDecoder(Jackson2JsonDecoder(mapper, MediaType.APPLICATION_JSON))
         }
     }
+
+    private val client: WebClient = builder.baseUrl(url).build()
 
     /**
      * Executes specified GraphQL query or mutation.
@@ -71,7 +58,13 @@ open class GraphQLKtorClient<in T : HttpClientEngineConfig>(
      * default serialization would attempt to serialize results back to Any object. As a workaround we get raw results as String which we then
      * manually deserialize using passed in result type Class information.
      */
-    open suspend fun <T> execute(query: String, operationName: String? = null, variables: Any? = null, resultType: Class<T>, requestBuilder: HttpRequestBuilder.() -> Unit): GraphQLResponse<T> {
+    open suspend fun <T> execute(
+        query: String,
+        operationName: String? = null,
+        variables: Any? = null,
+        resultType: Class<T>,
+        requestBuilder: WebClient.RequestBodyUriSpec.() -> Unit
+    ): GraphQLResponse<T> {
         // Variables are simple data classes which will be serialized as map.
         // By using map instead of typed object we can eliminate the need to explicitly convert variables to a map
         val graphQLRequest = mapOf(
@@ -80,11 +73,14 @@ open class GraphQLKtorClient<in T : HttpClientEngineConfig>(
             "variables" to variables
         )
 
-        val rawResult = client.post<String>(url) {
-            apply(requestBuilder)
-            contentType(ContentType.Application.Json)
-            body = graphQLRequest
-        }
+        val rawResult = client.post()
+            .apply(requestBuilder)
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(graphQLRequest)
+            .retrieve()
+            .bodyToMono(String::class.java)
+            .awaitSingle()
 
         @Suppress("BlockingMethodInNonBlockingContext")
         return mapper.readValue(rawResult, parameterizedType(resultType))
@@ -96,20 +92,11 @@ open class GraphQLKtorClient<in T : HttpClientEngineConfig>(
     /**
      * Executes specified GraphQL query or mutation operation.
      */
-    suspend inline fun <reified T> execute(query: String, operationName: String? = null, variables: Any? = null, noinline requestBuilder: HttpRequestBuilder.() -> Unit): GraphQLResponse<T> =
+    suspend inline fun <reified T> execute(query: String, operationName: String? = null, variables: Any? = null, noinline requestBuilder: WebClient.RequestBodyUriSpec.() -> Unit): GraphQLResponse<T> =
         execute(query, operationName, variables, T::class.java, requestBuilder)
 
     private fun <T> parameterizedType(resultType: Class<T>): JavaType =
         typeCache.computeIfAbsent(resultType) {
             mapper.typeFactory.constructParametricType(GraphQLResponse::class.java, resultType)
         }
-
-    override fun close() {
-        client.close()
-    }
-
-    companion object {
-        operator fun invoke(url: URL, mapper: ObjectMapper = jacksonObjectMapper(), config: HttpClientConfig<CIOEngineConfig>.() -> Unit = {}) =
-            GraphQLKtorClient(url = url, engineFactory = CIO, mapper = mapper, configuration = config)
-    }
 }

--- a/clients/graphql-kotlin-spring-client/src/test/kotlin/GraphQLWebClientTest.kt
+++ b/clients/graphql-kotlin-spring-client/src/test/kotlin/GraphQLWebClientTest.kt
@@ -1,5 +1,22 @@
-package com.expediagroup.graphql.client
+/*
+ * Copyright 2021 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
+package com.expediagroup.graphql.client.spring
+
+import com.expediagroup.graphql.client.execute
 import com.expediagroup.graphql.types.GraphQLError
 import com.expediagroup.graphql.types.GraphQLResponse
 import com.expediagroup.graphql.types.SourceLocation

--- a/docs/client/client-customization.md
+++ b/docs/client/client-customization.md
@@ -185,7 +185,7 @@ And then configure build plugin by specifying
 graphql {
     packageName = "com.example.generated"
     endpoint = "http://localhost:8080/graphql"
-    converters.put("UUID", ScalarConverterMapping("java.util.UUID", "com.example.UUIDScalarConverter"))
+    customScalars = listOf(GraphQLScalar("UUID", "java.util.UUID", "com.example.UUIDScalarConverter"))
 }
 ```
 

--- a/docs/client/client-features.md
+++ b/docs/client/client-features.md
@@ -3,7 +3,7 @@ id: client-features
 title: Client Features
 ---
 
-## Polymorphic Types Support
+## Polymorphic Types Support
 
 GraphQL supports polymorphic types through unions and interfaces which can be represented in Kotlin as marker and
 regular interfaces. In order to ensure generated objects are not empty, GraphQL queries referencing polymorphic types
@@ -83,7 +83,7 @@ data class SecondInterfaceImplementation(
 ) : PolymorphicQuery.BasicInterface
 ```
 
-## Default Enum Values
+## Default Enum Values
 
 Enums represent predefined set of values. Adding additional enum values could be a potentially breaking change as your
 clients may not be able to process it. GraphQL Kotlin Client automatically adds default `@JsonEnumDefaultValue __UNKNOWN_VALUE`

--- a/docs/client/client-overview.md
+++ b/docs/client/client-overview.md
@@ -51,7 +51,7 @@ Basic `build.gradle.kts` Gradle configuration that executes introspection query 
 schema and then generate the clients under `com.example.generated` package name:
 
 ```kotlin
-import com.expediagroup.graphql.plugin.generator.GraphQLClientType
+import com.expediagroup.graphql.plugin.gradle.config.GraphQLClientType
 import com.expediagroup.graphql.plugin.gradle.graphql
 
 plugins {
@@ -164,7 +164,7 @@ Plugins will generate following client code
 ```kotlin
 package com.example.generated
 
-import com.expediagroup.graphql.client.GraphQLKtorClient
+import com.expediagroup.graphql.client.spring.GraphQLKtorClient
 import com.expediagroup.graphql.types.GraphQLResponse
 import kotlin.String
 
@@ -194,7 +194,7 @@ specified and defaults to fully asynchronous non-blocking [Coroutine-based IO en
 ```kotlin
 package com.example.client
 
-import com.expediagroup.graphql.client.GraphQLKtorClient
+import com.expediagroup.graphql.client.ktor.GraphQLKtorClient
 import com.expediagroup.graphql.generated.HelloWorldQuery
 import kotlinx.coroutines.runBlocking
 import java.net.URL

--- a/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/GraphQLClientGenerator.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/GraphQLClientGenerator.kt
@@ -41,7 +41,9 @@ import graphql.schema.idl.TypeDefinitionRegistry
 import io.ktor.client.request.HttpRequestBuilder
 import java.io.File
 
-private const val LIBRARY_PACKAGE = "com.expediagroup.graphql.client"
+private const val LIBRARY_CLIENT_PACKAGE = "com.expediagroup.graphql.client"
+private const val LIBRARY_CLIENT_KTOR_PACKAGE = "com.expediagroup.graphql.client.ktor"
+private const val LIBRARY_CLIENT_SPRING_PACKAGE = "com.expediagroup.graphql.client.spring"
 private const val CORE_TYPES_PACKAGE = "com.expediagroup.graphql.types"
 
 /**
@@ -136,7 +138,7 @@ class GraphQLClientGenerator(
                         .build()
                     funSpec.addParameter(ktorRequestCustomizer)
                     funSpec.addStatement("return graphQLClient.execute($queryConstName, $operationName, $variableCode, requestBuilder)")
-                    ClassName(LIBRARY_PACKAGE, "GraphQLKtorClient").parameterizedBy(STAR)
+                    ClassName(LIBRARY_CLIENT_KTOR_PACKAGE, "GraphQLKtorClient").parameterizedBy(STAR)
                 }
                 GraphQLClientType.WEBCLIENT -> {
                     val webClientRequestCustomizer: ParameterSpec = ParameterSpec.builder(
@@ -151,12 +153,12 @@ class GraphQLClientGenerator(
                         .build()
                     funSpec.addParameter(webClientRequestCustomizer)
                     funSpec.addStatement("return graphQLClient.execute($queryConstName, $operationName, $variableCode, requestBuilder)")
-                    ClassName(LIBRARY_PACKAGE, "GraphQLWebClient")
+                    ClassName(LIBRARY_CLIENT_SPRING_PACKAGE, "GraphQLWebClient")
                 }
                 else -> {
-                    val executeExtensionFunction = MemberName(LIBRARY_PACKAGE, "execute")
+                    val executeExtensionFunction = MemberName(LIBRARY_CLIENT_PACKAGE, "execute")
                     funSpec.addStatement("return graphQLClient.%M($queryConstName, $operationName, $variableCode)", executeExtensionFunction)
-                    ClassName(LIBRARY_PACKAGE, "GraphQLClient")
+                    ClassName(LIBRARY_CLIENT_PACKAGE, "GraphQLClient")
                 }
             }
 

--- a/plugins/client/graphql-kotlin-client-generator/src/test/kotlin/com/expediagroup/graphql/plugin/client/generator/types/GenerateGraphQLClientIT.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/kotlin/com/expediagroup/graphql/plugin/client/generator/types/GenerateGraphQLClientIT.kt
@@ -246,7 +246,7 @@ class GenerateGraphQLClientIT {
             """
                 package com.expediagroup.graphql.plugin.generator.integration
 
-                import com.expediagroup.graphql.client.GraphQLKtorClient
+                import com.expediagroup.graphql.client.ktor.GraphQLKtorClient
                 import com.expediagroup.graphql.types.GraphQLResponse
                 import io.ktor.client.request.HttpRequestBuilder
                 import kotlin.String
@@ -311,7 +311,7 @@ class GenerateGraphQLClientIT {
             """
                 package com.expediagroup.graphql.plugin.generator.integration
 
-                import com.expediagroup.graphql.client.GraphQLWebClient
+                import com.expediagroup.graphql.client.spring.GraphQLWebClient
                 import com.expediagroup.graphql.types.GraphQLResponse
                 import kotlin.String
                 import kotlin.Unit

--- a/plugins/graphql-kotlin-gradle-plugin/src/test/resources/templates/Application.mustache
+++ b/plugins/graphql-kotlin-gradle-plugin/src/test/resources/templates/Application.mustache
@@ -2,11 +2,11 @@ package com.example
 
 import com.example.generated.JUnitQuery
 {{#webClient}}
-    import com.expediagroup.graphql.client.GraphQLWebClient
+    import com.expediagroup.graphql.client.spring.GraphQLWebClient
     import org.springframework.web.reactive.function.client.WebClient
 {{/webClient}}
 {{^webClient}}
-    import com.expediagroup.graphql.client.GraphQLKtorClient
+    import com.expediagroup.graphql.client.ktor.GraphQLKtorClient
 {{/webClient}}
 import com.expediagroup.graphql.client.execute
 import io.ktor.client.features.defaultRequest

--- a/plugins/graphql-kotlin-gradle-plugin/src/test/resources/templates/JUnit.mustache
+++ b/plugins/graphql-kotlin-gradle-plugin/src/test/resources/templates/JUnit.mustache
@@ -1,7 +1,7 @@
 package com.example
 
 import com.example.generated.JUnitQuery
-import com.expediagroup.graphql.client.GraphQLKtorClient
+import com.expediagroup.graphql.client.ktor.GraphQLKtorClient
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull

--- a/plugins/graphql-kotlin-maven-plugin/src/integration/basic-setup/src/test/kotlin/com/expediagroup/graphql/plugin/maven/GraphQLMavenPluginTest.kt
+++ b/plugins/graphql-kotlin-maven-plugin/src/integration/basic-setup/src/test/kotlin/com/expediagroup/graphql/plugin/maven/GraphQLMavenPluginTest.kt
@@ -17,7 +17,7 @@
 package com.expediagroup.graphql.plugin.maven
 
 import com.expediagroup.graphql.plugin.generated.ExampleQuery
-import com.expediagroup.graphql.client.GraphQLKtorClient
+import com.expediagroup.graphql.client.ktor.GraphQLKtorClient
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull

--- a/plugins/graphql-kotlin-maven-plugin/src/integration/complete-setup/src/test/kotlin/com/expediagroup/graphql/plugin/maven/GraphQLMavenPluginTest.kt
+++ b/plugins/graphql-kotlin-maven-plugin/src/integration/complete-setup/src/test/kotlin/com/expediagroup/graphql/plugin/maven/GraphQLMavenPluginTest.kt
@@ -18,7 +18,7 @@ package com.expediagroup.graphql.plugin.maven
 
 import com.expediagroup.graphql.plugin.generated.ExampleQuery
 import com.expediagroup.graphql.plugin.generated.UUID
-import com.expediagroup.graphql.client.GraphQLKtorClient
+import com.expediagroup.graphql.client.ktor.GraphQLKtorClient
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull


### PR DESCRIPTION
### :pencil: Description

Moving `GraphQLKotlinKtorClient` and `GraphQLKotlinWebClient` to their specific `ktor` and `spring` packages. Also simplifying project structure as per https://kotlinlang.org/docs/reference/coding-conventions.html#directory-structure.

### :link: Related Issues

 See https://github.com/ExpediaGroup/graphql-kotlin/discussions/1000 for details.