### PR TITLE
[plugin] change tasks HttpClient engine from CIO to Apache

### DIFF
--- a/plugins/client/graphql-kotlin-client-generator/build.gradle.kts
+++ b/plugins/client/graphql-kotlin-client-generator/build.gradle.kts
@@ -2,6 +2,7 @@ description = "GraphQL Kotlin common utilities to generate a client."
 
 val compileTestingVersion: String by project
 val graphQLJavaVersion: String by project
+val jacksonVersion: String by project
 val junitVersion: String by project
 val kotlinPoetVersion: String by project
 val kotlinxSerializationVersion: String by project
@@ -15,8 +16,12 @@ dependencies {
     }
     api("com.squareup:kotlinpoet:$kotlinPoetVersion")
     api("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationVersion")
-    implementation("io.ktor:ktor-client-cio:$ktorVersion")
-    implementation("io.ktor:ktor-client-jackson:$ktorVersion")
+    implementation("io.ktor:ktor-client-apache:$ktorVersion")
+    implementation("io.ktor:ktor-client-jackson:$ktorVersion") {
+        exclude("com.fasterxml.jackson.core", "jackson-databind")
+        exclude("com.fasterxml.jackson.module", "jackson-module-kotlin")
+    }
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion")
     testImplementation(project(path = ":graphql-kotlin-client-jackson"))
     testImplementation("com.github.tomakehurst:wiremock-jre8:$wireMockVersion")
     testImplementation("com.github.tschuchortdev:kotlin-compile-testing:$compileTestingVersion")

--- a/plugins/client/graphql-kotlin-client-generator/src/test/kotlin/com/expediagroup/graphql/plugin/client/DownloadSchemaTest.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/kotlin/com/expediagroup/graphql/plugin/client/DownloadSchemaTest.kt
@@ -24,15 +24,15 @@ import com.github.tomakehurst.wiremock.client.WireMock.stubFor
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 import graphql.schema.idl.errors.SchemaProblem
 import io.ktor.client.features.ClientRequestException
+import io.ktor.client.features.HttpRequestTimeoutException
 import io.ktor.util.KtorExperimentalAPI
-import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import java.nio.channels.UnresolvedAddressException
+import java.net.UnknownHostException
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
@@ -97,12 +97,11 @@ class DownloadSchemaTest {
     @Test
     @KtorExperimentalAPI
     fun `verify downloadSchema will throw exception if URL is not valid`() {
-        val exception = assertThrows<RuntimeException> {
+        assertThrows<UnknownHostException> {
             runBlocking {
                 downloadSchema("https://non-existent-graphql-url.com/should_404")
             }
         }
-        assertTrue(exception.cause is UnresolvedAddressException)
     }
 
     @Test
@@ -147,7 +146,7 @@ class DownloadSchemaTest {
                     .withFixedDelay(1_000)
             )
         )
-        assertThrows<TimeoutCancellationException> {
+        assertThrows<HttpRequestTimeoutException> {
             runBlocking {
                 downloadSchema(endpoint = "${wireMockServer.baseUrl()}/sdl", connectTimeout = 100, readTimeout = 100)
             }

--- a/plugins/client/graphql-kotlin-client-generator/src/test/kotlin/com/expediagroup/graphql/plugin/client/IntrospectSchemaTest.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/kotlin/com/expediagroup/graphql/plugin/client/IntrospectSchemaTest.kt
@@ -20,8 +20,8 @@ import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 import io.ktor.client.features.ClientRequestException
+import io.ktor.client.features.HttpRequestTimeoutException
 import io.ktor.util.KtorExperimentalAPI
-import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import java.io.BufferedReader
+import java.net.UnknownHostException
 import kotlin.test.assertEquals
 
 class IntrospectSchemaTest {
@@ -129,9 +130,19 @@ class IntrospectSchemaTest {
                         .withFixedDelay(1_000)
                 )
         )
-        assertThrows<TimeoutCancellationException> {
+        assertThrows<HttpRequestTimeoutException> {
             runBlocking {
                 introspectSchema(endpoint = "${wireMockServer.baseUrl()}/graphql", connectTimeout = 100, readTimeout = 100)
+            }
+        }
+    }
+
+    @Test
+    @KtorExperimentalAPI
+    fun `verify introspectSchema will throw exception if URL is not valid`() {
+        assertThrows<UnknownHostException> {
+            runBlocking {
+                downloadSchema("https://non-existent-graphql-url.com/should_404")
             }
         }
     }

--- a/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/GraphQLDownloadSDLTaskIT.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/GraphQLDownloadSDLTaskIT.kt
@@ -154,7 +154,8 @@ class GraphQLDownloadSDLTaskIT : GraphQLGradlePluginAbstractIT() {
             .withArguments(DOWNLOAD_SDL_TASK_NAME, "--stacktrace")
             .buildAndFail()
 
+        println(result.output)
         assertEquals(TaskOutcome.FAILED, result.task(":$DOWNLOAD_SDL_TASK_NAME")?.outcome)
-        assertTrue(result.output.contains("Timed out waiting for 100 ms", ignoreCase = true))
+        assertTrue(result.output.contains("Request timeout has been expired", ignoreCase = true))
     }
 }

--- a/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/GraphQLIntrospectSchemaTaskIT.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/GraphQLIntrospectSchemaTaskIT.kt
@@ -152,6 +152,6 @@ class GraphQLIntrospectSchemaTaskIT : GraphQLGradlePluginAbstractIT() {
             .buildAndFail()
 
         assertEquals(TaskOutcome.FAILED, result.task(":$INTROSPECT_SCHEMA_TASK_NAME")?.outcome)
-        assertTrue(result.output.contains("Timed out waiting for 100 ms", ignoreCase = true))
+        assertTrue(result.output.contains("Request timeout has been expired", ignoreCase = true))
     }
 }


### PR DESCRIPTION
### :pencil: Description

It looks like using CIO engine causes some issues with the classpath (https://github.com/ExpediaGroup/graphql-kotlin/issues/1084). Unsure what is the root cause of the classpath issue - it looks like CIO engine relies on coroutines-core `native-mt` vs regular artifact that we pull in. Switching to a different engine seems to resolve the classpath issue.

### :link: Related Issues

Resolves: https://github.com/ExpediaGroup/graphql-kotlin/issues/1084