### PR TITLE
pass code registry to all directive environments

### DIFF
--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/directives/KotlinDirectiveWiringFactory.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/directives/KotlinDirectiveWiringFactory.kt
@@ -35,7 +35,7 @@ open class KotlinDirectiveWiringFactory(
     /**
      * Wire up the directive based on the GraphQL type.
      */
-    fun onWire(graphQLSchemaElement: GraphQLSchemaElement, coordinates: FieldCoordinates? = null, codeRegistry: GraphQLCodeRegistry.Builder? = null): GraphQLSchemaElement {
+    fun onWire(graphQLSchemaElement: GraphQLSchemaElement, coordinates: FieldCoordinates? = null, codeRegistry: GraphQLCodeRegistry.Builder): GraphQLSchemaElement {
         if (graphQLSchemaElement !is GraphQLDirectiveContainer) return graphQLSchemaElement
 
         return wireDirectives(graphQLSchemaElement, coordinates, graphQLSchemaElement.getAllDirectives(), codeRegistry)
@@ -51,7 +51,7 @@ open class KotlinDirectiveWiringFactory(
         element: GraphQLDirectiveContainer,
         coordinates: FieldCoordinates?,
         directives: List<GraphQLDirective>,
-        codeRegistry: GraphQLCodeRegistry.Builder?
+        codeRegistry: GraphQLCodeRegistry.Builder
     ): GraphQLDirectiveContainer {
         var modifiedObject = element
         for (directive in directives) {
@@ -60,13 +60,13 @@ open class KotlinDirectiveWiringFactory(
                     field = modifiedObject,
                     fieldDirective = directive,
                     coordinates = coordinates ?: throw InvalidSchemaDirectiveWiringException("Unable to wire directive on a field due to missing field coordinates"),
-                    codeRegistry = codeRegistry ?: throw InvalidSchemaDirectiveWiringException("Unable to wire directive on a field due to a missing code registry")
+                    codeRegistry = codeRegistry
                 )
             } else {
                 KotlinSchemaDirectiveEnvironment(
                     element = modifiedObject,
                     directive = directive,
-                    codeRegistry = codeRegistry ?: throw InvalidSchemaDirectiveWiringException("Unable to wire directive on an object due to a missing code registry")
+                    codeRegistry = codeRegistry
                 )
             }
 

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/directives/KotlinDirectiveWiringFactory.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/directives/KotlinDirectiveWiringFactory.kt
@@ -65,7 +65,8 @@ open class KotlinDirectiveWiringFactory(
             } else {
                 KotlinSchemaDirectiveEnvironment(
                     element = modifiedObject,
-                    directive = directive
+                    directive = directive,
+                    codeRegistry = codeRegistry ?: throw InvalidSchemaDirectiveWiringException("Unable to wire directive on an object due to a missing code registry")
                 )
             }
 

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/directives/KotlinFieldDirectiveEnvironment.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/directives/KotlinFieldDirectiveEnvironment.kt
@@ -29,8 +29,8 @@ class KotlinFieldDirectiveEnvironment(
     field: GraphQLFieldDefinition,
     fieldDirective: GraphQLDirective,
     private val coordinates: FieldCoordinates,
-    private val codeRegistry: GraphQLCodeRegistry.Builder
-) : KotlinSchemaDirectiveEnvironment<GraphQLFieldDefinition>(element = field, directive = fieldDirective) {
+    codeRegistry: GraphQLCodeRegistry.Builder
+) : KotlinSchemaDirectiveEnvironment<GraphQLFieldDefinition>(element = field, directive = fieldDirective, codeRegistry = codeRegistry) {
 
     /**
      * Retrieve current data fetcher associated with the target element.

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/directives/KotlinSchemaDirectiveEnvironment.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/directives/KotlinSchemaDirectiveEnvironment.kt
@@ -18,6 +18,7 @@ package com.expediagroup.graphql.generator.directives
 
 import graphql.introspection.Introspection
 import graphql.schema.GraphQLArgument
+import graphql.schema.GraphQLCodeRegistry
 import graphql.schema.GraphQLDirective
 import graphql.schema.GraphQLDirectiveContainer
 import graphql.schema.GraphQLEnumType
@@ -35,7 +36,8 @@ import graphql.schema.GraphQLUnionType
  */
 open class KotlinSchemaDirectiveEnvironment<out T : GraphQLDirectiveContainer>(
     val element: T,
-    val directive: GraphQLDirective
+    val directive: GraphQLDirective,
+    val codeRegistry: GraphQLCodeRegistry.Builder
 ) {
     /**
      * Verifies whether specified directive is applicable on the target element.

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/hooks/SchemaGeneratorHooks.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/hooks/SchemaGeneratorHooks.kt
@@ -121,7 +121,7 @@ interface SchemaGeneratorHooks {
      * Called after `willGenerateGraphQLType` and before `didGenerateGraphQLType`.
      * Enables you to change the wiring, e.g. apply directives to alter the target type.
      */
-    fun onRewireGraphQLType(generatedType: GraphQLSchemaElement, coordinates: FieldCoordinates? = null, codeRegistry: GraphQLCodeRegistry.Builder? = null): GraphQLSchemaElement =
+    fun onRewireGraphQLType(generatedType: GraphQLSchemaElement, coordinates: FieldCoordinates? = null, codeRegistry: GraphQLCodeRegistry.Builder): GraphQLSchemaElement =
         wiringFactory.onWire(generatedType, coordinates, codeRegistry)
 
     /**

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateArgument.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateArgument.kt
@@ -59,7 +59,7 @@ internal fun generateArgument(generator: SchemaGenerator, parameter: KParameter)
         builder.withDirective(it)
     }
 
-    return generator.config.hooks.onRewireGraphQLType(builder.build()).safeCast()
+    return generator.config.hooks.onRewireGraphQLType(builder.build(), null, generator.codeRegistry).safeCast()
 }
 
 private fun getUnwrappedClass(parameterType: KType): KClass<*> =

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateEnum.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateEnum.kt
@@ -41,7 +41,7 @@ internal fun generateEnum(generator: SchemaGenerator, kClass: KClass<out Enum<*>
     kClass.java.enumConstants.forEach {
         enumBuilder.value(getEnumValueDefinition(generator, it, kClass))
     }
-    return generator.config.hooks.onRewireGraphQLType(enumBuilder.build()).safeCast()
+    return generator.config.hooks.onRewireGraphQLType(enumBuilder.build(), null, generator.codeRegistry).safeCast()
 }
 
 private fun getEnumValueDefinition(generator: SchemaGenerator, enum: Enum<*>, kClass: KClass<out Enum<*>>): GraphQLEnumValueDefinition {
@@ -63,5 +63,5 @@ private fun getEnumValueDefinition(generator: SchemaGenerator, enum: Enum<*>, kC
         valueBuilder.withDirective(deprecatedDirectiveWithReason(it))
     }
 
-    return generator.config.hooks.onRewireGraphQLType(valueBuilder.build()).safeCast()
+    return generator.config.hooks.onRewireGraphQLType(valueBuilder.build(), null, generator.codeRegistry).safeCast()
 }

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateInputObject.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateInputObject.kt
@@ -44,5 +44,5 @@ internal fun generateInputObject(generator: SchemaGenerator, kClass: KClass<*>):
         builder.field(generateInputProperty(generator, it, kClass))
     }
 
-    return generator.config.hooks.onRewireGraphQLType(builder.build()).safeCast()
+    return generator.config.hooks.onRewireGraphQLType(builder.build(), null, generator.codeRegistry).safeCast()
 }

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateInputProperty.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateInputProperty.kt
@@ -43,5 +43,5 @@ internal fun generateInputProperty(generator: SchemaGenerator, prop: KProperty<*
         builder.withDirective(it)
     }
 
-    return generator.config.hooks.onRewireGraphQLType(builder.build()).safeCast()
+    return generator.config.hooks.onRewireGraphQLType(builder.build(), null, generator.codeRegistry).safeCast()
 }

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateInterface.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateInterface.kt
@@ -63,5 +63,5 @@ internal fun generateInterface(generator: SchemaGenerator, kClass: KClass<*>): G
 
     val interfaceType = builder.build()
     generator.codeRegistry.typeResolver(interfaceType) { env: TypeResolutionEnvironment -> env.schema.getObjectType(env.getObject<Any>().javaClass.kotlin.getSimpleName()) }
-    return generator.config.hooks.onRewireGraphQLType(interfaceType).safeCast()
+    return generator.config.hooks.onRewireGraphQLType(interfaceType, null, generator.codeRegistry).safeCast()
 }

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateObject.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateObject.kt
@@ -61,5 +61,5 @@ internal fun generateObject(generator: SchemaGenerator, kClass: KClass<*>): Grap
     kClass.getValidFunctions(generator.config.hooks)
         .forEach { builder.field(generateFunction(generator, it, name)) }
 
-    return generator.config.hooks.onRewireGraphQLType(builder.build()).safeCast()
+    return generator.config.hooks.onRewireGraphQLType(builder.build(), null, generator.codeRegistry).safeCast()
 }

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateScalar.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateScalar.kt
@@ -32,7 +32,7 @@ internal fun generateScalar(generator: SchemaGenerator, type: KType): GraphQLSca
     val scalar: GraphQLScalarType? = defaultScalarsMap[kClass]
 
     return scalar?.let {
-        generator.config.hooks.onRewireGraphQLType(it).safeCast()
+        generator.config.hooks.onRewireGraphQLType(it, null, generator.codeRegistry).safeCast()
     }
 }
 

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateUnion.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateUnion.kt
@@ -49,5 +49,5 @@ internal fun generateUnion(generator: SchemaGenerator, kClass: KClass<*>): Graph
 
     val unionType = builder.build()
     generator.codeRegistry.typeResolver(unionType) { env: TypeResolutionEnvironment -> env.schema.getObjectType(env.getObject<Any>().javaClass.kotlin.getSimpleName()) }
-    return generator.config.hooks.onRewireGraphQLType(unionType).safeCast()
+    return generator.config.hooks.onRewireGraphQLType(unionType, null, generator.codeRegistry).safeCast()
 }

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/directives/KotlinDirectiveWiringFactoryTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/directives/KotlinDirectiveWiringFactoryTest.kt
@@ -90,7 +90,7 @@ class KotlinDirectiveWiringFactoryTest {
     @Test
     fun `verify no action is taken if GraphQL object is not GraphQLDirectiveContainer`() {
         val original = GraphQLTypeReference("MyTypeReference")
-        val actual = SimpleWiringFactory().onWire(original)
+        val actual = SimpleWiringFactory().onWire(original, null, codeRegistry = mockk())
 
         assertEquals(original, actual)
     }
@@ -98,7 +98,7 @@ class KotlinDirectiveWiringFactoryTest {
     @Test
     fun `verify no action is taken if GraphQL object does not have directive`() {
         val original = GraphQLEnumType.newEnum().name("MyEnum").build()
-        val actual = SimpleWiringFactory().onWire(original)
+        val actual = SimpleWiringFactory().onWire(original, null, codeRegistry = mockk())
 
         assertEquals(original, actual)
     }
@@ -107,7 +107,7 @@ class KotlinDirectiveWiringFactoryTest {
     fun `verify no action is taken if no wirings are specified`() {
         val original = GraphQLEnumType.newEnum().name("MyEnum").withDirective(graphQLOverrideDescriptionDirective).build()
 
-        val modified = SimpleWiringFactory().onWire(original)
+        val modified = SimpleWiringFactory().onWire(original, null, codeRegistry = mockk())
         assertEquals(original, modified)
     }
 
@@ -138,7 +138,7 @@ class KotlinDirectiveWiringFactoryTest {
         val newDescription = "overwritten description"
         assertNotEquals(argument.description, newDescription)
 
-        val actual = SimpleWiringFactory(overrides = mapOf("overrideDescription" to UpdateDescriptionWiringKotlinSchema(newDescription))).onWire(argument)
+        val actual = SimpleWiringFactory(overrides = mapOf("overrideDescription" to UpdateDescriptionWiringKotlinSchema(newDescription))).onWire(argument, null, codeRegistry = mockk())
         assertNotEquals(argument, actual)
         val updatedArgument = actual as? GraphQLArgument
         assertEquals(newDescription, updatedArgument?.description)
@@ -225,20 +225,6 @@ class KotlinDirectiveWiringFactoryTest {
     }
 
     @Test
-    fun `verify exception is thrown if no code registry is specified for the field`() {
-        val myTestField = GraphQLFieldDefinition.newFieldDefinition()
-            .name("MyField")
-            .type { context, visitor -> context.thisNode().accept(context, visitor) }
-            .description("My Field Description")
-            .withDirective(graphQLLowercaseDirective)
-            .build()
-
-        assertFailsWith(InvalidSchemaDirectiveWiringException::class) {
-            SimpleWiringFactory().onWire(graphQLSchemaElement = myTestField, coordinates = mockk(), codeRegistry = null)
-        }
-    }
-
-    @Test
     fun `verify exception is thrown if directive is applied on invalid location`() {
         val myTestObject = GraphQLObjectType.newObject()
             .name("MyObject")
@@ -247,7 +233,8 @@ class KotlinDirectiveWiringFactoryTest {
             .build()
 
         assertFailsWith(InvalidSchemaDirectiveWiringException::class) {
-            SimpleWiringFactory(overrides = mapOf("overrideDescription" to UpdateDescriptionWiringKotlinSchema("should fail"))).onWire(myTestObject)
+            SimpleWiringFactory(overrides = mapOf("overrideDescription" to UpdateDescriptionWiringKotlinSchema("should fail")))
+                .onWire(myTestObject, null, codeRegistry = mockk())
         }
     }
 
@@ -261,7 +248,7 @@ class KotlinDirectiveWiringFactoryTest {
 
         assertFailsWith(InvalidSchemaDirectiveWiringException::class) {
             SimpleWiringFactory(overrides = mapOf("overrideDescription" to UpdateDescriptionWiringKotlinSchema("should fail")))
-                .onWire(graphQLSchemaElement = myTestObject, coordinates = mockk())
+                .onWire(graphQLSchemaElement = myTestObject, coordinates = mockk(), codeRegistry = mockk())
         }
     }
 }

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/directives/KotlinSchemaDirectiveEnvironmentTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/directives/KotlinSchemaDirectiveEnvironmentTest.kt
@@ -18,6 +18,7 @@ package com.expediagroup.graphql.generator.directives
 
 import graphql.introspection.Introspection
 import graphql.schema.GraphQLArgument
+import graphql.schema.GraphQLCodeRegistry
 import graphql.schema.GraphQLDirectiveContainer
 import graphql.schema.GraphQLEnumType
 import graphql.schema.GraphQLEnumValueDefinition
@@ -53,16 +54,18 @@ internal class KotlinSchemaDirectiveEnvironmentTest {
             )
             .build()
 
-        assertTrue(KotlinSchemaDirectiveEnvironment(mockk<GraphQLArgument>(), directive).isValid())
-        assertTrue(KotlinSchemaDirectiveEnvironment(mockk<GraphQLEnumType>(), directive).isValid())
-        assertTrue(KotlinSchemaDirectiveEnvironment(mockk<GraphQLEnumValueDefinition>(), directive).isValid())
-        assertTrue(KotlinSchemaDirectiveEnvironment(mockk<GraphQLFieldDefinition>(), directive).isValid())
-        assertTrue(KotlinSchemaDirectiveEnvironment(mockk<GraphQLInputObjectField>(), directive).isValid())
-        assertTrue(KotlinSchemaDirectiveEnvironment(mockk<GraphQLInputObjectType>(), directive).isValid())
-        assertTrue(KotlinSchemaDirectiveEnvironment(mockk<GraphQLInterfaceType>(), directive).isValid())
-        assertTrue(KotlinSchemaDirectiveEnvironment(mockk<GraphQLObjectType>(), directive).isValid())
-        assertTrue(KotlinSchemaDirectiveEnvironment(mockk<GraphQLScalarType>(), directive).isValid())
-        assertTrue(KotlinSchemaDirectiveEnvironment(mockk<GraphQLUnionType>(), directive).isValid())
+        val codeRegistry = mockk<GraphQLCodeRegistry.Builder>()
+
+        assertTrue(KotlinSchemaDirectiveEnvironment(mockk<GraphQLArgument>(), directive, codeRegistry).isValid())
+        assertTrue(KotlinSchemaDirectiveEnvironment(mockk<GraphQLEnumType>(), directive, codeRegistry).isValid())
+        assertTrue(KotlinSchemaDirectiveEnvironment(mockk<GraphQLEnumValueDefinition>(), directive, codeRegistry).isValid())
+        assertTrue(KotlinSchemaDirectiveEnvironment(mockk<GraphQLFieldDefinition>(), directive, codeRegistry).isValid())
+        assertTrue(KotlinSchemaDirectiveEnvironment(mockk<GraphQLInputObjectField>(), directive, codeRegistry).isValid())
+        assertTrue(KotlinSchemaDirectiveEnvironment(mockk<GraphQLInputObjectType>(), directive, codeRegistry).isValid())
+        assertTrue(KotlinSchemaDirectiveEnvironment(mockk<GraphQLInterfaceType>(), directive, codeRegistry).isValid())
+        assertTrue(KotlinSchemaDirectiveEnvironment(mockk<GraphQLObjectType>(), directive, codeRegistry).isValid())
+        assertTrue(KotlinSchemaDirectiveEnvironment(mockk<GraphQLScalarType>(), directive, codeRegistry).isValid())
+        assertTrue(KotlinSchemaDirectiveEnvironment(mockk<GraphQLUnionType>(), directive, codeRegistry).isValid())
     }
 
     @Test
@@ -71,11 +74,11 @@ internal class KotlinSchemaDirectiveEnvironmentTest {
             .name("enumDirective")
             .validLocations(Introspection.DirectiveLocation.ENUM)
             .build()
-        assertFalse(KotlinSchemaDirectiveEnvironment(mockk<GraphQLArgument>(), enumDirective).isValid())
+        assertFalse(KotlinSchemaDirectiveEnvironment(mockk<GraphQLArgument>(), enumDirective, mockk<GraphQLCodeRegistry.Builder>()).isValid())
     }
 
     @Test
     fun `isValid returns false on non valid type`() {
-        assertFalse(KotlinSchemaDirectiveEnvironment(mockk<GraphQLDirectiveContainer>(), mockk()).isValid())
+        assertFalse(KotlinSchemaDirectiveEnvironment(mockk<GraphQLDirectiveContainer>(), mockk(), mockk<GraphQLCodeRegistry.Builder>()).isValid())
     }
 }

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/directives/KotlinSchemaDirectiveWiringTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/directives/KotlinSchemaDirectiveWiringTest.kt
@@ -17,6 +17,7 @@
 package com.expediagroup.graphql.generator.directives
 
 import graphql.schema.GraphQLArgument
+import graphql.schema.GraphQLCodeRegistry
 import graphql.schema.GraphQLDirectiveContainer
 import graphql.schema.GraphQLEnumType
 import graphql.schema.GraphQLEnumValueDefinition
@@ -39,6 +40,7 @@ import kotlin.test.assertTrue
 class KotlinSchemaDirectiveWiringTest {
 
     private lateinit var mockWiring: KotlinSchemaDirectiveWiring
+    private val codeRegistry = mockk<GraphQLCodeRegistry.Builder>()
 
     @BeforeEach
     fun setUp() {
@@ -48,7 +50,7 @@ class KotlinSchemaDirectiveWiringTest {
     @Test
     fun `wireOnEnvironment with no matching element returns the type back`() {
         val mockElement: GraphQLDirectiveContainer = mockk()
-        val mockEnvironment = KotlinSchemaDirectiveEnvironment(mockElement, mockk())
+        val mockEnvironment = KotlinSchemaDirectiveEnvironment(mockElement, mockk(), codeRegistry)
 
         val result = mockWiring.wireOnEnvironment(mockEnvironment)
         assertEquals(mockElement, result)
@@ -57,7 +59,7 @@ class KotlinSchemaDirectiveWiringTest {
     @Test
     fun `wireOnEnvironment with GraphQLArgument`() {
         val mockElement: GraphQLArgument = mockk()
-        val mockEnvironment = KotlinSchemaDirectiveEnvironment(mockElement, mockk())
+        val mockEnvironment = KotlinSchemaDirectiveEnvironment(mockElement, mockk(), codeRegistry)
 
         val result = mockWiring.wireOnEnvironment(mockEnvironment)
         assertTrue(result is GraphQLArgument)
@@ -67,7 +69,7 @@ class KotlinSchemaDirectiveWiringTest {
     @Test
     fun `wireOnEnvironment with GraphQLEnumType`() {
         val mockElement: GraphQLEnumType = mockk()
-        val mockEnvironment = KotlinSchemaDirectiveEnvironment(mockElement, mockk())
+        val mockEnvironment = KotlinSchemaDirectiveEnvironment(mockElement, mockk(), codeRegistry)
 
         val result = mockWiring.wireOnEnvironment(mockEnvironment)
         assertTrue(result is GraphQLEnumType)
@@ -77,7 +79,7 @@ class KotlinSchemaDirectiveWiringTest {
     @Test
     fun `wireOnEnvironment with GraphQLEnumValueDefinition`() {
         val mockElement: GraphQLEnumValueDefinition = mockk()
-        val mockEnvironment = KotlinSchemaDirectiveEnvironment(mockElement, mockk())
+        val mockEnvironment = KotlinSchemaDirectiveEnvironment(mockElement, mockk(), codeRegistry)
 
         val result = mockWiring.wireOnEnvironment(mockEnvironment)
         assertTrue(result is GraphQLEnumValueDefinition)
@@ -98,7 +100,7 @@ class KotlinSchemaDirectiveWiringTest {
     @Test
     fun `wireOnEnvironment with GraphQLInputObjectField`() {
         val mockElement: GraphQLInputObjectField = mockk()
-        val mockEnvironment = KotlinSchemaDirectiveEnvironment(mockElement, mockk())
+        val mockEnvironment = KotlinSchemaDirectiveEnvironment(mockElement, mockk(), codeRegistry)
 
         val result = mockWiring.wireOnEnvironment(mockEnvironment)
         assertTrue(result is GraphQLInputObjectField)
@@ -108,7 +110,7 @@ class KotlinSchemaDirectiveWiringTest {
     @Test
     fun `wireOnEnvironment with GraphQLInputObjectType`() {
         val mockElement: GraphQLInputObjectType = mockk()
-        val mockEnvironment = KotlinSchemaDirectiveEnvironment(mockElement, mockk())
+        val mockEnvironment = KotlinSchemaDirectiveEnvironment(mockElement, mockk(), codeRegistry)
 
         val result = mockWiring.wireOnEnvironment(mockEnvironment)
         assertTrue(result is GraphQLInputObjectType)
@@ -118,7 +120,7 @@ class KotlinSchemaDirectiveWiringTest {
     @Test
     fun `wireOnEnvironment with GraphQLInterfaceType`() {
         val mockElement: GraphQLInterfaceType = mockk()
-        val mockEnvironment = KotlinSchemaDirectiveEnvironment(mockElement, mockk())
+        val mockEnvironment = KotlinSchemaDirectiveEnvironment(mockElement, mockk(), codeRegistry)
 
         val result = mockWiring.wireOnEnvironment(mockEnvironment)
         assertTrue(result is GraphQLInterfaceType)
@@ -128,7 +130,7 @@ class KotlinSchemaDirectiveWiringTest {
     @Test
     fun `wireOnEnvironment with GraphQLObjectType`() {
         val mockElement: GraphQLObjectType = mockk()
-        val mockEnvironment = KotlinSchemaDirectiveEnvironment(mockElement, mockk())
+        val mockEnvironment = KotlinSchemaDirectiveEnvironment(mockElement, mockk(), codeRegistry)
 
         val result = mockWiring.wireOnEnvironment(mockEnvironment)
         assertTrue(result is GraphQLObjectType)
@@ -138,7 +140,7 @@ class KotlinSchemaDirectiveWiringTest {
     @Test
     fun `wireOnEnvironment with GraphQLScalarType`() {
         val mockElement: GraphQLScalarType = mockk()
-        val mockEnvironment = KotlinSchemaDirectiveEnvironment(mockElement, mockk())
+        val mockEnvironment = KotlinSchemaDirectiveEnvironment(mockElement, mockk(), codeRegistry)
 
         val result = mockWiring.wireOnEnvironment(mockEnvironment)
         assertTrue(result is GraphQLScalarType)
@@ -148,7 +150,7 @@ class KotlinSchemaDirectiveWiringTest {
     @Test
     fun `wireOnEnvironment with GraphQLUnionType`() {
         val mockElement: GraphQLUnionType = mockk()
-        val mockEnvironment = KotlinSchemaDirectiveEnvironment(mockElement, mockk())
+        val mockEnvironment = KotlinSchemaDirectiveEnvironment(mockElement, mockk(), codeRegistry)
 
         val result = mockWiring.wireOnEnvironment(mockEnvironment)
         assertTrue(result is GraphQLUnionType)


### PR DESCRIPTION
### :pencil: Description

To override datafetchers for all fields in an object using a directive, the environment should expose the `GraphQLCodeRegistry`.

Or at least the only way of overriding datafetchers from a directive on an object was by iterating over the fields and setting the datafetcher.

Something like this I expect to work:

```kt
override fun onObject(environment: KotlinSchemaDirectiveEnvironment<GraphQLObjectType>): GraphQLObjectType {
    val obj = environment.element
    val reg = environment.codeRegistry

    val expressionArgument = environment.directive.getArgument("expression")
    val expressionString = expressionArgument?.value as? String ?: return obj

    val authorizationManager = authorizationManagerForExpression(expressionString)

    obj.fieldDefinitions.forEach { field ->
        val fetcher = reg.getDataFetcher(obj, field)
        val authDataFetcher = AuthDataFetcher(fetcher, authorizationManager)
        reg.dataFetcher(obj, field, authDataFetcher)
    }

    return obj
}
```

Which I think should be possible with the provided change.
