### PR TITLE
[plugin] updates to Gradle plugin tasks configuration avoidance

### DIFF
--- a/docs/client/client-customization.md
+++ b/docs/client/client-customization.md
@@ -184,4 +184,4 @@ graphql {
 }
 ```
 
-See [Gradle](../plugins/gradle-plugin.md) and [Maven](../plugins/maven-plugin.md) plugin documentation for additional details.
+See [Gradle](../plugins/gradle-plugin-tasks.md) and [Maven](../plugins/maven-plugin-goals.md) plugin documentation for additional details.

--- a/docs/client/client-overview.md
+++ b/docs/client/client-overview.md
@@ -6,8 +6,8 @@ title: Client Overview
 GraphQL Kotlin provides a set of lightweight type-safe GraphQL HTTP clients. The library provides [Ktor HTTP client](https://ktor.io/clients/index.html)
 and [Spring WebClient](https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-webclient)
 based reference implementations as well as allows for custom implementations using other engines, see [client customization](client-customization.md)
-documentation for additional details. Type-safe data models are generated at build time by the GraphQL Kotlin [Gradle](../plugins/gradle-plugin.md)
-and [Maven](../plugins/maven-plugin.md) plugins.
+documentation for additional details. Type-safe data models are generated at build time by the GraphQL Kotlin [Gradle](../plugins/gradle-plugin-tasks.md)
+and [Maven](../plugins/maven-plugin-goals.md) plugins.
 
 Client Features:
 * Supports query and mutation operations
@@ -134,8 +134,8 @@ working examples of Gradle and Maven based projects.
 By default, GraphQL Kotlin build plugins will attempt to generate GraphQL clients from all `*.graphql` files located under
 `src/main/resources`. Queries are validated against the target GraphQL schema, which can be manually provided, retrieved by
 the plugins through introspection (as configured in examples above) or downloaded directly from a custom SDL endpoint.
-See our documentation for more details on supported [Gradle tasks](../plugins/gradle-plugin.md)
-and [Maven Mojos](../plugins/maven-plugin.md).
+See our documentation for more details on supported [Gradle tasks](../plugins/gradle-plugin-tasks.md)
+and [Maven Mojos](../plugins/maven-plugin-goals.md).
 
 When creating your GraphQL queries make sure to always specify an operation name and name the files accordingly. Each
 one of your query files will generate a corresponding Kotlin file with a class matching your operation

--- a/docs/plugins/gradle-plugin-tasks.md
+++ b/docs/plugins/gradle-plugin-tasks.md
@@ -1,6 +1,7 @@
 ---
-id: gradle-plugin
-title: Gradle Plugin
+id: gradle-plugin-tasks
+title: Gradle Plugin Tasks
+sidebar_label: Tasks
 ---
 
 GraphQL Kotlin Gradle Plugin provides functionality to generate a lightweight GraphQL HTTP client and generate GraphQL
@@ -121,8 +122,6 @@ graphql {
   schema {
     // List of supported packages that can contain GraphQL schema type definitions
     packages = listOf("com.example")
-    // Optional artifact name that contains SchemaGeneratorHooks service provider
-    hooksProviderArtifact = "com.expediagroup:graphql-kotlin-federated-hooks-provider:$graphQLKotlinVersion"
   }
 }
 ```
