### PR TITLE
Client Generation - Allow schema to be on the classpath

### DIFF
--- a/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generateClient.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generateClient.kt
@@ -31,7 +31,7 @@ fun generateClient(
     allowDeprecated: Boolean = false,
     customScalarsMap: List<GraphQLScalar> = emptyList(),
     serializer: GraphQLSerializer = GraphQLSerializer.JACKSON,
-    schemaPath: String, // this is the file location, not the contents
+    schemaPath: String,
     queries: List<File>
 ): List<FileSpec> {
     val customScalars = customScalarsMap.associateBy { it.scalar }

--- a/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generateClient.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generateClient.kt
@@ -23,6 +23,11 @@ import com.expediagroup.graphql.plugin.client.generator.GraphQLScalar
 import com.squareup.kotlinpoet.FileSpec
 import graphql.schema.idl.SchemaParser
 import java.io.File
+import java.io.Reader
+import java.io.StringReader
+import java.net.URI
+import java.nio.charset.Charset
+import java.nio.file.Files
 
 /**
  * Generate GraphQL client data classes from specified queries and target schema.
@@ -32,7 +37,7 @@ fun generateClient(
     allowDeprecated: Boolean = false,
     customScalarsMap: List<GraphQLScalar> = emptyList(),
     serializer: GraphQLSerializer = GraphQLSerializer.JACKSON,
-    schema: File,
+    schema: String, // this is the file location, not the contents
     queries: List<File>
 ): List<FileSpec> {
     val customScalars = customScalarsMap.associateBy { it.scalar }
@@ -42,7 +47,19 @@ fun generateClient(
         customScalarMap = customScalars,
         serializer = serializer
     )
-    val graphQLSchema = SchemaParser().parse(schema)
+    val graphQLSchema = SchemaParser().parse(getSchemaReader(schema))
     val generator = GraphQLClientGenerator(graphQLSchema, config)
     return generator.generate(queries)
 }
+
+private fun getSchemaReader(schemaPath: String): Reader =
+    if (schemaPath.startsWith("classpath://")) {
+        val resource = object {}.javaClass.getResource(URI(schemaPath).path) ?: throw RuntimeException("specified GraphQL schema not found, $schemaPath")
+        StringReader(resource.readText())
+    } else {
+        val file = File(schemaPath)
+        if (!file.isFile) {
+            throw RuntimeException("specified GraphQL schema is not a file, $schemaPath")
+        }
+        Files.newBufferedReader(file.toPath(), Charset.defaultCharset())
+    }

--- a/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/GraphQLClientGenerator.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/GraphQLClientGenerator.kt
@@ -17,6 +17,7 @@
 package com.expediagroup.graphql.plugin.client.generator
 
 import com.expediagroup.graphql.plugin.client.generator.exceptions.MultipleOperationsInFileException
+import com.expediagroup.graphql.plugin.client.generator.exceptions.SchemaUnavailableException
 import com.expediagroup.graphql.plugin.client.generator.types.generateGraphQLObjectTypeSpec
 import com.expediagroup.graphql.plugin.client.generator.types.generateVariableTypeSpec
 import com.squareup.kotlinpoet.ClassName
@@ -208,7 +209,7 @@ class GraphQLClientGenerator(
         return if (schemaFile.isFile) {
             SchemaParser().parse(schemaFile)
         } else {
-            val schemaInputStream = this.javaClass.classLoader.getResourceAsStream(path) ?: throw RuntimeException("specified schema file=$path does not exist")
+            val schemaInputStream = this.javaClass.classLoader.getResourceAsStream(path) ?: throw SchemaUnavailableException(path)
             SchemaParser().parse(schemaInputStream)
         }
     }

--- a/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/GraphQLClientGenerator.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/GraphQLClientGenerator.kt
@@ -42,7 +42,7 @@ private const val CORE_TYPES_PACKAGE = "com.expediagroup.graphql.client.types"
  * GraphQL client code generator that uses [KotlinPoet](https://github.com/square/kotlinpoet) to generate Kotlin classes based on the specified GraphQL queries.
  */
 class GraphQLClientGenerator(
-    private val schemaPath: String,
+    schemaPath: String,
     private val config: GraphQLClientGeneratorConfig
 ) {
     private val documentParser: Parser = Parser()
@@ -203,7 +203,6 @@ class GraphQLClientGenerator(
         return graphQLSchema.getType(rootType).get() as ObjectTypeDefinition
     }
 
-    // TODO: unit tests
     private fun parseSchema(path: String): TypeDefinitionRegistry {
         val schemaFile = File(path)
         return if (schemaFile.isFile) {

--- a/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/exceptions/SchemaUnavailableException.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/exceptions/SchemaUnavailableException.kt
@@ -1,0 +1,6 @@
+package com.expediagroup.graphql.plugin.client.generator.exceptions
+
+/**
+ * Exception thrown when specified schema file path is not found or unavailable
+ */
+internal class SchemaUnavailableException(schemaPath: String) : RuntimeException("Specified schema file=$schemaPath does not exist")

--- a/plugins/client/graphql-kotlin-client-generator/src/test/kotlin/com/expediagroup/graphql/plugin/client/generator/GenerateInvalidClientIT.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/kotlin/com/expediagroup/graphql/plugin/client/generator/GenerateInvalidClientIT.kt
@@ -16,6 +16,8 @@
 
 package com.expediagroup.graphql.plugin.client.generator
 
+import com.expediagroup.graphql.plugin.client.generator.exceptions.SchemaUnavailableException
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
@@ -31,11 +33,19 @@ class GenerateInvalidClientIT {
         val (queries, _) = locateTestFiles(testDirectory)
         val expectedException = File(testDirectory, "exception.txt").readText().trim()
 
-        val generator = GraphQLClientGenerator(testSchema(), defaultConfig)
+        val generator = GraphQLClientGenerator(TEST_SCHEMA_PATH, defaultConfig)
         val exception = assertFails {
             generator.generate(queries)
         }
         assertEquals(expectedException, exception::class.simpleName)
+    }
+
+    @Test
+    fun `verify an invalid schema path will raise an exception`() {
+        val exception = assertFails {
+            GraphQLClientGenerator("missingSchema.graphql", defaultConfig)
+        }
+        assertEquals(SchemaUnavailableException::class, exception::class)
     }
 
     companion object {

--- a/plugins/client/graphql-kotlin-client-generator/src/test/kotlin/com/expediagroup/graphql/plugin/client/generator/GraphQLTestUtils.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/kotlin/com/expediagroup/graphql/plugin/client/generator/GraphQLTestUtils.kt
@@ -19,8 +19,6 @@ package com.expediagroup.graphql.plugin.client.generator
 import com.expediagroup.graphql.client.converter.ScalarConverter
 import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.SourceFile
-import graphql.schema.idl.SchemaParser
-import graphql.schema.idl.TypeDefinitionRegistry
 import org.junit.jupiter.params.provider.Arguments
 import java.io.File
 import java.util.UUID
@@ -52,12 +50,7 @@ internal fun locateTestFiles(directory: File): Pair<List<File>, Map<String, File
     return queries to expectedFiles
 }
 
-internal fun testSchema(): TypeDefinitionRegistry {
-    val schemaFileStream = ClassLoader.getSystemClassLoader().getResourceAsStream("testSchema.graphql") ?: throw RuntimeException("unable to locate test schema")
-    return schemaFileStream.use {
-        SchemaParser().parse(schemaFileStream)
-    }
-}
+internal fun testSchema(): String = "testSchema.graphql"
 
 internal fun verifyClientGeneration(config: GraphQLClientGeneratorConfig, testDirectory: File) {
     val (queries, expectedFiles) = locateTestFiles(testDirectory)

--- a/plugins/client/graphql-kotlin-client-generator/src/test/kotlin/com/expediagroup/graphql/plugin/client/generator/GraphQLTestUtils.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/kotlin/com/expediagroup/graphql/plugin/client/generator/GraphQLTestUtils.kt
@@ -50,12 +50,12 @@ internal fun locateTestFiles(directory: File): Pair<List<File>, Map<String, File
     return queries to expectedFiles
 }
 
-internal fun testSchema(): String = "testSchema.graphql"
+internal const val TEST_SCHEMA_PATH = "testSchema.graphql"
 
 internal fun verifyClientGeneration(config: GraphQLClientGeneratorConfig, testDirectory: File) {
     val (queries, expectedFiles) = locateTestFiles(testDirectory)
 
-    val generator = GraphQLClientGenerator(testSchema(), config)
+    val generator = GraphQLClientGenerator(TEST_SCHEMA_PATH, config)
     val fileSpecs = generator.generate(queries)
     assertTrue(fileSpecs.isNotEmpty())
     assertEquals(expectedFiles.size, fileSpecs.size)

--- a/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePlugin.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePlugin.kt
@@ -104,7 +104,7 @@ class GraphQLGradlePlugin : Plugin<Project> {
                         introspectSchemaTask.headers.convention(project.provider { extension.clientExtension.headers })
                         introspectSchemaTask.timeoutConfig.convention(project.provider { extension.clientExtension.timeoutConfig })
                         generateClientTask.dependsOn(introspectSchemaTask.path)
-                        generateClientTask.schemaFile.convention(introspectSchemaTask.outputFile.get())
+                        generateClientTask.schemaFile.convention(introspectSchemaTask.outputFile)
                     }
                     extension.clientExtension.sdlEndpoint != null -> {
                         val downloadSDLTask = project.tasks.named(DOWNLOAD_SDL_TASK_NAME, GraphQLDownloadSDLTask::class.java).get()
@@ -112,7 +112,7 @@ class GraphQLGradlePlugin : Plugin<Project> {
                         downloadSDLTask.headers.convention(project.provider { extension.clientExtension.headers })
                         downloadSDLTask.timeoutConfig.convention(project.provider { extension.clientExtension.timeoutConfig })
                         generateClientTask.dependsOn(downloadSDLTask.path)
-                        generateClientTask.schemaFile.convention(downloadSDLTask.outputFile.get())
+                        generateClientTask.schemaFile.convention(downloadSDLTask.outputFile)
                     }
                     else -> {
                         throw RuntimeException("Invalid GraphQL client extension configuration - missing required endpoint/sdlEndpoint property")

--- a/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePlugin.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePlugin.kt
@@ -104,7 +104,7 @@ class GraphQLGradlePlugin : Plugin<Project> {
                         introspectSchemaTask.headers.convention(project.provider { extension.clientExtension.headers })
                         introspectSchemaTask.timeoutConfig.convention(project.provider { extension.clientExtension.timeoutConfig })
                         generateClientTask.dependsOn(introspectSchemaTask.path)
-                        generateClientTask.schemaFile.convention(introspectSchemaTask.outputFile)
+                        generateClientTask.schemaFile.convention(introspectSchemaTask.outputFile.get().asFile.path)
                     }
                     extension.clientExtension.sdlEndpoint != null -> {
                         val downloadSDLTask = project.tasks.named(DOWNLOAD_SDL_TASK_NAME, GraphQLDownloadSDLTask::class.java).get()
@@ -112,7 +112,7 @@ class GraphQLGradlePlugin : Plugin<Project> {
                         downloadSDLTask.headers.convention(project.provider { extension.clientExtension.headers })
                         downloadSDLTask.timeoutConfig.convention(project.provider { extension.clientExtension.timeoutConfig })
                         generateClientTask.dependsOn(downloadSDLTask.path)
-                        generateClientTask.schemaFile.convention(downloadSDLTask.outputFile)
+                        generateClientTask.schemaFile.convention(downloadSDLTask.outputFile.get().asFile.path)
                     }
                     else -> {
                         throw RuntimeException("Invalid GraphQL client extension configuration - missing required endpoint/sdlEndpoint property")

--- a/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePlugin.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePlugin.kt
@@ -104,7 +104,7 @@ class GraphQLGradlePlugin : Plugin<Project> {
                         introspectSchemaTask.headers.convention(project.provider { extension.clientExtension.headers })
                         introspectSchemaTask.timeoutConfig.convention(project.provider { extension.clientExtension.timeoutConfig })
                         generateClientTask.dependsOn(introspectSchemaTask.path)
-                        generateClientTask.schemaFile.convention(introspectSchemaTask.outputFile.get().asFile.path)
+                        generateClientTask.schemaFile.convention(introspectSchemaTask.outputFile.get())
                     }
                     extension.clientExtension.sdlEndpoint != null -> {
                         val downloadSDLTask = project.tasks.named(DOWNLOAD_SDL_TASK_NAME, GraphQLDownloadSDLTask::class.java).get()
@@ -112,7 +112,7 @@ class GraphQLGradlePlugin : Plugin<Project> {
                         downloadSDLTask.headers.convention(project.provider { extension.clientExtension.headers })
                         downloadSDLTask.timeoutConfig.convention(project.provider { extension.clientExtension.timeoutConfig })
                         generateClientTask.dependsOn(downloadSDLTask.path)
-                        generateClientTask.schemaFile.convention(downloadSDLTask.outputFile.get().asFile.path)
+                        generateClientTask.schemaFile.convention(downloadSDLTask.outputFile.get())
                     }
                     else -> {
                         throw RuntimeException("Invalid GraphQL client extension configuration - missing required endpoint/sdlEndpoint property")

--- a/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/actions/GenerateClientAction.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/actions/GenerateClientAction.kt
@@ -35,11 +35,11 @@ abstract class GenerateClientAction : WorkAction<GenerateClientParameters> {
         val allowDeprecated = parameters.allowDeprecated.get()
         val customScalarMap = parameters.customScalars.get().map { GraphQLScalar(it.scalar, it.type, it.converter) }
         val serializer = GraphQLSerializer.valueOf(parameters.serializer.get().name)
-        val schemaFile = parameters.schemaFile.get()
+        val schemaPath = parameters.schemaPath.get()
         val queryFiles = parameters.queryFiles.get()
         val targetDirectory = parameters.targetDirectory.get()
 
-        generateClient(targetPackage, allowDeprecated, customScalarMap, serializer, schemaFile, queryFiles).forEach {
+        generateClient(targetPackage, allowDeprecated, customScalarMap, serializer, schemaPath, queryFiles).forEach {
             it.writeTo(targetDirectory)
         }
     }

--- a/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/parameters/GenerateClientParameters.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/parameters/GenerateClientParameters.kt
@@ -36,8 +36,8 @@ interface GenerateClientParameters : WorkParameters {
     val customScalars: ListProperty<GraphQLScalar>
     /** Type of JSON serializer that will be used to generate the data classes. */
     val serializer: Property<GraphQLSerializer>
-    /** GraphQL schema file that will be used to generate client code. */
-    val schemaFile: Property<String>
+    /** GraphQL schema file path that will be used to generate client code. */
+    val schemaPath: Property<String>
     /** List of query files that will be processed to generate HTTP clients. */
     val queryFiles: ListProperty<File>
     /** Directory where to save the generated source files. */

--- a/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/parameters/GenerateClientParameters.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/parameters/GenerateClientParameters.kt
@@ -37,7 +37,7 @@ interface GenerateClientParameters : WorkParameters {
     /** Type of JSON serializer that will be used to generate the data classes. */
     val serializer: Property<GraphQLSerializer>
     /** GraphQL schema file that will be used to generate client code. */
-    val schemaFile: Property<File>
+    val schemaFile: Property<String>
     /** List of query files that will be processed to generate HTTP clients. */
     val queryFiles: ListProperty<File>
     /** Directory where to save the generated source files. */

--- a/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/AbstractGenerateClientTask.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/AbstractGenerateClientTask.kt
@@ -66,7 +66,7 @@ abstract class AbstractGenerateClientTask : DefaultTask() {
      */
     @InputFile
     @Optional
-    val schemaFile: Property<String> = project.objects.property(String::class.java)
+    val schemaFile: RegularFileProperty = project.objects.fileProperty()
 
     /**
      * Target package name for generated code.
@@ -146,8 +146,8 @@ abstract class AbstractGenerateClientTask : DefaultTask() {
     fun generateGraphQLClientAction() {
         logger.debug("generating GraphQL client")
 
-        val graphQLSchema = when {
-            schemaFile.isPresent -> schemaFile.get() as String
+        val graphQLSchemaPath = when {
+            schemaFile.isPresent -> schemaFile.get().asFile.path
             schemaFileName.isPresent -> schemaFileName.get()
             else -> throw RuntimeException("schema not available")
         }
@@ -171,7 +171,7 @@ abstract class AbstractGenerateClientTask : DefaultTask() {
             throw RuntimeException("failed to generate generated source directory = $targetDirectory")
         }
 
-        logConfiguration(graphQLSchema, targetQueryFiles)
+        logConfiguration(graphQLSchemaPath, targetQueryFiles)
         val workQueue: WorkQueue = getWorkerExecutor().classLoaderIsolation { workerSpec: ClassLoaderWorkerSpec ->
             workerSpec.classpath.from(pluginClasspath)
             logger.debug("worker classpath: \n${workerSpec.classpath.files.joinToString("\n")}")
@@ -182,7 +182,7 @@ abstract class AbstractGenerateClientTask : DefaultTask() {
             parameters.allowDeprecated.set(allowDeprecatedFields)
             parameters.customScalars.set(customScalars)
             parameters.serializer.set(serializer)
-            parameters.schemaFile.set(graphQLSchema)
+            parameters.schemaPath.set(graphQLSchemaPath)
             parameters.queryFiles.set(targetQueryFiles)
             parameters.targetDirectory.set(targetDirectory)
         }

--- a/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/AbstractGenerateClientTask.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/AbstractGenerateClientTask.kt
@@ -66,7 +66,7 @@ abstract class AbstractGenerateClientTask : DefaultTask() {
      */
     @InputFile
     @Optional
-    val schemaFile: RegularFileProperty = project.objects.fileProperty()
+    val schemaFile: Property<String> = project.objects.property(String::class.java)
 
     /**
      * Target package name for generated code.
@@ -147,12 +147,9 @@ abstract class AbstractGenerateClientTask : DefaultTask() {
         logger.debug("generating GraphQL client")
 
         val graphQLSchema = when {
-            schemaFile.isPresent -> schemaFile.get().asFile
-            schemaFileName.isPresent -> File(schemaFileName.get())
+            schemaFile.isPresent -> schemaFile.get() as String
+            schemaFileName.isPresent -> schemaFileName.get()
             else -> throw RuntimeException("schema not available")
-        }
-        if (!graphQLSchema.isFile) {
-            throw RuntimeException("specified schema file does not exist")
         }
 
         val targetPackage = packageName.orNull ?: throw RuntimeException("package not specified")
@@ -193,9 +190,9 @@ abstract class AbstractGenerateClientTask : DefaultTask() {
         logger.debug("successfully generated GraphQL HTTP client")
     }
 
-    private fun logConfiguration(schema: File, queryFiles: List<File>) {
+    private fun logConfiguration(schemaPath: String, queryFiles: List<File>) {
         logger.debug("GraphQL Client generator configuration:")
-        logger.debug("  schema file = ${schema.path}")
+        logger.debug("  schema file = $schemaPath")
         logger.debug("  queries")
         queryFiles.forEach {
             logger.debug("    - ${it.name}")

--- a/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/GraphQLDownloadSDLTask.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/GraphQLDownloadSDLTask.kt
@@ -83,7 +83,7 @@ abstract class GraphQLDownloadSDLTask : DefaultTask() {
     }
 
     /**
-     * Download schema in SDL format from the specified endpoint and sve it locally in the target output file.
+     * Download schema in SDL format from the specified endpoint and save it locally in the target output file.
      */
     @TaskAction
     fun downloadSDLAction() {

--- a/plugins/graphql-kotlin-maven-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/maven/GenerateClientAbstractMojo.kt
+++ b/plugins/graphql-kotlin-maven-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/maven/GenerateClientAbstractMojo.kt
@@ -100,12 +100,7 @@ abstract class GenerateClientAbstractMojo : AbstractMojo() {
     override fun execute() {
         log.debug("generating GraphQL client")
 
-        val schemaPath =
-            if (schemaFile == null) {
-                File(project.build.directory, "schema.graphql").path
-            } else {
-                schemaFile
-            }!!
+        val schemaPath = schemaFile ?: File(project.build.directory, "schema.graphql").path
 
         val targetQueryFiles: List<File> = locateQueryFiles(queryFiles, queryFileDirectory)
 

--- a/plugins/graphql-kotlin-maven-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/maven/GenerateClientAbstractMojo.kt
+++ b/plugins/graphql-kotlin-maven-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/maven/GenerateClientAbstractMojo.kt
@@ -17,8 +17,8 @@
 package com.expediagroup.graphql.plugin.maven
 
 import com.expediagroup.graphql.plugin.client.generateClient
-import com.expediagroup.graphql.plugin.client.generator.GraphQLSerializer
 import com.expediagroup.graphql.plugin.client.generator.GraphQLScalar
+import com.expediagroup.graphql.plugin.client.generator.GraphQLSerializer
 import org.apache.maven.plugin.AbstractMojo
 import org.apache.maven.plugins.annotations.Parameter
 import org.apache.maven.project.MavenProject
@@ -39,7 +39,7 @@ abstract class GenerateClientAbstractMojo : AbstractMojo() {
      * GraphQL schema file that will be used to generate client code.
      */
     @Parameter(defaultValue = "\${graphql.schemaFile}", name = "schemaFile")
-    private var schemaFile: File? = null
+    private var schemaFile: String? = null
 
     /**
      * Target package name for generated code.
@@ -99,17 +99,23 @@ abstract class GenerateClientAbstractMojo : AbstractMojo() {
 
     override fun execute() {
         log.debug("generating GraphQL client")
-        val graphQLSchemaFile = schemaFile ?: File(project.build.directory, "schema.graphql")
-        validateGraphQLSchemaExists(graphQLSchemaFile)
+
+        val schemaPath =
+            if (schemaFile == null) {
+                File(project.build.directory, "schema.graphql").path
+            } else {
+                schemaFile
+            }!!
+
         val targetQueryFiles: List<File> = locateQueryFiles(queryFiles, queryFileDirectory)
 
         if (!outputDirectory.isDirectory && !outputDirectory.mkdirs()) {
             throw RuntimeException("failed to generate generated source directory")
         }
 
-        logConfiguration(graphQLSchemaFile, targetQueryFiles)
+        logConfiguration(schemaPath, targetQueryFiles)
         val customGraphQLScalars = customScalars.map { GraphQLScalar(it.scalar, it.type, it.converter) }
-        generateClient(packageName, allowDeprecatedFields, customGraphQLScalars, serializer, graphQLSchemaFile, targetQueryFiles).forEach {
+        generateClient(packageName, allowDeprecatedFields, customGraphQLScalars, serializer, schemaPath, targetQueryFiles).forEach {
             it.writeTo(outputDirectory)
         }
 
@@ -125,17 +131,11 @@ abstract class GenerateClientAbstractMojo : AbstractMojo() {
         return targetQueryFiles
     }
 
-    private fun validateGraphQLSchemaExists(graphQLSchemaFile: File) {
-        if (!graphQLSchemaFile.isFile) {
-            throw RuntimeException("specified GraphQL schema is not a file, ${graphQLSchemaFile.path}")
-        }
-    }
-
     abstract fun configureProjectWithGeneratedSources(mavenProject: MavenProject, generatedSourcesDirectory: File)
 
-    private fun logConfiguration(graphQLSchemaFile: File, queryFiles: List<File>) {
+    private fun logConfiguration(graphQLSchemaFilePath: String, queryFiles: List<File>) {
         log.debug("GraphQL Client generator configuration:")
-        log.debug("  schema file = ${graphQLSchemaFile.path}")
+        log.debug("  schema file = $graphQLSchemaFilePath")
         log.debug("  queries")
         queryFiles.forEach {
             log.debug("    - ${it.name}")


### PR DESCRIPTION
### :pencil: Description

Simply allow loading the schema file from your classpath, this allows you to include a maven dependency that stores your graphql SDLs as a package.

```xml
<plugin>
	<groupId>com.expediagroup</groupId>
	<artifactId>graphql-kotlin-maven-plugin</artifactId>
	<version>4.0.0-SNAPSHOT</version>
	<dependencies>
		<dependency>
			<groupId>com.expedia.schemas</groupId>
			<artifactId>schemas</artifactId>
		</dependency>
	</dependencies>
	<executions>
		<execution>
			<goals>
				<goal>generate-client</goal>
			</goals>
			<configuration>
				<packageName>com.expedia.graphql.generated.foobarservice</packageName>
				<schemaFile>expedia-schemas/foobar-service/schema.graphql</schemaFile>
				<queryFileDirectory>${project.basedir}/src/main/resources/queries</queryFileDirectory>
			</configuration>
		</execution>
	</executions>
</plugin>

```

I would love to understand how to test this for Gradle as well since it changed, I have tested for maven only so far!

Feedback appreciated :)

### :link: Related Issues
