### PR TITLE
[build] update release build to automatically release to nexus

### DIFF
--- a/.github/workflows/release-code.yml
+++ b/.github/workflows/release-code.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           NEW_VERSION=$(echo "${GITHUB_REF}" | cut -d "/" -f3)
           echo "New version: ${NEW_VERSION}"
-          ./gradlew publishToSonatype closeSonatypeStagingRepository -Pversion=${NEW_VERSION}
+          ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository publishPlugins -Pversion=${NEW_VERSION}
         env:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}


### PR DESCRIPTION
### :pencil: Description

This is a follow up to https://github.com/ExpediaGroup/graphql-kotlin/pull/1091 which seems to be working fine.

### :link: Related Issues

https://github.com/ExpediaGroup/graphql-kotlin/pull/1091