### PR TITLE
Add dependabot file to restrict to gradle

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: "/"
     labels:
       - "type: dependency changes"
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    labels:
+      - "type: dependency changes"

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -7,6 +7,7 @@ on:
       - '*.x.x'
     paths-ignore:
       - 'website/**'
+      - '*.md'
 
 jobs:
   build:


### PR DESCRIPTION
### :pencil: Description
Add a dependabot file and exclude JVM checks when only MD files are changed
