### PR TITLE
[client] generate enums in UPPERCASE and fix kotlinx request serialization

### DIFF
--- a/clients/graphql-kotlin-client-jackson/src/main/kotlin/com/expediagroup/graphql/client/jackson/GraphQLClientJacksonSerializer.kt
+++ b/clients/graphql-kotlin-client-jackson/src/main/kotlin/com/expediagroup/graphql/client/jackson/GraphQLClientJacksonSerializer.kt
@@ -18,6 +18,7 @@ package com.expediagroup.graphql.client.jackson
 
 import com.expediagroup.graphql.client.jackson.types.JacksonGraphQLResponse
 import com.expediagroup.graphql.client.serializer.GraphQLClientSerializer
+import com.expediagroup.graphql.client.types.GraphQLClientRequest
 import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.JavaType
 import com.fasterxml.jackson.databind.ObjectMapper
@@ -35,7 +36,9 @@ class GraphQLClientJacksonSerializer(private val mapper: ObjectMapper = jacksonO
         mapper.enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE)
     }
 
-    override fun serialize(request: Any): String = mapper.writeValueAsString(request)
+    override fun serialize(request: GraphQLClientRequest<*>): String = mapper.writeValueAsString(request)
+
+    override fun serialize(requests: List<GraphQLClientRequest<*>>): String = mapper.writeValueAsString(requests)
 
     override fun <T : Any> deserialize(rawResponse: String, responseType: KClass<T>): JacksonGraphQLResponse<T> =
         mapper.readValue(rawResponse, parameterizedType(responseType))

--- a/clients/graphql-kotlin-client-jackson/src/test/kotlin/com/expediagroup/graphql/client/jackson/data/EnumQuery.kt
+++ b/clients/graphql-kotlin-client-jackson/src/test/kotlin/com/expediagroup/graphql/client/jackson/data/EnumQuery.kt
@@ -16,23 +16,22 @@
 
 package com.expediagroup.graphql.client.jackson.data
 
+import com.expediagroup.graphql.client.jackson.data.enums.TestEnum
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
-import com.fasterxml.jackson.annotation.JsonEnumDefaultValue
 import kotlin.reflect.KClass
 
