### PR TITLE
Support OptionalInput of any list or array

### DIFF
--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/exceptions/InvalidWrappedTypeException.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/exceptions/InvalidWrappedTypeException.kt
@@ -19,7 +19,7 @@ package com.expediagroup.graphql.generator.exceptions
 import kotlin.reflect.KType
 
 /**
- * Thrown on mapping an invalid list type
+ * Thrown on mapping an invalid wrapped type
  */
-class InvalidListTypeException(type: KType) :
-    GraphQLKotlinException("Could not get the type of the first argument for the list $type")
+class InvalidWrappedTypeException(type: KType) :
+    GraphQLKotlinException("Could not get the type of the first argument for the type $type")

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/extensions/kParameterExtensions.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/extensions/kParameterExtensions.kt
@@ -24,10 +24,6 @@ import kotlin.reflect.full.isSubclassOf
 
 internal fun KParameter.isInterface() = this.type.getKClass().isInterface()
 
-internal fun KParameter.isList() = this.type.getKClass().isSubclassOf(List::class)
-
-internal fun KParameter.isListType() = this.isList() || this.type.getJavaClass().isArray
-
 internal fun KParameter.isGraphQLContext() = this.type.getKClass().isSubclassOf(GraphQLContext::class)
 
 internal fun KParameter.isDataFetchingEnvironment() = this.type.classifier == DataFetchingEnvironment::class

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/extensions/kTypeExtensions.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/extensions/kTypeExtensions.kt
@@ -41,7 +41,11 @@ internal fun KType.getJavaClass(): Class<*> = this.getKClass().java
 
 internal fun KType.isSubclassOf(kClass: KClass<*>) = this.getKClass().isSubclassOf(kClass)
 
-internal fun KType.isListType() = this.isSubclassOf(List::class) || this.getJavaClass().isArray
+internal fun KType.isList() = this.isSubclassOf(List::class)
+
+internal fun KType.isArray() = this.getJavaClass().isArray
+
+internal fun KType.isListType() = this.isList() || this.isArray()
 
 internal fun KType.isOptionalInputType() = this.isSubclassOf(OptionalInput::class)
 

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/extensions/kTypeExtensions.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/extensions/kTypeExtensions.kt
@@ -16,7 +16,7 @@
 
 package com.expediagroup.graphql.generator.internal.extensions
 
-import com.expediagroup.graphql.generator.exceptions.InvalidListTypeException
+import com.expediagroup.graphql.generator.exceptions.InvalidWrappedTypeException
 import com.expediagroup.graphql.generator.execution.OptionalInput
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
@@ -55,9 +55,9 @@ internal fun KType.unwrapOptionalInputType() = if (this.isOptionalInputType()) {
     this
 }
 
-@Throws(InvalidListTypeException::class)
+@Throws(InvalidWrappedTypeException::class)
 internal fun KType.getTypeOfFirstArgument(): KType =
-    this.arguments.firstOrNull()?.type ?: throw InvalidListTypeException(this)
+    this.arguments.firstOrNull()?.type ?: throw InvalidWrappedTypeException(this)
 
 internal fun KType.getWrappedType(): KType {
     val primitiveClass = primitiveArrayTypes[this.getKClass()]

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/execution/FunctionDataFetcherTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/execution/FunctionDataFetcherTest.kt
@@ -69,6 +69,11 @@ class FunctionDataFetcherTest {
             is OptionalInput.Undefined -> "input was UNDEFINED"
             is OptionalInput.Defined -> "input was ${input.value}"
         }
+
+        fun optionalArrayInputObjects(input: OptionalInput<Array<MyInputClass>>): String = when (input) {
+            is OptionalInput.Undefined -> "input was UNDEFINED"
+            is OptionalInput.Defined -> "first input was ${input.value?.first()?.field1}"
+        }
     }
 
     @GraphQLName("MyInputClassRenamed")
@@ -275,5 +280,16 @@ class FunctionDataFetcherTest {
             every { containsArgument(any()) } returns false
         }
         assertEquals(expected = "input was UNDEFINED", actual = dataFetcher.get(mockEnvironmet))
+    }
+
+    @Test
+    fun `optional array of input objects is deserialized correctly`() {
+        val dataFetcher = FunctionDataFetcher(target = MyClass(), fn = MyClass::optionalArrayInputObjects)
+        val mockEnvironmet: DataFetchingEnvironment = mockk {
+            every { arguments } returns mapOf("input" to arrayListOf(linkedMapOf("jacksonField" to "foo")))
+            every { containsArgument("input") } returns true
+        }
+        val result = dataFetcher.get(mockEnvironmet)
+        assertEquals(expected = "first input was foo", actual = result)
     }
 }

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/extensions/KParameterExtensionsKtTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/extensions/KParameterExtensionsKtTest.kt
@@ -126,19 +126,4 @@ class KParameterExtensionsKtTest {
         val param = Container::interfaceInput.findParameterByName("myInterface")
         assertFalse(param?.isDataFetchingEnvironment().isTrue())
     }
