### PR TITLE
Add data loader registry to subscription execution

### DIFF
--- a/servers/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/server/spring/SubscriptionAutoConfiguration.kt
+++ b/servers/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/server/spring/SubscriptionAutoConfiguration.kt
@@ -16,6 +16,7 @@
 
 package com.expediagroup.graphql.server.spring
 
+import com.expediagroup.graphql.server.execution.DataLoaderRegistryFactory
 import com.expediagroup.graphql.server.operations.Subscription
 import com.expediagroup.graphql.server.spring.subscriptions.ApolloSubscriptionHooks
 import com.expediagroup.graphql.server.spring.subscriptions.ApolloSubscriptionProtocolHandler
@@ -55,7 +56,10 @@ class SubscriptionAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    fun subscriptionHandler(graphQL: GraphQL) = SpringGraphQLSubscriptionHandler(graphQL)
+    fun subscriptionHandler(
+        graphQL: GraphQL,
+        dataLoaderRegistryFactory: DataLoaderRegistryFactory
+    ) = SpringGraphQLSubscriptionHandler(graphQL, dataLoaderRegistryFactory)
 
     @Bean
     @ConditionalOnMissingBean


### PR DESCRIPTION
### :pencil: Description
Pass the `DataLoaderRegistryFactory` to the subscription handler so for each request we can generate a `DataLoaderRegistry` to give to graphql-java

### :link: Related Issues
Resolves https://github.com/ExpediaGroup/graphql-kotlin/issues/602