@@ -162,7 +161,6 @@ graphql {
     }
     schema {
         packages = ["com.example"]
-        hooksProviderArtifact = "com.expediagroup:graphql-kotlin-federated-hooks-provider:$graphQLKotlinVersion"
     }
 }
 ```
@@ -171,8 +169,25 @@ graphql {
 
 ## Tasks
 
+By default, `graphql-kotlin-gradle-plugin` lazily registers all its tasks which means that while they are known to the build,
+they are not created nor executed until something in the build needs the instantiated object (e.g. adding explicit dependency
+on those tasks or explicitly creating them). **Configuring plugin through the `graphql` extension will automatically creates
+all the corresponding tasks**.
+
 All `graphql-kotlin-gradle-plugin` tasks are grouped together under `GraphQL` task group and their names are prefixed with
 `graphql`. You can find detailed information about GraphQL kotlin tasks by running Gradle `help --task <taskName>` task.
+
+```shell
+> gradle --tasks
+
+GraphQL tasks
+-------------
+graphqlDownloadSDL - Download schema in SDL format from target endpoint.
+graphqlGenerateClient - Generate HTTP client from the specified GraphQL queries.
+graphqlGenerateSDL - Generate GraphQL schema in SDL format.
+graphqlGenerateTestClient - Generate HTTP test client from the specified GraphQL queries.
+graphqlIntrospectSchema - Run introspection query against target GraphQL endpoint and save schema locally.
+```
 
 ### graphqlDownloadSDL
 
@@ -222,9 +237,20 @@ GraphQL types.
 
 | Property | Type | Required | Description |
 | -------- | ---- | -------- | ----------- |
-| `hooksProvider` | String | | Optional fully qualified artifact name that contains SchemaGeneratorHooks service provider. **Default hooks:** `NoopSchemaGeneratorHooks` |
 | `packages` | List<String> | yes | List of supported packages that can be scanned to generate SDL. |
 | `schemaFile` | File | | Target GraphQL schema file to be generated.<br/>**Default value is:** `${project.buildDir}/schema.graphql` |
+
+By default, this task will attempt to generate the schema using `NoopSchemaGeneratorHooks`. If you need to customize your
+schema generation process, you will need to provide your custom instance of `SchemaGeneratorHooksProvider` service provider.
+Service provider can be provided as part of your project, included in one of your project dependencies or through explicitly
+provided artifact to the `graphqlSDL` configuration.
+
+```kotlin
+// build.gradle.kts
+dependencies {
+    graphqlSDL("com.expediagroup:graphql-kotlin-federated-hooks-provider:$graphQLKotlinVersion")
+}
+```
 
 ### graphqlGenerateTestClient
 

--- a/docs/plugins/gradle-plugin-usage.md
+++ b/docs/plugins/gradle-plugin-usage.md
@@ -1,7 +1,7 @@
 ---
-id: gradle-plugin-examples
-title: Gradle Plugin Examples
-sidebar_label: Gradle Examples
+id: gradle-plugin-usage
+title: Gradle Plugin Usage
+sidebar_label: Usage
 ---
 
 ## Downloading Schema SDL
@@ -366,7 +366,7 @@ import com.expediagroup.graphql.plugin.gradle.config.GraphQLClientType
 import com.expediagroup.graphql.plugin.gradle.config.GraphQLScalar
 import com.expediagroup.graphql.plugin.gradle.config.TimeoutConfiguration
 import com.expediagroup.graphql.plugin.gradle.tasks.GraphQLDownloadSDLTask
-import com.expediagroup.graphql.plugin.gradle.tasks.GraphQLIntrospectSchemaTask
+import com.expediagroup.graphql.plugin.gradle.tasks.GraphQLGenerateClientTask
 
 val graphqlDownloadSDL by tasks.getting(GraphQLDownloadSDLTask::class) {
     endpoint.set("http://localhost:8080/sdl")
@@ -434,6 +434,72 @@ graphqlGenerateClient {
     queryFiles.from("${project.projectDir}/src/main/resources/queries/MyQuery.graphql")
 
     dependsOn graphqlDownloadSDL
+}
+```
+
+<!--END_DOCUSAURUS_CODE_TABS-->
+
+## Generating Multiple Clients
+
+GraphQL Kotlin Gradle Plugin registers tasks for generation of a client queries targeting single GraphQL endpoint. You
+can generate queries targeting additional endpoints by explicitly creating and configuring additional tasks.
+
+<!--DOCUSAURUS_CODE_TABS-->
+<!--Kotlin-->
+
+```kotlin
+// build.gradle.kts
+import com.expediagroup.graphql.plugin.gradle.tasks.GraphQLDownloadSDLTask
+import com.expediagroup.graphql.plugin.gradle.tasks.GraphQLGenerateClientTask
+
+val graphqlDownloadSDL by tasks.getting(GraphQLDownloadSDLTask::class) {
+    endpoint.set("http://localhost:8080/sdl")
+}
+val graphqlGenerateClient by tasks.getting(GraphQLGenerateClientTask::class) {
+    packageName.set("com.example.generated.first")
+    schemaFile.set(graphqlDownloadSDL.outputFile)
+    queryFiles.from("${project.projectDir}/src/main/resources/queries/MyFirstQuery.graphql")
+    dependsOn("graphqlDownloadSDL")
+}
+
+val graphqlDownloadOtherSDL by tasks.creating(GraphQLDownloadSDLTask::class) {
+    endpoint.set("http://localhost:8081/sdl")
+}
+val graphqlGenerateOtherClient by tasks.creating(GraphQLGenerateClientTask::class) {
+    packageName.set("com.example.generated.second")
+    schemaFile.set(graphqlDownloadOtherSDL.outputFile)
+    queryFiles.from("${project.projectDir}/src/main/resources/queries/MySecondQuery.graphql")
+    dependsOn("graphqlDownloadOtherSDL")
+}
+```
+
+<!--Groovy-->
+
+```groovy
+//build.gradle
+import com.expediagroup.graphql.plugin.gradle.tasks.GraphQLDownloadSDLTask
+import com.expediagroup.graphql.plugin.gradle.tasks.GraphQLGenerateClientTask
+
+graphqlDownloadSDL {
+    endpoint = "http://localhost:8080/sdl"
+}
+graphqlGenerateClient {
+    packageName = "com.example.generated.first"
+    schemaFile = graphqlDownloadSDL.outputFile
+    queryFiles.from("${project.projectDir}/src/main/resources/queries/MyFirstQuery.graphql")
+
+    dependsOn graphqlDownloadSDL
+}
+
+task graphqlDownloadOtherSDL(type: GraphQLDownloadSDLTask) {
+    endpoint = "http://localhost:8081/sdl"
+}
+task graphqlGenerateOtherClient(type: GraphQLGenerateClientTask) {
+    packageName = "com.other.generated.second"
+    schemaFile = graphqlDownloadOtherSDL.outputFile
+    queryFiles.from("${project.projectDir}/src/main/resources/queries/MySecondQuery.graphql")
+
+    dependsOn graphqlDownloadOtherSDL
 }
 ```
 
