### PR TITLE
Incorrect Gradle Target for Executing/Building the Example Spring Server

### DIFF
--- a/examples/server/ktor-server/README.md
+++ b/examples/server/ktor-server/README.md
@@ -7,7 +7,7 @@ Build the application by running the following from examples root directory:
 
 ```bash
 # build example
-./gradlew ktor-example:build
+./gradlew ktor-server:build
 ```
 
 > NOTE: in order to ensure you use the right version of Gradle we highly recommend that you use the provided wrapper scripts
@@ -17,7 +17,7 @@ Alternatively, you can start the server using Gradle.
 
 ```bash
 cd /path/to/graphql-kotlin/examples
-./gradlew ktor-example:run
+./gradlew ktor-server:run
 ```
 
 Once the app has started you can explore the example schema by opening Playground endpoint at http://localhost:5000/graphql

--- a/examples/server/spring-server/README.md
+++ b/examples/server/spring-server/README.md
@@ -13,7 +13,7 @@ From the root examples directory you can run the following:
 ./gradlew build
 
 # only build spring-example project
-./gradlew :spring-example:build
+./gradlew :spring-server:build
 ```
 
 > NOTE: in order to ensure you use the right version of Gradle we highly recommend to use the provided wrapper scripts
@@ -24,7 +24,7 @@ Then to start the server:
 * Alternatively you can also use the spring boot plugin from the command line in the root examples directory.
 
 ```shell script
-./gradlew :spring-example:bootRun
+./gradlew :spring-server:bootRun
 ```
 
 Once the app has started you can explore the example schema by opening the GraphQL Playground endpoint at http://localhost:8080/playground.


### PR DESCRIPTION
### :pencil: Description

Incorrect gradle target for executing, or building, the example spring server. Updated to correct targets:

` ./gradlew :spring-server:build`
`./gradlew :spring-server:bootRun`