### PR TITLE
[build] enable GH action to upload build reports on failure

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -69,5 +69,5 @@ jobs:
         if: failure()
         with:
           name: build-examples-reports-${{ matrix.java }}
-          path: ./**/build/reports
+          path: ./examples/**/build/reports
           retention-days: 7

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -63,3 +63,11 @@ jobs:
       - name: Build examples with Gradle
         working-directory: examples
         run: ./gradlew clean build
+
+      - name: Archive examples build reports
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: build-examples-reports-${{ matrix.java }}
+          path: ./**/build/reports
+          retention-days: 7

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -49,6 +49,17 @@ jobs:
       - name: Build library with Gradle
         run: ./gradlew clean build
 
+      - name: Archive build reports
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: build-reports-${{ matrix.java }}
+          path: |
+            ./**/build/reports
+            plugins/graphql-kotlin-maven-plugin/build/integration/**/build.log
+            plugins/graphql-kotlin-maven-plugin/build/integration/**/target/surefire-reports
+          retention-days: 7
+
       - name: Build examples with Gradle
         working-directory: examples
         run: ./gradlew clean build

--- a/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePluginIT.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePluginIT.kt
@@ -64,7 +64,7 @@ class GraphQLGradlePluginIT : GraphQLGradlePluginAbstractIT() {
         val buildResult = GradleRunner.create()
             .withProjectDir(testProjectDirectory)
             .withPluginClasspath()
-            .withArguments("build", "run")
+            .withArguments("build", "run", "--stacktrace")
             .build()
 
         assertEquals(TaskOutcome.SUCCESS, buildResult.task(":$INTROSPECT_SCHEMA_TASK_NAME")?.outcome)
@@ -121,7 +121,7 @@ class GraphQLGradlePluginIT : GraphQLGradlePluginAbstractIT() {
         val buildResult = GradleRunner.create()
             .withProjectDir(testProjectDirectory)
             .withPluginClasspath()
-            .withArguments("build", "run")
+            .withArguments("build", "run", "--stacktrace")
             .build()
 
         assertEquals(TaskOutcome.SUCCESS, buildResult.task(":$DOWNLOAD_SDL_TASK_NAME")?.outcome)
@@ -193,7 +193,7 @@ class GraphQLGradlePluginIT : GraphQLGradlePluginAbstractIT() {
         val buildResult = GradleRunner.create()
             .withProjectDir(testProjectDirectory)
             .withPluginClasspath()
-            .withArguments("build", "run")
+            .withArguments("build", "run", "--stacktrace")
             .build()
 
         assertEquals(TaskOutcome.SUCCESS, buildResult.task(":$DOWNLOAD_SDL_TASK_NAME")?.outcome)
@@ -254,7 +254,7 @@ class GraphQLGradlePluginIT : GraphQLGradlePluginAbstractIT() {
         val buildResult = GradleRunner.create()
             .withProjectDir(testProjectDirectory)
             .withPluginClasspath()
-            .withArguments("build", "run")
+            .withArguments("build", "run", "--stacktrace")
             .build()
 
         assertEquals(TaskOutcome.SUCCESS, buildResult.task(":$DOWNLOAD_SDL_TASK_NAME")?.outcome)
@@ -298,7 +298,7 @@ class GraphQLGradlePluginIT : GraphQLGradlePluginAbstractIT() {
         val buildResult = GradleRunner.create()
             .withProjectDir(testProjectDirectory)
             .withPluginClasspath()
-            .withArguments("build", "run")
+            .withArguments("build", "run", "--stacktrace")
             .build()
 
         assertEquals(TaskOutcome.SUCCESS, buildResult.task(":$DOWNLOAD_SDL_TASK_NAME")?.outcome)
@@ -331,7 +331,7 @@ class GraphQLGradlePluginIT : GraphQLGradlePluginAbstractIT() {
         val buildResult = GradleRunner.create()
             .withProjectDir(testProjectDirectory)
             .withPluginClasspath()
-            .withArguments(GENERATE_SDL_TASK_NAME)
+            .withArguments(GENERATE_SDL_TASK_NAME, "--stacktrace")
             .build()
         assertEquals(TaskOutcome.SUCCESS, buildResult.task(":$GENERATE_SDL_TASK_NAME")?.outcome)
 
@@ -362,7 +362,7 @@ class GraphQLGradlePluginIT : GraphQLGradlePluginAbstractIT() {
         val buildResult = GradleRunner.create()
             .withProjectDir(testProjectDirectory)
             .withPluginClasspath()
-            .withArguments(GENERATE_SDL_TASK_NAME)
+            .withArguments(GENERATE_SDL_TASK_NAME, "--stacktrace")
             .build()
         assertEquals(TaskOutcome.SUCCESS, buildResult.task(":$GENERATE_SDL_TASK_NAME")?.outcome)
 
@@ -394,7 +394,7 @@ class GraphQLGradlePluginIT : GraphQLGradlePluginAbstractIT() {
         val buildResult = GradleRunner.create()
             .withProjectDir(testProjectDirectory)
             .withPluginClasspath()
-            .withArguments(GENERATE_SDL_TASK_NAME)
+            .withArguments(GENERATE_SDL_TASK_NAME, "--stacktrace")
             .build()
         assertEquals(TaskOutcome.SUCCESS, buildResult.task(":$GENERATE_SDL_TASK_NAME")?.outcome)
 
@@ -426,7 +426,7 @@ class GraphQLGradlePluginIT : GraphQLGradlePluginAbstractIT() {
         val buildResult = GradleRunner.create()
             .withProjectDir(testProjectDirectory)
             .withPluginClasspath()
-            .withArguments(GENERATE_SDL_TASK_NAME)
+            .withArguments(GENERATE_SDL_TASK_NAME, "--stacktrace")
             .build()
         assertEquals(TaskOutcome.SUCCESS, buildResult.task(":$GENERATE_SDL_TASK_NAME")?.outcome)
 
@@ -525,7 +525,7 @@ class GraphQLGradlePluginIT : GraphQLGradlePluginAbstractIT() {
         val buildResult = GradleRunner.create()
             .withProjectDir(testProjectDirectory)
             .withPluginClasspath()
-            .withArguments(GENERATE_SDL_TASK_NAME)
+            .withArguments(GENERATE_SDL_TASK_NAME, "--stacktrace")
             .build()
         assertEquals(TaskOutcome.SUCCESS, buildResult.task(":$GENERATE_SDL_TASK_NAME")?.outcome)
 

--- a/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/GraphQLDownloadSDLTaskIT.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/GraphQLDownloadSDLTaskIT.kt
@@ -142,7 +142,7 @@ class GraphQLDownloadSDLTaskIT : GraphQLGradlePluginAbstractIT() {
         val result = GradleRunner.create()
             .withProjectDir(testProjectDirectory)
             .withPluginClasspath()
-            .withArguments(DOWNLOAD_SDL_TASK_NAME)
+            .withArguments(DOWNLOAD_SDL_TASK_NAME, "--stacktrace")
             .build()
 
         assertEquals(TaskOutcome.SUCCESS, result.task(":$DOWNLOAD_SDL_TASK_NAME")?.outcome)
@@ -153,7 +153,7 @@ class GraphQLDownloadSDLTaskIT : GraphQLGradlePluginAbstractIT() {
         val result = GradleRunner.create()
             .withProjectDir(testProjectDirectory)
             .withPluginClasspath()
-            .withArguments(DOWNLOAD_SDL_TASK_NAME)
+            .withArguments(DOWNLOAD_SDL_TASK_NAME, "--stacktrace")
             .buildAndFail()
 
         assertEquals(TaskOutcome.FAILED, result.task(":$DOWNLOAD_SDL_TASK_NAME")?.outcome)

--- a/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/GraphQLGenerateClientTaskIT.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/GraphQLGenerateClientTaskIT.kt
@@ -92,7 +92,7 @@ class GraphQLGenerateClientTaskIT : GraphQLGradlePluginAbstractIT() {
         val buildResult = GradleRunner.create()
             .withProjectDir(testProjectDirectory)
             .withPluginClasspath()
-            .withArguments(GENERATE_CLIENT_TASK_NAME)
+            .withArguments(GENERATE_CLIENT_TASK_NAME, "--stacktrace")
             .buildAndFail()
 
         assertEquals(TaskOutcome.FAILED, buildResult.task(":$GENERATE_CLIENT_TASK_NAME")?.outcome)
@@ -194,7 +194,7 @@ class GraphQLGenerateClientTaskIT : GraphQLGradlePluginAbstractIT() {
         val buildResult = GradleRunner.create()
             .withProjectDir(testProjectDirectory)
             .withPluginClasspath()
-            .withArguments(GENERATE_TEST_CLIENT_TASK_NAME, "test")
+            .withArguments(GENERATE_TEST_CLIENT_TASK_NAME, "test", "--stacktrace")
             .build()
 
         assertEquals(TaskOutcome.SUCCESS, buildResult.task(":$GENERATE_TEST_CLIENT_TASK_NAME")?.outcome)
@@ -245,7 +245,7 @@ class GraphQLGenerateClientTaskIT : GraphQLGradlePluginAbstractIT() {
         val buildResult = GradleRunner.create()
             .withProjectDir(testProjectDirectory)
             .withPluginClasspath()
-            .withArguments(GENERATE_CLIENT_TASK_NAME, "run")
+            .withArguments(GENERATE_CLIENT_TASK_NAME, "run", "--stacktrace")
             .build()
         assertEquals(TaskOutcome.SUCCESS, buildResult.task(":$GENERATE_CLIENT_TASK_NAME")?.outcome)
         assertTrue(File(testProjectDirectory, "build/generated/source/graphql/main/com/example/generated/JUnitQuery.kt").exists())

--- a/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/GraphQLGenerateSDLTaskIT.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/GraphQLGenerateSDLTaskIT.kt
@@ -144,7 +144,7 @@ class GraphQLGenerateSDLTaskIT : GraphQLGradlePluginAbstractIT() {
         val buildResult = GradleRunner.create()
             .withProjectDir(testProjectDirectory)
             .withPluginClasspath()
-            .withArguments(GENERATE_SDL_TASK_NAME)
+            .withArguments(GENERATE_SDL_TASK_NAME, "--stacktrace")
             .build()
         assertEquals(TaskOutcome.SUCCESS, buildResult.task(":$GENERATE_SDL_TASK_NAME")?.outcome)
 
@@ -175,7 +175,7 @@ class GraphQLGenerateSDLTaskIT : GraphQLGradlePluginAbstractIT() {
         val buildResult = GradleRunner.create()
             .withProjectDir(testProjectDirectory)
             .withPluginClasspath()
-            .withArguments(GENERATE_SDL_TASK_NAME)
+            .withArguments(GENERATE_SDL_TASK_NAME, "--stacktrace")
             .build()
         assertEquals(TaskOutcome.SUCCESS, buildResult.task(":$GENERATE_SDL_TASK_NAME")?.outcome)
 
@@ -205,7 +205,7 @@ class GraphQLGenerateSDLTaskIT : GraphQLGradlePluginAbstractIT() {
         val buildResult = GradleRunner.create()
             .withProjectDir(testProjectDirectory)
             .withPluginClasspath()
-            .withArguments(GENERATE_SDL_TASK_NAME)
+            .withArguments(GENERATE_SDL_TASK_NAME, "--stacktrace")
             .build()
         assertEquals(TaskOutcome.SUCCESS, buildResult.task(":$GENERATE_SDL_TASK_NAME")?.outcome)
 
@@ -236,7 +236,7 @@ class GraphQLGenerateSDLTaskIT : GraphQLGradlePluginAbstractIT() {
         val buildResult = GradleRunner.create()
             .withProjectDir(testProjectDirectory)
             .withPluginClasspath()
-            .withArguments(GENERATE_SDL_TASK_NAME)
+            .withArguments(GENERATE_SDL_TASK_NAME, "--stacktrace")
             .build()
         assertEquals(TaskOutcome.SUCCESS, buildResult.task(":$GENERATE_SDL_TASK_NAME")?.outcome)
 

--- a/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/GraphQLIntrospectSchemaTaskIT.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/GraphQLIntrospectSchemaTaskIT.kt
@@ -137,7 +137,7 @@ class GraphQLIntrospectSchemaTaskIT : GraphQLGradlePluginAbstractIT() {
         val result = GradleRunner.create()
             .withProjectDir(testProjectDirectory)
             .withPluginClasspath()
-            .withArguments(INTROSPECT_SCHEMA_TASK_NAME)
+            .withArguments(INTROSPECT_SCHEMA_TASK_NAME, "--stacktrace")
             .build()
 
         assertEquals(TaskOutcome.SUCCESS, result.task(":$INTROSPECT_SCHEMA_TASK_NAME")?.outcome)
@@ -148,7 +148,7 @@ class GraphQLIntrospectSchemaTaskIT : GraphQLGradlePluginAbstractIT() {
         val result = GradleRunner.create()
             .withProjectDir(testProjectDirectory)
             .withPluginClasspath()
-            .withArguments(INTROSPECT_SCHEMA_TASK_NAME)
+            .withArguments(INTROSPECT_SCHEMA_TASK_NAME, "--stacktrace")
             .buildAndFail()
 
         assertEquals(TaskOutcome.FAILED, result.task(":$INTROSPECT_SCHEMA_TASK_NAME")?.outcome)


### PR DESCRIPTION
### :pencil: Description

Enables https://github.com/actions/upload-artifact to upload all generated build reports (detekt, jacoco, ktlint, junit) on build failure. Currently we only have access to build logs which may not provide enough information about the failure. If this works as expected we will enable this on the main CI build as well.

### :link: Related Issues

N/A