### PR TITLE
Fix playground route logic

### DIFF
--- a/servers/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/server/spring/PlaygroundRouteConfiguration.kt
+++ b/servers/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/server/spring/PlaygroundRouteConfiguration.kt
@@ -33,7 +33,7 @@ import org.springframework.web.reactive.function.server.html
 class PlaygroundRouteConfiguration(
     private val config: GraphQLConfigurationProperties,
     @Value("classpath:/graphql-playground.html") private val playgroundHtml: Resource,
-    @Value("\${spring.webflux.base-path:null}") private val contextPath: String?
+    @Value("\${spring.webflux.base-path:#{null}}") private val contextPath: String?
 ) {
 
     private val body = playgroundHtml.inputStream.bufferedReader().use { reader ->

--- a/servers/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/server/spring/subscriptions/ApolloSubscriptionProtocolHandler.kt
+++ b/servers/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/server/spring/subscriptions/ApolloSubscriptionProtocolHandler.kt
@@ -161,25 +161,11 @@ class ApolloSubscriptionProtocolHandler(
      */
     private fun saveContext(operationMessage: SubscriptionOperationMessage, session: WebSocketSession) {
         runBlocking {
-            val connectionParams = getConnectionParams(operationMessage.payload)
+            val connectionParams = castToMapOfStringString(operationMessage.payload)
             val context = contextFactory.generateContext(session)
             val onConnect = subscriptionHooks.onConnect(connectionParams, session, context)
             sessionState.saveContext(session, onConnect)
         }
-    }
-
-    /**
-     * This is the best cast saftey we can get with the generics
-     */
-    @Suppress("UNCHECKED_CAST")
-    private fun getConnectionParams(payload: Any?): Map<String, String> {
-        if (payload != null && payload is Map<*, *> && payload.isNotEmpty()) {
-            if (payload.keys.first() is String && payload.values.first() is String) {
-                return payload as Map<String, String>
-            }
-        }
-
-        return emptyMap()
     }
 
     /**

--- a/servers/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/server/spring/subscriptions/subscriptionUtils.kt
+++ b/servers/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/server/spring/subscriptions/subscriptionUtils.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.server.spring.subscriptions
+
+/**
+ * This is the best cast saftey we can get with the generics
+ */
+@Suppress("UNCHECKED_CAST")
+internal fun castToMapOfStringString(payload: Any?): Map<String, String> {
+    if (payload != null && payload is Map<*, *> && payload.isNotEmpty()) {
+        if (payload.keys.first() is String && payload.values.first() is String) {
+            return payload as Map<String, String>
+        }
+    }
+
+    return emptyMap()
+}

--- a/servers/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/server/spring/subscriptions/SubscriptionUtilsKtTest.kt
+++ b/servers/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/server/spring/subscriptions/SubscriptionUtilsKtTest.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2021 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.server.spring.subscriptions
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class SubscriptionUtilsKtTest {
+
+    @Test
+    fun `casting null returns empty map`() {
+        val result = castToMapOfStringString(null)
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `casting non-map returns empty map`() {
+        val result = castToMapOfStringString("foo")
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `casting empty map returns empty map`() {
+        val result = castToMapOfStringString(emptyMap<String, String>())
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `casting map of String-Int returns empty map`() {
+        val result = castToMapOfStringString(mapOf("foo" to 1))
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `casting map of Int-String returns empty map`() {
+        val result = castToMapOfStringString(mapOf(1 to "foo"))
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `casting map of String-String returns the map`() {
+        val result = castToMapOfStringString(mapOf("foo" to "bar"))
+        assertFalse(result.isEmpty())
+        assertEquals("bar", result["foo"])
+    }
+}


### PR DESCRIPTION
### :pencil: Description
The playground route is being set as `/null/graphql` this is because the default value is being set as the string value `"null"` and not a strict null value

### :link: Related Issues
https://github.com/ExpediaGroup/graphql-kotlin/pull/1098