### PR TITLE
Call hooks for return type on properties

### DIFF
--- a/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/server/spring/model/DataLoaderQueryModel.kt
+++ b/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/server/spring/model/DataLoaderQueryModel.kt
@@ -21,8 +21,12 @@ import com.expediagroup.graphql.generator.annotations.GraphQLIgnore
 
 data class Employee(
     val name: String,
+
     @GraphQLIgnore
-    val companyId: Int
+    val companyId: Int,
+
+    @GraphQLDescription("A list of unique skills")
+    val skills: Set<String> = emptySet()
 ) {
     @GraphQLDescription("This value will be populated by a custom data fetcher using data loaders")
     lateinit var company: Company

--- a/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/server/spring/query/DataLoaderQuery.kt
+++ b/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/server/spring/query/DataLoaderQuery.kt
@@ -33,8 +33,8 @@ import java.util.concurrent.CompletableFuture
 @Component
 class DataLoaderQuery : Query {
     private val employees = listOf(
-        Employee(name = "Mike", companyId = 1),
-        Employee(name = "John", companyId = 1),
+        Employee(name = "Mike", companyId = 1, skills = setOf("sales", "sales")),
+        Employee(name = "John", companyId = 1, skills = setOf("management")),
         Employee(name = "Steve", companyId = 2)
     )
 

--- a/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/server/spring/query/SimpleQuery.kt
+++ b/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/server/spring/query/SimpleQuery.kt
@@ -84,5 +84,6 @@ class SimpleQuery : Query {
         Selection.TWO -> "You chose the second one"
     }
 
-    fun setList(): Set<String> = setOf("one", "one", "two")
+    @GraphQLDescription("Set exposed as a function")
+    fun setList(): Set<Int> = setOf(1, 1, 2, 3)
 }

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/hooks/SchemaGeneratorHooks.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/hooks/SchemaGeneratorHooks.kt
@@ -68,14 +68,14 @@ interface SchemaGeneratorHooks {
     fun willAddGraphQLTypeToSchema(type: KType, generatedType: GraphQLType): GraphQLType = generatedType
 
     /**
-     * Called before resolving a KType to the GraphQL type.
-     * This allows for a custom resolver on how to extract wrapped values, like in a CompletableFuture.
+     * Called before resolving a return type to the GraphQL type.
+     * This allows for changes in the supported return types or unwrapping of specific classes.
      */
     fun willResolveMonad(type: KType): KType = type
 
     /**
-     * Called before resolving a KType to the input GraphQL type.
-     * This allows resolvers for custom deserialization logic of wrapped input values, like in an Optional.
+     * Called before resolving an input type to the input GraphQL type.
+     * This allows for changes in the supported input values and unwrapping of custom types, like in an Optional.
      */
     fun willResolveInputMonad(type: KType): KType = type
 

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateProperty.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateProperty.kt
@@ -31,7 +31,8 @@ import kotlin.reflect.KClass
 import kotlin.reflect.KProperty
 
 internal fun generateProperty(generator: SchemaGenerator, prop: KProperty<*>, parentClass: KClass<*>): GraphQLFieldDefinition {
-    val propertyType = generateGraphQLType(generator, type = prop.returnType)
+    val typeFromHooks = generator.config.hooks.willResolveMonad(prop.returnType)
+    val propertyType = generateGraphQLType(generator, type = typeFromHooks)
         .safeCast<GraphQLOutputType>()
 
     val propertyName = prop.getPropertyName(parentClass)


### PR DESCRIPTION
### :pencil: Description
Add support for overriding the return type of properties with the `willResolveMond` hook. We now call this hooks in `generateProperty` so KClass properties can also support things like `Set` overrides.

We probably could look into renaming the hook `willResolveReturnType` in v5.

### :link: Related Issues
https://github.com/ExpediaGroup/graphql-kotlin/discussions/1110