### PR TITLE
[client] fix unknown enum import

### DIFF
--- a/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/types/generateGraphQLObjectTypeSpec.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/types/generateGraphQLObjectTypeSpec.kt
@@ -66,8 +66,8 @@ internal fun generateGraphQLObjectTypeSpec(
 
         val constructorParameter = ParameterSpec.builder(propertySpec.name, propertySpec.type)
         val className = propertySpec.type as? ClassName
-        if (context.enumClassToTypeSpecs.keys.contains(className)) {
-            val unknownValue = MemberName(context.packageName, "${className?.simpleName}.$UNKNOWN_VALUE")
+        if (className != null && context.enumClassToTypeSpecs.keys.contains(className)) {
+            val unknownValue = MemberName(className.packageName, "${className.simpleName}.$UNKNOWN_VALUE")
             constructorParameter.defaultValue("%M", unknownValue)
         }
         constructorBuilder.addParameter(constructorParameter.build())

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/enums/EnumQuery.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/enums/EnumQuery.kt
@@ -2,6 +2,7 @@ package com.expediagroup.graphql.generated
 
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
 import com.expediagroup.graphql.generated.enums.CustomEnum
+import com.expediagroup.graphql.generated.enums.CustomEnum.__UNKNOWN_VALUE
 import kotlin.String
 import kotlin.reflect.KClass
 

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/enums/EnumQuery.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/enums/EnumQuery.kt
@@ -2,6 +2,7 @@ package com.expediagroup.graphql.generated
 
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
 import com.expediagroup.graphql.generated.enums.CustomEnum
+import com.expediagroup.graphql.generated.enums.CustomEnum.__UNKNOWN_VALUE
 import kotlin.String
 import kotlin.reflect.KClass
 import kotlinx.serialization.Serializable

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/multiple_queries/FirstQuery.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/multiple_queries/FirstQuery.kt
@@ -2,6 +2,7 @@ package com.expediagroup.graphql.generated
 
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
 import com.expediagroup.graphql.generated.enums.CustomEnum
+import com.expediagroup.graphql.generated.enums.CustomEnum.__UNKNOWN_VALUE
 import com.expediagroup.graphql.generated.firstquery.BasicInterface
 import com.expediagroup.graphql.generated.firstquery.ComplexObject
 import com.expediagroup.graphql.generated.firstquery.ScalarWrapper

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/multiple_queries/SecondQuery.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/multiple_queries/SecondQuery.kt
@@ -2,6 +2,7 @@ package com.expediagroup.graphql.generated
 
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
 import com.expediagroup.graphql.generated.enums.CustomEnum
+import com.expediagroup.graphql.generated.enums.CustomEnum.__UNKNOWN_VALUE
 import com.expediagroup.graphql.generated.inputs.ComplexArgumentInput
 import com.expediagroup.graphql.generated.secondquery.BasicInterface
 import com.expediagroup.graphql.generated.secondquery.ComplexObject


### PR DESCRIPTION
### :pencil: Description

While we clearly were using wrong package name for referencing enum member. I don't know why the test cases were generating code without that invalid reference (generated code is compared against the sources stored under `test/data` directory).

### :link: Related Issues

Resolves: https://github.com/ExpediaGroup/graphql-kotlin/issues/1106