### PR TITLE
Fixed typo "reccomend" => "recommend"

### DIFF
--- a/website/docs/server/graphql-server.md
+++ b/website/docs/server/graphql-server.md
@@ -8,7 +8,7 @@ The official reference implementations are:
 
 - [graphql-kotlin-spring-server](./spring-server/spring-overview.mdx)
 
-We reccomend using one of the implementations as the common code has very little logic but you can still use the common
+We recommend using one of the implementations as the common code has very little logic but you can still use the common
 package to create implementation for other libraries (Ktor, Spark, etc).
 
 There are demos of how to use these server libraries in the `/examples` folder of the repo.


### PR DESCRIPTION
### :pencil: Description
Just a small typo in the documentation.