@@ -520,8 +586,11 @@ import com.expediagroup.graphql.plugin.gradle.graphql
 graphql {
   schema {
     packages = listOf("com.example")
-    hooksProviderArtifact = "com.expediagroup:graphql-kotlin-federated-hooks-provider:$graphQLKotlinVersion"
   }
+}
+
+dependencies {
+    graphqlSDL("com.expediagroup:graphql-kotlin-federated-hooks-provider:$graphQLKotlinVersion")
 }
 ```
 
@@ -533,7 +602,10 @@ import com.expediagroup.graphql.plugin.gradle.tasks.GraphQLGenerateSDLTask
 
 val graphqlGenerateSDL by tasks.getting(GraphQLGenerateSDLTask::class) {
     packages.set(listOf("com.example"))
-    hooksProvider.set("com.expediagroup:graphql-kotlin-federated-hooks-provider:$graphQLKotlinVersion")
+}
+
+dependencies {
+    graphqlSDL("com.expediagroup:graphql-kotlin-federated-hooks-provider:$graphQLKotlinVersion")
 }
 ```
 
@@ -544,8 +616,11 @@ val graphqlGenerateSDL by tasks.getting(GraphQLGenerateSDLTask::class) {
 graphql {
   schema {
     packages = ["com.example"]
-    hooksProviderArtifact = "com.expediagroup:graphql-kotlin-federated-hooks-provider:$graphQLKotlinVersion"
   }
+}
+
+dependencies {
+    graphqlSDL "com.expediagroup:graphql-kotlin-federated-hooks-provider:$DEFAULT_PLUGIN_VERSION"
 }
 ```
 
@@ -555,7 +630,10 @@ Above configuration is equivalent to the following task definition
 //build.gradle
 graphqlGenerateSDL {
     packages = ["com.example"]
-    hooksProvider = "com.expediagroup:graphql-kotlin-federated-hooks-provider:$graphQLKotlinVersion"
+}
+
+dependencies {
+    graphqlSDL "com.expediagroup:graphql-kotlin-federated-hooks-provider:$DEFAULT_PLUGIN_VERSION"
 }
 ```
 

--- a/docs/plugins/maven-plugin-goals.md
+++ b/docs/plugins/maven-plugin-goals.md
@@ -1,6 +1,7 @@
 ---
-id: maven-plugin
-title: Maven Plugin
+id: maven-plugin-goals
+title: Maven Plugin Goals
+sidebar_label: Goals
 ---
 
 GraphQL Kotlin Maven Plugin provides functionality to generate a lightweight GraphQL HTTP client and generate GraphQL

--- a/docs/plugins/maven-plugin-usage.md
+++ b/docs/plugins/maven-plugin-usage.md
@@ -1,7 +1,7 @@
 ---
-id: maven-plugin-examples
-title: Maven Plugin Examples
-sidebar_label: Maven Examples
+id: maven-plugin-usage
+title: Maven Plugin Usage
+sidebar_label: Usage
 ---
 
 ## Downloading Schema SDL
@@ -301,6 +301,49 @@ the GraphQL client code based on the provided query.
                 </timeoutConfiguration>
                 <queryFiles>
                     <queryFile>${project.basedir}/src/main/resources/queries/MyQuery.graphql</queryFile>
+                </queryFiles>
+            </configuration>
+        </execution>
+    </executions>
+</plugin>
+```
+
+## Generating Multiple Clients
+
+In order to generate GraphQL clients targeting multiple endpoints, we need to configure separate executions targeting
+different endpoints.
+
+```xml
+<plugin>
+    <groupId>com.expediagroup</groupId>
+    <artifactId>graphql-kotlin-maven-plugin</artifactId>
+    <version>${graphql-kotlin.version}</version>
+    <executions>
+        <execution>
+            <id>generate-first-client</id>
+            <goals>
+                <goal>introspect-schema</goal>
+                <goal>generate-client</goal>
+            </goals>
+            <configuration>
+                <endpoint>http://localhost:8080/graphql</endpoint>
+                <packageName>com.example.generated.first</packageName>
+                <queryFiles>
+                    <queryFile>${project.basedir}/src/main/resources/queries/FirstQuery.graphql</queryFile>
+                </queryFiles>
+            </configuration>
+        </execution>
+        <execution>
+            <id>generate-second-client</id>
+            <goals>
+                <goal>introspect-schema</goal>
+                <goal>generate-client</goal>
+            </goals>
+            <configuration>
+                <endpoint>http://localhost:8081/graphql</endpoint>
+                <packageName>com.example.generated.second</packageName>
+                <queryFiles>
+                    <queryFile>${project.basedir}/src/main/resources/queries/SecondQuery.graphql</queryFile>
                 </queryFiles>
             </configuration>
         </execution>

--- a/generator/graphql-kotlin-federation/build.gradle.kts
+++ b/generator/graphql-kotlin-federation/build.gradle.kts
@@ -19,7 +19,7 @@ tasks {
                 limit {
                     counter = "BRANCH"
                     value = "COVEREDRATIO"
-                    minimum = "0.93".toBigDecimal()
+                    minimum = "0.90".toBigDecimal()
                 }
             }
         }

