### PR TITLE
Generate context with suspend and nullable in subscriptions

### DIFF
--- a/examples/build.gradle.kts
+++ b/examples/build.gradle.kts
@@ -40,6 +40,7 @@ subprojects {
 
     val kotlinVersion: String by project
     val junitVersion: String by project
+    val kotlinCoroutinesVersion: String by project
 
     val detektVersion: String by project
     val ktlintVersion: String by project
@@ -50,6 +51,8 @@ subprojects {
 
     dependencies {
         implementation(kotlin("stdlib", kotlinVersion))
+        implementation(kotlin("reflect", kotlinVersion))
+        implementation("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:$kotlinCoroutinesVersion")
         testImplementation(kotlin("test-junit5", kotlinVersion))
         testImplementation("org.junit.jupiter:junit-jupiter-api:$junitVersion")
         testImplementation("org.junit.jupiter:junit-jupiter-engine:$junitVersion")

--- a/examples/server/ktor-server/src/main/kotlin/com/expediagroup/graphql/examples/server/ktor/KtorGraphQLContextFactory.kt
+++ b/examples/server/ktor-server/src/main/kotlin/com/expediagroup/graphql/examples/server/ktor/KtorGraphQLContextFactory.kt
@@ -25,7 +25,7 @@ import io.ktor.request.ApplicationRequest
  */
 class KtorGraphQLContextFactory : GraphQLContextFactory<AuthorizedContext, ApplicationRequest> {
 
-    override fun generateContext(request: ApplicationRequest): AuthorizedContext {
+    override suspend fun generateContext(request: ApplicationRequest): AuthorizedContext {
         val loggedInUser = User(
             email = "fake@site.com",
             firstName = "Someone",

--- a/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/server/spring/context/MyGraphQLContext.kt
+++ b/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/server/spring/context/MyGraphQLContext.kt
@@ -24,8 +24,8 @@ import org.springframework.web.reactive.socket.WebSocketSession
  * Simple [GraphQLContext] that holds extra value and the [ServerRequest]
  */
 class MyGraphQLContext(
-    val myCustomValue: String,
-    val request: ServerRequest
+    val request: ServerRequest,
+    val myCustomValue: String
 ) : GraphQLContext
 
 /**
@@ -33,5 +33,5 @@ class MyGraphQLContext(
  */
 class MySubscriptionGraphQLContext(
     val request: WebSocketSession,
-    var subscriptionValue: String? = null
+    var auth: String? = null
 ) : GraphQLContext

--- a/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/server/spring/context/MyGraphQLContextFactory.kt
+++ b/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/server/spring/context/MyGraphQLContextFactory.kt
@@ -30,16 +30,19 @@ import org.springframework.web.reactive.socket.WebSocketSession
 class MyGraphQLContextFactory : SpringGraphQLContextFactory<MyGraphQLContext>() {
 
     override suspend fun generateContext(request: ServerRequest): MyGraphQLContext = MyGraphQLContext(
-        myCustomValue = request.headers().firstHeader("MyHeader") ?: "defaultContext",
-        request = request
+        request = request,
+        myCustomValue = request.headers().firstHeader("MyHeader") ?: "defaultContext"
     )
 }
 
+/**
+ * [GraphQLContextFactory] that generates [MySubscriptionGraphQLContext] that will be available when processing subscription operations.
+ */
 @Component
 class MySubscriptionGraphQLContextFactory : SpringSubscriptionGraphQLContextFactory<MySubscriptionGraphQLContext>() {
 
     override suspend fun generateContext(request: WebSocketSession): MySubscriptionGraphQLContext = MySubscriptionGraphQLContext(
         request = request,
-        subscriptionValue = null
+        auth = null
     )
 }

--- a/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/server/spring/context/MyGraphQLContextFactory.kt
+++ b/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/server/spring/context/MyGraphQLContextFactory.kt
@@ -29,7 +29,7 @@ import org.springframework.web.reactive.socket.WebSocketSession
 @Component
 class MyGraphQLContextFactory : SpringGraphQLContextFactory<MyGraphQLContext>() {
 
-    override fun generateContext(request: ServerRequest): MyGraphQLContext = MyGraphQLContext(
+    override suspend fun generateContext(request: ServerRequest): MyGraphQLContext = MyGraphQLContext(
         myCustomValue = request.headers().firstHeader("MyHeader") ?: "defaultContext",
         request = request
     )
@@ -38,7 +38,7 @@ class MyGraphQLContextFactory : SpringGraphQLContextFactory<MyGraphQLContext>() 
 @Component
 class MySubscriptionGraphQLContextFactory : SpringSubscriptionGraphQLContextFactory<MySubscriptionGraphQLContext>() {
 
-    override fun generateContext(request: WebSocketSession): MySubscriptionGraphQLContext = MySubscriptionGraphQLContext(
+    override suspend fun generateContext(request: WebSocketSession): MySubscriptionGraphQLContext = MySubscriptionGraphQLContext(
         request = request,
         subscriptionValue = null
     )

--- a/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/server/spring/execution/MySubscriptionHooks.kt
+++ b/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/server/spring/execution/MySubscriptionHooks.kt
@@ -19,9 +19,7 @@ package com.expediagroup.graphql.examples.server.spring.execution
 import com.expediagroup.graphql.examples.server.spring.context.MySubscriptionGraphQLContext
 import com.expediagroup.graphql.generator.execution.GraphQLContext
 import com.expediagroup.graphql.server.spring.subscriptions.ApolloSubscriptionHooks
-import kotlinx.coroutines.reactor.mono
 import org.springframework.web.reactive.socket.WebSocketSession
-import reactor.core.publisher.Mono
 
 /**
  * A simple implementation of Apollo Subscription Lifecycle Events.
@@ -31,12 +29,12 @@ class MySubscriptionHooks : ApolloSubscriptionHooks {
     override fun onConnect(
         connectionParams: Map<String, String>,
         session: WebSocketSession,
-        graphQLContext: GraphQLContext
-    ): Mono<GraphQLContext> = mono {
-        if (graphQLContext is MySubscriptionGraphQLContext) {
+        graphQLContext: GraphQLContext?
+    ): GraphQLContext? {
+        if (graphQLContext != null && graphQLContext is MySubscriptionGraphQLContext) {
             val bearer = connectionParams["Authorization"] ?: "none"
             graphQLContext.subscriptionValue = bearer
         }
-        graphQLContext
+        return graphQLContext
     }
 }

--- a/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/server/spring/execution/MySubscriptionHooks.kt
+++ b/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/server/spring/execution/MySubscriptionHooks.kt
@@ -32,8 +32,7 @@ class MySubscriptionHooks : ApolloSubscriptionHooks {
         graphQLContext: GraphQLContext?
     ): GraphQLContext? {
         if (graphQLContext != null && graphQLContext is MySubscriptionGraphQLContext) {
-            val bearer = connectionParams["Authorization"] ?: "none"
-            graphQLContext.subscriptionValue = bearer
+            graphQLContext.auth = connectionParams["Authorization"]
         }
         return graphQLContext
     }

--- a/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/server/spring/subscriptions/SimpleSubscription.kt
+++ b/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/server/spring/subscriptions/SimpleSubscription.kt
@@ -82,5 +82,5 @@ class SimpleSubscription : Subscription {
 
     @GraphQLDescription("Returns a value from the subscription context")
     fun subscriptionContext(myGraphQLContext: MySubscriptionGraphQLContext): Flux<String> =
-        Flux.just(myGraphQLContext.subscriptionValue ?: "", "value 2", "value3")
+        Flux.just(myGraphQLContext.auth ?: "no-auth")
 }

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/execution/FunctionDataFetcher.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/execution/FunctionDataFetcher.kt
@@ -59,7 +59,7 @@ open class FunctionDataFetcher(
      * Invoke a suspend function or blocking function, passing in the [target] if not null or default to using the source from the environment.
      */
     override fun get(environment: DataFetchingEnvironment): Any? {
-        val instance = target ?: environment.getSource<Any?>()
+        val instance: Any? = target ?: environment.getSource<Any?>()
         val instanceParameter = fn.instanceParameter
 
         return if (instance != null && instanceParameter != null) {

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/execution/GraphQLContext.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/execution/GraphQLContext.kt
@@ -16,19 +16,8 @@
 
 package com.expediagroup.graphql.generator.execution
 
-import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.ConcurrentMap
-
 /**
  * Marker interface to indicate that the implementing class should be considered
  * as the GraphQL context. This means the implementing class will not appear in the schema.
  */
 interface GraphQLContext
-
-/**
- * Default [GraphQLContext] that can be used if there is none provided. Exposes generic concurrent hash map
- * that can be populated with custom data.
- */
-class DefaultGraphQLContext : GraphQLContext {
-    val contents: ConcurrentMap<Any, Any> = ConcurrentHashMap()
-}

--- a/servers/graphql-kotlin-server/src/main/kotlin/com/expediagroup/graphql/server/execution/GraphQLContextFactory.kt
+++ b/servers/graphql-kotlin-server/src/main/kotlin/com/expediagroup/graphql/server/execution/GraphQLContextFactory.kt
@@ -16,7 +16,6 @@
 
 package com.expediagroup.graphql.server.execution
 
-import com.expediagroup.graphql.generator.execution.DefaultGraphQLContext
 import com.expediagroup.graphql.generator.execution.GraphQLContext
 
 /**
@@ -28,12 +27,5 @@ interface GraphQLContextFactory<out Context : GraphQLContext, Request> {
      * Generate GraphQL context based on the incoming request and the corresponding response.
      * If no context should be generated and used in the request, return null.
      */
-    fun generateContext(request: Request): Context?
-}
-
-/**
- * Default context factory that generates GraphQL context with empty concurrent map that can store any elements.
- */
-class DefaultGraphQLContextFactory<T> : GraphQLContextFactory<DefaultGraphQLContext, T> {
-    override fun generateContext(request: T) = DefaultGraphQLContext()
+    suspend fun generateContext(request: Request): Context?
 }

--- a/servers/graphql-kotlin-server/src/main/kotlin/com/expediagroup/graphql/server/extensions/requestExtensions.kt
+++ b/servers/graphql-kotlin-server/src/main/kotlin/com/expediagroup/graphql/server/extensions/requestExtensions.kt
@@ -16,7 +16,6 @@
 
 package com.expediagroup.graphql.server.extensions
 
-import com.expediagroup.graphql.generator.execution.DefaultGraphQLContext
 import com.expediagroup.graphql.types.GraphQLRequest
 import graphql.ExecutionInput
 import org.dataloader.DataLoaderRegistry
@@ -29,6 +28,6 @@ fun GraphQLRequest.toExecutionInput(graphQLContext: Any? = null, dataLoaderRegis
         .query(this.query)
         .operationName(this.operationName)
         .variables(this.variables ?: emptyMap())
-        .context(graphQLContext ?: DefaultGraphQLContext())
+        .context(graphQLContext)
         .dataLoaderRegistry(dataLoaderRegistry ?: DataLoaderRegistry())
         .build()

--- a/servers/graphql-kotlin-server/src/test/kotlin/com/expediagroup/graphql/server/extensions/RequestExtensionsKtTest.kt
+++ b/servers/graphql-kotlin-server/src/test/kotlin/com/expediagroup/graphql/server/extensions/RequestExtensionsKtTest.kt
@@ -16,14 +16,13 @@
 
 package com.expediagroup.graphql.server.extensions
 
-import com.expediagroup.graphql.generator.execution.GraphQLContext
 import com.expediagroup.graphql.types.GraphQLRequest
 import io.mockk.mockk
 import org.dataloader.DataLoaderRegistry
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
-import kotlin.test.assertTrue
+import kotlin.test.assertNull
 
 class RequestExtensionsKtTest {
 
@@ -32,7 +31,7 @@ class RequestExtensionsKtTest {
         val request = GraphQLRequest(query = "query { whatever }")
         val executionInput = request.toExecutionInput()
         assertEquals(request.query, executionInput.query)
-        assertTrue(executionInput.context is GraphQLContext)
+        assertNull(executionInput.context)
         assertNotNull(executionInput.dataLoaderRegistry)
     }
 

--- a/servers/graphql-kotlin-spring-server/build.gradle.kts
+++ b/servers/graphql-kotlin-spring-server/build.gradle.kts
@@ -35,7 +35,7 @@ tasks {
                 limit {
                     counter = "BRANCH"
                     value = "COVEREDRATIO"
-                    minimum = "0.74".toBigDecimal()
+                    minimum = "0.70".toBigDecimal()
                 }
             }
         }

--- a/servers/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/server/spring/SubscriptionAutoConfiguration.kt
+++ b/servers/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/server/spring/SubscriptionAutoConfiguration.kt
@@ -67,7 +67,7 @@ class SubscriptionAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    fun springSubscriptionGraphQLContextFactory(): SpringSubscriptionGraphQLContextFactory<*> = DefaultSpringSubscriptionGraphQLContextFactory
+    fun springSubscriptionGraphQLContextFactory(): SpringSubscriptionGraphQLContextFactory<*> = DefaultSpringSubscriptionGraphQLContextFactory()
 
     @Bean
     fun apolloSubscriptionProtocolHandler(

--- a/servers/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/server/spring/execution/SpringGraphQLContextFactory.kt
+++ b/servers/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/server/spring/execution/SpringGraphQLContextFactory.kt
@@ -16,7 +16,6 @@
 
 package com.expediagroup.graphql.server.spring.execution
 
-import com.expediagroup.graphql.generator.execution.DefaultGraphQLContext
 import com.expediagroup.graphql.generator.execution.GraphQLContext
 import com.expediagroup.graphql.server.execution.GraphQLContextFactory
 import org.springframework.web.reactive.function.server.ServerRequest
@@ -27,8 +26,8 @@ import org.springframework.web.reactive.function.server.ServerRequest
 abstract class SpringGraphQLContextFactory<out T : GraphQLContext> : GraphQLContextFactory<T, ServerRequest>
 
 /**
- * Basic implementation of [SpringGraphQLContextFactory] that just returns a [DefaultGraphQLContext]
+ * Basic implementation of [SpringGraphQLContextFactory] that just returns null
  */
-class DefaultSpringGraphQLContextFactory : SpringGraphQLContextFactory<DefaultGraphQLContext>() {
-    override fun generateContext(request: ServerRequest) = DefaultGraphQLContext()
+class DefaultSpringGraphQLContextFactory : SpringGraphQLContextFactory<GraphQLContext>() {
+    override suspend fun generateContext(request: ServerRequest): GraphQLContext? = null
 }

--- a/servers/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/server/spring/subscriptions/ApolloSubscriptionHooks.kt
+++ b/servers/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/server/spring/subscriptions/ApolloSubscriptionHooks.kt
@@ -17,7 +17,6 @@ package com.expediagroup.graphql.server.spring.subscriptions
 
 import com.expediagroup.graphql.generator.execution.GraphQLContext
 import org.springframework.web.reactive.socket.WebSocketSession
-import reactor.core.publisher.Mono
 
 /**
  * Implementation of Apollo Subscription Server Lifecycle Events
@@ -33,8 +32,8 @@ interface ApolloSubscriptionHooks {
     fun onConnect(
         connectionParams: Map<String, String>,
         session: WebSocketSession,
-        graphQLContext: GraphQLContext
-    ): Mono<GraphQLContext> = Mono.just(graphQLContext)
+        graphQLContext: GraphQLContext?
+    ): GraphQLContext? = graphQLContext
 
     /**
      * Called when the client executes a GraphQL operation.
@@ -43,7 +42,7 @@ interface ApolloSubscriptionHooks {
     fun onOperation(
         operationMessage: SubscriptionOperationMessage,
         session: WebSocketSession,
-        graphQLContext: GraphQLContext
+        graphQLContext: GraphQLContext?
     ): Unit = Unit
 
     /**

--- a/servers/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/server/spring/subscriptions/ApolloSubscriptionProtocolHandler.kt
+++ b/servers/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/server/spring/subscriptions/ApolloSubscriptionProtocolHandler.kt
@@ -114,7 +114,7 @@ class ApolloSubscriptionProtocolHandler(
             return Flux.just(basicConnectionErrorMessage)
         }
 
-        if (sessionState.operationExists(session, operationMessage)) {
+        if (sessionState.doesOperationExist(session, operationMessage)) {
             logger.info("Already subscribed to operation ${operationMessage.id} for session ${session.id}")
             return Flux.empty()
         }

--- a/servers/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/server/spring/subscriptions/ApolloSubscriptionSessionState.kt
+++ b/servers/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/server/spring/subscriptions/ApolloSubscriptionSessionState.kt
@@ -31,8 +31,8 @@ internal class ApolloSubscriptionSessionState {
     // Operations are saved by web socket session id, then operation id
     internal val activeOperations = ConcurrentHashMap<String, ConcurrentHashMap<String, Subscription>>()
 
-    // OnConnect hooks are saved by web socket session id, then operation id
-    private val onConnectHooks = ConcurrentHashMap<String, GraphQLContext?>()
+    // The context is saved by web socket session id, then operation id
+    private val onConnectHooks = ConcurrentHashMap<String, GraphQLContext>()
 
     /**
      * Save the context created from the factory and possibly updated in the onConnect hook.

--- a/servers/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/server/spring/subscriptions/ApolloSubscriptionSessionState.kt
+++ b/servers/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/server/spring/subscriptions/ApolloSubscriptionSessionState.kt
@@ -32,21 +32,23 @@ internal class ApolloSubscriptionSessionState {
     internal val activeOperations = ConcurrentHashMap<String, ConcurrentHashMap<String, Subscription>>()
 
     // OnConnect hooks are saved by web socket session id, then operation id
-    private val onConnectHooks = ConcurrentHashMap<String, Mono<GraphQLContext>>()
+    private val onConnectHooks = ConcurrentHashMap<String, GraphQLContext?>()
 
     /**
      * Save the context created from the factory and possibly updated in the onConnect hook.
      * This allows us to include some intial state to be used when handling all the messages.
      * This will be removed in [terminateSession].
      */
-    fun saveContext(session: WebSocketSession, onConnect: Mono<GraphQLContext>) {
-        onConnectHooks[session.id] = onConnect
+    fun saveContext(session: WebSocketSession, graphQLContext: GraphQLContext?) {
+        if (graphQLContext != null) {
+            onConnectHooks[session.id] = graphQLContext
+        }
     }
 
     /**
      * Return the onConnect mono so that the operation can wait to start until it has been resolved.
      */
-    fun getContext(session: WebSocketSession): Mono<GraphQLContext>? = onConnectHooks[session.id]
+    fun getContext(session: WebSocketSession): GraphQLContext? = onConnectHooks[session.id]
 
     /**
      * Save the session that is sending keep alive messages.

--- a/servers/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/server/spring/subscriptions/SpringGraphQLSubscriptionHandler.kt
+++ b/servers/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/server/spring/subscriptions/SpringGraphQLSubscriptionHandler.kt
@@ -34,8 +34,8 @@ import reactor.kotlin.core.publisher.toFlux
  */
 open class SpringGraphQLSubscriptionHandler(private val graphQL: GraphQL) {
 
-    fun executeSubscription(graphQLRequest: GraphQLRequest, graphQLContext: GraphQLContext?): Flux<GraphQLResponse<*>> = Flux.deferContextual {
-        graphQL.execute(graphQLRequest.toExecutionInput(graphQLContext))
+    fun executeSubscription(graphQLRequest: GraphQLRequest, graphQLContext: GraphQLContext?): Flux<GraphQLResponse<*>> {
+        return graphQL.execute(graphQLRequest.toExecutionInput(graphQLContext))
             .getData<Publisher<ExecutionResult>>()
             .toFlux()
             .map { result -> result.toGraphQLResponse() }

--- a/servers/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/server/spring/subscriptions/SpringGraphQLSubscriptionHandler.kt
+++ b/servers/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/server/spring/subscriptions/SpringGraphQLSubscriptionHandler.kt
@@ -34,8 +34,8 @@ import reactor.kotlin.core.publisher.toFlux
  */
 open class SpringGraphQLSubscriptionHandler(private val graphQL: GraphQL) {
 
-    fun executeSubscription(graphQLRequest: GraphQLRequest, graphQLContext: GraphQLContext?): Flux<GraphQLResponse<*>> {
-        return graphQL.execute(graphQLRequest.toExecutionInput(graphQLContext))
+    fun executeSubscription(graphQLRequest: GraphQLRequest, graphQLContext: GraphQLContext?): Flux<GraphQLResponse<*>> =
+        graphQL.execute(graphQLRequest.toExecutionInput(graphQLContext))
             .getData<Publisher<ExecutionResult>>()
             .toFlux()
             .map { result -> result.toGraphQLResponse() }
@@ -43,5 +43,4 @@ open class SpringGraphQLSubscriptionHandler(private val graphQL: GraphQL) {
                 val error = KotlinGraphQLError(throwable).toGraphQLKotlinType()
                 Flux.just(GraphQLResponse<Any>(errors = listOf(error)))
             }
-    }
 }

--- a/servers/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/server/spring/subscriptions/SpringSubscriptionGraphQLContextFactory.kt
+++ b/servers/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/server/spring/subscriptions/SpringSubscriptionGraphQLContextFactory.kt
@@ -16,7 +16,6 @@
 
 package com.expediagroup.graphql.server.spring.subscriptions
 
-import com.expediagroup.graphql.generator.execution.DefaultGraphQLContext
 import com.expediagroup.graphql.generator.execution.GraphQLContext
 import com.expediagroup.graphql.server.execution.GraphQLContextFactory
 import org.springframework.web.reactive.socket.WebSocketSession
@@ -26,6 +25,9 @@ import org.springframework.web.reactive.socket.WebSocketSession
  */
 abstract class SpringSubscriptionGraphQLContextFactory<out T : GraphQLContext> : GraphQLContextFactory<T, WebSocketSession>
 
-object DefaultSpringSubscriptionGraphQLContextFactory : SpringSubscriptionGraphQLContextFactory<DefaultGraphQLContext>() {
-    override fun generateContext(request: WebSocketSession) = DefaultGraphQLContext()
+/**
+ * Basic implementation of [SpringSubscriptionGraphQLContextFactory] that just returns null
+ */
+class DefaultSpringSubscriptionGraphQLContextFactory : SpringSubscriptionGraphQLContextFactory<GraphQLContext>() {
+    override suspend fun generateContext(request: WebSocketSession): GraphQLContext? = null
 }

--- a/servers/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/server/spring/context/GraphQLContextFactoryIT.kt
+++ b/servers/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/server/spring/context/GraphQLContextFactoryIT.kt
@@ -62,7 +62,7 @@ class GraphQLContextFactoryIT(@Autowired private val testClient: WebTestClient) 
         @Bean
         @ExperimentalCoroutinesApi
         fun customContextFactory(): SpringGraphQLContextFactory<CustomContext> = object : SpringGraphQLContextFactory<CustomContext>() {
-            override fun generateContext(request: ServerRequest): CustomContext {
+            override suspend fun generateContext(request: ServerRequest): CustomContext {
                 return CustomContext(
                     first = request.headers().firstHeader("X-First-Header") ?: "DEFAULT_FIRST",
                     second = request.headers().firstHeader("X-Second-Header") ?: "DEFAULT_SECOND"

--- a/servers/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/server/spring/routes/RouteConfigurationIT.kt
+++ b/servers/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/server/spring/routes/RouteConfigurationIT.kt
@@ -38,7 +38,10 @@ import org.springframework.web.reactive.function.server.ServerRequest
 
 @SpringBootTest(
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
-    properties = ["graphql.packages=com.expediagroup.graphql.server.spring.routes"]
+    properties = [
+        "graphql.packages=com.expediagroup.graphql.server.spring.routes",
+        "graphql.sdl.enabled=true"
+    ]
 )
 @EnableAutoConfiguration
 class RouteConfigurationIT(@Autowired private val testClient: WebTestClient) {
@@ -50,7 +53,7 @@ class RouteConfigurationIT(@Autowired private val testClient: WebTestClient) {
 
         @Bean
         fun customContextFactory(): SpringGraphQLContextFactory<CustomContext> = object : SpringGraphQLContextFactory<CustomContext>() {
-            override fun generateContext(request: ServerRequest): CustomContext = CustomContext(
+            override suspend fun generateContext(request: ServerRequest): CustomContext = CustomContext(
                 value = request.headers().firstHeader("X-Custom-Header") ?: "default"
             )
         }

--- a/servers/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/server/spring/subscriptions/ApolloSubscriptionProtocolHandlerTest.kt
+++ b/servers/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/server/spring/subscriptions/ApolloSubscriptionProtocolHandlerTest.kt
@@ -462,12 +462,13 @@ class ApolloSubscriptionProtocolHandlerTest {
         }
         val subscriptionHandler: SpringGraphQLSubscriptionHandler = mockk()
         val subscriptionHooks: ApolloSubscriptionHooks = mockk {
-            every { onConnect(any(), any(), any()) } returns mockk()
+            every { onConnect(any(), any(), any()) } returns null
         }
         val handler = ApolloSubscriptionProtocolHandler(config, nullContextFactory, subscriptionHandler, objectMapper, subscriptionHooks)
         val flux = handler.handle(simpleInitMessage.toJson(), session)
-        flux.then().subscribe()
+        val disposable = flux.subscribe()
         verify(exactly = 1) { subscriptionHooks.onConnect(any(), any(), any()) }
+        disposable.dispose()
     }
 
     @Test
@@ -484,12 +485,13 @@ class ApolloSubscriptionProtocolHandlerTest {
         }
         val subscriptionHandler: SpringGraphQLSubscriptionHandler = mockk()
         val subscriptionHooks: ApolloSubscriptionHooks = mockk {
-            every { onConnect(any(), any(), any()) } returns mockk()
+            every { onConnect(any(), any(), any()) } returns null
         }
         val handler = ApolloSubscriptionProtocolHandler(config, nullContextFactory, subscriptionHandler, objectMapper, subscriptionHooks)
         val flux = handler.handle(operationMessage, session)
-        flux.blockFirst(Duration.ofSeconds(2))
+        val disposable = flux.subscribe()
         verify(exactly = 1) { subscriptionHooks.onConnect(payload, session, any()) }
+        disposable.dispose()
     }
 
     @Test
@@ -587,8 +589,9 @@ class ApolloSubscriptionProtocolHandlerTest {
         }
         val handler = ApolloSubscriptionProtocolHandler(config, nullContextFactory, subscriptionHandler, objectMapper, subscriptionHooks)
         val flux = handler.handle(operationMessage, session)
-        flux.blockFirst(Duration.ofSeconds(2))
+        val disposable = flux.subscribe()
         verify(exactly = 1) { subscriptionHooks.onOperationComplete(session) }
+        disposable.dispose()
     }
 
     @Test

--- a/servers/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/server/spring/subscriptions/ApolloSubscriptionProtocolHandlerTest.kt
+++ b/servers/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/server/spring/subscriptions/ApolloSubscriptionProtocolHandlerTest.kt
@@ -103,9 +103,9 @@ class ApolloSubscriptionProtocolHandlerTest {
         val handler = ApolloSubscriptionProtocolHandler(config, nullContextFactory, subscriptionHandler, objectMapper, subscriptionHooks)
         val flux = handler.handle(simpleInitMessage.toJson(), session)
 
-        val message = flux.blockFirst(Duration.ofSeconds(2))
-        assertNotNull(message)
-        assertEquals(expected = GQL_CONNECTION_ACK.type, actual = message.type)
+        StepVerifier.create(flux)
+            .expectNextMatches { it.type == GQL_CONNECTION_ACK.type }
+            .verifyComplete()
     }
 
     @Test
@@ -127,6 +127,8 @@ class ApolloSubscriptionProtocolHandlerTest {
         StepVerifier.create(initFlux)
             .expectNextMatches { it.type == GQL_CONNECTION_ACK.type }
             .expectNextMatches { it.type == GQL_CONNECTION_KEEP_ALIVE.type }
+            .thenCancel()
+            .verify()
     }
 
     @Test
@@ -447,9 +449,8 @@ class ApolloSubscriptionProtocolHandlerTest {
         }
         val handler = ApolloSubscriptionProtocolHandler(config, nullContextFactory, subscriptionHandler, objectMapper, subscriptionHooks)
         val flux = handler.handle(simpleInitMessage.toJson(), session)
-        val disposable = flux.subscribe()
+        flux.subscribe().dispose()
         verify(exactly = 1) { subscriptionHooks.onConnect(any(), any(), any()) }
-        disposable.dispose()
     }
 
     @Test
@@ -470,9 +471,8 @@ class ApolloSubscriptionProtocolHandlerTest {
         }
         val handler = ApolloSubscriptionProtocolHandler(config, nullContextFactory, subscriptionHandler, objectMapper, subscriptionHooks)
         val flux = handler.handle(operationMessage, session)
-        val disposable = flux.subscribe()
+        flux.subscribe().dispose()
         verify(exactly = 1) { subscriptionHooks.onConnect(payload, session, any()) }
-        disposable.dispose()
     }
 
     @Test
@@ -568,9 +568,8 @@ class ApolloSubscriptionProtocolHandlerTest {
         }
         val handler = ApolloSubscriptionProtocolHandler(config, nullContextFactory, subscriptionHandler, objectMapper, subscriptionHooks)
         val flux = handler.handle(operationMessage, session)
-        val disposable = flux.subscribe()
+        flux.subscribe().dispose()
         verify(exactly = 1) { subscriptionHooks.onOperationComplete(session) }
-        disposable.dispose()
     }
 
     @Test

--- a/servers/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/server/spring/subscriptions/SubscriptionWebSocketHandlerIT.kt
+++ b/servers/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/server/spring/subscriptions/SubscriptionWebSocketHandlerIT.kt
@@ -189,7 +189,7 @@ class SubscriptionWebSocketHandlerIT(
             .delayElements(Duration.ofMillis(100))
 
         @Suppress("unused")
-        fun ticker(ctx: SubscriptionContext?): Flux<String> = Flux.just("${ctx?.value}:${Random.nextInt()}")
+        fun ticker(ctx: SubscriptionContext): Flux<String> = Flux.just("${ctx.value}:${Random.nextInt()}")
     }
 
     data class SubscriptionContext(val value: String) : GraphQLContext

--- a/servers/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/server/spring/subscriptions/SubscriptionWebSocketHandlerIT.kt
+++ b/servers/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/server/spring/subscriptions/SubscriptionWebSocketHandlerIT.kt
@@ -165,7 +165,7 @@ class SubscriptionWebSocketHandlerIT(
 
         @Bean
         fun customContextFactory(): SpringSubscriptionGraphQLContextFactory<SubscriptionContext> = object : SpringSubscriptionGraphQLContextFactory<SubscriptionContext>() {
-            override fun generateContext(request: WebSocketSession): SubscriptionContext = SubscriptionContext(
+            override suspend fun generateContext(request: WebSocketSession): SubscriptionContext = SubscriptionContext(
                 value = request.handshakeInfo.headers.getFirst("X-Custom-Header") ?: "default"
             )
         }
@@ -189,7 +189,7 @@ class SubscriptionWebSocketHandlerIT(
             .delayElements(Duration.ofMillis(100))
 
         @Suppress("unused")
-        fun ticker(ctx: SubscriptionContext): Flux<String> = Flux.just("${ctx.value}:${Random.nextInt()}")
+        fun ticker(ctx: SubscriptionContext?): Flux<String> = Flux.just("${ctx?.value}:${Random.nextInt()}")
     }
 
     data class SubscriptionContext(val value: String) : GraphQLContext

--- a/servers/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/server/spring/subscriptions/SubscriptionWebSocketHandlerIT.kt
+++ b/servers/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/server/spring/subscriptions/SubscriptionWebSocketHandlerIT.kt
@@ -61,12 +61,11 @@ class SubscriptionWebSocketHandlerIT(
     fun `verify subscription`() {
         val request = GraphQLRequest("subscription { characters }")
         val messageId = "1"
-        val initMessage = getInitMessage(messageId)
         val startMessage = getStartMessage(messageId, request)
         val dataOutput = TestPublisher.create<String>()
 
         val response = client.execute(uri) { session ->
-            executeSubsciption(session, initMessage, startMessage, dataOutput)
+            executeSubsciption(session, startMessage, dataOutput)
         }.subscribe()
 
         StepVerifier.create(dataOutput)
@@ -86,12 +85,11 @@ class SubscriptionWebSocketHandlerIT(
     fun `verify subscription to counter`() {
         val request = GraphQLRequest("subscription { counter }")
         val messageId = "2"
-        val initMessage = getInitMessage(messageId)
         val startMessage = getStartMessage(messageId, request)
         val dataOutput = TestPublisher.create<String>()
 
         val response = client.execute(uri) { session ->
-            executeSubsciption(session, initMessage, startMessage, dataOutput)
+            executeSubsciption(session, startMessage, dataOutput)
         }.subscribe()
 
         StepVerifier.create(dataOutput)
@@ -111,14 +109,13 @@ class SubscriptionWebSocketHandlerIT(
     fun `verify subscription with context`() {
         val request = GraphQLRequest("subscription { ticker }")
         val messageId = "3"
-        val initMessage = getInitMessage(messageId)
         val startMessage = getStartMessage(messageId, request)
         val dataOutput = TestPublisher.create<String>()
         val headers = HttpHeaders()
         headers.set("X-Custom-Header", "junit")
 
         val response = client.execute(uri, headers) { session ->
-            executeSubsciption(session, initMessage, startMessage, dataOutput)
+            executeSubsciption(session, startMessage, dataOutput)
         }.subscribe()
 
         StepVerifier.create(dataOutput)
@@ -131,27 +128,37 @@ class SubscriptionWebSocketHandlerIT(
 
     private fun executeSubsciption(
         session: WebSocketSession,
-        initMessage: String,
         startMessage: String,
         dataOutput: TestPublisher<String>
     ): Mono<Void> {
-        val firstMessage = session.textMessage(initMessage).toMono()
-            .concatWith(session.textMessage(startMessage).toMono())
+        return initConnection(session).thenMany(
+            session.send(session.textMessage(startMessage).toMono())
+                .thenMany(
+                    session.receive()
+                        .map { objectMapper.readValue<SubscriptionOperationMessage>(it.payloadAsText) }
+                        .doOnNext {
+                            if (it.type == ServerMessages.GQL_DATA.type) {
+                                val data = objectMapper.writeValueAsString(it.payload)
+                                dataOutput.next(data)
+                            } else if (it.type == ServerMessages.GQL_COMPLETE.type) {
+                                dataOutput.complete()
+                            }
+                        }
+                )
+        ).then()
+    }
 
-        return session.send(firstMessage)
+    private fun initConnection(session: WebSocketSession): Mono<Void> {
+        return session.send(session.textMessage(basicInitMessage).toMono())
             .thenMany(
                 session.receive()
                     .map { objectMapper.readValue<SubscriptionOperationMessage>(it.payloadAsText) }
                     .doOnNext {
-                        if (it.type == ServerMessages.GQL_DATA.type) {
-                            val data = objectMapper.writeValueAsString(it.payload)
-                            dataOutput.next(data)
-                        } else if (it.type == ServerMessages.GQL_COMPLETE.type) {
-                            dataOutput.complete()
+                        if (it.type != ServerMessages.GQL_CONNECTION_ERROR.type) {
+                            throw Exception("Error connecting to the server")
                         }
                     }
-            )
-            .then()
+            ).then()
     }
 
     @Configuration
@@ -164,11 +171,7 @@ class SubscriptionWebSocketHandlerIT(
         fun subscription(): Subscription = SimpleSubscription()
 
         @Bean
-        fun customContextFactory(): SpringSubscriptionGraphQLContextFactory<SubscriptionContext> = object : SpringSubscriptionGraphQLContextFactory<SubscriptionContext>() {
-            override suspend fun generateContext(request: WebSocketSession): SubscriptionContext = SubscriptionContext(
-                value = request.handshakeInfo.headers.getFirst("X-Custom-Header") ?: "default"
-            )
-        }
+        fun customContextFactory(): SpringSubscriptionGraphQLContextFactory<SubscriptionContext> = CustomContextFactory()
     }
 
     // GraphQL spec requires at least single query to be present as Query type is needed to run introspection queries
@@ -194,7 +197,13 @@ class SubscriptionWebSocketHandlerIT(
 
     data class SubscriptionContext(val value: String) : GraphQLContext
 
+    class CustomContextFactory : SpringSubscriptionGraphQLContextFactory<SubscriptionContext>() {
+        override suspend fun generateContext(request: WebSocketSession): SubscriptionContext = SubscriptionContext(
+            value = request.handshakeInfo.headers.getFirst("X-Custom-Header") ?: "default"
+        )
+    }
+
     private fun SubscriptionOperationMessage.toJson() = objectMapper.writeValueAsString(this)
-    private fun getInitMessage(id: String) = SubscriptionOperationMessage(ClientMessages.GQL_CONNECTION_INIT.type, id).toJson()
+    private val basicInitMessage = SubscriptionOperationMessage(ClientMessages.GQL_CONNECTION_INIT.type).toJson()
     private fun getStartMessage(id: String, payload: Any) = SubscriptionOperationMessage(ClientMessages.GQL_START.type, id, payload).toJson()
 }

--- a/website/docs/schema-generator/execution/contextual-data.md
+++ b/website/docs/schema-generator/execution/contextual-data.md
@@ -2,6 +2,7 @@
 id: contextual-data
 title: Contextual Data
 ---
+
 All GraphQL servers have a concept of a "context". A GraphQL context contains metadata that is useful to the GraphQL
 server, but shouldn't necessarily be part of the GraphQL schema. A prime example of something that is appropriate
 for the GraphQL context would be trace headers for an OpenTracing system such as
@@ -10,9 +11,8 @@ its function, but the server needs the information to ensure observability.
 
 The contents of the GraphQL context vary across applications and it is up to the GraphQL server developers to decide
 what it should contain. `graphql-kotlin-server` provides a simple mechanism to
-build context per query execution through
-[GraphQLContextFactory](../../server/graphql-context-factory.md).
-Once a context factory is available it will then be used to populate GraphQL context based on the incoming request and make it available during query execution.
+build a context per operation with the [GraphQLContextFactory](../../server/graphql-context-factory.md).
+If a custom factory is defined, it will then be used to populate GraphQL context based on the incoming request and make it available during execution.
 
 ## GraphQLContext Interface
 
@@ -20,39 +20,46 @@ The easiest way to specify a context class is to use the `GraphQLContext` marker
 it is just used to inform the schema generator that this is the class that should be used as the context for every request.
 
 ```kotlin
-
 class MyGraphQLContext(val customValue: String) : GraphQLContext
-
 ```
 
 Then you can just use the class as an argument and it will be automatically injected during execution time.
 
 ```kotlin
-
-class ContextualQuery {
+class ContextualQuery : Query {
     fun contextualQuery(
         context: MyGraphQLContext,
         value: Int
     ): String = "The custom value was ${context.customValue} and the value was $value"
 }
-
 ```
 
 The above query would produce the following GraphQL schema:
 
 ```graphql
-
-schema {
-  query: Query
-}
-
 type Query {
   contextualQuery(value: Int!): String!
 }
-
 ```
 
 Note that the argument that implements `GraphQLContext` is not reflected in the GraphQL schema.
+
+## Handling Context Errors
+
+The [GraphQLContextFactory](../../server/graphql-context-factory.md) may return `null`. If your factory implementation never returns `null`, then there is no need to change your schema.
+If the factory could return `null`, then the context arugments in your schema should be nullable so a runtime exception is not thrown.
+
+```kotlin
+class ContextualQuery : Query {
+    fun contextualQuery(context: MyGraphQLContext?, value: Int): String {
+        if (context != null) {
+            return "The custom value was ${context.customValue} and the value was $value"
+        }
+
+        return "The context was null and the value was $value"
+    }
+}
+```
 
 ## Injection Customization
 

--- a/website/docs/server/graphql-context-factory.md
+++ b/website/docs/server/graphql-context-factory.md
@@ -2,31 +2,67 @@
 id: graphql-context-factory
 title: GraphQLContextFactory
 ---
-Similar to the [GraphQLRequestParser](./graphql-request-parser.md), `GraphQLContextFactory` has a generic method for handling the `Request` and the `GraphQLContext`.
+
+`GraphQLContextFactory` is a generic method for generating a `GraphQLContext` for each request.
 
 ```kotlin
 
 interface GraphQLContextFactory<out Context : GraphQLContext, Request> {
-    fun generateContext(request: Request): Context?
+    suspend fun generateContext(request: Request): Context?
 }
 
 ```
 
-Given the server request, the interface should create the custom `GraphQLContext` class to be used for every new operation.
+Given the generic server request, the interface should create a `GraphQLContext` class to be used for every new operation.
 The context must implement the `GraphQLContext` interface from `graphql-kotlin-schema-generator`.
 See [execution context](../schema-generator/execution/contextual-data.md) for more info on how the context can be used in the schema functions.
 
-A specific `graphql-kotlin-*-server` library may provide an abstract class on top of this interface so users only have to be concerned with the context.
+## Nullable Context
 
+The factory may return `null` if a context is not required for execution. This allows the library to have a default factory that just returns `null`.
+If your custom factory never returns `null`, then there is no need to use nullable arguments.
+However, if your custom factory may return `null`, you must define the context argument as nullable in the schema functions or a runtime exception will be thrown.
+
+```kotlin
+data class CustomContext(val value: String) : GraphQLContext
+
+class CustomFactory : GraphQLContextFactory<CustomContext, ServerRequest> {
+    suspend fun generateContext(request: Request): Context? {
+        if (isSpecialRequest(request)) {
+            return null
+        }
+
+        val value = callSomeSuspendableService(request)
+        return CustomContext(value)
+    }
+}
+
+class MyQuery : Query {
+
+    fun getResults(context: CustomContext?, input: String): String {
+        if (context != null) {
+            return getDataWithContext(input, context)
+        }
+
+        return getBasicData(input)
+    }
+}
+```
+
+## Suspendable Factory
+The interface is marked as a `suspend` function to allow the asynchronous fetching of context data.
+This may be helpful if you need to call some other services to calculate a context value.
+
+## Server-Specific Abstractions
+
+A specific `graphql-kotlin-*-server` library may provide an abstract class on top of this interface so users only have to be concerned with the context class and not the server class type.
 For example the `graphql-kotlin-spring-server` provides the following class, which sets the request type:
 
 ```kotlin
-
 abstract class SpringGraphQLContextFactory<out T : GraphQLContext> : GraphQLContextFactory<T, ServerRequest>
-
 ```
 
-## HTTP Headers
+## HTTP Headers and Cookies
 
-For common use cases around authorization, authentication, or tracing you may need to read HTTP headers.
+For common use cases around authorization, authentication, or tracing you may need to read HTTP headers and cookies.
 This should be done in the `GraphQLContextFactory` and relevant data should be added to the context to be accessible during schema exectuion.

--- a/website/docs/server/graphql-request-handler.md
+++ b/website/docs/server/graphql-request-handler.md
@@ -2,7 +2,10 @@
 id: graphql-request-handler
 title: GraphQLRequestHandler
 ---
-The `GraphQLRequestHandler` is an open and extendable class that contains the basic logic to get a `GraphQLResponse` from `graphql-kotlin-types`.
-It accepts a `GraphQLRequest`, an optional [GraphQLContext](./graphql-context-factory.md) and sends that to the GraphQL schema along with the [DataLoaderRegistry](data-loaders.md).
+The `GraphQLRequestHandler` is an open and extendable class that contains the basic logic to get a `GraphQLResponse`.
+
+It requires a `GraphQLSchema` and a [DataLoaderRegistryFactory](data-loaders.md) in the constructor.
+For each request, it accepts a `GraphQLRequest` and an optional [GraphQLContext](./graphql-context-factory.md), and calls the `DataLoaderRegistryFactory` to generate a new `DataLoaderRegistry`.
+Then all of these objects are sent to the schema for execution and the result is mapped to a `GraphQLResponse`.
 
 There shouldn't be much need to change this class but if you wanted to add custom logic or logging it is possible to override it or just create your own.

--- a/website/docs/server/graphql-request-parser.md
+++ b/website/docs/server/graphql-request-parser.md
@@ -2,34 +2,30 @@
 id: graphql-request-parser
 title: GraphQLRequestParser
 ---
-The `GraphQLRequestParser` interface is requrired to parse the library-specific HTTP request object into the common `GraphQLRequest` class from `graphql-kotlin-types`.
+The `GraphQLRequestParser` interface is requrired to parse the library-specific HTTP request object into the common `GraphQLRequest` class.
 
 ```kotlin
-
 interface GraphQLRequestParser<Request> {
     suspend fun parseRequest(request: Request): GraphQLServerRequest<*>?
 }
-
 ```
 
 While not officially part of the spec, there is a standard format used by most GraphQL clients and servers for [serving GraphQL over HTTP](https://graphql.org/learn/serving-over-http/).
 Following the above convention, GraphQL clients should generally use HTTP POST requests with the following body structure
 
 ```json
-
 {
   "query": "...",
   "operationName": "...",
   "variables": { "myVariable": "someValue" }
 }
-
 ```
 
 where
 
--   `query` is a required field and contains operation (query, mutation or subscription) that specify their selection set to be executed
--   `operationName` is an optional operation name, only required if multiple operations are specified in `query` string
--   `variables` is an optional field that holds an arbitrary JSON objects that are referenced as input arguments from `query` string
+- `query` is a required field and contains the operation (query, mutation, or subscription) to be executed
+- `operationName` is an optional string, only required if multiple operations are specified in the `query` string.
+- `variables` is an optional map of JSON objects that are referenced as input arguments in the `query` string
 
 GraphQL Kotlin server supports both single and batch GraphQL requests. Batch requests are represented as a list of individual
 GraphQL requests. When processing batch requests, same context will be used for processing all requests and server will respond

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -30,8 +30,14 @@ module.exports = {
   plugins: [],
   themeConfig: {
     image: "img/undraw_online.svg",
+    colorMode: {
+      defaultMode: 'dark',
+    },
     prism: {
-      additionalLanguages: ['kotlin'],
+      defaultLanguage: 'kotlin',
+      additionalLanguages: ['kotlin', 'groovy'],
+      theme: require('prism-react-renderer/themes/github'),
+      darkTheme: require('prism-react-renderer/themes/dracula')
     },
     navbar: {
       title: "GraphQL Kotlin",


### PR DESCRIPTION
### :pencil: Description
There are two issues we are fixing here:
* The `GraphQLContextFactory` should support `suspend` functions
* Subscriptions need to support getting a null context from the factory

Supporting `suspend` functions is easy enough. We just updated the interface. However that also means in `ApolloSubscriptionProtocolHandler` we need to be able to run the suspend function in a class that deals with reactor `Flux`. Once we generate the context it could come back as `null`. If it does our old logic was to return a class `DefaultGraphQLContext`. However, this was now blowing up because if you had a custom context of type `MyCustomContext` and used that as an argument in your subscription functions, graphql-java was throwing an illegal argument exception because we were trying to pass `DefaultGraphQLContext` to the type `MyCustomContext`.

So what that means is that we really can't have a `DefaultGraphQLContext` instead, if the `GraphQLContextFactory` implementation could possibly return null, the schema functions need to have a parameter type defined as nullable

```kotlin
fun ticker(ctx: SubscriptionContext?): Flux<String> = Flux.just("${ctx?.value}:${Random.nextInt()}")
```


### :link: Related Issues
Default Context added here: https://github.com/ExpediaGroup/graphql-kotlin/pull/955
Resolves: https://github.com/ExpediaGroup/graphql-kotlin/issues/945
Resolves: https://github.com/ExpediaGroup/graphql-kotlin/issues/1052