### PR TITLE
WIP: Change the parameterName so it can be used in the maven plugin config…

### DIFF
--- a/plugins/graphql-kotlin-maven-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/maven/GenerateClientAbstractMojo.kt
+++ b/plugins/graphql-kotlin-maven-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/maven/GenerateClientAbstractMojo.kt
@@ -70,7 +70,7 @@ abstract class GenerateClientAbstractMojo : AbstractMojo() {
      * </customScalars>
      * ```
      */
-    @Parameter(name = "converters")
+    @Parameter(name = "customScalars")
     private var customScalars: List<CustomScalar> = mutableListOf()
 
     /**


### PR DESCRIPTION
This resolves the maven configuration problem I asked about in issue #1067

### :pencil: Description

Changes the maven parameter name from `converters` to `customScalars`.

### :link: Related Issues
* #1067 
