### PR TITLE
Add docs on the spring specific context requirements

### DIFF
--- a/website/docs/server/graphql-context-factory.md
+++ b/website/docs/server/graphql-context-factory.md
@@ -3,6 +3,10 @@ id: graphql-context-factory
 title: GraphQLContextFactory
 ---
 
+:::note
+If you are using `graphql-kotlin-spring-server`, see the [Spring specific documentation](./spring-server/spring-graphql-context.md).
+:::
+
 `GraphQLContextFactory` is a generic method for generating a `GraphQLContext` for each request.
 
 ```kotlin

--- a/website/docs/server/spring-server/spring-graphql-context.md
+++ b/website/docs/server/spring-server/spring-graphql-context.md
@@ -2,13 +2,12 @@
 id: spring-graphql-context
 title: Generating GraphQL Context
 ---
-`graphql-kotlin-spring-server` provides a Spring specific implementation [GraphQLContextFactory](../graphql-context-factory.md) and the context.
+`graphql-kotlin-spring-server` provides a Spring specific implementation of [GraphQLContextFactory](../graphql-context-factory.md) and the context.
 
 * `SpringGraphQLContext` - Implements the Spring `ServerRequest` and federation tracing `HTTPRequestHeaders`
 * `SpringGraphQLContextFactory` - Generates a `SpringGraphQLContext` per request
 
-If you need a custom context and you are using `graphql-kotlin-spring-server`, it is recommmended you extend these two classes
-so you maintain support with all the other features
+If you are using `graphql-kotlin-spring-server`, you should extend `SpringGraphQLContext` and `SpringGraphQLContextFactory` to maintain support with all the other features.
 
 ```kotlin
 class MyGraphQLContext(val myCustomValue: String, request: ServerRequest) : SpringGraphQLContext(request)
@@ -22,10 +21,11 @@ class MyGraphQLContextFactory : SpringGraphQLContextFactory<MyGraphQLContext>() 
 }
 ```
 
-Once your application is configured to build your custom `MyGraphQLContext`, we can then specify it as function argument but it will not be included in the schema.
+Once your application is configured to build your custom `MyGraphQLContext`, you can then specify it as function argument.
 While executing the query, the corresponding GraphQL context will be read from the environment and automatically injected to the function input arguments.
+This argument will not appear in the GraphQL schema.
 
-For more details see the [Contextual Data documentation](../../schema-generator/execution/contextual-data.md).
+For more details, see the [Contextual Data Documentation](../../schema-generator/execution/contextual-data.md).
 
 ## Federated Context
 


### PR DESCRIPTION
### :pencil: Description
Add docs explaining that the context should be extended from the Spring specific classes when using `graphql-kotlin-spring-server`

Using the new [Docusaurus Admonitions](https://docusaurus.io/docs/next/markdown-features/admonitions)

![Screen Shot 2021-03-29 at 10 44 55 AM](https://user-images.githubusercontent.com/2446877/112877591-cf67de00-907b-11eb-8446-026da47e2867.png)


### :link: Related Issues
https://github.com/ExpediaGroup/graphql-kotlin/issues/1096