### PR TITLE
[client] support selection of multiple enums

### DIFF
--- a/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/types/generateGraphQLObjectTypeSpec.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/types/generateGraphQLObjectTypeSpec.kt
@@ -23,7 +23,7 @@ import com.expediagroup.graphql.plugin.client.generator.extensions.findFragmentD
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
-import com.squareup.kotlinpoet.MemberName
+import com.squareup.kotlinpoet.MemberName.Companion.member
 import com.squareup.kotlinpoet.ParameterSpec
 import com.squareup.kotlinpoet.TypeSpec
 import graphql.language.FragmentSpread
@@ -67,8 +67,7 @@ internal fun generateGraphQLObjectTypeSpec(
         val constructorParameter = ParameterSpec.builder(propertySpec.name, propertySpec.type)
         val className = propertySpec.type as? ClassName
         if (className != null && context.enumClassToTypeSpecs.keys.contains(className)) {
-            val unknownValue = MemberName(className.packageName, "${className.simpleName}.$UNKNOWN_VALUE")
-            constructorParameter.defaultValue("%M", unknownValue)
+            constructorParameter.defaultValue("%T.%N", className, className.member(UNKNOWN_VALUE))
         }
         constructorBuilder.addParameter(constructorParameter.build())
     }

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/enums/EnumQuery.graphql
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/enums/EnumQuery.graphql
@@ -1,3 +1,4 @@
 query EnumQuery {
   enumQuery
+  otherEnumQuery
 }

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/enums/EnumQuery.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/enums/EnumQuery.kt
@@ -2,11 +2,11 @@ package com.expediagroup.graphql.generated
 
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
 import com.expediagroup.graphql.generated.enums.CustomEnum
-import com.expediagroup.graphql.generated.enums.CustomEnum.__UNKNOWN_VALUE
+import com.expediagroup.graphql.generated.enums.OtherEnum
 import kotlin.String
 import kotlin.reflect.KClass
 
-public const val ENUM_QUERY: String = "query EnumQuery {\n  enumQuery\n}"
+public const val ENUM_QUERY: String = "query EnumQuery {\n  enumQuery\n  otherEnumQuery\n}"
 
 public class EnumQuery : GraphQLClientRequest<EnumQuery.Result> {
   public override val query: String = ENUM_QUERY
@@ -19,6 +19,10 @@ public class EnumQuery : GraphQLClientRequest<EnumQuery.Result> {
     /**
      * Query that returns enum value
      */
-    public val enumQuery: CustomEnum = CustomEnum.__UNKNOWN_VALUE
+    public val enumQuery: CustomEnum = CustomEnum.__UNKNOWN_VALUE,
+    /**
+     * Query that returns other enum value
+     */
+    public val otherEnumQuery: OtherEnum = OtherEnum.__UNKNOWN_VALUE
   )
 }

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/enums/enums/OtherEnum.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/enums/enums/OtherEnum.kt
@@ -1,0 +1,16 @@
+package com.expediagroup.graphql.generated.enums
+
+import com.fasterxml.jackson.`annotation`.JsonEnumDefaultValue
+
+/**
+ * Other enum description
+ */
+public enum class OtherEnum {
+  FIRST,
+  SECOND,
+  /**
+   * This is a default enum value that will be used when attempting to deserialize unknown value.
+   */
+  @JsonEnumDefaultValue
+  __UNKNOWN_VALUE,
+}

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/enums/EnumQuery.graphql
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/enums/EnumQuery.graphql
@@ -1,3 +1,4 @@
 query EnumQuery {
   enumQuery
+  otherEnumQuery
 }

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/enums/EnumQuery.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/enums/EnumQuery.kt
@@ -2,12 +2,12 @@ package com.expediagroup.graphql.generated
 
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
 import com.expediagroup.graphql.generated.enums.CustomEnum
