### PR TITLE
[build] upload failure reports on CI and release workflows

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -40,9 +40,28 @@ jobs:
       - name: Build libraries with Gradle
         run: ./gradlew clean build
 
+      - name: Archive failure build reports
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: build-reports-${{ matrix.java }}
+          path: |
+            ./**/build/reports
+            plugins/graphql-kotlin-maven-plugin/build/integration/**/build.log
+            plugins/graphql-kotlin-maven-plugin/build/integration/**/target/surefire-reports
+          retention-days: 7
+
       - name: Build examples with Gradle
         working-directory: examples
         run: ./gradlew clean build
+
+      - name: Archive examples failure build reports
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: build-examples-reports-${{ matrix.java }}
+          path: ./examples/**/build/reports
+          retention-days: 7
 
   release-notes:
     timeout-minutes: 10

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Build library with Gradle
         run: ./gradlew clean build
 
-      - name: Archive build reports
+      - name: Archive failure build reports
         uses: actions/upload-artifact@v2
         if: failure()
         with:
@@ -64,7 +64,7 @@ jobs:
         working-directory: examples
         run: ./gradlew clean build
 
-      - name: Archive examples build reports
+      - name: Archive examples failure build reports
         uses: actions/upload-artifact@v2
         if: failure()
         with:

--- a/.github/workflows/release-code.yml
+++ b/.github/workflows/release-code.yml
@@ -36,3 +36,14 @@ jobs:
           GPG_PASSPHRASE: ${{ secrets.GPG_PRIVATE_KEY_PASSPHRASE }}
           PLUGIN_PORTAL_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
           PLUGIN_PORTAL_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
+
+      - name: Archive failure build reports
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: build-reports-${{ matrix.java }}
+          path: |
+            ./**/build/reports
+            plugins/graphql-kotlin-maven-plugin/build/integration/**/build.log
+            plugins/graphql-kotlin-maven-plugin/build/integration/**/target/surefire-reports
+          retention-days: 7


### PR DESCRIPTION
### :pencil: Description

Enables https://github.com/actions/upload-artifact to upload all generated build reports (detekt, jacoco, ktlint, junit) on build failure. Currently GH actions do not allow access to their workspace and we only have access to build logs which may not provide enough information about the failure.

### :link: Related Issues

https://github.com/ExpediaGroup/graphql-kotlin/pull/1011