### PR TITLE
fix release-docs workflow

### DIFF
--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           git config --local user.email "oss@expediagroup.com"
           git config --local user.name "eg-oss-ci"
-          git add website docs
+          git add website
           git commit -m "Add new docs version"
 
       - name: Push changes


### PR DESCRIPTION
### :pencil: Description

remove reference to old `docs` folder

### :link: Related Issues
