### PR TITLE
Add valid locations annotation 

### DIFF
--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/annotations/GraphQLValidObjectLocations.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/annotations/GraphQLValidObjectLocations.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2021 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.generator.annotations
+
+/**
+ * Kotlin classes can be used as GraphQL input types, output types, or both.
+ * If you want to enforce that a Kotlin class only be used as an input or output type,
+ * include this annotation with the preferred location parameter.
+ *
+ * By default, classes will be allowed as both input and output types.
+ */
+annotation class GraphQLValidObjectLocations(
+    @get:GraphQLIgnore
+    val locations: Array<Locations>
+) {
+    enum class Locations {
+        OBJECT,
+        INPUT_OBJECT
+    }
+}

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/annotations/GraphQLValidObjectLocations.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/annotations/GraphQLValidObjectLocations.kt
@@ -23,10 +23,7 @@ package com.expediagroup.graphql.generator.annotations
  *
  * By default, classes will be allowed as both input and output types.
  */
-annotation class GraphQLValidObjectLocations(
-    @get:GraphQLIgnore
-    val locations: Array<Locations>
-) {
+annotation class GraphQLValidObjectLocations(val locations: Array<Locations>) {
     enum class Locations {
         OBJECT,
         INPUT_OBJECT

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/exceptions/InvalidObjectLocationException.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/exceptions/InvalidObjectLocationException.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2021 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.generator.exceptions
+
+import com.expediagroup.graphql.generator.annotations.GraphQLValidObjectLocations
+import kotlin.reflect.KClass
+
+/**
+ * Thrown when the schema is using a Kotlin class in an invalid location marked by [GraphQLValidObjectLocations].
+ */
+class InvalidObjectLocationException(kClass: KClass<*>, validLocations: Array<GraphQLValidObjectLocations.Locations>) :
+    GraphQLKotlinException("The class $kClass was used in an invalid location. Only $validLocations are allowed")

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateInputObject.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateInputObject.kt
@@ -17,15 +17,19 @@
 package com.expediagroup.graphql.generator.internal.types
 
 import com.expediagroup.graphql.generator.SchemaGenerator
+import com.expediagroup.graphql.generator.annotations.GraphQLValidObjectLocations
 import com.expediagroup.graphql.generator.internal.extensions.getGraphQLDescription
 import com.expediagroup.graphql.generator.internal.extensions.getSimpleName
 import com.expediagroup.graphql.generator.internal.extensions.getValidProperties
 import com.expediagroup.graphql.generator.internal.extensions.safeCast
+import com.expediagroup.graphql.generator.internal.types.utils.validateObjectLocation
 import graphql.introspection.Introspection.DirectiveLocation
 import graphql.schema.GraphQLInputObjectType
 import kotlin.reflect.KClass
 
 internal fun generateInputObject(generator: SchemaGenerator, kClass: KClass<*>): GraphQLInputObjectType {
+    validateObjectLocation(kClass, GraphQLValidObjectLocations.Locations.INPUT_OBJECT)
+
     val builder = GraphQLInputObjectType.newInputObject()
 
     builder.name(kClass.getSimpleName(isInputClass = true))

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateObject.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateObject.kt
@@ -17,6 +17,7 @@
 package com.expediagroup.graphql.generator.internal.types
 
 import com.expediagroup.graphql.generator.SchemaGenerator
+import com.expediagroup.graphql.generator.annotations.GraphQLValidObjectLocations
 import com.expediagroup.graphql.generator.extensions.unwrapType
 import com.expediagroup.graphql.generator.internal.extensions.getGraphQLDescription
 import com.expediagroup.graphql.generator.internal.extensions.getSimpleName
@@ -24,6 +25,7 @@ import com.expediagroup.graphql.generator.internal.extensions.getValidFunctions
 import com.expediagroup.graphql.generator.internal.extensions.getValidProperties
 import com.expediagroup.graphql.generator.internal.extensions.getValidSuperclasses
 import com.expediagroup.graphql.generator.internal.extensions.safeCast
+import com.expediagroup.graphql.generator.internal.types.utils.validateObjectLocation
 import graphql.introspection.Introspection.DirectiveLocation
 import graphql.schema.GraphQLInterfaceType
 import graphql.schema.GraphQLObjectType
@@ -32,6 +34,8 @@ import kotlin.reflect.KClass
 import kotlin.reflect.full.createType
 
 internal fun generateObject(generator: SchemaGenerator, kClass: KClass<*>): GraphQLObjectType {
+    validateObjectLocation(kClass, GraphQLValidObjectLocations.Locations.OBJECT)
+
     val builder = GraphQLObjectType.newObject()
 
     val name = kClass.getSimpleName()

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/utils/validateObjectLocation.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/utils/validateObjectLocation.kt
@@ -24,7 +24,7 @@ import kotlin.reflect.full.findAnnotation
 /**
  * Throws an exception if this KClass was used in an invalid location
  */
-fun validateObjectLocation(kClass: KClass<*>, location: GraphQLValidObjectLocations.Locations) {
+internal fun validateObjectLocation(kClass: KClass<*>, location: GraphQLValidObjectLocations.Locations) {
     kClass.findAnnotation<GraphQLValidObjectLocations>()?.let { annotation ->
         val validLocations = annotation.locations
         if (!validLocations.contains(location)) {

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/utils/validateObjectLocation.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/utils/validateObjectLocation.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2021 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.generator.internal.types.utils
+
+import com.expediagroup.graphql.generator.annotations.GraphQLValidObjectLocations
+import com.expediagroup.graphql.generator.exceptions.InvalidObjectLocationException
+import kotlin.reflect.KClass
+import kotlin.reflect.full.findAnnotation
+
+/**
+ * Throws an exception if this KClass was used in an invalid location
+ */
+fun validateObjectLocation(kClass: KClass<*>, location: GraphQLValidObjectLocations.Locations) {
+    kClass.findAnnotation<GraphQLValidObjectLocations>()?.let { annotation ->
+        val validLocations = annotation.locations
+        if (!validLocations.contains(location)) {
+            throw InvalidObjectLocationException(kClass, validLocations)
+        }
+    }
+}

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/types/GenerateInputObjectTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/types/GenerateInputObjectTest.kt
@@ -18,24 +18,38 @@ package com.expediagroup.graphql.generator.internal.types
 
 import com.expediagroup.graphql.generator.annotations.GraphQLDescription
 import com.expediagroup.graphql.generator.annotations.GraphQLName
+import com.expediagroup.graphql.generator.annotations.GraphQLValidObjectLocations
+import com.expediagroup.graphql.generator.exceptions.InvalidObjectLocationException
 import com.expediagroup.graphql.generator.test.utils.SimpleDirective
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 
-internal class GenerateInputObjectTest : TypeTestHelper() {
+class GenerateInputObjectTest : TypeTestHelper() {
 
     @Suppress("Detekt.UnusedPrivateClass")
     @GraphQLDescription("The truth")
     @SimpleDirective
-    private class InputClass {
+    class InputClass {
         @SimpleDirective
         val myField: String = "car"
     }
 
     @Suppress("Detekt.UnusedPrivateClass")
     @GraphQLName("InputClassRenamed")
-    private class InputClassCustomName {
+    class InputClassCustomName {
         @GraphQLName("myFieldRenamed")
+        val myField: String = "car"
+    }
+
+    @GraphQLValidObjectLocations(locations = [GraphQLValidObjectLocations.Locations.INPUT_OBJECT])
+    class InputOnly {
+        val myField: String = "car"
+    }
+
+    @GraphQLValidObjectLocations(locations = [GraphQLValidObjectLocations.Locations.OBJECT])
+    class OutputOnly {
         val myField: String = "car"
     }
 
@@ -76,5 +90,19 @@ internal class GenerateInputObjectTest : TypeTestHelper() {
         val result = generateInputObject(generator, InputClass::class)
         assertEquals(1, result.fields.first().directives.size)
         assertEquals("simpleDirective", result.fields.first().directives.first().name)
+    }
+
+    @Test
+    fun `input only objects are generated`() {
+        assertDoesNotThrow {
+            generateInputObject(generator, InputOnly::class)
+        }
+    }
+
+    @Test
+    fun `output only objects throw an exception`() {
+        assertFailsWith(InvalidObjectLocationException::class) {
+            generateInputObject(generator, OutputOnly::class)
+        }
     }
 }

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/types/utils/ValidateObjectLocationKtTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/types/utils/ValidateObjectLocationKtTest.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2021 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.generator.internal.types.utils
+
+import com.expediagroup.graphql.generator.annotations.GraphQLValidObjectLocations
+import com.expediagroup.graphql.generator.annotations.GraphQLValidObjectLocations.Locations
+import com.expediagroup.graphql.generator.exceptions.InvalidObjectLocationException
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import kotlin.test.assertFailsWith
+
+class ValidateObjectLocationKtTest {
+
+    class SimpleClass
+
+    @GraphQLValidObjectLocations([Locations.INPUT_OBJECT, Locations.OBJECT])
+    class InputAndOutput
+
+    @GraphQLValidObjectLocations([Locations.INPUT_OBJECT])
+    class InputOnly
+
+    @GraphQLValidObjectLocations([Locations.OBJECT])
+    class OutputOnly
+
+    @Test
+    fun `does nothing on class missing annotation`() {
+        assertDoesNotThrow {
+            validateObjectLocation(SimpleClass::class, Locations.INPUT_OBJECT)
+            validateObjectLocation(SimpleClass::class, Locations.OBJECT)
+        }
+    }
+
+    @Test
+    fun `allows all locations on class with all locations`() {
+        assertDoesNotThrow {
+            validateObjectLocation(InputAndOutput::class, Locations.INPUT_OBJECT)
+            validateObjectLocation(InputAndOutput::class, Locations.OBJECT)
+        }
+    }
+
+    @Test
+    fun `validates input only classes`() {
+        assertDoesNotThrow {
+            validateObjectLocation(InputOnly::class, Locations.INPUT_OBJECT)
+        }
+        assertFailsWith(InvalidObjectLocationException::class) {
+            validateObjectLocation(InputOnly::class, Locations.OBJECT)
+        }
+    }
+
+    @Test
+    fun `validates output only classes`() {
+        assertDoesNotThrow {
+            validateObjectLocation(OutputOnly::class, Locations.OBJECT)
+        }
+        assertFailsWith(InvalidObjectLocationException::class) {
+            validateObjectLocation(OutputOnly::class, Locations.INPUT_OBJECT)
+        }
+    }
+}

--- a/website/docs/schema-generator/customizing-schemas/restricting-input-output.md
+++ b/website/docs/schema-generator/customizing-schemas/restricting-input-output.md
@@ -1,0 +1,29 @@
+---
+id: restricting-input-output
+title: Restricting Input and Output Types
+---
+
+Since we are using Kotlin classes to represent both GraphQL input and output objects we can use the same class for both and the generator will handle type conflicts.
+
+If you want to enforce that a type should never be used as an input or output you can use the `@GraphQLValidObjectLocations` annotation.
+If the class was used in the schema in an invalid location an exception will be thrown.
+
+```kotlin
+class SimpleClass(val value: String)
+
+@GraphQLValidObjectLocations([Locations.INPUT_OBJECT])
+class InputOnly(val value: String)
+
+@GraphQLValidObjectLocations([Locations.OBJECT])
+class OutputOnly(val value: String)
+
+// Valid Usage
+fun output1() = SimpleClass("foo")
+fun output2() = OutputOnly("foo")
+fun input1(input: SimpleClass) = "value was ${input.value}"
+fun input2(input: InputOnly) = "value was ${input.value}"
+
+// Throws Exception
+fun output3() = InputOnly("foo")
+fun input3(input: OutputOnly) = "value was ${input.value}"
+```

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -33,6 +33,7 @@
           "schema-generator/customizing-schemas/renaming-fields",
           "schema-generator/customizing-schemas/directives",
           "schema-generator/customizing-schemas/deprecating-schema",
+          "schema-generator/customizing-schemas/restricting-input-output",
           "schema-generator/customizing-schemas/advanced-features"
         ]
       },


### PR DESCRIPTION
### :pencil: Description
Kotlin classes can be used as GraphQL input types, output types, or both. If you want to enforce that a Kotlin class only be used as an input or output type, include this annotation, `@GraphQLValidObjectLocations`, with the preferred location parameter.

By default, classes will be allowed as both input and output types.

We also use this feature internal at Expedia Group but had a custom annotation. This feature is handy to have in the open source library.

### :link: Related Issues
N\A