-class EnumQuery : GraphQLClientRequest<EnumQuery.Result> {
+class EnumQuery(
+    override val variables: Variables
+) : GraphQLClientRequest<EnumQuery.Result> {
     override val query: String = "ENUM_QUERY"
 
     override val operationName: String = "EnumQuery"
 
     override fun responseType(): KClass<Result> = Result::class
 
-    enum class TestEnum {
-        ONE,
-        TWO,
-        @JsonEnumDefaultValue
-        __UNKNOWN
-    }
+    data class Variables(
+        val enum: TestEnum? = null
+    )
 
     data class Result(
         val enumResult: TestEnum = TestEnum.__UNKNOWN

--- a/clients/graphql-kotlin-client-jackson/src/test/kotlin/com/expediagroup/graphql/client/jackson/data/enums/TestEnum.kt
+++ b/clients/graphql-kotlin-client-jackson/src/test/kotlin/com/expediagroup/graphql/client/jackson/data/enums/TestEnum.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2021 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.client.jackson.data.enums
+
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue
+import com.fasterxml.jackson.annotation.JsonProperty
+
+enum class TestEnum {
+    ONE,
+    TWO,
+    @JsonProperty("three")
+    THREE,
+    @JsonEnumDefaultValue
+    __UNKNOWN
+}

--- a/clients/graphql-kotlin-client-serialization/build.gradle.kts
+++ b/clients/graphql-kotlin-client-serialization/build.gradle.kts
@@ -20,7 +20,7 @@ tasks {
                 limit {
                     counter = "INSTRUCTION"
                     value = "COVEREDRATIO"
-                    minimum = "0.75".toBigDecimal()
+                    minimum = "0.73".toBigDecimal()
                 }
             }
         }

--- a/clients/graphql-kotlin-client-serialization/src/test/kotlin/com/expediagroup/graphql/client/serialization/data/EnumQuery.kt
+++ b/clients/graphql-kotlin-client-serialization/src/test/kotlin/com/expediagroup/graphql/client/serialization/data/EnumQuery.kt
@@ -14,23 +14,30 @@
  * limitations under the License.
  */
 
-package com.expediagroup.graphql.client.serialization.types.data
+package com.expediagroup.graphql.client.serialization.data
 
-import com.expediagroup.graphql.client.serialization.types.data.polymorphicquery.BasicInterface
+import com.expediagroup.graphql.client.serialization.data.enums.TestEnum
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
 import kotlinx.serialization.Serializable
 import kotlin.reflect.KClass
 
 @Serializable
-class PolymorphicQuery : GraphQLClientRequest<PolymorphicQuery.Result> {
-    override val query: String = "POLYMORPHIC_QUERY"
+class EnumQuery(
+    override val variables: Variables
+) : GraphQLClientRequest<EnumQuery.Result> {
+    override val query: String = "ENUM_QUERY"
 
-    override val operationName: String = "PolymorphicQuery"
+    override val operationName: String = "EnumQuery"
 
     override fun responseType(): KClass<Result> = Result::class
 
     @Serializable
+    data class Variables(
+        val enum: TestEnum? = null
+    )
+
+    @Serializable
     data class Result(
-        val polymorphicResult: BasicInterface
+        val enumResult: TestEnum = TestEnum.__UNKNOWN
     )
 }

--- a/clients/graphql-kotlin-client-serialization/src/test/kotlin/com/expediagroup/graphql/client/serialization/data/FirstQuery.kt
+++ b/clients/graphql-kotlin-client-serialization/src/test/kotlin/com/expediagroup/graphql/client/serialization/data/FirstQuery.kt
@@ -14,31 +14,29 @@
  * limitations under the License.
  */
 
-package com.expediagroup.graphql.client.jackson.data
+package com.expediagroup.graphql.client.serialization.data
 
-import com.expediagroup.graphql.client.jackson.data.scalars.UUID
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
+import kotlinx.serialization.Serializable
 import kotlin.reflect.KClass
 
-// typealiases would be in separate file
-typealias ID = String
-
-class ScalarQuery(
+@Serializable
+class FirstQuery(
     override val variables: Variables
-) : GraphQLClientRequest<ScalarQuery.Result> {
-    override val query: String = "SCALAR_QUERY"
+) : GraphQLClientRequest<FirstQuery.Result> {
+    override val query: String = "FIRST_QUERY"
 
-    override val operationName: String = "ScalarQuery"
+    override val operationName: String = "FirstQuery"
 
     override fun responseType(): KClass<Result> = Result::class
 
+    @Serializable
     data class Variables(
-        val alias: ID? = null,
-        val custom: UUID? = null
+        val input: Float? = null
     )
 
+    @Serializable
     data class Result(
-        val scalarAlias: ID,
-        val customScalar: UUID
+        val stringResult: String
     )
 }

--- a/clients/graphql-kotlin-client-serialization/src/test/kotlin/com/expediagroup/graphql/client/serialization/data/OtherQuery.kt
+++ b/clients/graphql-kotlin-client-serialization/src/test/kotlin/com/expediagroup/graphql/client/serialization/data/OtherQuery.kt
@@ -14,29 +14,23 @@
  * limitations under the License.
  */
 
-package com.expediagroup.graphql.client.serialization.types.data
+package com.expediagroup.graphql.client.serialization.data
 
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
 import kotlinx.serialization.Serializable
 import kotlin.reflect.KClass
 
 @Serializable
-class FirstQuery(
-    override val variables: Variables
-) : GraphQLClientRequest<FirstQuery.Result> {
-    override val query: String = "FIRST_QUERY"
+class OtherQuery : GraphQLClientRequest<OtherQuery.Result> {
+    override val query: String = "OTHER_QUERY"
 
-    override val operationName: String = "FirstQuery"
+    override val operationName: String = "OtherQuery"
 
     override fun responseType(): KClass<Result> = Result::class
 
     @Serializable
-    data class Variables(
-        val input: Float? = null
-    )
-
-    @Serializable
     data class Result(
-        val stringResult: String
+        val stringResult: String,
+        val integerResult: Int
     )
 }

--- a/clients/graphql-kotlin-client-serialization/src/test/kotlin/com/expediagroup/graphql/client/serialization/data/PolymorphicQuery.kt
+++ b/clients/graphql-kotlin-client-serialization/src/test/kotlin/com/expediagroup/graphql/client/serialization/data/PolymorphicQuery.kt
@@ -14,28 +14,23 @@
  * limitations under the License.
  */
 
-package com.expediagroup.graphql.client.serialization.types.data
+package com.expediagroup.graphql.client.serialization.data
 
+import com.expediagroup.graphql.client.serialization.data.polymorphicquery.BasicInterface
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
 import kotlinx.serialization.Serializable
 import kotlin.reflect.KClass
 
 @Serializable
-class EnumQuery : GraphQLClientRequest<EnumQuery.Result> {
-    override val query: String = "ENUM_QUERY"
+class PolymorphicQuery : GraphQLClientRequest<PolymorphicQuery.Result> {
+    override val query: String = "POLYMORPHIC_QUERY"
 
-    override val operationName: String = "EnumQuery"
+    override val operationName: String = "PolymorphicQuery"
 
     override fun responseType(): KClass<Result> = Result::class
 
-    enum class TestEnum {
-        ONE,
-        TWO,
-        __UNKNOWN
-    }
-
     @Serializable
     data class Result(
-        val enumResult: TestEnum = TestEnum.__UNKNOWN
+        val polymorphicResult: BasicInterface
     )
 }

--- a/clients/graphql-kotlin-client-serialization/src/test/kotlin/com/expediagroup/graphql/client/serialization/data/ScalarQuery.kt
+++ b/clients/graphql-kotlin-client-serialization/src/test/kotlin/com/expediagroup/graphql/client/serialization/data/ScalarQuery.kt
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-package com.expediagroup.graphql.client.serialization.types.data
+package com.expediagroup.graphql.client.serialization.data
 
-import com.expediagroup.graphql.client.serialization.types.data.scalars.UUID
+import com.expediagroup.graphql.client.serialization.data.scalars.UUID
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
 import kotlinx.serialization.Serializable
 import kotlin.reflect.KClass
@@ -24,12 +24,21 @@ import kotlin.reflect.KClass
 // typealiases would be in separate file
 typealias ID = String
 
-class ScalarQuery : GraphQLClientRequest<ScalarQuery.Result> {
+@Serializable
+class ScalarQuery(
+    override val variables: Variables
+) : GraphQLClientRequest<ScalarQuery.Result> {
     override val query: String = "SCALAR_QUERY"
 
     override val operationName: String = "ScalarQuery"
 
     override fun responseType(): KClass<Result> = Result::class
+
+    @Serializable
+    data class Variables(
+        val alias: ID? = null,
+        val custom: UUID? = null
+    )
 
     @Serializable
     data class Result(

--- a/clients/graphql-kotlin-client-serialization/src/test/kotlin/com/expediagroup/graphql/client/serialization/data/enums/TestEnum.kt
+++ b/clients/graphql-kotlin-client-serialization/src/test/kotlin/com/expediagroup/graphql/client/serialization/data/enums/TestEnum.kt
@@ -14,23 +14,16 @@
  * limitations under the License.
  */
 
-package com.expediagroup.graphql.client.serialization.types.data
+package com.expediagroup.graphql.client.serialization.data.enums
 
-import com.expediagroup.graphql.client.types.GraphQLClientRequest
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlin.reflect.KClass
 
 @Serializable
-class OtherQuery : GraphQLClientRequest<OtherQuery.Result> {
-    override val query: String = "OTHER_QUERY"
-
-    override val operationName: String = "OtherQuery"
-
-    override fun responseType(): KClass<Result> = Result::class
-
-    @Serializable
-    data class Result(
-        val stringResult: String,
-        val integerResult: Int
-    )
+enum class TestEnum {
+    ONE,
+    TWO,
+    @SerialName("three")
+    THREE,
+    __UNKNOWN
 }

--- a/clients/graphql-kotlin-client-serialization/src/test/kotlin/com/expediagroup/graphql/client/serialization/data/polymorphicquery/BasicInterface.kt
+++ b/clients/graphql-kotlin-client-serialization/src/test/kotlin/com/expediagroup/graphql/client/serialization/data/polymorphicquery/BasicInterface.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.expediagroup.graphql.client.serialization.types.data.polymorphicquery
+package com.expediagroup.graphql.client.serialization.data.polymorphicquery
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable

--- a/clients/graphql-kotlin-client-serialization/src/test/kotlin/com/expediagroup/graphql/client/serialization/data/scalars/UUID.kt
+++ b/clients/graphql-kotlin-client-serialization/src/test/kotlin/com/expediagroup/graphql/client/serialization/data/scalars/UUID.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.expediagroup.graphql.client.serialization.types.data.scalars
+package com.expediagroup.graphql.client.serialization.data.scalars
 
 import com.expediagroup.graphql.client.converter.ScalarConverter
 import kotlinx.serialization.KSerializer

--- a/clients/graphql-kotlin-client/src/main/kotlin/com/expediagroup/graphql/client/serializer/GraphQLClientSerializer.kt
+++ b/clients/graphql-kotlin-client/src/main/kotlin/com/expediagroup/graphql/client/serializer/GraphQLClientSerializer.kt
@@ -16,6 +16,7 @@
 
 package com.expediagroup.graphql.client.serializer
 
+import com.expediagroup.graphql.client.types.GraphQLClientRequest
 import com.expediagroup.graphql.client.types.GraphQLClientResponse
 import java.util.ServiceLoader
 import kotlin.reflect.KClass
@@ -34,7 +35,12 @@ interface GraphQLClientSerializer {
     /**
      * Serialize GraphQLClientRequest (or batch request) to a raw String representation.
      */
-    fun serialize(request: Any): String
+    fun serialize(request: GraphQLClientRequest<*>): String
+
+    /**
+     * Serialize GraphQLClientRequest (or batch request) to a raw String representation.
+     */
+    fun serialize(requests: List<GraphQLClientRequest<*>>): String
 
     /**
      * Deserialize raw response String to a target GraphQLClientResponse.

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/enums/enums/CustomEnum.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/enums/enums/CustomEnum.kt
@@ -1,6 +1,7 @@
 package com.expediagroup.graphql.generated.enums
 
 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue
+import com.fasterxml.jackson.annotation.JsonProperty
 import kotlin.Deprecated
 
 /**
@@ -22,6 +23,12 @@ enum class CustomEnum {
    * Second enum value
    */
   TWO,
+
+  /**
+   * Lowercase enum value
+   */
+  @JsonProperty("four")
+  FOUR,
 
   /**
    * This is a default enum value that will be used when attempting to deserialize unknown value.

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/enums/enums/CustomEnum.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/enums/enums/CustomEnum.kt
@@ -1,10 +1,13 @@
 package com.expediagroup.graphql.generated.enums
 
 import kotlin.Deprecated
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 
 /**
  * Custom enum description
  */
+@Serializable
 enum class CustomEnum {
   /**
    * First enum value
@@ -21,6 +24,12 @@ enum class CustomEnum {
    * Second enum value
    */
   TWO,
+
+  /**
+   * Lowercase enum value
+   */
+  @SerialName("four")
+  FOUR,
 
   /**
    * This is a default enum value that will be used when attempting to deserialize unknown value.

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/multiple_queries/enums/CustomEnum.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/multiple_queries/enums/CustomEnum.kt
@@ -1,10 +1,13 @@
 package com.expediagroup.graphql.generated.enums
 
 import kotlin.Deprecated
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 
 /**
  * Custom enum description
  */
+@Serializable
 enum class CustomEnum {
   /**
    * First enum value
@@ -21,6 +24,12 @@ enum class CustomEnum {
    * Second enum value
    */
   TWO,
+
+  /**
+   * Lowercase enum value
+   */
+  @SerialName("four")
+  FOUR,
 
   /**
    * This is a default enum value that will be used when attempting to deserialize unknown value.

--- a/plugins/client/graphql-kotlin-client-generator/src/test/resources/testSchema.graphql
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/resources/testSchema.graphql
@@ -144,6 +144,8 @@ enum CustomEnum {
   THREE @deprecated(reason : "only goes up to two")
   "Second enum value"
   TWO
+  "Lowercase enum value"
+  four
 }
 "Custom scalar representing UUID"
 scalar UUID


### PR DESCRIPTION
### :pencil: Description

Update client generation logic to always generate enums in UPPERCASE and then use corresponding Jackson (`@JsonProperty`) or kotlinx-serialization (`@SerialName`) annotation to convert those back to expected schema values. This allows us to support enum values that cannot be used directly in Kotlin (i.e. `name` and `ordinal`) as they would clash with built in methods.

This PR also resolves incorrect serialization of requests when using `kotlinx-serialization`. We were applying our custom `AnySerializer` to serialize the requests which was in turn incorrectly serializing enums and custom scalars. I changed the logic to construct correct `KSerializer` based on the specified request.

### :link: Related Issues

Resolves: https://github.com/ExpediaGroup/graphql-kotlin/issues/1075