### PR TITLE
Add support for federated tracing

### DIFF
--- a/examples/federation/base-app/src/main/resources/application.yml
+++ b/examples/federation/base-app/src/main/resources/application.yml
@@ -1,6 +1,9 @@
 graphql:
   federation:
     enabled: true
+    tracing:
+      enabled: true
+      debug: true
   packages:
     - "com.expediagroup.graphql.examples.federation.base"
 

--- a/examples/federation/extend-app/src/main/resources/application.yml
+++ b/examples/federation/extend-app/src/main/resources/application.yml
@@ -1,6 +1,9 @@
 graphql:
   federation:
     enabled: true
+    tracing:
+      enabled: true
+      debug: true
   packages:
     - "com.expediagroup.graphql.examples.federation.extend"
 

--- a/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/server/spring/context/MyGraphQLContext.kt
+++ b/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/server/spring/context/MyGraphQLContext.kt
@@ -17,6 +17,7 @@
 package com.expediagroup.graphql.examples.server.spring.context
 
 import com.expediagroup.graphql.generator.execution.GraphQLContext
+import com.expediagroup.graphql.server.spring.execution.SpringGraphQLContext
 import org.springframework.web.reactive.function.server.ServerRequest
 import org.springframework.web.reactive.socket.WebSocketSession
 
@@ -24,9 +25,9 @@ import org.springframework.web.reactive.socket.WebSocketSession
  * Simple [GraphQLContext] that holds extra value and the [ServerRequest]
  */
 class MyGraphQLContext(
-    val request: ServerRequest,
+    request: ServerRequest,
     val myCustomValue: String
-) : GraphQLContext
+) : SpringGraphQLContext(request)
 
 /**
  * Simple [GraphQLContext] that holds extra value and the [WebSocketSession]

--- a/generator/graphql-kotlin-federation/build.gradle.kts
+++ b/generator/graphql-kotlin-federation/build.gradle.kts
@@ -1,9 +1,11 @@
 description = "Federated GraphQL schema generator"
 
 val junitVersion: String by project
+val federationGraphQLVersion: String by project
 
 dependencies {
     api(project(path = ":graphql-kotlin-schema-generator"))
+    api("com.apollographql.federation:federation-graphql-java-support:$federationGraphQLVersion")
     testImplementation("org.junit.jupiter:junit-jupiter-params:$junitVersion")
 }
 

--- a/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/execution/FederatedGraphQLContext.kt
+++ b/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/execution/FederatedGraphQLContext.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2021 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.generator.federation.execution
+
+import com.apollographql.federation.graphqljava.tracing.HTTPRequestHeaders
+import com.expediagroup.graphql.generator.execution.GraphQLContext
+
+/**
+ * Apollo federation needs access to the HTTP headers to inspect if the
+ * request came from the Apollo Gateway. That means we need a special interface
+ * for the federation context.
+ */
+interface FederatedGraphQLContext : GraphQLContext, HTTPRequestHeaders

--- a/gradle.properties
+++ b/gradle.properties
@@ -28,6 +28,7 @@ reactorExtensionsVersion = 1.1.2
 slf4jVersion = 1.7.30
 springBootVersion = 2.4.2
 springVersion = 5.3.3
+federationGraphQLVersion = 0.6.3
 
 # test dependency versions
 junitVersion = 5.7.0

