### PR TITLE
ignore case check for input type for use _input prefix in not camel s…

### DIFF
--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/extensions/kClassExtensions.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/extensions/kClassExtensions.kt
@@ -83,7 +83,7 @@ internal fun KClass<*>.getSimpleName(isInputClass: Boolean = false): String {
         ?: throw CouldNotGetNameOfKClassException(this)
 
     return when {
-        isInputClass -> if (name.endsWith(INPUT_SUFFIX)) name else "$name$INPUT_SUFFIX"
+        isInputClass -> if (name.endsWith(INPUT_SUFFIX, true)) name else "$name$INPUT_SUFFIX"
         else -> name
     }
 }


### PR DESCRIPTION
### :pencil: Description
I use under_score style for types and functions. I can't use camel case for Input types

