### PR TITLE
Added ability to return lists of DataFetcherResults in functions with Schema Generator

### DIFF
--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/types/utils/FunctionReturnTypesKtTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/types/utils/FunctionReturnTypesKtTest.kt
@@ -28,7 +28,9 @@ class FunctionReturnTypesKtTest {
     class MyClass {
         // Valid Types
         val string = "my string"
+        val listOfString: List<String> = listOf(string)
         val dataFetcherResult: DataFetcherResult<String> = DataFetcherResult.newResult<String>().data(string).build()
+        val listDataFetcherResult: List<DataFetcherResult<String>> = listOf(DataFetcherResult.newResult<String>().data(string).build())
         val publisher: Publisher<String> = Flowable.just(string)
         val flowable: Flowable<String> = Flowable.just(string)
         val publisherDataFetcherResult: Publisher<DataFetcherResult<String>> = Flowable.just(dataFetcherResult)
@@ -52,6 +54,11 @@ class FunctionReturnTypesKtTest {
         assertEquals(MyClass::string.returnType, actual = getWrappedReturnType(MyClass::dataFetcherResult.returnType))
         assertEquals(MyClass::completableFuture.returnType, actual = getWrappedReturnType(MyClass::invalidDataFetcherResultCompletableFuture.returnType))
         assertEquals(MyClass::publisher.returnType, actual = getWrappedReturnType(MyClass::invalidDataFetcherResultPublisher.returnType))
+    }
+
+    @Test
+    fun `getWrappedReturnType of List of DataFetcherResult`() {
+        assertEquals(MyClass::listOfString.returnType, actual = getWrappedReturnType(MyClass::listDataFetcherResult.returnType))
     }
 
     @Test

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/test/integration/DataFetcherResultListTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/test/integration/DataFetcherResultListTest.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2021 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.generator.test.integration
+
+import com.expediagroup.graphql.generator.TopLevelObject
+import com.expediagroup.graphql.generator.testSchemaConfig
+import com.expediagroup.graphql.generator.toSchema
+import graphql.execution.DataFetcherResult
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class DataFetcherResultListTest {
+
+    @Test
+    fun validateSchema() {
+        val queries = listOf(TopLevelObject(SimpleQuery()))
+        val schema = toSchema(testSchemaConfig, queries)
+        assertNotNull(schema)
+        assertEquals("String!", schema.queryType.getFieldDefinition("getString").type.toString())
+        assertEquals("String!", schema.queryType.getFieldDefinition("getDataFetcherResultString").type.toString())
+        assertEquals("[String!]!", schema.queryType.getFieldDefinition("getListString").type.toString())
+    }
+
+    class SimpleQuery {
+        private val string = "hello"
+
+        fun getString(): String = string
+        fun getDataFetcherResultString(): DataFetcherResult<String> =
+            DataFetcherResult.newResult<String>().data(string).build()
+        fun getListString(): List<DataFetcherResult<String>> = listOf(DataFetcherResult.newResult<String>().data(string).build())
+    }
+}


### PR DESCRIPTION
### :pencil: Description
A fix for the schema generator to support List<DataFetcherResult<T>> as a return for functions, most notably to support local  context. GraphQL-Java supported using DataFetcherResult as an item for list fields with this [PR](https://github.com/graphql-java/graphql-java/pull/1567)

### :link: Related Issues
[Issue 1146](https://github.com/ExpediaGroup/graphql-kotlin/issues/1146)