-
-    @Test
-    fun isList() {
-        assertTrue(Container::listInput.findParameterByName("myList")?.isList() == true)
-        assertTrue(Container::arrayInput.findParameterByName("myArray")?.isList() == false)
-        assertTrue(Container::interfaceInput.findParameterByName("myInterface")?.isList() == false)
-    }
-
-    @Test
-    fun isListType() {
-        assertTrue(Container::listInput.findParameterByName("myList")?.isListType() == true)
-        assertTrue(Container::arrayListInput.findParameterByName("myList")?.isListType() == true)
-        assertTrue(Container::arrayInput.findParameterByName("myArray")?.isListType() == true)
-        assertTrue(Container::interfaceInput.findParameterByName("myInterface")?.isListType() == false)
-    }
 }

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/extensions/KTypeExtensionsKtTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/extensions/KTypeExtensionsKtTest.kt
@@ -17,7 +17,7 @@
 package com.expediagroup.graphql.generator.internal.extensions
 
 import com.expediagroup.graphql.generator.exceptions.CouldNotGetNameOfKClassException
-import com.expediagroup.graphql.generator.exceptions.InvalidListTypeException
+import com.expediagroup.graphql.generator.exceptions.InvalidWrappedTypeException
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.Test
@@ -58,17 +58,17 @@ class KTypeExtensionsKtTest {
 
         assertEquals(Int::class.starProjectedType, MyClass::primitiveArrayFun.findParameterByName("intArray")?.type?.getWrappedType())
 
-        assertFailsWith(InvalidListTypeException::class) {
+        assertFailsWith(InvalidWrappedTypeException::class) {
             MyClass::stringFun.findParameterByName("string")?.type?.getTypeOfFirstArgument()
         }
 
-        assertFailsWith(InvalidListTypeException::class) {
+        assertFailsWith(InvalidWrappedTypeException::class) {
             val mockType: KType = mockk()
             every { mockType.arguments } returns emptyList()
             mockType.getTypeOfFirstArgument()
         }
 
-        assertFailsWith(InvalidListTypeException::class) {
+        assertFailsWith(InvalidWrappedTypeException::class) {
             val mockArgument: KTypeProjection = mockk()
             every { mockArgument.type } returns null
             val mockType: KType = mockk()
@@ -140,7 +140,7 @@ class KTypeExtensionsKtTest {
         assertEquals(Boolean::class.starProjectedType, BooleanArray::class.starProjectedType.getWrappedType())
         assertEquals(String::class.starProjectedType, MyClass::listFun.findParameterByName("list")?.type?.getWrappedType())
 
-        assertFailsWith(InvalidListTypeException::class) {
+        assertFailsWith(InvalidWrappedTypeException::class) {
             MyClass::stringFun.findParameterByName("string")?.type?.getWrappedType()
         }
     }

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/extensions/KTypeExtensionsKtTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/extensions/KTypeExtensionsKtTest.kt
@@ -106,7 +106,31 @@ class KTypeExtensionsKtTest {
     }
 
     @Test
-    fun getArrayType() {
+    fun isList() {
+        assertTrue(List::class.starProjectedType.isList())
+        assertFalse(Array::class.starProjectedType.isList())
+        assertFalse(IntArray::class.starProjectedType.isList())
+        assertFalse(MyClass::class.starProjectedType.isList())
+    }
+
+    @Test
+    fun isArray() {
+        assertTrue(Array::class.starProjectedType.isArray())
+        assertTrue(IntArray::class.starProjectedType.isArray())
+        assertFalse(List::class.starProjectedType.isArray())
+        assertFalse(MyClass::class.starProjectedType.isArray())
+    }
+
+    @Test
+    fun isListType() {
+        assertTrue(List::class.starProjectedType.isListType())
+        assertTrue(Array::class.starProjectedType.isListType())
+        assertTrue(IntArray::class.starProjectedType.isListType())
+        assertFalse(MyClass::class.starProjectedType.isListType())
+    }
+
+    @Test
+    fun getWrappedType() {
         assertEquals(Int::class.starProjectedType, IntArray::class.starProjectedType.getWrappedType())
         assertEquals(Long::class.starProjectedType, LongArray::class.starProjectedType.getWrappedType())
         assertEquals(Short::class.starProjectedType, ShortArray::class.starProjectedType.getWrappedType())

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/test/integration/OptionalInputTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/test/integration/OptionalInputTest.kt
@@ -46,7 +46,7 @@ class OptionalInputTest {
             Arguments.of("{ optionaListScalarInput(input: [\"ABC\"] )  }", "input value: [ABC]"),
             Arguments.of("{ optionaListInputObject }", "input was not specified"),
             Arguments.of("{ optionaListInputObject(input: null) }", "input value: null"),
-            Arguments.of("{ optionaListInputObject(input: [{id: 1, name: \"ABC\"}] )  }", "input value: [{id=1, name=ABC}]"),
+            Arguments.of("{ optionaListInputObject(input: [{id: 1, name: \"ABC\"}] )  }", "input value: [SimpleArgument(id=1, name=ABC)]"),
             Arguments.of("{ inputWithOptionalScalarValues(input: { required: \"ABC\" }) }", "argument with optional scalar was not specified"),
             Arguments.of("{ inputWithOptionalScalarValues(input: { required: \"ABC\" optional: null }) }", "argument scalar value: null"),
             Arguments.of("{ inputWithOptionalScalarValues(input: { required: \"ABC\" optional: 1 }) }", "argument scalar value: 1"),


### PR DESCRIPTION
### :pencil: Description
When we have an optional input of lists or arrays it would have a casting exception if the input was converted to a linked hash map or array.

This resolves this issue by first checking for the optional input type, then reusing the same code we have for converting all the other arguments, including lists and arrays.

### :link: Related Issues
https://github.com/ExpediaGroup/graphql-kotlin/pull/1100