### PR TITLE
[generator] create Kotlin PropertyDataFetcher

### DIFF
--- a/docs/schema-generator/execution/fetching-data.md
+++ b/docs/schema-generator/execution/fetching-data.md
@@ -6,7 +6,8 @@ title: Fetching Data
 Each field exposed in the GraphQL schema has a corresponding resolver (aka data fetcher) associated with it. `graphql-kotlin-schema-generator` generates the GraphQL schema
 directly from the source code, automatically mapping all the fields either to use
 [FunctionDataFetcher](https://github.com/ExpediaGroup/graphql-kotlin/blob/master/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/execution/FunctionDataFetcher.kt)
-to resolve underlying functions or the default data fetcher from graphql-java, [PropertyDataFetcher](https://www.graphql-java.com/documentation/v15/data-fetching/) to read a value from an underlying Kotlin property.
+to resolve underlying functions or the [PropertyDataFetcher](https://github.com/ExpediaGroup/graphql-kotlin/blob/master/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/execution/PropertyDataFetcher.kt)
+to read a value from an underlying Kotlin property.
 
 While all the fields in a GraphQL schema are resolved independently to produce a final result, whether a field is backed by a function or a property can have significant
 performance repercussions. For example, given the following schema:

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/execution/KotlinDataFetcherFactoryProvider.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/execution/KotlinDataFetcherFactoryProvider.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Expedia, Inc
+ * Copyright 2021 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@ package com.expediagroup.graphql.generator.execution
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import graphql.schema.DataFetcherFactory
-import graphql.schema.PropertyDataFetcher
 import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
 import kotlin.reflect.KProperty
@@ -64,7 +63,7 @@ open class SimpleKotlinDataFetcherFactoryProvider(
         )
     }
 
-    override fun propertyDataFetcherFactory(kClass: KClass<*>, kProperty: KProperty<*>) = DataFetcherFactory<Any?> {
-        PropertyDataFetcher(kProperty.name)
+    override fun propertyDataFetcherFactory(kClass: KClass<*>, kProperty: KProperty<*>) = DataFetcherFactory {
+        PropertyDataFetcher(kProperty.getter)
     }
 }

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/execution/PropertyDataFetcher.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/execution/PropertyDataFetcher.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.generator.execution
+
+import graphql.schema.DataFetcher
+import graphql.schema.DataFetchingEnvironment
+import kotlin.reflect.KProperty
+
+/**
+ * Property [DataFetcher] that directly invokes underlying property getter.
+ *
+ * @param propertyGetter Kotlin property getter that will be invoked to resolve a field
+ */
+class PropertyDataFetcher(private val propertyGetter: KProperty.Getter<*>) : DataFetcher<Any?> {
+
+    /**
+     * Invokes target getter function.
+     */
+    override fun get(environment: DataFetchingEnvironment): Any? = environment.getSource<Any?>()?.let { instance ->
+        propertyGetter.call(instance)
+    }
+}

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/execution/PropertyDataFetcherTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/execution/PropertyDataFetcherTest.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2021 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.generator.execution
+
+import com.expediagroup.graphql.generator.TopLevelObject
+import com.expediagroup.graphql.generator.testSchemaConfig
+import com.expediagroup.graphql.generator.toSchema
+import graphql.GraphQL
+import graphql.schema.DataFetchingEnvironment
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class PropertyDataFetcherTest {
+
+    private val schema = toSchema(
+        queries = listOf(TopLevelObject(PrefixedQuery())),
+        config = testSchemaConfig
+    )
+    private val graphQL = GraphQL.newGraphQL(schema).build()
+
+    @Test
+    fun `verify null source returns null`() {
+        val dataFetcher = PropertyDataFetcher(propertyGetter = PrefixedFields::isBooleanValue.getter)
+        val mockEnvironment: DataFetchingEnvironment = mockk {
+            every { getSource<Any>() } returns null
+        }
+        assertNull(dataFetcher.get(mockEnvironment))
+    }
+
+    @Test
+    fun `verify is prefix resolution for boolean field`() {
+        val result = graphQL.execute("{ prefixed { booleanValue isBooleanValue } }")
+        val data: Map<String, Map<String, Any>>? = result.getData()
+
+        val prefixedResults = data?.get("prefixed")
+        assertNotNull(prefixedResults)
+        assertEquals(2, prefixedResults.size)
+        assertEquals(true, prefixedResults["booleanValue"])
+        assertEquals(false, prefixedResults["isBooleanValue"])
+    }
+
+    @Test
+    fun `verify properties are correctly resolved`() {
+        val result = graphQL.execute("{ prefixed { islandName isWhatever } }")
+        val data: Map<String, Map<String, Any>>? = result.getData()
+
+        val prefixedResults = data?.get("prefixed")
+        assertNotNull(prefixedResults)
+        assertEquals(2, prefixedResults.size)
+        assertEquals("Iceland", prefixedResults["islandName"])
+        assertEquals("whatever", prefixedResults["isWhatever"])
+    }
+
+    class PrefixedQuery {
+        fun prefixed() = PrefixedFields()
+    }
+
+    data class PrefixedFields(
+        val islandName: String = "Iceland",
+        val booleanValue: Boolean = true,
+        val isBooleanValue: Boolean = false,
+        val isWhatever: String = "whatever"
+    )
+}

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/types/GeneratePropertyTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/types/GeneratePropertyTest.kt
@@ -24,6 +24,7 @@ import com.expediagroup.graphql.generator.annotations.GraphQLName
 import com.expediagroup.graphql.generator.directives.KotlinDirectiveWiringFactory
 import com.expediagroup.graphql.generator.directives.KotlinSchemaDirectiveWiring
 import com.expediagroup.graphql.generator.execution.KotlinDataFetcherFactoryProvider
+import com.expediagroup.graphql.generator.execution.PropertyDataFetcher
 import com.expediagroup.graphql.generator.hooks.SchemaGeneratorHooks
 import com.expediagroup.graphql.generator.internal.extensions.getSimpleName
 import com.expediagroup.graphql.generator.scalars.ID
@@ -36,7 +37,6 @@ import graphql.schema.FieldCoordinates
 import graphql.schema.GraphQLNamedType
 import graphql.schema.GraphQLNonNull
 import graphql.schema.GraphQLTypeUtil
-import graphql.schema.PropertyDataFetcher
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.spyk


### PR DESCRIPTION
### :pencil: Description

`graphql-java` [PropertyDataFetcher](https://github.com/graphql-java/graphql-java/blob/master/src/main/java/graphql/schema/PropertyDataFetcher.java) is the default data fetcher/resolver that will automatically resolve fields on target POJOs. It does so by using reflections to find out the target getter function that needs to be invoked - it accepts a property name and attempts to find matching getter in available class methods.

Since we are generating the schema directly from the source code, when we process the target property we already know which field it is so we can invoke it direcly and skip the redundant reflection logic from `graphql-java`. As a bonus we also address the ambiguity of accessing properties that use `is` prefix (as described in https://github.com/ExpediaGroup/graphql-kotlin/issues/529).

`graphql-java` caches those reflection lookups to avoid unncessary computations. I've run some basic benchmarks and as expected there is not much of a difference.

Simple benchmark (after warmup of 100_000 executions -> there is a pretty big warmup hit on `graphql-java`):
* per each datafetcher execute 100 iterations of 100_000 GraphQL query executions attempting to retrieve a property field

`graphql-java` avg: 2558 ms per 100_000 executions
`graphql-kotlin` avg: 2536 ms per 100_000 executions

### :link: Related Issues

Resolves: https://github.com/ExpediaGroup/graphql-kotlin/issues/529