-import com.expediagroup.graphql.generated.enums.CustomEnum.__UNKNOWN_VALUE
+import com.expediagroup.graphql.generated.enums.OtherEnum
 import kotlin.String
 import kotlin.reflect.KClass
 import kotlinx.serialization.Serializable
 
-public const val ENUM_QUERY: String = "query EnumQuery {\n  enumQuery\n}"
+public const val ENUM_QUERY: String = "query EnumQuery {\n  enumQuery\n  otherEnumQuery\n}"
 
 @Serializable
 public class EnumQuery : GraphQLClientRequest<EnumQuery.Result> {
@@ -22,6 +22,10 @@ public class EnumQuery : GraphQLClientRequest<EnumQuery.Result> {
     /**
      * Query that returns enum value
      */
-    public val enumQuery: CustomEnum = CustomEnum.__UNKNOWN_VALUE
+    public val enumQuery: CustomEnum = CustomEnum.__UNKNOWN_VALUE,
+    /**
+     * Query that returns other enum value
+     */
+    public val otherEnumQuery: OtherEnum = OtherEnum.__UNKNOWN_VALUE
   )
 }

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/enums/enums/OtherEnum.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/enums/enums/OtherEnum.kt
@@ -1,0 +1,16 @@
+package com.expediagroup.graphql.generated.enums
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Other enum description
+ */
+@Serializable
+public enum class OtherEnum {
+  FIRST,
+  SECOND,
+  /**
+   * This is a default enum value that will be used when attempting to deserialize unknown value.
+   */
+  __UNKNOWN_VALUE,
+}

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/multiple_queries/FirstQuery.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/multiple_queries/FirstQuery.kt
@@ -2,7 +2,6 @@ package com.expediagroup.graphql.generated
 
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
 import com.expediagroup.graphql.generated.enums.CustomEnum
-import com.expediagroup.graphql.generated.enums.CustomEnum.__UNKNOWN_VALUE
 import com.expediagroup.graphql.generated.firstquery.BasicInterface
 import com.expediagroup.graphql.generated.firstquery.ComplexObject
 import com.expediagroup.graphql.generated.firstquery.ScalarWrapper

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/multiple_queries/SecondQuery.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/multiple_queries/SecondQuery.kt
@@ -2,7 +2,6 @@ package com.expediagroup.graphql.generated
 
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
 import com.expediagroup.graphql.generated.enums.CustomEnum
-import com.expediagroup.graphql.generated.enums.CustomEnum.__UNKNOWN_VALUE
 import com.expediagroup.graphql.generated.inputs.ComplexArgumentInput
 import com.expediagroup.graphql.generated.secondquery.BasicInterface
 import com.expediagroup.graphql.generated.secondquery.ComplexObject

--- a/plugins/client/graphql-kotlin-client-generator/src/test/resources/testSchema.graphql
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/resources/testSchema.graphql
@@ -92,6 +92,8 @@ type Query {
   deprecatedQuery: String! @deprecated(reason : "old query should not be used")
   "Query that returns enum value"
   enumQuery: CustomEnum!
+  "Query that returns other enum value"
+  otherEnumQuery: OtherEnum!
   "Query that accepts some input arguments"
   inputObjectQuery(criteria: SimpleArgumentInput!): Boolean!
   "Query returning an interface"
@@ -146,6 +148,11 @@ enum CustomEnum {
   TWO
   "Lowercase enum value"
   four
+}
+"Other enum description"
+enum OtherEnum {
+    FIRST,
+    SECOND
 }
 "Custom scalar representing UUID"
 scalar UUID


### PR DESCRIPTION
### :pencil: Description

We are providing default `__UNKNOWN_VALUE` value for enums. When generating references to this default value using kotlinpoet `MemberName` it was adding redundant explicit import of that enum value. If there were multiple fields asking for different enums then compilation would fail with multiple imports of `__UNKNOWN_VALUE`. Updated logic to use the explicit `TypeName` of the enum and `Name` of the constant.

### :link: Related Issues

Resolves: https://github.com/ExpediaGroup/graphql-kotlin/issues/1114