### PR TITLE
[build] drop jcenter repositories

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,13 +24,11 @@ allprojects {
         repositories {
             mavenLocal()
             mavenCentral()
-            jcenter()
         }
     }
 
     repositories {
         mavenCentral()
-        jcenter()
         mavenLocal {
             content {
                 includeGroup("com.expediagroup")

--- a/examples/build.gradle.kts
+++ b/examples/build.gradle.kts
@@ -11,7 +11,6 @@ allprojects {
     buildscript {
         repositories {
             mavenCentral()
-            jcenter()
             mavenLocal {
                 content {
                     includeGroup("com.expediagroup")
@@ -22,7 +21,6 @@ allprojects {
 
     repositories {
         mavenCentral()
-        jcenter()
         mavenLocal {
             content {
                 includeGroup("com.expediagroup")


### PR DESCRIPTION
### :pencil: Description

JCenter is being sunset as per https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/. We don't have any JCenter specific dependencies and we only had it configured in the build file for convenience in resolving artifacts.

### :link: Related Issues
