### PR TITLE
[client] Batch query support

### DIFF
--- a/clients/graphql-kotlin-client/README.md
+++ b/clients/graphql-kotlin-client/README.md
@@ -12,6 +12,7 @@ together with one of the GraphQL Kotlin build plugins to auto-generate type safe
 ## Features
 
 * Supports query and mutation operations
+* Supports batch operations
 * Automatic generation of type-safe Kotlin models
 * Custom scalar support - defaults to String but can be configured to deserialize to specific types
 * Supports default enum values to gracefully handle new/unknown server values

--- a/clients/graphql-kotlin-client/src/main/kotlin/com/expediagroup/graphql/client/GraphQLClientRequest.kt
+++ b/clients/graphql-kotlin-client/src/main/kotlin/com/expediagroup/graphql/client/GraphQLClientRequest.kt
@@ -16,20 +16,19 @@
 
 package com.expediagroup.graphql.client
 
-import com.expediagroup.graphql.types.GraphQLResponse
-
 /**
- * A lightweight typesafe GraphQL HTTP client.
+ * Abstract class representing GraphQL request that follows the common GraphQL HTTP request format.
+ *
+ * @see [GraphQL Over HTTP](https://graphql.org/learn/serving-over-http/#post-request) for additional details
  */
-interface GraphQLClient<RequestCustomizer> {
+abstract class GraphQLClientRequest(
+    val query: String,
+    val operationName: String? = null,
+    val variables: Any? = null
+) {
 
     /**
-     * Executes [GraphQLClientRequest] and returns corresponding [GraphQLResponse].
+     * Parameterized type of a corresponding GraphQLResponse.
      */
-    suspend fun <T> execute(request: GraphQLClientRequest, requestCustomizer: RequestCustomizer.() -> Unit = {}): GraphQLResponse<T>
-
-    /**
-     * Executes batch requests that contains a number of [GraphQLClientRequest]s and returns a list of corresponding [GraphQLResponse]s.
-     */
-    suspend fun execute(requests: List<GraphQLClientRequest>, requestCustomizer: RequestCustomizer.() -> Unit = {}): List<GraphQLResponse<*>>
+    abstract fun responseType(): Class<*>
 }

--- a/clients/graphql-kotlin-ktor-client/README.md
+++ b/clients/graphql-kotlin-ktor-client/README.md
@@ -46,8 +46,8 @@ CLI:
 ```
 
 This runs an introspection query against the target GraphQL server and saves the resulting schema in the `schema.graphql` file
-under the build directory. GraphQL schemas can change over time so you should configure this task to run
-as part of your build/release process.
+under the build directory. GraphQL schemas can change over time, so you should configure this task to run as part of your
+build/release process.
 
 ```kotlin
 // build.gradle.kts
@@ -92,15 +92,19 @@ Additional information about Gradle and Maven plugins as well as their respectiv
 
 ### Execute Queries
 
-Your auto generated classes accept an instance of `GraphQLKtorClient` which requires the target URL to be specified. `GraphQLKtorClient`
-uses the Ktor HTTP client to execute the underlying queries and allows you to specify different engines (defaults to CIO) and
-HTTP client features. Please refer to [Ktor HTTP client documentation](https://ktor.io/clients/index.html) for additional
-details.
+Your auto generated classes are simple POJOs that optionally accept variables (only if underlying operation uses variables)
+as a constructor parameter. While `GraphQLClient` exposes generic methods that allow you to execute either a single or batch
+request, plugins will also automatically generate a convenient `execute<OperationName>` extension function that returns
+target operation result type.
+
+`GraphQLKtorClient` uses the Ktor HTTP client to execute the underlying queries and allows you to specify different engines
+(defaults to CIO) and HTTP client features. Please refer to [Ktor HTTP client documentation](https://ktor.io/clients/index.html)
+for additional details.
 
 ```kotlin
 val client = GraphQLKtorClient(url = URL("http://localhost:8080/graphql"))
-val query = MyAwesomeQuery(client)
-val result = query.execute()
+val query = MyAwesomeQuery()
+val result = client.executeMyAwesomeQuery(query)
 ```
 
 The result of your query is a type safe object that corresponds to your GraphQL query.

--- a/clients/graphql-kotlin-ktor-client/src/test/kotlin/com/expediagroup/graphql/client/ktor/GraphQLKtorClientTest.kt
+++ b/clients/graphql-kotlin-ktor-client/src/test/kotlin/com/expediagroup/graphql/client/ktor/GraphQLKtorClientTest.kt
@@ -16,7 +16,7 @@
 
 package com.expediagroup.graphql.client.ktor
 
-import com.expediagroup.graphql.client.execute
+import com.expediagroup.graphql.client.GraphQLClientRequest
 import com.expediagroup.graphql.types.GraphQLError
 import com.expediagroup.graphql.types.GraphQLResponse
 import com.expediagroup.graphql.types.SourceLocation
@@ -76,10 +76,7 @@ class GraphQLKtorClientTest {
 
         val client = GraphQLKtorClient(URL("${wireMockServer.baseUrl()}/graphql"))
         runBlocking {
-            val result: GraphQLResponse<HelloWorldResult> = client.execute(
-                query = "query HelloWorldQuery { helloWorld }",
-                operationName = "HelloWorldQuery"
-            )
+            val result: GraphQLResponse<HelloWorldResult> = client.execute(HelloWorldRequest)
 
             assertNotNull(result)
             assertNotNull(result.data)
@@ -124,10 +121,7 @@ class GraphQLKtorClientTest {
         }
         runBlocking {
             assertFailsWith(SocketTimeoutException::class) {
-                client.execute<GraphQLResponse<HelloWorldResult>>(
-                    query = "query HelloWorldQuery { helloWorld }",
-                    operationName = "HelloWorldQuery"
-                )
+                client.execute<GraphQLResponse<HelloWorldResult>>(HelloWorldRequest)
             }
         }
     }
@@ -141,10 +135,7 @@ class GraphQLKtorClientTest {
 
         val client = GraphQLKtorClient(URL("${wireMockServer.baseUrl()}/graphql"))
         runBlocking {
-            val result: GraphQLResponse<HelloWorldResult> = client.execute(
-                query = "query HelloWorldQuery { helloWorld }",
-                operationName = "HelloWorldQuery"
-            ) {
+            val result: GraphQLResponse<HelloWorldResult> = client.execute(HelloWorldRequest) {
                 header(customHeaderName, customHeaderValue)
             }
 
@@ -166,7 +157,7 @@ class GraphQLKtorClientTest {
         val client = GraphQLKtorClient(URL("${wireMockServer.baseUrl()}/graphql"))
         val error = assertFailsWith<ServerResponseException> {
             runBlocking {
-                client.execute<HelloWorldResult>("query HelloWorldQuery { helloWorld }")
+                client.execute<HelloWorldResult>(HelloWorldRequest)
             }
         }
         assertEquals(500, error.response.status.value)
@@ -183,7 +174,7 @@ class GraphQLKtorClientTest {
         val client = GraphQLKtorClient(URL("${wireMockServer.baseUrl()}/graphql"))
         assertFailsWith<MismatchedInputException> {
             runBlocking {
-                client.execute<HelloWorldResult>("query HelloWorldQuery { helloWorld }")
+                client.execute<HelloWorldResult>(HelloWorldRequest)
             }
         }
     }
@@ -199,6 +190,13 @@ class GraphQLKtorClientTest {
             )
 
     data class HelloWorldResult(val helloWorld: String)
+
+    object HelloWorldRequest : GraphQLClientRequest(
+        query = "query HelloWorldQuery { helloWorld }",
+        operationName = "HelloWorld"
+    ) {
+        override fun responseType(): Class<HelloWorldResult> = HelloWorldResult::class.java
+    }
 
     companion object {
         internal val wireMockServer: WireMockServer = WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort())

--- a/clients/graphql-kotlin-spring-client/README.md
+++ b/clients/graphql-kotlin-spring-client/README.md
@@ -45,8 +45,8 @@ CLI:
 ```
 
 This runs an introspection query against the target GraphQL server and saves the resulting schema in the `schema.graphql` file
-under the build directory. GraphQL schemas can change over time so you should configure this task to run
-as part of your build/release process.
+under the build directory. GraphQL schemas can change over time, so you should configure this task to run as part of your
+build/release process.
 
 ```kotlin
 // build.gradle.kts
@@ -91,14 +91,18 @@ Additional information about Gradle and Maven plugins as well as their respectiv
 
 ### Execute Queries
 
-Your auto generated classes accept an instance of `GraphQLWebClient` which requires the target URL to be specified.
+Your auto generated classes are simple POJOs that optionally accept variables (only if underlying operation uses variables)
+as a constructor parameter. While `GraphQLClient` exposes generic methods that allow you to execute either a single or batch
+request, plugins will also automatically generate a convenient `execute<OperationName>` extension function that returns
+target operation result type.
+
 `GraphQLWebClient` is a thin wrapper on top of [Spring WebClient](https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/web/reactive/function/client/WebClient.html)
 and can be customized by providing customized instance of Spring `WebClient.Builder`.
 
 ```kotlin
 val client = GraphQLWebClient(url = "http://localhost:8080/graphql")
-val query = MyAwesomeQuery(client)
-val result = query.execute()
+val query = MyAwesomeQuery()
+val result = client.executeMyAwesomeQuery(query)
 ```
 
 The result of your query is a type safe object that corresponds to your GraphQL query.

--- a/clients/graphql-kotlin-spring-client/src/main/kotlin/com/expediagroup/graphql/client/spring/GraphQLWebClient.kt
+++ b/clients/graphql-kotlin-spring-client/src/main/kotlin/com/expediagroup/graphql/client/spring/GraphQLWebClient.kt
@@ -17,9 +17,11 @@
 package com.expediagroup.graphql.client.spring
 
 import com.expediagroup.graphql.client.GraphQLClient
+import com.expediagroup.graphql.client.GraphQLClientRequest
 import com.expediagroup.graphql.types.GraphQLResponse
 import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.JavaType
+import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import kotlinx.coroutines.reactive.awaitSingle
@@ -36,7 +38,7 @@ open class GraphQLWebClient(
     url: String,
     private val mapper: ObjectMapper = jacksonObjectMapper(),
     builder: WebClient.Builder = WebClient.builder()
-) : GraphQLClient {
+) : GraphQLClient<WebClient.RequestBodyUriSpec> {
 
     private val typeCache = ConcurrentHashMap<Class<*>, JavaType>()
 
@@ -51,49 +53,53 @@ open class GraphQLWebClient(
 
     private val client: WebClient = builder.baseUrl(url).build()
 
-    /**
-     * Executes specified GraphQL query or mutation.
-     *
-     * NOTE: explicit result type Class parameter is required due to the type erasure at runtime, i.e. since generic type is erased at runtime our
-     * default serialization would attempt to serialize results back to Any object. As a workaround we get raw results as String which we then
-     * manually deserialize using passed in result type Class information.
-     */
-    open suspend fun <T> execute(
-        query: String,
-        operationName: String? = null,
-        variables: Any? = null,
-        resultType: Class<T>,
-        requestBuilder: WebClient.RequestBodyUriSpec.() -> Unit
-    ): GraphQLResponse<T> {
-        // Variables are simple data classes which will be serialized as map.
-        // By using map instead of typed object we can eliminate the need to explicitly convert variables to a map
-        val graphQLRequest = mapOf(
-            "query" to query,
-            "operationName" to operationName,
-            "variables" to variables
+    override suspend fun <T> execute(request: GraphQLClientRequest, requestCustomizer: WebClient.RequestBodyUriSpec.() -> Unit): GraphQLResponse<T> {
+        val rawRequest = mapOf(
+            "query" to request.query,
+            "operationName" to request.operationName,
+            "variables" to request.variables
         )
 
         val rawResult = client.post()
-            .apply(requestBuilder)
+            .apply(requestCustomizer)
             .accept(MediaType.APPLICATION_JSON)
             .contentType(MediaType.APPLICATION_JSON)
-            .bodyValue(graphQLRequest)
+            .bodyValue(rawRequest)
             .retrieve()
             .bodyToMono(String::class.java)
             .awaitSingle()
 
         @Suppress("BlockingMethodInNonBlockingContext")
-        return mapper.readValue(rawResult, parameterizedType(resultType))
+        return mapper.readValue(rawResult, parameterizedType(request.responseType()))
     }
 
-    override suspend fun <T> execute(query: String, operationName: String?, variables: Any?, resultType: Class<T>): GraphQLResponse<T> =
-        execute(query, operationName, variables, resultType, {})
+    override suspend fun execute(requests: List<GraphQLClientRequest>, requestCustomizer: WebClient.RequestBodyUriSpec.() -> Unit): List<GraphQLResponse<*>> {
+        val rawRequests = requests.map { request ->
+            mapOf(
+                "query" to request.query,
+                "operationName" to request.operationName,
+                "variables" to request.variables
+            )
+        }
 
-    /**
-     * Executes specified GraphQL query or mutation operation.
-     */
-    suspend inline fun <reified T> execute(query: String, operationName: String? = null, variables: Any? = null, noinline requestBuilder: WebClient.RequestBodyUriSpec.() -> Unit): GraphQLResponse<T> =
-        execute(query, operationName, variables, T::class.java, requestBuilder)
+        val rawResult = client.post()
+            .apply(requestCustomizer)
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(rawRequests)
+            .retrieve()
+            .bodyToMono(JsonNode::class.java)
+            .awaitSingle()
+
+        return if (rawResult.isArray) {
+            rawResult.withIndex().map { (index, element) ->
+                val singleResponse: GraphQLResponse<*> = mapper.convertValue(element, parameterizedType(requests[index].responseType()))
+                singleResponse
+            }
+        } else {
+            listOf(mapper.convertValue(rawResult, parameterizedType(requests.first().responseType())))
+        }
+    }
 
     private fun <T> parameterizedType(resultType: Class<T>): JavaType =
         typeCache.computeIfAbsent(resultType) {

--- a/docs/client/client-customization.md
+++ b/docs/client/client-customization.md
@@ -49,17 +49,13 @@ val client = GraphQLKtorClient(
 
 ### Per Request Customization
 
-In order to be able to customize individual GraphQL requests you need to configure GraphQL Kotlin plugin to generate Ktor
-specific client code. See [Gradle](https://expediagroup.github.io/graphql-kotlin/docs/plugins/gradle-plugin) and [Maven](https://expediagroup.github.io/graphql-kotlin/docs/plugins/maven-plugin)
-plugin documentation for additional details.
-
 Individual GraphQL requests can be customized through [HttpRequestBuilder](https://api.ktor.io/1.3.2/io.ktor.client.request/-http-request-builder/).
 You can use this mechanism to specify custom headers, update target url to include custom query parameters, configure
 attributes that can be accessed from the pipeline features as well specify timeouts per request.
 
 ```kotlin
-val helloWorldQuery = HelloWorldQuery(client)
-val result = helloWorldQuery.execute(variables = HelloWorldQuery.Variables(name = null)) {
+val helloWorldQuery = HelloWorldQuery(variables = HelloWorldQuery.Variables(name = "John Doe"))
+val result = client.execute(helloWorldQuery) {
     header("X-B3-TraceId", "0123456789abcdef")
 }
 ```
@@ -96,17 +92,12 @@ val client = GraphQLWebClient(
 
 ### Per Request Customization
 
-In order to be able to customize individual GraphQL requests you need to configure GraphQL Kotlin plugin to generate Spring
-WebClient specific client code. See [Gradle](https://expediagroup.github.io/graphql-kotlin/docs/plugins/gradle-plugin)
-and [Maven](https://expediagroup.github.io/graphql-kotlin/docs/plugins/maven-plugin) plugin documentation for additional
-details.
-
 Individual GraphQL requests can be customized by providing `WebClient.RequestBodyUriSpec` lambda. You can use this mechanism
 to specify custom headers or include custom attributes or query parameters.
 
 ```kotlin
-val helloWorldQuery = HelloWorldQuery(client)
-val result = helloWorldQuery.execute(variables = HelloWorldQuery.Variables(name = null)) {
+val helloWorldQuery = HelloWorldQuery(variables = HelloWorldQuery.Variables(name = "John Doe"))
+val result = client.execute(helloWorldQuery) {
     header("X-B3-TraceId", "0123456789abcdef")
 }
 ```
@@ -120,19 +111,14 @@ extend them to provide some custom `execute` logic.
 ```kotlin
 class CustomGraphQLClient(url: URL) : GraphQLKtorClient<CIOEngineConfig>(url = url, engineFactory = CIO) {
 
-    override suspend fun <T> execute(query: String, operationName: String?, variables: Any?, resultType: Class<T>, requestBuilder: HttpRequestBuilder.() -> Unit): GraphQLResponse<T> {
+    override suspend fun <T> execute(request: GraphQLClientRequest, requestCustomizer: HttpRequestBuilder.() -> Unit): GraphQLResponse<T> {
         // custom init logic
-        val result = super.execute(query, operationName, variables, resultType, requestBuilder)
+        val result = super.execute(request, requestCustomizer)
         // custom finalize logic
         return result
     }
 }
 ```
-
-> NOTE: When implementing custom `GraphQLClient` make sure to select proper client type when generating your client code.
-> By default, generated client code is targeting generic interface which allows you to use any client implementations. If
-> you are using Ktor or Spring WebClient based implementations make sure to select corresponding type as that will provide
-> customization options.
 
 ## Jackson Customization
 

--- a/docs/client/client-features.md
+++ b/docs/client/client-features.md
@@ -126,10 +126,23 @@ data class BasicObject(
 
 ## Native Support for Coroutines
 
-GraphQL Kotlin Client is a thin wrapper on top of [Ktor HTTP Client](https://ktor.io/clients/index.html) which provides
-fully asynchronous communication through Kotlin coroutines. `GraphQLClient` exposes single `execute` method that will
-suspend your GraphQL operation until it gets a response back without blocking the underlying thread. In order to fetch
-data asynchronously and perform some additional computations at the same time you should wrap your client execution in
-`launch` or `async` coroutine builder and explicitly `await` for their results.
+GraphQL Kotlin Client is a generic interface that exposes `execute` methods that will suspend your GraphQL operation until
+it gets a response back without blocking the underlying thread. Reference Ktor and Spring WebClient based implementations
+offer fully asynchronous communication through Kotlin coroutines. In order to fetch data asynchronously you should wrap
+your client execution in `launch` or `async` coroutine builder and explicitly `await` for their results.
 
 See [Kotlin coroutines documentation](https://kotlinlang.org/docs/reference/coroutines-overview.html) for additional details.
+
+## Batch Operation Support
+
+GraphQL Kotlin Clients provide out of the box support for batching multiple client operations into a single GraphQL request.
+Batch requests are sent as an array of individual GraphQL requests and clients expect the server to respond with a corresponding
+array of GraphQL responses. Each response is then deserialized to a corresponding result type.
+
+```kotlin
+val client = GraphQLKtorClient(url = URL("http://localhost:8080/graphql"))
+val firstQuery = FirstQuery(variables = FirstQuery.Variables(foo = "bar"))
+val secondQuery = SecondQuery(variables = SecondQuery.Variables(foo = "baz"))
+
+val results: List<GraphQLResponse<*>> = client.execute(listOf(firstQuery, secondQuery))
+```

--- a/examples/client/gradle-client/src/main/kotlin/com/expediagroup/graphql/examples/client/gradle/Application.kt
+++ b/examples/client/gradle-client/src/main/kotlin/com/expediagroup/graphql/examples/client/gradle/Application.kt
@@ -22,6 +22,10 @@ import com.expediagroup.graphql.generated.ExampleQuery
 import com.expediagroup.graphql.generated.HelloWorldQuery
 import com.expediagroup.graphql.generated.RetrieveObjectQuery
 import com.expediagroup.graphql.generated.UpdateObjectMutation
+import com.expediagroup.graphql.generated.executeAddObjectMutation
+import com.expediagroup.graphql.generated.executeExampleQuery
+import com.expediagroup.graphql.generated.executeRetrieveObjectQuery
+import com.expediagroup.graphql.generated.executeUpdateObjectMutation
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.ktor.client.engine.okhttp.OkHttp
 import io.ktor.client.features.logging.DEFAULT
@@ -51,36 +55,37 @@ fun main() {
             level = LogLevel.HEADERS
         }
     }
-    val helloWorldQuery = HelloWorldQuery(client)
     println("HelloWorld examples")
     runBlocking {
-        val helloWorldResultNoParam = helloWorldQuery.execute(variables = HelloWorldQuery.Variables(name = null))
-        println("\tquery without parameters result: ${helloWorldResultNoParam.data?.helloWorld}")
+        val results = client.execute(
+            listOf(
+                HelloWorldQuery(variables = HelloWorldQuery.Variables(name = null)),
+                HelloWorldQuery(variables = HelloWorldQuery.Variables(name = "Dariusz"))
+            )
+        )
 
-        val helloWorldResult = helloWorldQuery.execute(variables = HelloWorldQuery.Variables(name = "Dariusz"))
-        println("\tquery with parameters result: ${helloWorldResult.data?.helloWorld}")
+        val resultsNoParam = results[0].data as? HelloWorldQuery.Result
+        val resultsWithParam = results[1].data as? HelloWorldQuery.Result
+        println("\tquery without parameters result: ${resultsNoParam?.helloWorld}")
+        println("\tquery with parameters result: ${resultsWithParam?.helloWorld}")
     }
 
     // mutation examples
     println("simple mutation examples")
-    val retrieveObjectQuery = RetrieveObjectQuery(client)
-    val addObjectMutation = AddObjectMutation(client)
-    val updateObjectMutation = UpdateObjectMutation(client)
     runBlocking {
-        val retrieveNonExistentObject = retrieveObjectQuery.execute(variables = RetrieveObjectQuery.Variables(id = 1))
+        val retrieveNonExistentObject = client.executeRetrieveObjectQuery(RetrieveObjectQuery(variables = RetrieveObjectQuery.Variables(id = 1)))
         println("\tretrieve non existent object: ${retrieveNonExistentObject.data?.retrieveBasicObject}")
 
-        val addResult = addObjectMutation.execute(variables = AddObjectMutation.Variables(newObject = AddObjectMutation.BasicObjectInput(1, "first")))
+        val addResult = client.executeAddObjectMutation(AddObjectMutation(variables = AddObjectMutation.Variables(newObject = AddObjectMutation.BasicObjectInput(1, "first"))))
         println("\tadd new object: ${addResult.data?.addBasicObject}")
 
-        val updateResult = updateObjectMutation.execute(variables = UpdateObjectMutation.Variables(updatedObject = UpdateObjectMutation.BasicObjectInput(1, "updated")))
+        val updateResult = client.executeUpdateObjectMutation(UpdateObjectMutation(variables = UpdateObjectMutation.Variables(updatedObject = UpdateObjectMutation.BasicObjectInput(1, "updated"))))
         println("\tupdate new object: ${updateResult.data?.updateBasicObject}")
     }
 
     println("additional examples")
-    val exampleQuery = ExampleQuery(client)
     runBlocking {
-        val exampleData = exampleQuery.execute(variables = ExampleQuery.Variables(simpleCriteria = ExampleQuery.SimpleArgumentInput(max = 1.0f)))
+        val exampleData = client.executeExampleQuery(ExampleQuery(variables = ExampleQuery.Variables(simpleCriteria = ExampleQuery.SimpleArgumentInput(max = 1.0f))))
         println("\tretrieved interface: ${exampleData.data?.interfaceQuery} ")
         println("\tretrieved union: ${exampleData.data?.unionQuery} ")
         println("\tretrieved enum: ${exampleData.data?.enumQuery} ")

--- a/plugins/client/graphql-kotlin-client-generator/src/test/kotlin/com/expediagroup/graphql/plugin/client/generator/types/GenerateGraphQLClientIT.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/kotlin/com/expediagroup/graphql/plugin/client/generator/types/GenerateGraphQLClientIT.kt
@@ -38,17 +38,15 @@ class GenerateGraphQLClientIT {
                 package com.expediagroup.graphql.plugin.generator.integration
 
                 import com.expediagroup.graphql.client.GraphQLClient
-                import com.expediagroup.graphql.client.execute
+                import com.expediagroup.graphql.client.GraphQLClientRequest
                 import com.expediagroup.graphql.types.GraphQLResponse
+                import java.lang.Class
                 import kotlin.String
 
                 const val MI_XE_DCA_SE_QUERY: String = "query miXEDcaSEQuery {\n  scalarQuery {\n    name\n  }\n}"
 
-                class MiXEDcaSEQuery(
-                  private val graphQLClient: GraphQLClient
-                ) {
-                  suspend fun execute(): GraphQLResponse<MiXEDcaSEQuery.Result> =
-                      graphQLClient.execute(MI_XE_DCA_SE_QUERY, "miXEDcaSEQuery", null)
+                class MiXEDcaSEQuery : GraphQLClientRequest(MI_XE_DCA_SE_QUERY, "miXEDcaSEQuery") {
+                  override fun responseType(): Class<MiXEDcaSEQuery.Result> = MiXEDcaSEQuery.Result::class.java
 
                   /**
                    * Wrapper that holds all supported scalar types
@@ -67,6 +65,9 @@ class GenerateGraphQLClientIT {
                     val scalarQuery: MiXEDcaSEQuery.ScalarWrapper
                   )
                 }
+
+                suspend fun GraphQLClient<*>.executeMiXEDcaSEQuery(request: MiXEDcaSEQuery):
+                    GraphQLResponse<MiXEDcaSEQuery.Result> = execute(request)
             """.trimIndent()
 
         val query =
@@ -87,17 +88,16 @@ class GenerateGraphQLClientIT {
                 package com.expediagroup.graphql.plugin.generator.integration
 
                 import com.expediagroup.graphql.client.GraphQLClient
-                import com.expediagroup.graphql.client.execute
+                import com.expediagroup.graphql.client.GraphQLClientRequest
                 import com.expediagroup.graphql.types.GraphQLResponse
+                import java.lang.Class
                 import kotlin.String
 
                 const val ANONYMOUS_TEST_QUERY: String = "query {\n  scalarQuery {\n    name\n  }\n}"
 
-                class AnonymousTestQuery(
-                  private val graphQLClient: GraphQLClient
-                ) {
-                  suspend fun execute(): GraphQLResponse<AnonymousTestQuery.Result> =
-                      graphQLClient.execute(ANONYMOUS_TEST_QUERY, null, null)
+                class AnonymousTestQuery : GraphQLClientRequest(ANONYMOUS_TEST_QUERY) {
+                  override fun responseType(): Class<AnonymousTestQuery.Result> =
+                      AnonymousTestQuery.Result::class.java
 
                   /**
                    * Wrapper that holds all supported scalar types
@@ -116,6 +116,9 @@ class GenerateGraphQLClientIT {
                     val scalarQuery: AnonymousTestQuery.ScalarWrapper
                   )
                 }
+
+                suspend fun GraphQLClient<*>.executeAnonymousTestQuery(request: AnonymousTestQuery):
+                    GraphQLResponse<AnonymousTestQuery.Result> = execute(request)
             """.trimIndent()
 
         val query =
@@ -144,19 +147,17 @@ class GenerateGraphQLClientIT {
                 package com.expediagroup.graphql.plugin.generator.integration
 
                 import com.expediagroup.graphql.client.GraphQLClient
-                import com.expediagroup.graphql.client.execute
+                import com.expediagroup.graphql.client.GraphQLClientRequest
                 import com.expediagroup.graphql.types.GraphQLResponse
+                import java.lang.Class
                 import kotlin.Boolean
                 import kotlin.String
 
                 const val ALIAS_TEST_QUERY: String =
                     "query AliasTestQuery {\n  first: inputObjectQuery(criteria: { min: 1.0, max: 5.0 } )\n  second: inputObjectQuery(criteria: { min: 5.0, max: 10.0 } )\n}"
 
-                class AliasTestQuery(
-                  private val graphQLClient: GraphQLClient
-                ) {
-                  suspend fun execute(): GraphQLResponse<AliasTestQuery.Result> =
-                      graphQLClient.execute(ALIAS_TEST_QUERY, "AliasTestQuery", null)
+                class AliasTestQuery : GraphQLClientRequest(ALIAS_TEST_QUERY, "AliasTestQuery") {
+                  override fun responseType(): Class<AliasTestQuery.Result> = AliasTestQuery.Result::class.java
 
                   data class Result(
                     /**
@@ -169,6 +170,9 @@ class GenerateGraphQLClientIT {
                     val second: Boolean
                   )
                 }
+
+                suspend fun GraphQLClient<*>.executeAliasTestQuery(request: AliasTestQuery):
+                    GraphQLResponse<AliasTestQuery.Result> = execute(request)
             """.trimIndent()
 
         val query =
@@ -201,18 +205,17 @@ class GenerateGraphQLClientIT {
                 package com.expediagroup.graphql.plugin.generator.integration
 
                 import com.expediagroup.graphql.client.GraphQLClient
-                import com.expediagroup.graphql.client.execute
+                import com.expediagroup.graphql.client.GraphQLClientRequest
                 import com.expediagroup.graphql.types.GraphQLResponse
+                import java.lang.Class
                 import kotlin.Deprecated
                 import kotlin.String
 
                 const val DEPRECATED_FIELD_QUERY: String = "query DeprecatedFieldQuery {\n  deprecatedQuery\n}"
 
-                class DeprecatedFieldQuery(
-                  private val graphQLClient: GraphQLClient
-                ) {
-                  suspend fun execute(): GraphQLResponse<DeprecatedFieldQuery.Result> =
-                      graphQLClient.execute(DEPRECATED_FIELD_QUERY, "DeprecatedFieldQuery", null)
+                class DeprecatedFieldQuery : GraphQLClientRequest(DEPRECATED_FIELD_QUERY, "DeprecatedFieldQuery") {
+                  override fun responseType(): Class<DeprecatedFieldQuery.Result> =
+                      DeprecatedFieldQuery.Result::class.java
 
                   data class Result(
                     /**
@@ -222,6 +225,9 @@ class GenerateGraphQLClientIT {
                     val deprecatedQuery: String
                   )
                 }
+
+                suspend fun GraphQLClient<*>.executeDeprecatedFieldQuery(request: DeprecatedFieldQuery):
+                    GraphQLResponse<DeprecatedFieldQuery.Result> = execute(request)
             """.trimIndent()
 
         val invalidQuery =
@@ -246,20 +252,19 @@ class GenerateGraphQLClientIT {
             """
                 package com.expediagroup.graphql.plugin.generator.integration
 
+                import com.expediagroup.graphql.client.GraphQLClientRequest
                 import com.expediagroup.graphql.client.ktor.GraphQLKtorClient
                 import com.expediagroup.graphql.types.GraphQLResponse
                 import io.ktor.client.request.HttpRequestBuilder
+                import java.lang.Class
                 import kotlin.String
                 import kotlin.Unit
 
                 const val ANONYMOUS_TEST_QUERY: String = "query {\n  scalarQuery {\n    name\n  }\n}"
 
-                class AnonymousTestQuery(
-                  private val graphQLClient: GraphQLKtorClient<*>
-                ) {
-                  suspend fun execute(requestBuilder: HttpRequestBuilder.() -> Unit = {}):
-                      GraphQLResponse<AnonymousTestQuery.Result> = graphQLClient.execute(ANONYMOUS_TEST_QUERY, null,
-                      null, requestBuilder)
+                class AnonymousTestQuery : GraphQLClientRequest(ANONYMOUS_TEST_QUERY) {
+                  override fun responseType(): Class<AnonymousTestQuery.Result> =
+                      AnonymousTestQuery.Result::class.java
 
                   /**
                    * Wrapper that holds all supported scalar types
@@ -278,6 +283,10 @@ class GenerateGraphQLClientIT {
                     val scalarQuery: AnonymousTestQuery.ScalarWrapper
                   )
                 }
+
+                suspend fun GraphQLKtorClient<*>.executeAnonymousTestQuery(request: AnonymousTestQuery,
+                    requestCustomizer: HttpRequestBuilder.() -> Unit = {}):
+                    GraphQLResponse<AnonymousTestQuery.Result> = execute(request, requestCustomizer)
             """.trimIndent()
 
         val query =
@@ -311,20 +320,19 @@ class GenerateGraphQLClientIT {
             """
                 package com.expediagroup.graphql.plugin.generator.integration
 
+                import com.expediagroup.graphql.client.GraphQLClientRequest
                 import com.expediagroup.graphql.client.spring.GraphQLWebClient
                 import com.expediagroup.graphql.types.GraphQLResponse
+                import java.lang.Class
                 import kotlin.String
                 import kotlin.Unit
                 import org.springframework.web.reactive.function.client.WebClient
 
                 const val ANONYMOUS_TEST_QUERY: String = "query {\n  scalarQuery {\n    name\n  }\n}"
 
-                class AnonymousTestQuery(
-                  private val graphQLClient: GraphQLWebClient
-                ) {
-                  suspend fun execute(requestBuilder: WebClient.RequestBodyUriSpec.() -> Unit = {}):
-                      GraphQLResponse<AnonymousTestQuery.Result> = graphQLClient.execute(ANONYMOUS_TEST_QUERY, null,
-                      null, requestBuilder)
+                class AnonymousTestQuery : GraphQLClientRequest(ANONYMOUS_TEST_QUERY) {
+                  override fun responseType(): Class<AnonymousTestQuery.Result> =
+                      AnonymousTestQuery.Result::class.java
 
                   /**
                    * Wrapper that holds all supported scalar types
@@ -343,6 +351,10 @@ class GenerateGraphQLClientIT {
                     val scalarQuery: AnonymousTestQuery.ScalarWrapper
                   )
                 }
+
+                suspend fun GraphQLWebClient.executeAnonymousTestQuery(request: AnonymousTestQuery,
+                    requestCustomizer: WebClient.RequestBodyUriSpec.() -> Unit = {}):
+                    GraphQLResponse<AnonymousTestQuery.Result> = execute(request, requestCustomizer)
             """.trimIndent()
 
         val query =
@@ -377,19 +389,17 @@ class GenerateGraphQLClientIT {
                 package com.expediagroup.graphql.plugin.generator.integration
 
                 import com.expediagroup.graphql.client.GraphQLClient
-                import com.expediagroup.graphql.client.execute
+                import com.expediagroup.graphql.client.GraphQLClientRequest
                 import com.expediagroup.graphql.types.GraphQLResponse
+                import java.lang.Class
                 import kotlin.Int
                 import kotlin.String
 
                 const val REUSED_TYPES_QUERY: String =
                     "query ReusedTypesQuery {\n  first: complexObjectQuery {\n    id\n    name\n  }\n  second: complexObjectQuery {\n    id\n    name\n    details {\n      id\n      value\n    }\n  }\n  third: complexObjectQuery {\n    id\n    name\n    details {\n      id\n    }\n  }\n  fourth: complexObjectQuery {\n    id\n    name\n  }\n  fifth: complexObjectQuery {\n    id\n    name\n    details {\n      id\n      value\n    }\n  }\n}"
 
-                class ReusedTypesQuery(
-                  private val graphQLClient: GraphQLClient
-                ) {
-                  suspend fun execute(): GraphQLResponse<ReusedTypesQuery.Result> =
-                      graphQLClient.execute(REUSED_TYPES_QUERY, "ReusedTypesQuery", null)
+                class ReusedTypesQuery : GraphQLClientRequest(REUSED_TYPES_QUERY, "ReusedTypesQuery") {
+                  override fun responseType(): Class<ReusedTypesQuery.Result> = ReusedTypesQuery.Result::class.java
 
                   /**
                    * Multi line description of a complex type.
@@ -494,6 +504,9 @@ class GenerateGraphQLClientIT {
                     val fifth: ReusedTypesQuery.ComplexObject2
                   )
                 }
+
+                suspend fun GraphQLClient<*>.executeReusedTypesQuery(request: ReusedTypesQuery):
+                    GraphQLResponse<ReusedTypesQuery.Result> = execute(request)
             """.trimIndent()
         val reusedTypesQuery =
             """
@@ -541,8 +554,9 @@ class GenerateGraphQLClientIT {
                 package com.expediagroup.graphql.plugin.generator.integration
 
                 import com.expediagroup.graphql.client.GraphQLClient
-                import com.expediagroup.graphql.client.execute
+                import com.expediagroup.graphql.client.GraphQLClientRequest
                 import com.expediagroup.graphql.types.GraphQLResponse
+                import java.lang.Class
                 import kotlin.Int
                 import kotlin.String
                 import kotlin.collections.List
@@ -550,11 +564,9 @@ class GenerateGraphQLClientIT {
                 const val REUSED_LIST_TYPES_QUERY: String =
                     "query ReusedListTypesQuery {\n  first: listQuery {\n    id\n    name\n  }\n  second: listQuery {\n    name\n  }\n  third: listQuery {\n    id\n    name\n  }\n  firstComplex: complexObjectQuery {\n    id\n    name\n    basicList {\n      id\n      name\n    }\n  }\n  secondComplex: complexObjectQuery {\n    id\n    name\n    basicList {\n      id\n      name\n    }\n  }\n  thirdComplex: complexObjectQuery {\n    id\n    name\n    basicList {\n      name\n    }\n  }\n  fourthComplex: complexObjectQuery {\n    id\n    basicList {\n      id\n    }\n  }\n}"
 
-                class ReusedListTypesQuery(
-                  private val graphQLClient: GraphQLClient
-                ) {
-                  suspend fun execute(): GraphQLResponse<ReusedListTypesQuery.Result> =
-                      graphQLClient.execute(REUSED_LIST_TYPES_QUERY, "ReusedListTypesQuery", null)
+                class ReusedListTypesQuery : GraphQLClientRequest(REUSED_LIST_TYPES_QUERY, "ReusedListTypesQuery") {
+                  override fun responseType(): Class<ReusedListTypesQuery.Result> =
+                      ReusedListTypesQuery.Result::class.java
 
                   /**
                    * Some basic description
@@ -671,6 +683,9 @@ class GenerateGraphQLClientIT {
                     val fourthComplex: ReusedListTypesQuery.ComplexObject3
                   )
                 }
+
+                suspend fun GraphQLClient<*>.executeReusedListTypesQuery(request: ReusedListTypesQuery):
+                    GraphQLResponse<ReusedListTypesQuery.Result> = execute(request)
             """.trimIndent()
         val reusedTypesQuery =
             """

--- a/plugins/client/graphql-kotlin-client-generator/src/test/kotlin/com/expediagroup/graphql/plugin/client/generator/types/GenerateGraphQLCustomScalarTypeAliasIT.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/kotlin/com/expediagroup/graphql/plugin/client/generator/types/GenerateGraphQLCustomScalarTypeAliasIT.kt
@@ -42,18 +42,17 @@ class GenerateGraphQLCustomScalarTypeAliasIT {
                 package com.expediagroup.graphql.plugin.generator.integration
 
                 import com.expediagroup.graphql.client.GraphQLClient
-                import com.expediagroup.graphql.client.execute
+                import com.expediagroup.graphql.client.GraphQLClientRequest
                 import com.expediagroup.graphql.types.GraphQLResponse
+                import java.lang.Class
                 import kotlin.String
 
                 const val SCALAR_ALIAS_TEST_QUERY: String =
                     "query ScalarAliasTestQuery {\n  scalarQuery {\n    id\n    custom\n  }\n}"
 
-                class ScalarAliasTestQuery(
-                  private val graphQLClient: GraphQLClient
-                ) {
-                  suspend fun execute(): GraphQLResponse<ScalarAliasTestQuery.Result> =
-                      graphQLClient.execute(SCALAR_ALIAS_TEST_QUERY, "ScalarAliasTestQuery", null)
+                class ScalarAliasTestQuery : GraphQLClientRequest(SCALAR_ALIAS_TEST_QUERY, "ScalarAliasTestQuery") {
+                  override fun responseType(): Class<ScalarAliasTestQuery.Result> =
+                      ScalarAliasTestQuery.Result::class.java
 
                   /**
                    * Wrapper that holds all supported scalar types
@@ -76,6 +75,9 @@ class GenerateGraphQLCustomScalarTypeAliasIT {
                     val scalarQuery: ScalarAliasTestQuery.ScalarWrapper
                   )
                 }
+
+                suspend fun GraphQLClient<*>.executeScalarAliasTestQuery(request: ScalarAliasTestQuery):
+                    GraphQLResponse<ScalarAliasTestQuery.Result> = execute(request)
             """.trimIndent()
 
         val query =

--- a/plugins/client/graphql-kotlin-client-generator/src/test/kotlin/com/expediagroup/graphql/plugin/client/generator/types/GenerateGraphQLCustomScalarTypeSpecIT.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/kotlin/com/expediagroup/graphql/plugin/client/generator/types/GenerateGraphQLCustomScalarTypeSpecIT.kt
@@ -30,11 +30,12 @@ class GenerateGraphQLCustomScalarTypeSpecIT {
                 package com.expediagroup.graphql.plugin.generator.integration
 
                 import com.expediagroup.graphql.client.GraphQLClient
-                import com.expediagroup.graphql.client.execute
+                import com.expediagroup.graphql.client.GraphQLClientRequest
                 import com.expediagroup.graphql.plugin.generator.UUIDScalarConverter
                 import com.expediagroup.graphql.types.GraphQLResponse
                 import com.fasterxml.jackson.annotation.JsonCreator
                 import com.fasterxml.jackson.annotation.JsonValue
+                import java.lang.Class
                 import kotlin.Any
                 import kotlin.String
                 import kotlin.jvm.JvmStatic
@@ -42,11 +43,10 @@ class GenerateGraphQLCustomScalarTypeSpecIT {
                 const val CUSTOM_SCALAR_TEST_QUERY: String =
                     "query CustomScalarTestQuery {\n  scalarQuery {\n    custom\n  }\n}"
 
-                class CustomScalarTestQuery(
-                  private val graphQLClient: GraphQLClient
-                ) {
-                  suspend fun execute(): GraphQLResponse<CustomScalarTestQuery.Result> =
-                      graphQLClient.execute(CUSTOM_SCALAR_TEST_QUERY, "CustomScalarTestQuery", null)
+                class CustomScalarTestQuery : GraphQLClientRequest(CUSTOM_SCALAR_TEST_QUERY,
+                    "CustomScalarTestQuery") {
+                  override fun responseType(): Class<CustomScalarTestQuery.Result> =
+                      CustomScalarTestQuery.Result::class.java
 
                   /**
                    * Custom scalar representing UUID
@@ -83,6 +83,9 @@ class GenerateGraphQLCustomScalarTypeSpecIT {
                     val scalarQuery: CustomScalarTestQuery.ScalarWrapper
                   )
                 }
+
+                suspend fun GraphQLClient<*>.executeCustomScalarTestQuery(request: CustomScalarTestQuery):
+                    GraphQLResponse<CustomScalarTestQuery.Result> = execute(request)
             """.trimIndent()
 
         val query =
@@ -111,11 +114,12 @@ class GenerateGraphQLCustomScalarTypeSpecIT {
                 package com.expediagroup.graphql.plugin.generator.integration
 
                 import com.expediagroup.graphql.client.GraphQLClient
-                import com.expediagroup.graphql.client.execute
+                import com.expediagroup.graphql.client.GraphQLClientRequest
                 import com.expediagroup.graphql.plugin.generator.UUIDScalarConverter
                 import com.expediagroup.graphql.types.GraphQLResponse
                 import com.fasterxml.jackson.annotation.JsonCreator
                 import com.fasterxml.jackson.annotation.JsonValue
+                import java.lang.Class
                 import kotlin.Any
                 import kotlin.Int
                 import kotlin.String
@@ -124,11 +128,10 @@ class GenerateGraphQLCustomScalarTypeSpecIT {
                 const val CUSTOM_SCALAR_TEST_QUERY: String =
                     "query CustomScalarTestQuery {\n  first: scalarQuery {\n    ... scalarSelections\n  }\n  second: scalarQuery {\n    ... scalarSelections\n  }\n}\nfragment scalarSelections on ScalarWrapper {\n  count\n  custom\n  id\n}"
 
-                class CustomScalarTestQuery(
-                  private val graphQLClient: GraphQLClient
-                ) {
-                  suspend fun execute(): GraphQLResponse<CustomScalarTestQuery.Result> =
-                      graphQLClient.execute(CUSTOM_SCALAR_TEST_QUERY, "CustomScalarTestQuery", null)
+                class CustomScalarTestQuery : GraphQLClientRequest(CUSTOM_SCALAR_TEST_QUERY,
+                    "CustomScalarTestQuery") {
+                  override fun responseType(): Class<CustomScalarTestQuery.Result> =
+                      CustomScalarTestQuery.Result::class.java
 
                   /**
                    * Custom scalar representing UUID
@@ -177,6 +180,9 @@ class GenerateGraphQLCustomScalarTypeSpecIT {
                     val second: CustomScalarTestQuery.ScalarWrapper
                   )
                 }
+
+                suspend fun GraphQLClient<*>.executeCustomScalarTestQuery(request: CustomScalarTestQuery):
+                    GraphQLResponse<CustomScalarTestQuery.Result> = execute(request)
             """.trimIndent()
 
         val query =

--- a/plugins/client/graphql-kotlin-client-generator/src/test/kotlin/com/expediagroup/graphql/plugin/client/generator/types/GenerateGraphQLDocsIT.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/kotlin/com/expediagroup/graphql/plugin/client/generator/types/GenerateGraphQLDocsIT.kt
@@ -11,18 +11,16 @@ class GenerateGraphQLDocsIT {
                 package com.expediagroup.graphql.plugin.generator.integration
 
                 import com.expediagroup.graphql.client.GraphQLClient
-                import com.expediagroup.graphql.client.execute
+                import com.expediagroup.graphql.client.GraphQLClientRequest
                 import com.expediagroup.graphql.types.GraphQLResponse
+                import java.lang.Class
                 import kotlin.Int
                 import kotlin.String
 
-                const val TEST_QUERY: String = "query TestQuery {\n  docQuery {\n    id\n  }\n}"
+                const val DOCS_QUERY: String = "query DocsQuery {\n  docQuery {\n    id\n  }\n}"
 
-                class TestQuery(
-                  private val graphQLClient: GraphQLClient
-                ) {
-                  suspend fun execute(): GraphQLResponse<TestQuery.Result> = graphQLClient.execute(TEST_QUERY,
-                      "TestQuery", null)
+                class DocsQuery : GraphQLClientRequest(DOCS_QUERY, "DocsQuery") {
+                  override fun responseType(): Class<DocsQuery.Result> = DocsQuery.Result::class.java
 
                   /**
                    * Doc object with % and $ floating around
@@ -38,13 +36,16 @@ class GenerateGraphQLDocsIT {
                     /**
                      * Query to test doc strings
                      */
-                    val docQuery: TestQuery.DocObject
+                    val docQuery: DocsQuery.DocObject
                   )
                 }
+
+                suspend fun GraphQLClient<*>.executeDocsQuery(request: DocsQuery): GraphQLResponse<DocsQuery.Result>
+                    = execute(request)
             """.trimIndent()
         val query =
             """
-                query TestQuery {
+                query DocsQuery {
                   docQuery {
                     id
                   }

--- a/plugins/client/graphql-kotlin-client-generator/src/test/kotlin/com/expediagroup/graphql/plugin/client/generator/types/GenerateGraphQLEnumTypeSpecIT.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/kotlin/com/expediagroup/graphql/plugin/client/generator/types/GenerateGraphQLEnumTypeSpecIT.kt
@@ -28,19 +28,17 @@ class GenerateGraphQLEnumTypeSpecIT {
                 package com.expediagroup.graphql.plugin.generator.integration
 
                 import com.expediagroup.graphql.client.GraphQLClient
-                import com.expediagroup.graphql.client.execute
+                import com.expediagroup.graphql.client.GraphQLClientRequest
                 import com.expediagroup.graphql.types.GraphQLResponse
                 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue
+                import java.lang.Class
                 import kotlin.Deprecated
                 import kotlin.String
 
                 const val ENUM_TEST_QUERY: String = "query EnumTestQuery {\n  enumQuery\n}"
 
-                class EnumTestQuery(
-                  private val graphQLClient: GraphQLClient
-                ) {
-                  suspend fun execute(): GraphQLResponse<EnumTestQuery.Result> =
-                      graphQLClient.execute(ENUM_TEST_QUERY, "EnumTestQuery", null)
+                class EnumTestQuery : GraphQLClientRequest(ENUM_TEST_QUERY, "EnumTestQuery") {
+                  override fun responseType(): Class<EnumTestQuery.Result> = EnumTestQuery.Result::class.java
 
                   /**
                    * Custom enum description
@@ -76,6 +74,9 @@ class GenerateGraphQLEnumTypeSpecIT {
                     val enumQuery: EnumTestQuery.CustomEnum
                   )
                 }
+
+                suspend fun GraphQLClient<*>.executeEnumTestQuery(request: EnumTestQuery):
+                    GraphQLResponse<EnumTestQuery.Result> = execute(request)
             """.trimIndent()
 
         val query =

--- a/plugins/client/graphql-kotlin-client-generator/src/test/kotlin/com/expediagroup/graphql/plugin/client/generator/types/GenerateGraphQLInputObjectTypeSpecIT.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/kotlin/com/expediagroup/graphql/plugin/client/generator/types/GenerateGraphQLInputObjectTypeSpecIT.kt
@@ -28,19 +28,18 @@ class GenerateGraphQLInputObjectTypeSpecIT {
                 package com.expediagroup.graphql.plugin.generator.integration
 
                 import com.expediagroup.graphql.client.GraphQLClient
-                import com.expediagroup.graphql.client.execute
+                import com.expediagroup.graphql.client.GraphQLClientRequest
                 import com.expediagroup.graphql.types.GraphQLResponse
+                import java.lang.Class
                 import kotlin.Boolean
                 import kotlin.String
 
                 const val INPUT_OBJECT_TEST_QUERY: String =
                     "query InputObjectTestQuery {\n  inputObjectQuery(criteria: { min: 1.0, max: 5.0 } )\n}"
 
-                class InputObjectTestQuery(
-                  private val graphQLClient: GraphQLClient
-                ) {
-                  suspend fun execute(): GraphQLResponse<InputObjectTestQuery.Result> =
-                      graphQLClient.execute(INPUT_OBJECT_TEST_QUERY, "InputObjectTestQuery", null)
+                class InputObjectTestQuery : GraphQLClientRequest(INPUT_OBJECT_TEST_QUERY, "InputObjectTestQuery") {
+                  override fun responseType(): Class<InputObjectTestQuery.Result> =
+                      InputObjectTestQuery.Result::class.java
 
                   data class Result(
                     /**
@@ -49,6 +48,9 @@ class GenerateGraphQLInputObjectTypeSpecIT {
                     val inputObjectQuery: Boolean
                   )
                 }
+
+                suspend fun GraphQLClient<*>.executeInputObjectTestQuery(request: InputObjectTestQuery):
+                    GraphQLResponse<InputObjectTestQuery.Result> = execute(request)
             """.trimIndent()
 
         val query =
@@ -67,8 +69,9 @@ class GenerateGraphQLInputObjectTypeSpecIT {
                 package com.expediagroup.graphql.plugin.generator.integration
 
                 import com.expediagroup.graphql.client.GraphQLClient
-                import com.expediagroup.graphql.client.execute
+                import com.expediagroup.graphql.client.GraphQLClientRequest
                 import com.expediagroup.graphql.types.GraphQLResponse
+                import java.lang.Class
                 import kotlin.Boolean
                 import kotlin.Float
                 import kotlin.String
@@ -77,11 +80,10 @@ class GenerateGraphQLInputObjectTypeSpecIT {
                     "query InputObjectTestQuery(${'$'}{'${'$'}'}input: ComplexArgumentInput) {\n  complexInputObjectQuery(criteria: ${'$'}{'${'$'}'}input)\n}"
 
                 class InputObjectTestQuery(
-                  private val graphQLClient: GraphQLClient
-                ) {
-                  suspend fun execute(variables: InputObjectTestQuery.Variables):
-                      GraphQLResponse<InputObjectTestQuery.Result> = graphQLClient.execute(INPUT_OBJECT_TEST_QUERY,
-                      "InputObjectTestQuery", variables)
+                  variables: InputObjectTestQuery.Variables
+                ) : GraphQLClientRequest(INPUT_OBJECT_TEST_QUERY, "InputObjectTestQuery", variables) {
+                  override fun responseType(): Class<InputObjectTestQuery.Result> =
+                      InputObjectTestQuery.Result::class.java
 
                   data class Variables(
                     val input: InputObjectTestQuery.ComplexArgumentInput? = null
@@ -112,6 +114,9 @@ class GenerateGraphQLInputObjectTypeSpecIT {
                     val complexInputObjectQuery: Boolean
                   )
                 }
+
+                suspend fun GraphQLClient<*>.executeInputObjectTestQuery(request: InputObjectTestQuery):
+                    GraphQLResponse<InputObjectTestQuery.Result> = execute(request)
             """.trimIndent()
 
         val query =

--- a/plugins/client/graphql-kotlin-client-generator/src/test/kotlin/com/expediagroup/graphql/plugin/client/generator/types/GenerateGraphQLInterfaceTypeSpecIT.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/kotlin/com/expediagroup/graphql/plugin/client/generator/types/GenerateGraphQLInterfaceTypeSpecIT.kt
@@ -34,12 +34,13 @@ class GenerateGraphQLInterfaceTypeSpecIT {
                 package com.expediagroup.graphql.plugin.generator.integration
 
                 import com.expediagroup.graphql.client.GraphQLClient
-                import com.expediagroup.graphql.client.execute
+                import com.expediagroup.graphql.client.GraphQLClientRequest
                 import com.expediagroup.graphql.types.GraphQLResponse
                 import com.fasterxml.jackson.annotation.JsonSubTypes
                 import com.fasterxml.jackson.annotation.JsonTypeInfo
                 import com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY
                 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME
+                import java.lang.Class
                 import kotlin.Float
                 import kotlin.Int
                 import kotlin.String
@@ -47,12 +48,11 @@ class GenerateGraphQLInterfaceTypeSpecIT {
                 const val INTERFACE_WITH_INLINE_FRAGMENTS_TEST_QUERY: String =
                     "query InterfaceWithInlineFragmentsTestQuery {\n  interfaceQuery {\n    __typename\n    id\n    name\n    ... on FirstInterfaceImplementation {\n      intValue\n    }\n    ... on SecondInterfaceImplementation {\n      floatValue\n    }\n  }\n}"
 
-                class InterfaceWithInlineFragmentsTestQuery(
-                  private val graphQLClient: GraphQLClient
-                ) {
-                  suspend fun execute(): GraphQLResponse<InterfaceWithInlineFragmentsTestQuery.Result> =
-                      graphQLClient.execute(INTERFACE_WITH_INLINE_FRAGMENTS_TEST_QUERY,
-                      "InterfaceWithInlineFragmentsTestQuery", null)
+                class InterfaceWithInlineFragmentsTestQuery :
+                    GraphQLClientRequest(INTERFACE_WITH_INLINE_FRAGMENTS_TEST_QUERY,
+                    "InterfaceWithInlineFragmentsTestQuery") {
+                  override fun responseType(): Class<InterfaceWithInlineFragmentsTestQuery.Result> =
+                      InterfaceWithInlineFragmentsTestQuery.Result::class.java
 
                   /**
                    * Example interface implementation where value is an integer
@@ -122,6 +122,10 @@ class GenerateGraphQLInterfaceTypeSpecIT {
                     val interfaceQuery: InterfaceWithInlineFragmentsTestQuery.BasicInterface
                   )
                 }
+
+                suspend
+                    fun GraphQLClient<*>.executeInterfaceWithInlineFragmentsTestQuery(request: InterfaceWithInlineFragmentsTestQuery):
+                    GraphQLResponse<InterfaceWithInlineFragmentsTestQuery.Result> = execute(request)
             """.trimIndent()
 
         val query =
@@ -150,12 +154,13 @@ class GenerateGraphQLInterfaceTypeSpecIT {
                 package com.expediagroup.graphql.plugin.generator.integration
 
                 import com.expediagroup.graphql.client.GraphQLClient
-                import com.expediagroup.graphql.client.execute
+                import com.expediagroup.graphql.client.GraphQLClientRequest
                 import com.expediagroup.graphql.types.GraphQLResponse
                 import com.fasterxml.jackson.annotation.JsonSubTypes
                 import com.fasterxml.jackson.annotation.JsonTypeInfo
                 import com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY
                 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME
+                import java.lang.Class
                 import kotlin.Float
                 import kotlin.Int
                 import kotlin.String
@@ -163,12 +168,11 @@ class GenerateGraphQLInterfaceTypeSpecIT {
                 const val INTERFACE_WITH_NAMED_FRAGMENTS_TEST_QUERY: String =
                     "query InterfaceWithNamedFragmentsTestQuery {\n  interfaceQuery {\n    __typename\n    id\n    name\n    ... firstInterfaceImplFields\n    ... secondInterfaceImplFields\n  }\n}\n\nfragment firstInterfaceImplFields on FirstInterfaceImplementation {\n  id\n  name\n  intValue\n}\nfragment secondInterfaceImplFields on SecondInterfaceImplementation {\n  id\n  name\n  floatValue\n}"
 
-                class InterfaceWithNamedFragmentsTestQuery(
-                  private val graphQLClient: GraphQLClient
-                ) {
-                  suspend fun execute(): GraphQLResponse<InterfaceWithNamedFragmentsTestQuery.Result> =
-                      graphQLClient.execute(INTERFACE_WITH_NAMED_FRAGMENTS_TEST_QUERY,
-                      "InterfaceWithNamedFragmentsTestQuery", null)
+                class InterfaceWithNamedFragmentsTestQuery :
+                    GraphQLClientRequest(INTERFACE_WITH_NAMED_FRAGMENTS_TEST_QUERY,
+                    "InterfaceWithNamedFragmentsTestQuery") {
+                  override fun responseType(): Class<InterfaceWithNamedFragmentsTestQuery.Result> =
+                      InterfaceWithNamedFragmentsTestQuery.Result::class.java
 
                   /**
                    * Example interface implementation where value is an integer
@@ -238,6 +242,10 @@ class GenerateGraphQLInterfaceTypeSpecIT {
                     val interfaceQuery: InterfaceWithNamedFragmentsTestQuery.BasicInterface
                   )
                 }
+
+                suspend
+                    fun GraphQLClient<*>.executeInterfaceWithNamedFragmentsTestQuery(request: InterfaceWithNamedFragmentsTestQuery):
+                    GraphQLResponse<InterfaceWithNamedFragmentsTestQuery.Result> = execute(request)
             """.trimIndent()
 
         val queryWithNamedFragments =
@@ -328,12 +336,13 @@ class GenerateGraphQLInterfaceTypeSpecIT {
                 package com.expediagroup.graphql.plugin.generator.integration
 
                 import com.expediagroup.graphql.client.GraphQLClient
-                import com.expediagroup.graphql.client.execute
+                import com.expediagroup.graphql.client.GraphQLClientRequest
                 import com.expediagroup.graphql.types.GraphQLResponse
                 import com.fasterxml.jackson.annotation.JsonSubTypes
                 import com.fasterxml.jackson.annotation.JsonTypeInfo
                 import com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY
                 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME
+                import java.lang.Class
                 import kotlin.Float
                 import kotlin.Int
                 import kotlin.String
@@ -341,11 +350,10 @@ class GenerateGraphQLInterfaceTypeSpecIT {
                 const val DIFFERENT_SELECTION_SET_QUERY: String =
                     "query DifferentSelectionSetQuery {\n  first: interfaceQuery {\n    __typename\n    id\n    name\n    ... on FirstInterfaceImplementation {\n      intValue\n    }\n    ... on SecondInterfaceImplementation {\n      floatValue\n    }\n  }\n  second: interfaceQuery {\n    __typename\n    name\n    ... on FirstInterfaceImplementation {\n      intValue\n    }\n    ... on SecondInterfaceImplementation {\n      floatValue\n    }\n  }\n}"
 
-                class DifferentSelectionSetQuery(
-                  private val graphQLClient: GraphQLClient
-                ) {
-                  suspend fun execute(): GraphQLResponse<DifferentSelectionSetQuery.Result> =
-                      graphQLClient.execute(DIFFERENT_SELECTION_SET_QUERY, "DifferentSelectionSetQuery", null)
+                class DifferentSelectionSetQuery : GraphQLClientRequest(DIFFERENT_SELECTION_SET_QUERY,
+                    "DifferentSelectionSetQuery") {
+                  override fun responseType(): Class<DifferentSelectionSetQuery.Result> =
+                      DifferentSelectionSetQuery.Result::class.java
 
                   /**
                    * Example interface implementation where value is an integer
@@ -467,6 +475,9 @@ class GenerateGraphQLInterfaceTypeSpecIT {
                     val second: DifferentSelectionSetQuery.BasicInterface2
                   )
                 }
+
+                suspend fun GraphQLClient<*>.executeDifferentSelectionSetQuery(request: DifferentSelectionSetQuery):
+                    GraphQLResponse<DifferentSelectionSetQuery.Result> = execute(request)
             """.trimIndent()
         val differentSelectionQuery =
             """
@@ -504,12 +515,13 @@ class GenerateGraphQLInterfaceTypeSpecIT {
                 package com.expediagroup.graphql.plugin.generator.integration
 
                 import com.expediagroup.graphql.client.GraphQLClient
-                import com.expediagroup.graphql.client.execute
+                import com.expediagroup.graphql.client.GraphQLClientRequest
                 import com.expediagroup.graphql.types.GraphQLResponse
                 import com.fasterxml.jackson.annotation.JsonSubTypes
                 import com.fasterxml.jackson.annotation.JsonTypeInfo
                 import com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY
                 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME
+                import java.lang.Class
                 import kotlin.Float
                 import kotlin.Int
                 import kotlin.String
@@ -517,11 +529,10 @@ class GenerateGraphQLInterfaceTypeSpecIT {
                 const val DIFFERENT_SELECTION_SET_QUERY: String =
                     "query DifferentSelectionSetQuery {\n  first: interfaceQuery {\n    __typename\n    id\n    ... on FirstInterfaceImplementation {\n      intValue\n    }\n    ... on SecondInterfaceImplementation {\n      floatValue\n    }\n  }\n  second: interfaceQuery {\n    __typename\n    id\n    ... on FirstInterfaceImplementation {\n      name\n      intValue\n    }\n    ... on SecondInterfaceImplementation {\n      name\n      floatValue\n    }\n  }\n}"
 
-                class DifferentSelectionSetQuery(
-                  private val graphQLClient: GraphQLClient
-                ) {
-                  suspend fun execute(): GraphQLResponse<DifferentSelectionSetQuery.Result> =
-                      graphQLClient.execute(DIFFERENT_SELECTION_SET_QUERY, "DifferentSelectionSetQuery", null)
+                class DifferentSelectionSetQuery : GraphQLClientRequest(DIFFERENT_SELECTION_SET_QUERY,
+                    "DifferentSelectionSetQuery") {
+                  override fun responseType(): Class<DifferentSelectionSetQuery.Result> =
+                      DifferentSelectionSetQuery.Result::class.java
 
                   /**
                    * Example interface implementation where value is an integer
@@ -638,6 +649,9 @@ class GenerateGraphQLInterfaceTypeSpecIT {
                     val second: DifferentSelectionSetQuery.BasicInterface2
                   )
                 }
+
+                suspend fun GraphQLClient<*>.executeDifferentSelectionSetQuery(request: DifferentSelectionSetQuery):
+                    GraphQLResponse<DifferentSelectionSetQuery.Result> = execute(request)
             """.trimIndent()
         val differentSelectionQuery =
             """

--- a/plugins/client/graphql-kotlin-client-generator/src/test/kotlin/com/expediagroup/graphql/plugin/client/generator/types/GenerateGraphQLObjectTypeSpecIT.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/kotlin/com/expediagroup/graphql/plugin/client/generator/types/GenerateGraphQLObjectTypeSpecIT.kt
@@ -34,8 +34,9 @@ class GenerateGraphQLObjectTypeSpecIT {
                 package com.expediagroup.graphql.plugin.generator.integration
 
                 import com.expediagroup.graphql.client.GraphQLClient
-                import com.expediagroup.graphql.client.execute
+                import com.expediagroup.graphql.client.GraphQLClientRequest
                 import com.expediagroup.graphql.types.GraphQLResponse
+                import java.lang.Class
                 import kotlin.Boolean
                 import kotlin.Int
                 import kotlin.String
@@ -43,11 +44,10 @@ class GenerateGraphQLObjectTypeSpecIT {
                 const val COMPLEX_OBJECT_TEST_QUERY: String =
                     "query ComplexObjectTestQuery {\n  complexObjectQuery {\n    id\n    name\n    optional\n    details {\n      id\n      flag\n      value\n    }\n  }\n}"
 
-                class ComplexObjectTestQuery(
-                  private val graphQLClient: GraphQLClient
-                ) {
-                  suspend fun execute(): GraphQLResponse<ComplexObjectTestQuery.Result> =
-                      graphQLClient.execute(COMPLEX_OBJECT_TEST_QUERY, "ComplexObjectTestQuery", null)
+                class ComplexObjectTestQuery : GraphQLClientRequest(COMPLEX_OBJECT_TEST_QUERY,
+                    "ComplexObjectTestQuery") {
+                  override fun responseType(): Class<ComplexObjectTestQuery.Result> =
+                      ComplexObjectTestQuery.Result::class.java
 
                   /**
                    * Inner type object description
@@ -99,6 +99,9 @@ class GenerateGraphQLObjectTypeSpecIT {
                     val complexObjectQuery: ComplexObjectTestQuery.ComplexObject
                   )
                 }
+
+                suspend fun GraphQLClient<*>.executeComplexObjectTestQuery(request: ComplexObjectTestQuery):
+                    GraphQLResponse<ComplexObjectTestQuery.Result> = execute(request)
             """.trimIndent()
         val query =
             """
@@ -125,20 +128,20 @@ class GenerateGraphQLObjectTypeSpecIT {
                 package com.expediagroup.graphql.plugin.generator.integration
 
                 import com.expediagroup.graphql.client.GraphQLClient
-                import com.expediagroup.graphql.client.execute
+                import com.expediagroup.graphql.client.GraphQLClientRequest
                 import com.expediagroup.graphql.types.GraphQLResponse
+                import java.lang.Class
                 import kotlin.Int
                 import kotlin.String
 
                 const val COMPLEX_OBJECT_QUERY_WITH_NAMED_FRAGMENT: String =
                     "query ComplexObjectQueryWithNamedFragment {\n  complexObjectQuery {\n    ...complexObjectFields\n  }\n}\n\nfragment complexObjectFields on ComplexObject {\n  id\n  name\n  details {\n    ...detailObjectFields\n  }\n}\n\nfragment detailObjectFields on DetailsObject {\n  value\n}"
 
-                class ComplexObjectQueryWithNamedFragment(
-                  private val graphQLClient: GraphQLClient
-                ) {
-                  suspend fun execute(): GraphQLResponse<ComplexObjectQueryWithNamedFragment.Result> =
-                      graphQLClient.execute(COMPLEX_OBJECT_QUERY_WITH_NAMED_FRAGMENT,
-                      "ComplexObjectQueryWithNamedFragment", null)
+                class ComplexObjectQueryWithNamedFragment :
+                    GraphQLClientRequest(COMPLEX_OBJECT_QUERY_WITH_NAMED_FRAGMENT,
+                    "ComplexObjectQueryWithNamedFragment") {
+                  override fun responseType(): Class<ComplexObjectQueryWithNamedFragment.Result> =
+                      ComplexObjectQueryWithNamedFragment.Result::class.java
 
                   /**
                    * Inner type object description
@@ -177,6 +180,10 @@ class GenerateGraphQLObjectTypeSpecIT {
                     val complexObjectQuery: ComplexObjectQueryWithNamedFragment.ComplexObject
                   )
                 }
+
+                suspend
+                    fun GraphQLClient<*>.executeComplexObjectQueryWithNamedFragment(request: ComplexObjectQueryWithNamedFragment):
+                    GraphQLResponse<ComplexObjectQueryWithNamedFragment.Result> = execute(request)
             """.trimIndent()
 
         val queryWithNamedFragment =
@@ -254,8 +261,9 @@ class GenerateGraphQLObjectTypeSpecIT {
                 package com.expediagroup.graphql.plugin.generator.integration
 
                 import com.expediagroup.graphql.client.GraphQLClient
-                import com.expediagroup.graphql.client.execute
+                import com.expediagroup.graphql.client.GraphQLClientRequest
                 import com.expediagroup.graphql.types.GraphQLResponse
+                import java.lang.Class
                 import kotlin.Int
                 import kotlin.String
                 import kotlin.collections.List
@@ -263,11 +271,8 @@ class GenerateGraphQLObjectTypeSpecIT {
                 const val J_UNIT_TEST_QUERY: String =
                     "query JUnitTestQuery {\n  listQuery {\n    id\n    name\n  }\n}"
 
-                class JUnitTestQuery(
-                  private val graphQLClient: GraphQLClient
-                ) {
-                  suspend fun execute(): GraphQLResponse<JUnitTestQuery.Result> =
-                      graphQLClient.execute(J_UNIT_TEST_QUERY, "JUnitTestQuery", null)
+                class JUnitTestQuery : GraphQLClientRequest(J_UNIT_TEST_QUERY, "JUnitTestQuery") {
+                  override fun responseType(): Class<JUnitTestQuery.Result> = JUnitTestQuery.Result::class.java
 
                   /**
                    * Some basic description
@@ -287,6 +292,9 @@ class GenerateGraphQLObjectTypeSpecIT {
                     val listQuery: List<JUnitTestQuery.BasicObject>
                   )
                 }
+
+                suspend fun GraphQLClient<*>.executeJUnitTestQuery(request: JUnitTestQuery):
+                    GraphQLResponse<JUnitTestQuery.Result> = execute(request)
             """.trimIndent()
 
         val query =
@@ -308,8 +316,9 @@ class GenerateGraphQLObjectTypeSpecIT {
                 package com.expediagroup.graphql.plugin.generator.integration
 
                 import com.expediagroup.graphql.client.GraphQLClient
-                import com.expediagroup.graphql.client.execute
+                import com.expediagroup.graphql.client.GraphQLClientRequest
                 import com.expediagroup.graphql.types.GraphQLResponse
+                import java.lang.Class
                 import kotlin.Int
                 import kotlin.String
                 import kotlin.collections.List
@@ -317,11 +326,8 @@ class GenerateGraphQLObjectTypeSpecIT {
                 const val NESTED_QUERY: String =
                     "query NestedQuery {\n  nestedObjectQuery {\n    id\n    name\n    children {\n      name\n      children {\n        id\n        name\n        children {\n          id\n          name\n        }\n      }\n    }\n  }\n}"
 
-                class NestedQuery(
-                  private val graphQLClient: GraphQLClient
-                ) {
-                  suspend fun execute(): GraphQLResponse<NestedQuery.Result> = graphQLClient.execute(NESTED_QUERY,
-                      "NestedQuery", null)
+                class NestedQuery : GraphQLClientRequest(NESTED_QUERY, "NestedQuery") {
+                  override fun responseType(): Class<NestedQuery.Result> = NestedQuery.Result::class.java
 
                   /**
                    * Example of an object self-referencing itself
@@ -394,6 +400,9 @@ class GenerateGraphQLObjectTypeSpecIT {
                     val nestedObjectQuery: NestedQuery.NestedObject
                   )
                 }
+
+                suspend fun GraphQLClient<*>.executeNestedQuery(request: NestedQuery):
+                    GraphQLResponse<NestedQuery.Result> = execute(request)
             """.trimIndent()
         val nestedQuery =
             """
@@ -425,19 +434,19 @@ class GenerateGraphQLObjectTypeSpecIT {
                 package com.expediagroup.graphql.plugin.generator.integration
 
                 import com.expediagroup.graphql.client.GraphQLClient
-                import com.expediagroup.graphql.client.execute
+                import com.expediagroup.graphql.client.GraphQLClientRequest
                 import com.expediagroup.graphql.types.GraphQLResponse
+                import java.lang.Class
                 import kotlin.Int
                 import kotlin.String
 
                 const val DIFFERENT_SELECTIONS_QUERY: String =
                     "query DifferentSelectionsQuery {\n  first: complexObjectQuery {\n    id\n    name\n  }\n  second: complexObjectQuery {\n    id\n    name\n    details {\n      id\n      value\n    }\n  }\n}"
 
-                class DifferentSelectionsQuery(
-                  private val graphQLClient: GraphQLClient
-                ) {
-                  suspend fun execute(): GraphQLResponse<DifferentSelectionsQuery.Result> =
-                      graphQLClient.execute(DIFFERENT_SELECTIONS_QUERY, "DifferentSelectionsQuery", null)
+                class DifferentSelectionsQuery : GraphQLClientRequest(DIFFERENT_SELECTIONS_QUERY,
+                    "DifferentSelectionsQuery") {
+                  override fun responseType(): Class<DifferentSelectionsQuery.Result> =
+                      DifferentSelectionsQuery.Result::class.java
 
                   /**
                    * Multi line description of a complex type.
@@ -500,6 +509,9 @@ class GenerateGraphQLObjectTypeSpecIT {
                     val second: DifferentSelectionsQuery.ComplexObject2
                   )
                 }
+
+                suspend fun GraphQLClient<*>.executeDifferentSelectionsQuery(request: DifferentSelectionsQuery):
+                    GraphQLResponse<DifferentSelectionsQuery.Result> = execute(request)
             """.trimIndent()
         val differentSelectionsQuery =
             """
@@ -528,8 +540,9 @@ class GenerateGraphQLObjectTypeSpecIT {
                 package com.expediagroup.graphql.plugin.generator.integration
 
                 import com.expediagroup.graphql.client.GraphQLClient
-                import com.expediagroup.graphql.client.execute
+                import com.expediagroup.graphql.client.GraphQLClientRequest
                 import com.expediagroup.graphql.types.GraphQLResponse
+                import java.lang.Class
                 import kotlin.Boolean
                 import kotlin.Int
                 import kotlin.String
@@ -537,11 +550,10 @@ class GenerateGraphQLObjectTypeSpecIT {
                 const val DIFFERENT_SELECTIONS_QUERY: String =
                     "query DifferentSelectionsQuery {\n  first: complexObjectQuery {\n    id\n    name\n    details {\n      id\n      value\n      flag\n    }\n  }\n  second: complexObjectQuery {\n    id\n    name\n    details {\n      id\n      value\n    }\n  }\n}"
 
-                class DifferentSelectionsQuery(
-                  private val graphQLClient: GraphQLClient
-                ) {
-                  suspend fun execute(): GraphQLResponse<DifferentSelectionsQuery.Result> =
-                      graphQLClient.execute(DIFFERENT_SELECTIONS_QUERY, "DifferentSelectionsQuery", null)
+                class DifferentSelectionsQuery : GraphQLClientRequest(DIFFERENT_SELECTIONS_QUERY,
+                    "DifferentSelectionsQuery") {
+                  override fun responseType(): Class<DifferentSelectionsQuery.Result> =
+                      DifferentSelectionsQuery.Result::class.java
 
                   /**
                    * Inner type object description
@@ -626,6 +638,9 @@ class GenerateGraphQLObjectTypeSpecIT {
                     val second: DifferentSelectionsQuery.ComplexObject2
                   )
                 }
+
+                suspend fun GraphQLClient<*>.executeDifferentSelectionsQuery(request: DifferentSelectionsQuery):
+                    GraphQLResponse<DifferentSelectionsQuery.Result> = execute(request)
             """.trimIndent()
         val differentSelectionsQuery =
             """

--- a/plugins/client/graphql-kotlin-client-generator/src/test/kotlin/com/expediagroup/graphql/plugin/client/generator/types/GenerateGraphQLUnionTypeSpecIT.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/kotlin/com/expediagroup/graphql/plugin/client/generator/types/GenerateGraphQLUnionTypeSpecIT.kt
@@ -34,24 +34,23 @@ class GenerateGraphQLUnionTypeSpecIT {
                 package com.expediagroup.graphql.plugin.generator.integration
 
                 import com.expediagroup.graphql.client.GraphQLClient
-                import com.expediagroup.graphql.client.execute
+                import com.expediagroup.graphql.client.GraphQLClientRequest
                 import com.expediagroup.graphql.types.GraphQLResponse
                 import com.fasterxml.jackson.annotation.JsonSubTypes
                 import com.fasterxml.jackson.annotation.JsonTypeInfo
                 import com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY
                 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME
+                import java.lang.Class
                 import kotlin.Int
                 import kotlin.String
 
                 const val UNION_QUERY_WITH_INLINE_FRAGMENTS: String =
                     "query UnionQueryWithInlineFragments {\n  unionQuery {\n    __typename\n    ... on BasicObject {\n      id\n      name\n    }\n    ... on ComplexObject {\n      id\n      name\n      optional\n    }\n  }\n}"
 
-                class UnionQueryWithInlineFragments(
-                  private val graphQLClient: GraphQLClient
-                ) {
-                  suspend fun execute(): GraphQLResponse<UnionQueryWithInlineFragments.Result> =
-                      graphQLClient.execute(UNION_QUERY_WITH_INLINE_FRAGMENTS, "UnionQueryWithInlineFragments",
-                      null)
+                class UnionQueryWithInlineFragments : GraphQLClientRequest(UNION_QUERY_WITH_INLINE_FRAGMENTS,
+                    "UnionQueryWithInlineFragments") {
+                  override fun responseType(): Class<UnionQueryWithInlineFragments.Result> =
+                      UnionQueryWithInlineFragments.Result::class.java
 
                   /**
                    * Some basic description
@@ -106,6 +105,10 @@ class GenerateGraphQLUnionTypeSpecIT {
                     val unionQuery: UnionQueryWithInlineFragments.BasicUnion
                   )
                 }
+
+                suspend
+                    fun GraphQLClient<*>.executeUnionQueryWithInlineFragments(request: UnionQueryWithInlineFragments):
+                    GraphQLResponse<UnionQueryWithInlineFragments.Result> = execute(request)
             """.trimIndent()
         val queryWithInlineFragments =
             """
@@ -134,23 +137,23 @@ class GenerateGraphQLUnionTypeSpecIT {
                 package com.expediagroup.graphql.plugin.generator.integration
 
                 import com.expediagroup.graphql.client.GraphQLClient
-                import com.expediagroup.graphql.client.execute
+                import com.expediagroup.graphql.client.GraphQLClientRequest
                 import com.expediagroup.graphql.types.GraphQLResponse
                 import com.fasterxml.jackson.annotation.JsonSubTypes
                 import com.fasterxml.jackson.annotation.JsonTypeInfo
                 import com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY
                 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME
+                import java.lang.Class
                 import kotlin.Int
                 import kotlin.String
 
                 const val UNION_QUERY_WITH_NAMED_FRAGMENTS: String =
                     "query UnionQueryWithNamedFragments {\n  unionQuery {\n    ... basicObjectFields\n    ... complexObjectFields\n  }\n}\n\nfragment basicObjectFields on BasicObject {\n  __typename\n  id\n  name\n}\nfragment complexObjectFields on ComplexObject {\n  __typename\n  id\n  name\n  optional\n}"
 
-                class UnionQueryWithNamedFragments(
-                  private val graphQLClient: GraphQLClient
-                ) {
-                  suspend fun execute(): GraphQLResponse<UnionQueryWithNamedFragments.Result> =
-                      graphQLClient.execute(UNION_QUERY_WITH_NAMED_FRAGMENTS, "UnionQueryWithNamedFragments", null)
+                class UnionQueryWithNamedFragments : GraphQLClientRequest(UNION_QUERY_WITH_NAMED_FRAGMENTS,
+                    "UnionQueryWithNamedFragments") {
+                  override fun responseType(): Class<UnionQueryWithNamedFragments.Result> =
+                      UnionQueryWithNamedFragments.Result::class.java
 
                   /**
                    * Some basic description
@@ -205,6 +208,10 @@ class GenerateGraphQLUnionTypeSpecIT {
                     val unionQuery: UnionQueryWithNamedFragments.BasicUnion
                   )
                 }
+
+                suspend
+                    fun GraphQLClient<*>.executeUnionQueryWithNamedFragments(request: UnionQueryWithNamedFragments):
+                    GraphQLResponse<UnionQueryWithNamedFragments.Result> = execute(request)
             """.trimIndent()
         val queryWithNamedFragments =
             """
@@ -292,23 +299,23 @@ class GenerateGraphQLUnionTypeSpecIT {
                 package com.expediagroup.graphql.plugin.generator.integration
 
                 import com.expediagroup.graphql.client.GraphQLClient
-                import com.expediagroup.graphql.client.execute
+                import com.expediagroup.graphql.client.GraphQLClientRequest
                 import com.expediagroup.graphql.types.GraphQLResponse
                 import com.fasterxml.jackson.annotation.JsonSubTypes
                 import com.fasterxml.jackson.annotation.JsonTypeInfo
                 import com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY
                 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME
+                import java.lang.Class
                 import kotlin.Int
                 import kotlin.String
 
                 const val DIFFERENT_SELECTION_SET_QUERY: String =
                     "query DifferentSelectionSetQuery {\n  unionQuery {\n    __typename\n    ... on BasicObject {\n      id\n      name\n    }\n    ... on ComplexObject {\n      id\n      name\n      optional\n    }\n  }\n  complexObjectQuery {\n    id\n    name\n    details {\n      value\n    }\n  }\n}"
 
-                class DifferentSelectionSetQuery(
-                  private val graphQLClient: GraphQLClient
-                ) {
-                  suspend fun execute(): GraphQLResponse<DifferentSelectionSetQuery.Result> =
-                      graphQLClient.execute(DIFFERENT_SELECTION_SET_QUERY, "DifferentSelectionSetQuery", null)
+                class DifferentSelectionSetQuery : GraphQLClientRequest(DIFFERENT_SELECTION_SET_QUERY,
+                    "DifferentSelectionSetQuery") {
+                  override fun responseType(): Class<DifferentSelectionSetQuery.Result> =
+                      DifferentSelectionSetQuery.Result::class.java
 
                   /**
                    * Some basic description
@@ -397,6 +404,9 @@ class GenerateGraphQLUnionTypeSpecIT {
                     val complexObjectQuery: DifferentSelectionSetQuery.ComplexObject2
                   )
                 }
+
+                suspend fun GraphQLClient<*>.executeDifferentSelectionSetQuery(request: DifferentSelectionSetQuery):
+                    GraphQLResponse<DifferentSelectionSetQuery.Result> = execute(request)
             """.trimIndent()
         val differentSelectionQuery =
             """
@@ -432,23 +442,23 @@ class GenerateGraphQLUnionTypeSpecIT {
                 package com.expediagroup.graphql.plugin.generator.integration
 
                 import com.expediagroup.graphql.client.GraphQLClient
-                import com.expediagroup.graphql.client.execute
+                import com.expediagroup.graphql.client.GraphQLClientRequest
                 import com.expediagroup.graphql.types.GraphQLResponse
                 import com.fasterxml.jackson.annotation.JsonSubTypes
                 import com.fasterxml.jackson.annotation.JsonTypeInfo
                 import com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY
                 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME
+                import java.lang.Class
                 import kotlin.Int
                 import kotlin.String
 
                 const val DIFFERENT_SELECTION_SET_QUERY: String =
                     "query DifferentSelectionSetQuery {\n  first: unionQuery {\n    __typename\n    ... on BasicObject {\n      id\n    }\n    ... on ComplexObject {\n      id\n    }\n  }\n  second: unionQuery {\n    __typename\n    ... on BasicObject {\n      name\n    }\n    ... on ComplexObject {\n      name\n    }\n  }\n}"
 
-                class DifferentSelectionSetQuery(
-                  private val graphQLClient: GraphQLClient
-                ) {
-                  suspend fun execute(): GraphQLResponse<DifferentSelectionSetQuery.Result> =
-                      graphQLClient.execute(DIFFERENT_SELECTION_SET_QUERY, "DifferentSelectionSetQuery", null)
+                class DifferentSelectionSetQuery : GraphQLClientRequest(DIFFERENT_SELECTION_SET_QUERY,
+                    "DifferentSelectionSetQuery") {
+                  override fun responseType(): Class<DifferentSelectionSetQuery.Result> =
+                      DifferentSelectionSetQuery.Result::class.java
 
                   /**
                    * Some basic description
@@ -530,6 +540,9 @@ class GenerateGraphQLUnionTypeSpecIT {
                     val second: DifferentSelectionSetQuery.BasicUnion2
                   )
                 }
+
+                suspend fun GraphQLClient<*>.executeDifferentSelectionSetQuery(request: DifferentSelectionSetQuery):
+                    GraphQLResponse<DifferentSelectionSetQuery.Result> = execute(request)
             """.trimIndent()
         val differentSelectionQuery =
             """

--- a/plugins/client/graphql-kotlin-client-generator/src/test/kotlin/com/expediagroup/graphql/plugin/client/generator/types/GenerateVariableTypeSpecIT.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/kotlin/com/expediagroup/graphql/plugin/client/generator/types/GenerateVariableTypeSpecIT.kt
@@ -29,8 +29,9 @@ class GenerateVariableTypeSpecIT {
                 package com.expediagroup.graphql.plugin.generator.integration
 
                 import com.expediagroup.graphql.client.GraphQLClient
-                import com.expediagroup.graphql.client.execute
+                import com.expediagroup.graphql.client.GraphQLClientRequest
                 import com.expediagroup.graphql.types.GraphQLResponse
+                import java.lang.Class
                 import kotlin.Boolean
                 import kotlin.Float
                 import kotlin.String
@@ -39,11 +40,10 @@ class GenerateVariableTypeSpecIT {
                     "query TestQueryWithVariables(${'$'}{'${'$'}'}criteria: SimpleArgumentInput) {\n  inputObjectQuery(criteria: ${'$'}{'${'$'}'}criteria)\n}"
 
                 class TestQueryWithVariables(
-                  private val graphQLClient: GraphQLClient
-                ) {
-                  suspend fun execute(variables: TestQueryWithVariables.Variables):
-                      GraphQLResponse<TestQueryWithVariables.Result> =
-                      graphQLClient.execute(TEST_QUERY_WITH_VARIABLES, "TestQueryWithVariables", variables)
+                  variables: TestQueryWithVariables.Variables
+                ) : GraphQLClientRequest(TEST_QUERY_WITH_VARIABLES, "TestQueryWithVariables", variables) {
+                  override fun responseType(): Class<TestQueryWithVariables.Result> =
+                      TestQueryWithVariables.Result::class.java
 
                   data class Variables(
                     val criteria: TestQueryWithVariables.SimpleArgumentInput? = null
@@ -74,6 +74,9 @@ class GenerateVariableTypeSpecIT {
                     val inputObjectQuery: Boolean
                   )
                 }
+
+                suspend fun GraphQLClient<*>.executeTestQueryWithVariables(request: TestQueryWithVariables):
+                    GraphQLResponse<TestQueryWithVariables.Result> = execute(request)
             """.trimIndent()
         val query =
             """

--- a/plugins/graphql-kotlin-gradle-plugin/src/test/resources/templates/Application.mustache
+++ b/plugins/graphql-kotlin-gradle-plugin/src/test/resources/templates/Application.mustache
@@ -1,14 +1,14 @@
 package com.example
 
 import com.example.generated.JUnitQuery
+import com.example.generated.executeJUnitQuery
 {{#webClient}}
-    import com.expediagroup.graphql.client.spring.GraphQLWebClient
-    import org.springframework.web.reactive.function.client.WebClient
+import com.expediagroup.graphql.client.spring.GraphQLWebClient
+import org.springframework.web.reactive.function.client.WebClient
 {{/webClient}}
 {{^webClient}}
-    import com.expediagroup.graphql.client.ktor.GraphQLKtorClient
+import com.expediagroup.graphql.client.ktor.GraphQLKtorClient
 {{/webClient}}
-import com.expediagroup.graphql.client.execute
 import io.ktor.client.features.defaultRequest
 import io.ktor.client.request.header
 import kotlinx.coroutines.runBlocking
@@ -16,36 +16,37 @@ import java.net.URL
 
 fun main() {
     {{^defaultHeader}}
-        val client = GraphQLKtorClient(URL(System.getProperty("graphQLEndpoint")))
+    val client = GraphQLKtorClient(URL(System.getProperty("graphQLEndpoint")))
     {{/defaultHeader}}
     {{#defaultHeader}}
         {{#webClient}}
-            val webClientBuilder = WebClient.builder()
-                .defaultHeader("{{name}}", "{{value}}")
-            val client = GraphQLWebClient(
-                url = System.getProperty("graphQLEndpoint"),
-                builder = webClientBuilder
-            )
+    val webClientBuilder = WebClient.builder()
+        .defaultHeader("{{name}}", "{{value}}")
+    val client = GraphQLWebClient(
+        url = System.getProperty("graphQLEndpoint"),
+        builder = webClientBuilder
+    )
         {{/webClient}}
         {{^webClient}}
-            val client = GraphQLKtorClient(URL(System.getProperty("graphQLEndpoint"))) {
-                defaultRequest {
-                    header("{{name}}", "{{value}}")
-                }
-            }
+    val client = GraphQLKtorClient(URL(System.getProperty("graphQLEndpoint"))) {
+        defaultRequest {
+            header("{{name}}", "{{value}}")
+        }
+    }
         {{/webClient}}
     {{/defaultHeader}}
-    val query = JUnitQuery(client)
-
     val variables = JUnitQuery.Variables(JUnitQuery.SimpleArgumentInput(min = null, max = null, newName = "blah"))
+    val query = JUnitQuery(variables)
+
+
     runBlocking {
         {{^requestHeader}}
-            val response = query.execute(variables = variables)
+        val response = client.executeJUnitQuery(query)
         {{/requestHeader}}
         {{#requestHeader}}
-            val response = query.execute(variables = variables) {
-                header("{{name}}", "{{value}}")
-            }
+        val response = client.executeJUnitQuery(query) {
+            header("{{name}}", "{{value}}")
+        }
         {{/requestHeader}}
 
         val data = response.data
@@ -55,10 +56,10 @@ fun main() {
         assert(scalarResult != null)
         assert(scalarResult?.count is Int)
         {{#customScalarsEnabled}}
-            assert(scalarResult?.custom is JUnitQuery.UUID)
+        assert(scalarResult?.custom is JUnitQuery.UUID)
         {{/customScalarsEnabled}}
         {{^customScalarsEnabled}}
-            assert(scalarResult?.custom is String)
+        assert(scalarResult?.custom is String)
         {{/customScalarsEnabled}}
         assert(JUnitQuery.CustomEnum.ONE == data?.enumQuery)
         val interfaceResult = data?.interfaceQuery

--- a/plugins/graphql-kotlin-gradle-plugin/src/test/resources/templates/JUnit.mustache
+++ b/plugins/graphql-kotlin-gradle-plugin/src/test/resources/templates/JUnit.mustache
@@ -1,6 +1,7 @@
 package com.example
 
 import com.example.generated.JUnitQuery
+import com.example.generated.executeJUnitQuery
 import com.expediagroup.graphql.client.ktor.GraphQLKtorClient
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -25,12 +26,13 @@ class GraphQLMavenPluginTest {
     fun `verify client code was generated and can execute query`() {
         val graphQLEndpoint = System.getProperty("graphQLEndpoint")
         val client = GraphQLKtorClient(URL(graphQLEndpoint))
-        val query = JUnitQuery(client)
 
         val variables = JUnitQuery.Variables(simpleCriteria = JUnitQuery.SimpleArgumentInput(min = null, max = null, newName = "blah"))
+        val query = JUnitQuery(variables)
+
         assertDoesNotThrow {
             runBlocking {
-                val response = query.execute(variables = variables)
+                val response = client.executeJUnitQuery(query)
                 assertTrue(response.errors == null)
                 val data = response.data
                 assertNotNull(data)
@@ -39,10 +41,10 @@ class GraphQLMavenPluginTest {
                 assertNotNull(scalarResult)
                 assertTrue(scalarResult?.count is Int)
                 {{#customScalarsEnabled}}
-                    assertTrue(scalarResult?.custom is JUnitQuery.UUID)
+                assertTrue(scalarResult?.custom is JUnitQuery.UUID)
                 {{/customScalarsEnabled}}
                 {{^customScalarsEnabled}}
-                    assertTrue(scalarResult?.custom is String)
+                assertTrue(scalarResult?.custom is String)
                 {{/customScalarsEnabled}}
                 assertEquals(JUnitQuery.CustomEnum.ONE, data?.enumQuery)
                 val interfaceResult = data?.interfaceQuery

--- a/plugins/graphql-kotlin-maven-plugin/src/integration/basic-setup/src/test/kotlin/com/expediagroup/graphql/plugin/maven/GraphQLMavenPluginTest.kt
+++ b/plugins/graphql-kotlin-maven-plugin/src/integration/basic-setup/src/test/kotlin/com/expediagroup/graphql/plugin/maven/GraphQLMavenPluginTest.kt
@@ -17,6 +17,7 @@
 package com.expediagroup.graphql.plugin.maven
 
 import com.expediagroup.graphql.plugin.generated.ExampleQuery
+import com.expediagroup.graphql.plugin.generated.executeExampleQuery
 import com.expediagroup.graphql.client.ktor.GraphQLKtorClient
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -48,12 +49,12 @@ class GraphQLMavenPluginTest {
     fun `verify client code was generated and can execute query`() {
         val graphQLEndpoint = System.getProperty("graphQLEndpoint")
         val client = GraphQLKtorClient(URL(graphQLEndpoint))
-        val query = ExampleQuery(client)
 
         val variables = ExampleQuery.Variables(simpleCriteria = ExampleQuery.SimpleArgumentInput(newName = "whatever", min = null, max = null))
+        val query = ExampleQuery(variables)
         assertDoesNotThrow {
             runBlocking {
-                val response = query.execute(variables = variables)
+                val response = client.executeExampleQuery(query)
                 assertTrue(response.errors == null)
                 val data = response.data
                 assertNotNull(data)

--- a/plugins/graphql-kotlin-maven-plugin/src/integration/complete-setup/src/test/kotlin/com/expediagroup/graphql/plugin/maven/GraphQLMavenPluginTest.kt
+++ b/plugins/graphql-kotlin-maven-plugin/src/integration/complete-setup/src/test/kotlin/com/expediagroup/graphql/plugin/maven/GraphQLMavenPluginTest.kt
@@ -18,6 +18,7 @@ package com.expediagroup.graphql.plugin.maven
 
 import com.expediagroup.graphql.plugin.generated.ExampleQuery
 import com.expediagroup.graphql.plugin.generated.UUID
+import com.expediagroup.graphql.plugin.generated.executeExampleQuery
 import com.expediagroup.graphql.client.ktor.GraphQLKtorClient
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -49,12 +50,12 @@ class GraphQLMavenPluginTest {
     fun `verify client code was generated and can execute query`() {
         val graphQLEndpoint = System.getProperty("graphQLEndpoint")
         val client = GraphQLKtorClient(URL(graphQLEndpoint))
-        val query = ExampleQuery(client)
 
         val variables = ExampleQuery.Variables(simpleCriteria = ExampleQuery.SimpleArgumentInput(newName = "whatever", min = null, max = null))
+        val query = ExampleQuery(variables)
         assertDoesNotThrow {
             runBlocking {
-                val response = query.execute(variables = variables)
+                val response = client.executeExampleQuery(query)
                 assertTrue(response.errors == null)
                 val data = response.data
                 assertNotNull(data)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,6 +12,7 @@ pluginManagement {
     plugins {
         kotlin("jvm") version kotlinVersion
         kotlin("kapt") version kotlinVersion
+        kotlin("plugin.serialization") version kotlinVersion
         kotlin("plugin.spring") version kotlinVersion
         id("com.gradle.plugin-publish") version pluginPublishPluginVersion
         id("de.benediktritter.maven-plugin-development") version mavenPluginDevelopmentVersion


### PR DESCRIPTION
### :pencil: Description

Refactor of GraphQL client to support batch operations.

Instead of injecting an instance of GraphQL client to a generated operation class, generated classes are now simple POJOs that represent underlying GraphQL request. This change breaks the tight coupling between generated classes and client implementation and allows clients to execute arbitrary `GraphQLClientRequest`s.

Old generated model

```kotlin
class HelloWorldQuery(
  private val graphQLClient: GraphQLKtorClient<*>
) {
  suspend fun execute(requestBuilder: HttpRequestBuilder.() -> Unit = {}): GraphQLResponse<HelloWorldQuery.Result> =
      graphQLClient.execute(HELLO_WORLD_QUERY, "HelloWorldQuery", null, requestBuilder)

  data class Result(
    val helloWorld: String
  )
}
```

New generated model

```kotlin
class HelloWorldQuery: GraphQLClientRequest(HELLO_WORLD_QUERY, "HelloWorldQuery") {
  override fun returnType(): Class<HelloWorldQuery.Result> = HelloWorldQuery.Result::class.java

  data class Result(
    val helloWorld: String
  )
}
```

`GraphQLClient` interface was udated to accept arbitrary `GraphQLClientRequest`s which allows us to support both individual as well as batch requests.

```kotlin
interface GraphQLClient<R> {

    suspend fun <T> execute(request: GraphQLClientRequest, requestBuilder: R.() -> Unit = {}): GraphQLResponse<T>

    suspend fun execute(requests: List<GraphQLClientRequest>, requestBuilder: R.() -> Unit = {}): List<GraphQLResponse<*>>
}
```

In order to be able to generically deserialize batch requests, `GraphQLClientRequest`s also need to provide return type `Class` information. For convenience, GraphQL Kotlin plugin also generate corresponding `execute<OperationName>` extension methods on the target client type that return operation specific `GraphQLResponse`.

### :link: Related Issues