--- a/plugins/graphql-kotlin-gradle-plugin/README.md
+++ b/plugins/graphql-kotlin-gradle-plugin/README.md
@@ -57,8 +57,6 @@ graphql {
   schema {
       // List of supported packages that can contain GraphQL schema type definitions
       packages = listOf("com.example")
-      // Optional artifact name that contains SchemaGeneratorHooks service provider
-      hooksProviderArtifact = "com.expediagroup:graphql-kotlin-federated-hooks-provider:$graphQLKotlinVersion"
   }
 }
 ```
@@ -117,9 +115,20 @@ GraphQL types.
 
 | Property | Type | Required | Description |
 | -------- | ---- | -------- | ----------- |
-| `hooksProvider` | String | | Optional fully qualified artifact name that contains SchemaGeneratorHooks service provider. **Default hooks:** `NoopSchemaGeneratorHooks` |
 | `packages` | List<String> | yes | List of supported packages that can be scanned to generate SDL. |
 | `schemaFile` | File | | Target GraphQL schema file to be generated.<br/>**Default value is:** `${project.buildDir}/schema.graphql` |
+
+By default, this task will attempt to generate the schema using `NoopSchemaGeneratorHooks`. If you need to customize your
+schema generation process, you will need to provide your custom instance of `SchemaGeneratorHooksProvider` service provider.
+Service provider can be provided as part of your project, included in one of your project dependencies or through explicitly
+provided artifact to the `graphqlSDL` configuration.
+
+```kotlin
+// build.gradle.kts
+dependencies {
+    graphqlSDL("com.expediagroup:graphql-kotlin-federated-hooks-provider:$graphQLKotlinVersion")
+}
+```
 
 ### graphqlGenerateTestClient
 

--- a/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePlugin.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePlugin.kt
@@ -16,11 +16,15 @@
 
 package com.expediagroup.graphql.plugin.gradle
 
-import com.expediagroup.graphql.plugin.gradle.tasks.*
 import com.expediagroup.graphql.plugin.gradle.tasks.DOWNLOAD_SDL_TASK_NAME
 import com.expediagroup.graphql.plugin.gradle.tasks.GENERATE_CLIENT_TASK_NAME
 import com.expediagroup.graphql.plugin.gradle.tasks.GENERATE_SDL_TASK_NAME
 import com.expediagroup.graphql.plugin.gradle.tasks.GENERATE_TEST_CLIENT_TASK_NAME
+import com.expediagroup.graphql.plugin.gradle.tasks.GraphQLDownloadSDLTask
+import com.expediagroup.graphql.plugin.gradle.tasks.GraphQLGenerateClientTask
+import com.expediagroup.graphql.plugin.gradle.tasks.GraphQLGenerateSDLTask
+import com.expediagroup.graphql.plugin.gradle.tasks.GraphQLGenerateTestClientTask
+import com.expediagroup.graphql.plugin.gradle.tasks.GraphQLIntrospectSchemaTask
 import com.expediagroup.graphql.plugin.gradle.tasks.INTROSPECT_SCHEMA_TASK_NAME
 import org.gradle.api.Plugin
 import org.gradle.api.Project

--- a/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePlugin.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePlugin.kt
@@ -129,10 +129,6 @@ class GraphQLGradlePlugin : Plugin<Project> {
 
             val generateSchemaTask = project.tasks.named(GENERATE_SDL_TASK_NAME, GraphQLGenerateSDLTask::class.java).get()
             generateSchemaTask.packages.set(supportedPackages)
-
-            if (extension.schemaExtension.hooksProviderArtifact != null) {
-                generateSchemaTask.hooksProvider.set(extension.schemaExtension.hooksProviderArtifact)
-            }
         }
     }
 
@@ -166,9 +162,6 @@ class GraphQLGradlePlugin : Plugin<Project> {
             generateSDLTask.projectClasspath.setFrom(mainSourceSet?.runtimeClasspath)
 
             val configuration = project.configurations.getAt(GENERATE_SDL_CONFIGURATION)
-            if (generateSDLTask.hooksProvider.isPresent) {
-                configuration.dependencies.add(project.dependencies.create(generateSDLTask.hooksProvider.get()))
-            }
             generateSDLTask.pluginClasspath.setFrom(configuration)
 
             generateSDLTask.dependsOn(project.tasks.named("compileKotlin"))

--- a/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLPluginExtension.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLPluginExtension.kt
@@ -85,6 +85,4 @@ open class GraphQLPluginClientExtension {
 open class GraphQLPluginSchemaExtension {
     /** List of supported packages that can contain GraphQL schema type definitions. */
     var packages: List<String> = emptyList()
-    /** Optional fully qualified artifact name that contains SchemaGeneratorHooks service provider. */
-    var hooksProviderArtifact: String? = null
 }

--- a/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/GraphQLGenerateClientTask.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/GraphQLGenerateClientTask.kt
@@ -40,7 +40,6 @@ import java.io.File
 import javax.inject.Inject
 
 internal const val GENERATE_CLIENT_TASK_NAME: String = "graphqlGenerateClient"
-internal const val GENERATE_TEST_CLIENT_TASK_NAME: String = "graphqlGenerateTestClient"
 
 /**
  * Generate GraphQL Kotlin client and corresponding data classes based on the provided GraphQL queries.
@@ -140,6 +139,8 @@ abstract class GraphQLGenerateClientTask : DefaultTask() {
         allowDeprecatedFields.convention(false)
         customScalars.convention(emptyList())
         clientType.convention(GraphQLClientType.DEFAULT)
+        queryFileDirectory.convention("${project.projectDir}/src/main/resources")
+        outputDirectory.convention(project.layout.buildDirectory.dir("generated/source/graphql/main"))
     }
 
     @Suppress("EXPERIMENTAL_API_USAGE")

--- a/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/GraphQLGenerateSDLTask.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/GraphQLGenerateSDLTask.kt
@@ -20,7 +20,6 @@ import com.expediagroup.graphql.plugin.gradle.actions.GenerateSDLAction
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.ListProperty
-import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
@@ -51,14 +50,6 @@ abstract class GraphQLGenerateSDLTask : SourceTask() {
     @Optional
     @Option(option = "packages", description = "List of supported packages that can be scanned to generate SDL")
     val packages: ListProperty<String> = project.objects.listProperty(String::class.java)
-
-    /**
-     * Optional fully qualified artifact name that contains SchemaGeneratorHooks service provider.
-     */
-    @Input
-    @Optional
-    @Option(option = "hooksProvider", description = "Artifact name containing hooks provider")
-    val hooksProvider: Property<String> = project.objects.property(String::class.java)
 
     /**
      * Target GraphQL schema file to be generated.

--- a/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/GraphQLGenerateTestClientTask.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/GraphQLGenerateTestClientTask.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2021 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.plugin.gradle.tasks
+
+internal const val GENERATE_TEST_CLIENT_TASK_NAME: String = "graphqlGenerateTestClient"
+
+/**
+ * Generate GraphQL Kotlin test client and corresponding data classes based on the provided GraphQL queries.
+ */
+@Suppress("UnstableApiUsage")
+abstract class GraphQLGenerateTestClientTask : GraphQLGenerateClientTask() {
+
+    init {
+        description = "Generate HTTP test client from the specified GraphQL queries."
+
+        queryFileDirectory.convention("${project.projectDir}/src/test/resources")
+        outputDirectory.convention(project.layout.buildDirectory.dir("generated/source/graphql/test"))
+    }
+}

--- a/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePluginAbstractIT.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePluginAbstractIT.kt
@@ -101,7 +101,7 @@ abstract class GraphQLGradlePluginAbstractIT {
         this.generateBuildFile(plugins, dependencies, contents)
     }
 
-    internal fun File.generateBuildFileForServer(contents: String) {
+    internal fun File.generateBuildFileForServer(contents: String, additionalDependencies: String = "") {
         val plugins =
             """
             plugins {
@@ -117,6 +117,7 @@ abstract class GraphQLGradlePluginAbstractIT {
                 implementation("org.jetbrains.kotlin:kotlin-stdlib")
                 implementation("com.expediagroup", "graphql-kotlin-spring-server", "$DEFAULT_PLUGIN_VERSION")
                 implementation("com.expediagroup", "graphql-kotlin-hooks-provider", "$DEFAULT_PLUGIN_VERSION")
+                $additionalDependencies
             }
             """.trimIndent()
         this.generateBuildFile(plugins, dependencies, contents)
@@ -181,7 +182,7 @@ abstract class GraphQLGradlePluginAbstractIT {
         return this.generateGroovyBuildFile(plugins, dependencies, contents)
     }
 
-    internal fun File.generateGroovyBuildFileForServer(contents: String) {
+    internal fun File.generateGroovyBuildFileForServer(contents: String, additionalDependencies: String = "") {
         val plugins =
             """
             plugins {
@@ -198,6 +199,7 @@ abstract class GraphQLGradlePluginAbstractIT {
                 implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
                 implementation "com.expediagroup:graphql-kotlin-spring-server:$DEFAULT_PLUGIN_VERSION"
                 implementation "com.expediagroup:graphql-kotlin-hooks-provider:$DEFAULT_PLUGIN_VERSION"
+                $additionalDependencies
             }
             """.trimIndent()
         return this.generateGroovyBuildFile(plugins, dependencies, contents)

--- a/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePluginIT.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePluginIT.kt
@@ -380,11 +380,11 @@ class GraphQLGradlePluginIT : GraphQLGradlePluginAbstractIT() {
             graphql {
               schema {
                 packages = listOf("com.example")
-                hooksProviderArtifact = "com.expediagroup:graphql-kotlin-federated-hooks-provider:$DEFAULT_PLUGIN_VERSION"
               }
             }
             """.trimIndent()
-        testProjectDirectory.generateBuildFileForServer(buildFileContents)
+        val generateSDLDependencies = "graphqlSDL(\"com.expediagroup:graphql-kotlin-federated-hooks-provider:$DEFAULT_PLUGIN_VERSION\")"
+        testProjectDirectory.generateBuildFileForServer(buildFileContents, generateSDLDependencies)
 
         testProjectDirectory.createTestFile("Application.kt", "src/main/kotlin/com/example")
             .writeText(loadTemplate("ServerApplication", mapOf("customScalarsEnabled" to false)))
@@ -412,11 +412,11 @@ class GraphQLGradlePluginIT : GraphQLGradlePluginAbstractIT() {
             graphql {
               schema {
                 packages = ["com.example"]
-                hooksProviderArtifact = "com.expediagroup:graphql-kotlin-federated-hooks-provider:$DEFAULT_PLUGIN_VERSION"
               }
             }
             """.trimIndent()
-        testProjectDirectory.generateGroovyBuildFileForServer(buildFileContents)
+        val generateSDLDependencies = "graphqlSDL \"com.expediagroup:graphql-kotlin-federated-hooks-provider:$DEFAULT_PLUGIN_VERSION\""
+        testProjectDirectory.generateGroovyBuildFileForServer(buildFileContents, generateSDLDependencies)
 
         testProjectDirectory.createTestFile("Application.kt", "src/main/kotlin/com/example")
             .writeText(loadTemplate("ServerApplication", mapOf("customScalarsEnabled" to false)))

--- a/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/GraphQLGenerateClientTaskIT.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/GraphQLGenerateClientTaskIT.kt
@@ -304,7 +304,11 @@ class GraphQLGenerateClientTaskIT : GraphQLGradlePluginAbstractIT() {
         assertTrue(File(testProjectDirectory, "build/generated/source/graphql/main/com/example/generated2/DeprecatedQuery.kt").exists())
     }
 
-    private fun verifyGenerateClientTaskSuccess(testProjectDirectory: File, tasks: List<String> = listOf(":$GENERATE_CLIENT_TASK_NAME", ":build", ":run"), outputDirectory: String = "build/generated/source/graphql/main") {
+    private fun verifyGenerateClientTaskSuccess(
+        testProjectDirectory: File,
+        tasks: List<String> = listOf(":$GENERATE_CLIENT_TASK_NAME", ":build", ":run"),
+        outputDirectory: String = "build/generated/source/graphql/main"
+    ) {
         val buildResult = GradleRunner.create()
             .withProjectDir(testProjectDirectory)
             .withPluginClasspath()

--- a/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/GraphQLGenerateClientTaskIT.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/GraphQLGenerateClientTaskIT.kt
@@ -116,6 +116,7 @@ class GraphQLGenerateClientTaskIT : GraphQLGradlePluginAbstractIT() {
             |- JUnitQuery.graphql
             |- DeprecatedQuery.graphql
          */
+        val customOutputDirectory = "/custom/output"
         val buildFileContents =
             """
             application {
@@ -133,6 +134,7 @@ class GraphQLGenerateClientTaskIT : GraphQLGradlePluginAbstractIT() {
                 "${'$'}{project.projectDir}/src/main/resources/queries/JUnitQuery.graphql",
                 "${'$'}{project.projectDir}/src/main/resources/queries/DeprecatedQuery.graphql"
               )
+              outputDirectory.set(File("${'$'}{project.layout.projectDirectory}/$customOutputDirectory"))
             }
             """.trimIndent()
         testProjectDirectory.generateBuildFileForClient(buildFileContents)
@@ -148,8 +150,8 @@ class GraphQLGenerateClientTaskIT : GraphQLGradlePluginAbstractIT() {
             .writeText(loadResource("mocks/UUIDScalarConverter.txt"))
         // end project setup
 
-        verifyGenerateClientTaskSuccess(testProjectDirectory)
-        assertTrue(File(testProjectDirectory, "build/generated/source/graphql/main/com/example/generated/DeprecatedQuery.kt").exists())
+        verifyGenerateClientTaskSuccess(testProjectDirectory, customOutputDirectory)
+        assertTrue(File(testProjectDirectory, "$customOutputDirectory/com/example/generated/DeprecatedQuery.kt").exists())
     }
 
     @Test
@@ -241,14 +243,14 @@ class GraphQLGenerateClientTaskIT : GraphQLGradlePluginAbstractIT() {
         assertTrue(File(testProjectDirectory, "build/generated/source/graphql/main/com/example/generated/DeprecatedQuery.kt").exists())
     }
 
-    private fun verifyGenerateClientTaskSuccess(testProjectDirectory: File) {
+    private fun verifyGenerateClientTaskSuccess(testProjectDirectory: File, outputDirectory: String = "build/generated/source/graphql/main") {
         val buildResult = GradleRunner.create()
             .withProjectDir(testProjectDirectory)
             .withPluginClasspath()
             .withArguments(GENERATE_CLIENT_TASK_NAME, "run", "--stacktrace")
             .build()
         assertEquals(TaskOutcome.SUCCESS, buildResult.task(":$GENERATE_CLIENT_TASK_NAME")?.outcome)
-        assertTrue(File(testProjectDirectory, "build/generated/source/graphql/main/com/example/generated/JUnitQuery.kt").exists())
+        assertTrue(File(testProjectDirectory, "$outputDirectory/com/example/generated/JUnitQuery.kt").exists())
         assertEquals(TaskOutcome.SUCCESS, buildResult.task(":run")?.outcome)
     }
 }

--- a/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/GraphQLGenerateSDLTaskIT.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/GraphQLGenerateSDLTaskIT.kt
@@ -162,10 +162,10 @@ class GraphQLGenerateSDLTaskIT : GraphQLGradlePluginAbstractIT() {
             """
             val graphqlGenerateSDL by tasks.getting(com.expediagroup.graphql.plugin.gradle.tasks.GraphQLGenerateSDLTask::class) {
                 packages.set(listOf("com.example"))
-                hooksProvider.set("com.expediagroup:graphql-kotlin-federated-hooks-provider:$DEFAULT_PLUGIN_VERSION")
             }
             """.trimIndent()
-        testProjectDirectory.generateBuildFileForServer(buildFileContents)
+        val generateSDLDependencies = "graphqlSDL(\"com.expediagroup:graphql-kotlin-federated-hooks-provider:$DEFAULT_PLUGIN_VERSION\")"
+        testProjectDirectory.generateBuildFileForServer(buildFileContents, generateSDLDependencies)
 
         testProjectDirectory.createTestFile("Application.kt", "src/main/kotlin/com/example")
             .writeText(loadTemplate("ServerApplication", mapOf("customScalarsEnabled" to false)))
@@ -223,10 +223,10 @@ class GraphQLGenerateSDLTaskIT : GraphQLGradlePluginAbstractIT() {
             """
             graphqlGenerateSDL {
                 packages = ["com.example"]
-                hooksProvider = "com.expediagroup:graphql-kotlin-federated-hooks-provider:$DEFAULT_PLUGIN_VERSION"
             }
             """.trimIndent()
-        testProjectDirectory.generateGroovyBuildFileForServer(buildFileContents)
+        val generateSDLDependencies = "graphqlSDL \"com.expediagroup:graphql-kotlin-federated-hooks-provider:$DEFAULT_PLUGIN_VERSION\""
+        testProjectDirectory.generateGroovyBuildFileForServer(buildFileContents, generateSDLDependencies)
 
         testProjectDirectory.createTestFile("Application.kt", "src/main/kotlin/com/example")
             .writeText(loadTemplate("ServerApplication", emptyMap()))

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -83,10 +83,22 @@
       "client/client-customization"
     ],
     "Build Plugins": [
-      "plugins/gradle-plugin",
-      "plugins/gradle-plugin-examples",
-      "plugins/maven-plugin",
-      "plugins/maven-plugin-examples",
+      {
+        "type": "subcategory",
+        "label": "Gradle Plugin",
+        "ids": [
+          "plugins/gradle-plugin-tasks",
+          "plugins/gradle-plugin-usage"
+        ]
+      },
+      {
+        "type": "subcategory",
+        "label": "Maven Plugin",
+        "ids": [
+          "plugins/maven-plugin-goals",
+          "plugins/maven-plugin-usage"
+        ]
+      },
       "plugins/hooks-provider"
     ],
     "Contributors": [


### PR DESCRIPTION
### :pencil: Description

Per Gradle docs (https://docs.gradle.org/current/userguide/task_configuration_avoidance.html#sec:task_configuration_avoidance_migration_guidelines) we should only mutate current task inside configuration action (i.e. when configuring `generateClient/generateTestClient` we should not modify `compileKotlin/compileTestKotlin` tasks by adding the explicit `dependsOn` clause).

Changes:
* Updating task configurations to use lazy providers instead of direct values.
* Updating client generation tasks to be finalized by compile Kotlin tasks.
* Updating task classpath configurations to apply to ALL tasks and not just registered tasks (i.e. if you register your own task it still should use custom configuration)
* Separated `graphqlGenerateClient` and `graphqlGenerateTestClient` into their own classes to allow applying default conventions on all tasks of those types
* Update `graphqlGenerateSDL` task to rely on regular dependency configuration instead of using String property

### :link: Related Issues
Resolves https://github.com/ExpediaGroup/graphql-kotlin/issues/1026