### PR TITLE
Fix Classname of ktor client

### DIFF
--- a/website/docs/client/client-serialization.mdx
+++ b/website/docs/client/client-serialization.mdx
@@ -366,7 +366,7 @@ graphql {
 By default, `ServiceLoader` mechanism will load the first available GraphQL client serializer from the classpath.
 
 ```kotlin
-val client = GraphQLWebClient(
+val client = GraphQLKtorClient(
   url = "http://localhost:8080/graphql"
   serializer = GraphQLClientKotlinxSerializer()
 )
@@ -465,7 +465,7 @@ By default, `ServiceLoader` mechanism will load the first available GraphQL clie
 also explicitly specify serializer during client construction
 
 ```kotlin
-val client = GraphQLWebClient(
+val client = GraphQLKtorClient(
   url = "http://localhost:8080/graphql"
   serializer = GraphQLClientJacksonSerializer()
 )

--- a/website/docs/client/client-serialization.mdx
+++ b/website/docs/client/client-serialization.mdx
@@ -367,7 +367,7 @@ By default, `ServiceLoader` mechanism will load the first available GraphQL clie
 
 ```kotlin
 val client = GraphQLKtorClient(
-  url = "http://localhost:8080/graphql"
+  url = URL("http://localhost:8080/graphql")
   serializer = GraphQLClientKotlinxSerializer()
 )
 ```
@@ -466,7 +466,7 @@ also explicitly specify serializer during client construction
 
 ```kotlin
 val client = GraphQLKtorClient(
-  url = "http://localhost:8080/graphql"
+  url = URL("http://localhost:8080/graphql")
   serializer = GraphQLClientJacksonSerializer()
 )
 ```


### PR DESCRIPTION
### :pencil: Description

While updating the graphql client to the new version I ran into a small confusion with the documentation. After some research I would assume that there was a copy/paste error and the Class was not renamed. So I thought I will create a Pull Request for this :) 

![Client serialization](https://user-images.githubusercontent.com/12533979/116207786-8b323100-a740-11eb-87a7-6fd925e42257.png)