--- a/servers/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/server/spring/GraphQLConfigurationProperties.kt
+++ b/servers/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/server/spring/GraphQLConfigurationProperties.kt
@@ -39,8 +39,31 @@ data class GraphQLConfigurationProperties(
      * Apollo Federation configuration properties.
      */
     data class FederationConfigurationProperties(
-        /** Boolean flag indicating whether to generate federated GraphQL model */
-        val enabled: Boolean = false
+        /**
+         * Boolean flag indicating whether to generate federated GraphQL model
+         */
+        val enabled: Boolean = false,
+
+        /**
+         * Federation tracing config
+         */
+        val tracing: FederationTracingConfigurationProperties = FederationTracingConfigurationProperties()
+    )
+
+    /**
+     * Apollo Federation tracing configuration properties
+     */
+    data class FederationTracingConfigurationProperties(
+        /**
+         * Flag to enable or disable field tracing for the Apollo Gateway.
+         * Default is true as this is only used if the parent config is enabled.
+         */
+        val enabled: Boolean = true,
+
+        /**
+         * Flag to enable or disable debug logging
+         */
+        val debug: Boolean = false
     )
 
     /**

--- a/servers/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/server/spring/execution/SpringDataFetcher.kt
+++ b/servers/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/server/spring/execution/SpringDataFetcher.kt
@@ -18,7 +18,6 @@ package com.expediagroup.graphql.server.spring.execution
 
 import com.expediagroup.graphql.generator.execution.FunctionDataFetcher
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import graphql.schema.DataFetchingEnvironment
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Qualifier
@@ -35,7 +34,7 @@ import kotlin.reflect.jvm.javaType
 open class SpringDataFetcher(
     target: Any?,
     fn: KFunction<*>,
-    objectMapper: ObjectMapper = jacksonObjectMapper(),
+    objectMapper: ObjectMapper,
     private val applicationContext: ApplicationContext
 ) : FunctionDataFetcher(target, fn, objectMapper) {
 

--- a/servers/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/server/spring/execution/SpringGraphQLContext.kt
+++ b/servers/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/server/spring/execution/SpringGraphQLContext.kt
@@ -16,17 +16,14 @@
 
 package com.expediagroup.graphql.server.spring.execution
 
-import com.expediagroup.graphql.server.execution.GraphQLContextFactory
+import com.expediagroup.graphql.generator.federation.execution.FederatedGraphQLContext
 import org.springframework.web.reactive.function.server.ServerRequest
 
 /**
- * Wrapper class for specifically handling the Spring [ServerRequest]
+ * Implements the [FederatedGraphQLContext] to provide support for federation tracing.
+ * The class can be extended if other custom fields are needed.
  */
-abstract class SpringGraphQLContextFactory<out T : SpringGraphQLContext> : GraphQLContextFactory<T, ServerRequest>
-
-/**
- * Basic implementation of [SpringGraphQLContextFactory] that returns [SpringGraphQLContext]
- */
-class DefaultSpringGraphQLContextFactory : SpringGraphQLContextFactory<SpringGraphQLContext>() {
-    override suspend fun generateContext(request: ServerRequest) = SpringGraphQLContext(request)
+open class SpringGraphQLContext(private val request: ServerRequest) : FederatedGraphQLContext {
+    override fun getHTTPRequestHeader(caseInsensitiveHeaderName: String): String? =
+        request.headers().firstHeader(caseInsensitiveHeaderName)
 }

--- a/servers/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/server/spring/FederationConfigurationTest.kt
+++ b/servers/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/server/spring/FederationConfigurationTest.kt
@@ -16,6 +16,7 @@
 
 package com.expediagroup.graphql.server.spring
 
+import com.apollographql.federation.graphqljava.tracing.FederatedTracingInstrumentation
 import com.expediagroup.graphql.generator.SchemaGeneratorConfig
 import com.expediagroup.graphql.generator.TopLevelObject
 import com.expediagroup.graphql.generator.federation.FederatedSchemaGeneratorConfig
@@ -24,12 +25,14 @@ import com.expediagroup.graphql.generator.federation.directives.ExtendsDirective
 import com.expediagroup.graphql.generator.federation.directives.ExternalDirective
 import com.expediagroup.graphql.generator.federation.directives.FieldSet
 import com.expediagroup.graphql.generator.federation.directives.KeyDirective
+import com.expediagroup.graphql.generator.federation.execution.FederatedGraphQLContext
 import com.expediagroup.graphql.generator.toSchema
 import com.expediagroup.graphql.server.execution.GraphQLContextFactory
 import com.expediagroup.graphql.server.execution.GraphQLRequestHandler
 import com.expediagroup.graphql.types.operations.Query
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import graphql.ExecutionInput
 import graphql.GraphQL
 import graphql.schema.GraphQLObjectType
 import graphql.schema.GraphQLSchema
@@ -41,6 +44,10 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+private const val APOLLO_FEDERATION_TRACING_HEADER_NAME = "apollo-federation-include-trace"
+private const val APOLLO_FEDERATION_TRACING_HEADER_VALUE = "ftv1"
 
 class FederationConfigurationTest {
 
@@ -100,6 +107,37 @@ class FederationConfigurationTest {
             }
     }
 
+    @Test
+    fun `verify federated schema execution with federated tracing`() {
+        contextRunner.withUserConfiguration(FederatedConfiguration::class.java)
+            .withPropertyValues(
+                "graphql.packages=com.expediagroup.graphql.server.spring",
+                "graphql.federation.enabled=true",
+                "graphql.federation.tracing.enabled=true"
+            )
+            .run { ctx ->
+                assertThat(ctx).hasSingleBean(GraphQL::class.java)
+                assertThat(ctx).hasSingleBean(FederatedTracingInstrumentation::class.java)
+
+                val graphql = ctx.getBean(GraphQL::class.java)
+                val federatedContext = MockFederatedGraphQLContext()
+                val input = ExecutionInput.newExecutionInput()
+                    .query("query { widget { id name } }")
+                    .context(federatedContext)
+                    .build()
+
+                val result = graphql.execute(input).toSpecification()
+                val data = assertNotNull(result["data"] as? Map<*, *>)
+                val widget = assertNotNull(data["widget"] as? Map<*, *>)
+                assertEquals(1, widget["id"])
+                assertEquals("hello", widget["name"])
+
+                assertNull(result["errors"])
+                val extensions = assertNotNull(result["extensions"] as? Map<*, *>)
+                assertNotNull(extensions[APOLLO_FEDERATION_TRACING_HEADER_VALUE])
+            }
+    }
+
     @Configuration
     class FederatedConfiguration {
 
@@ -139,4 +177,13 @@ class FederationConfigurationTest {
     @ExtendsDirective
     @KeyDirective(fields = FieldSet("id"))
     data class Widget(@ExternalDirective val id: Int, val name: String)
+
+    class MockFederatedGraphQLContext : FederatedGraphQLContext {
+        override fun getHTTPRequestHeader(caseInsensitiveHeaderName: String): String? =
+            if (caseInsensitiveHeaderName == APOLLO_FEDERATION_TRACING_HEADER_NAME) {
+                APOLLO_FEDERATION_TRACING_HEADER_VALUE
+            } else {
+                null
+            }
+    }
 }

--- a/servers/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/server/spring/execution/SpringDataFetcherTest.kt
+++ b/servers/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/server/spring/execution/SpringDataFetcherTest.kt
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2021 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.server.spring.execution
+
+import com.expediagroup.graphql.generator.annotations.GraphQLIgnore
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import graphql.schema.DataFetchingEnvironment
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.NoSuchBeanDefinitionException
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.ApplicationContext
+import org.springframework.stereotype.Service
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class SpringDataFetcherTest {
+
+    private val objectMapper = jacksonObjectMapper()
+    private val context: ApplicationContext = mockk {
+        every { getBean(MyService::class.java) } returns MyService()
+        every { getBean(NotService::class.java) } throws NoSuchBeanDefinitionException(NotService::class.java)
+    }
+    private val dataFetchingEnvironment: DataFetchingEnvironment = mockk {
+        every { containsArgument("service") } returns false
+    }
+
+    @Test
+    fun `data is returned from spring annotated service argument`() {
+        val dataFetcher = SpringDataFetcher(
+            target = MyQuery(),
+            fn = MyQuery::callService,
+            objectMapper = objectMapper,
+            applicationContext = context
+        )
+
+        val result = dataFetcher.get(dataFetchingEnvironment)
+
+        assertEquals("foo", result)
+    }
+
+    @Test
+    fun `data not returned if argument is missing @Autowired`() {
+        val dataFetcher = SpringDataFetcher(
+            target = MyQuery(),
+            fn = MyQuery::callServiceNoAnnotation,
+            objectMapper = objectMapper,
+            applicationContext = context
+        )
+
+        assertFailsWith(IllegalArgumentException::class) {
+            dataFetcher.get(dataFetchingEnvironment)
+        }
+    }
+
+    @Test
+    fun `data not returned if class is not a spring bean`() {
+        val dataFetcher = SpringDataFetcher(
+            target = MyQuery(),
+            fn = MyQuery::callNotService,
+            objectMapper = objectMapper,
+            applicationContext = context
+        )
+
+        assertFailsWith(NoSuchBeanDefinitionException::class) {
+            dataFetcher.get(dataFetchingEnvironment)
+        }
+    }
+
+    @Test
+    fun `data not returned if class is not a spring bean and argument is missing @Autowired`() {
+        val dataFetcher = SpringDataFetcher(
+            target = MyQuery(),
+            fn = MyQuery::callNotServiceNoAnnotation,
+            objectMapper = objectMapper,
+            applicationContext = context
+        )
+
+        assertFailsWith(IllegalArgumentException::class) {
+            dataFetcher.get(dataFetchingEnvironment)
+        }
+    }
+
+    class MyQuery {
+        fun callService(@Autowired @GraphQLIgnore service: MyService) = service.getData()
+        fun callServiceNoAnnotation(service: MyService) = service.getData()
+        fun callNotService(@Autowired @GraphQLIgnore service: NotService) = service.getData()
+        fun callNotServiceNoAnnotation(service: NotService) = service.getData()
+    }
+
+    @Service
+    class MyService {
+        fun getData() = "foo"
+    }
+
+    class NotService {
+        fun getData() = "foo"
+    }
+}

--- a/servers/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/server/spring/execution/SpringGraphQLContextTest.kt
+++ b/servers/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/server/spring/execution/SpringGraphQLContextTest.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2021 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.server.spring.execution
+
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import org.springframework.web.reactive.function.server.ServerRequest
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class SpringGraphQLContextTest {
+
+    @Test
+    fun `getHTTPRequestHeader should get the value from http request`() {
+        val mockRequest: ServerRequest = mockk {
+            every { headers() } returns mockk {
+                every { firstHeader("foo") } returns "bar"
+            }
+        }
+        val context = SpringGraphQLContext(mockRequest)
+
+        assertEquals("bar", context.getHTTPRequestHeader("foo"))
+    }
+
+    @Test
+    fun `getHTTPRequestHeader should return null if there is no header`() {
+        val mockRequest: ServerRequest = mockk {
+            every { headers() } returns mockk {
+                every { firstHeader("foo") } returns null
+            }
+        }
+        val context = SpringGraphQLContext(mockRequest)
+
+        assertNull(context.getHTTPRequestHeader("foo"))
+    }
+}

--- a/servers/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/server/spring/routes/RouteConfigurationIT.kt
+++ b/servers/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/server/spring/routes/RouteConfigurationIT.kt
@@ -16,10 +16,10 @@
 
 package com.expediagroup.graphql.server.spring.routes
 
-import com.expediagroup.graphql.generator.execution.GraphQLContext
 import com.expediagroup.graphql.server.spring.execution.REQUEST_PARAM_OPERATION_NAME
 import com.expediagroup.graphql.server.spring.execution.REQUEST_PARAM_QUERY
 import com.expediagroup.graphql.server.spring.execution.REQUEST_PARAM_VARIABLES
+import com.expediagroup.graphql.server.spring.execution.SpringGraphQLContext
 import com.expediagroup.graphql.server.spring.execution.SpringGraphQLContextFactory
 import com.expediagroup.graphql.server.spring.execution.graphQLMediaType
 import com.expediagroup.graphql.types.GraphQLRequest
@@ -54,7 +54,8 @@ class RouteConfigurationIT(@Autowired private val testClient: WebTestClient) {
         @Bean
         fun customContextFactory(): SpringGraphQLContextFactory<CustomContext> = object : SpringGraphQLContextFactory<CustomContext>() {
             override suspend fun generateContext(request: ServerRequest): CustomContext = CustomContext(
-                value = request.headers().firstHeader("X-Custom-Header") ?: "default"
+                value = request.headers().firstHeader("X-Custom-Header") ?: "default",
+                request = request
             )
         }
     }
@@ -65,7 +66,7 @@ class RouteConfigurationIT(@Autowired private val testClient: WebTestClient) {
         fun context(ctx: CustomContext) = ctx.value
     }
 
-    data class CustomContext(val value: String) : GraphQLContext
+    class CustomContext(val value: String, request: ServerRequest) : SpringGraphQLContext(request)
 
     val expectedSchema =
         """

--- a/website/docs/schema-generator/federation/federation-tracing.md
+++ b/website/docs/schema-generator/federation/federation-tracing.md
@@ -1,0 +1,11 @@
+---
+id: federation-tracing
+title: Federation Tracing
+---
+
+Support for Apollo Federation tracing is added to the `graphql-kotlin-federation` package by using the [apollographql/federation-jvm](https://github.com/apollographql/federation-jvm) library.
+
+### `FederatedGraphQLContext`
+
+To best support tracing, the context must implement a specific method to get the HTTP headers from the request.
+This is done by implementing the `FederatedGraphQLContext` interface instead of just the `GraphQLContext` interface from `graphql-kotlin-schema-generator`.

--- a/website/docs/server/graphql-context-factory.md
+++ b/website/docs/server/graphql-context-factory.md
@@ -66,3 +66,9 @@ abstract class SpringGraphQLContextFactory<out T : GraphQLContext> : GraphQLCont
 
 For common use cases around authorization, authentication, or tracing you may need to read HTTP headers and cookies.
 This should be done in the `GraphQLContextFactory` and relevant data should be added to the context to be accessible during schema exectuion.
+
+## Federated Tracing
+
+If you need [federation tracing support](../schema-generator/federation/federation-tracing.md), the context must implement the separate `FederatedGraphQLContext` interface from `graphql-kotlin-federation`.
+
+The reference server implementation `graphql-kotlin-spring-server` [supports federated tracing in the context](./spring-server/spring-graphql-context.md).

--- a/website/docs/server/spring-server/spring-beans.md
+++ b/website/docs/server/spring-server/spring-beans.md
@@ -27,12 +27,13 @@ _Created only if federation is disabled_
 
 _Created only if federation is enabled_
 
-| Bean                           | Description                                                                                                                                                                                                               |
-| :----------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| FederatedTypeResolvers         | List of `FederatedTypeResolvers` marked as beans that should be added to hooks. See [Federated Type Resolution](../../schema-generator/federation/type-resolution.md) for more details                                               |
-| FederatedSchemaGeneratorHooks  | Schema generator hooks used to build federated schema                                                                                                                                                                     |
-| FederatedSchemaGeneratorConfig | Federated schema generator configuration information. You can customize the configuration by providing `TopLevelNames`, `FederatedSchemaGeneratorHooks` and `KotlinDataFetcherFactoryProvider` beans |
-| GraphQLSchema                  | GraphQL schema generated based on the federated schema generator configuration and  `Query`, `Mutation` and `Subscription` objects available in the application context.                             |
+| Bean                            | Description                                                                                                                                                                                                               |
+| :------------------------------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| FederatedTypeResolvers          | List of `FederatedTypeResolvers` marked as beans that should be added to hooks. See [Federated Type Resolution](../../schema-generator/federation/type-resolution.md) for more details                                               |
+| FederatedSchemaGeneratorHooks   | Schema generator hooks used to build federated schema                                                                                                                                                                     |
+| FederatedSchemaGeneratorConfig  | Federated schema generator configuration information. You can customize the configuration by providing `TopLevelNames`, `FederatedSchemaGeneratorHooks` and `KotlinDataFetcherFactoryProvider` beans |
+| FederatedTracingInstrumentation | If `graphql.federation.tracing.enabled` is true, it adds tracing info to the response via the [apollo federation-jvm](https://github.com/apollographql/federation-jvm) library. |
+| GraphQLSchema                   | GraphQL schema generated based on the federated schema generator configuration and  `Query`, `Mutation` and `Subscription` objects available in the application context.                             |
 
 ## GraphQL Configuration
 

--- a/website/docs/server/spring-server/spring-properties.md
+++ b/website/docs/server/spring-server/spring-properties.md
@@ -12,6 +12,8 @@ details on the supported configuration properties.
 | graphql.endpoint                        | GraphQL server endpoint                                                                                          | graphql       |
 | graphql.packages                        | List of supported packages that can contain GraphQL schema type definitions                                      |               |
 | graphql.federation.enabled              | Boolean flag indicating whether to generate federated GraphQL model                                              | false         |
+| graphql.federation.tracing.enabled      | Boolean flag indicating whether add federated tracing data to the extensions                                     | true (if federation enabled) |
+| graphql.federation.tracing.debug        | Boolean flag to log debug info in the federated tracing                                                          | false (if federation enabled) |
 | graphql.introspection.enabled           | Boolean flag indicating whether introspection queries are enabled                                                | true          |
 | graphql.playground.enabled              | Boolean flag indicating whether to enabled Prisma Labs Playground GraphQL IDE                                    | true          |
 | graphql.playground.endpoint             | Prisma Labs Playground GraphQL IDE endpoint                                                                      | playground    |

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -57,7 +57,8 @@
           "schema-generator/federation/apollo-federation",
           "schema-generator/federation/federated-schemas",
           "schema-generator/federation/federated-directives",
-          "schema-generator/federation/type-resolution"
+          "schema-generator/federation/type-resolution",
+          "schema-generator/federation/federation-tracing"
         ]
       }
     ],


### PR DESCRIPTION
### :pencil: Description
For federation we need to send back tracing metrics to get usage reporting. We can use Apollo's library: https://github.com/apollographql/federation-jvm

This adds a new `FederatedGraphQLContext` to the `graphql-kotlin-federation` package. It also creates a new `SpringGraphQLContext` and `SpringGraphQLContextFactory` that implement these required methods.

If users to do not have a custom context, they just need to set `graphq.federation.tracing.enabled=true`.

If there is a custom context, it should extend `SpringGraphQLContext` and also still have the properties set.

Since we are changing the required type of `SpringGraphQLContextFactory` this is a major change in the `4.x.x` branch.


### :link: Related Issues
Reimplements https://github.com/ExpediaGroup/graphql-kotlin/pull/962 for merge conflicts
Support in 3.x.x added here: #960