### PR TITLE
WIP: Demo returning query root

### DIFF
--- a/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/server/spring/mutation/SimpleMutation.kt
+++ b/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/server/spring/mutation/SimpleMutation.kt
@@ -17,6 +17,7 @@
 package com.expediagroup.graphql.examples.server.spring.mutation
 
 import com.expediagroup.graphql.generator.annotations.GraphQLDescription
+import com.expediagroup.graphql.generator.operations.QueryRoot
 import com.expediagroup.graphql.server.operations.Mutation
 import org.springframework.stereotype.Component
 
@@ -33,5 +34,12 @@ class SimpleMutation : Mutation {
     fun addToList(entry: String): MutableList<String> {
         data.add(entry)
         return data
+    }
+
+    fun mutationQueryResponse(input: String): QueryRoot {
+        // Do mutation actions with input
+
+        // Then just return empty object
+        return QueryRoot()
     }
 }

--- a/examples/server/spring-server/src/main/resources/application.yml
+++ b/examples/server/spring-server/src/main/resources/application.yml
@@ -1,6 +1,7 @@
 graphql:
   packages:
     - "com.expediagroup.graphql.examples.server.spring"
+    - "com.expediagroup.graphql.generator.operations"
   subscriptions:
     # Send a ka message every 1000 ms (1 second)
     keepAliveInterval: 1000

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/SchemaGenerator.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/SchemaGenerator.kt
@@ -26,6 +26,7 @@ import com.expediagroup.graphql.generator.internal.types.generateQueries
 import com.expediagroup.graphql.generator.internal.types.generateSubscriptions
 import graphql.schema.GraphQLCodeRegistry
 import graphql.schema.GraphQLDirective
+import graphql.schema.GraphQLObjectType
 import graphql.schema.GraphQLSchema
 import graphql.schema.GraphQLType
 import graphql.schema.GraphQLTypeUtil
@@ -52,6 +53,7 @@ open class SchemaGenerator(internal val config: SchemaGeneratorConfig) : Closeab
     internal val cache = TypesCache(config.supportedPackages)
     internal val codeRegistry = GraphQLCodeRegistry.newCodeRegistry()
     internal val directives = ConcurrentHashMap<String, GraphQLDirective>()
+    internal var queryRoot: GraphQLObjectType? = null
 
     /**
      * Validate that the supported packages contain classes
@@ -77,7 +79,8 @@ open class SchemaGenerator(internal val config: SchemaGeneratorConfig) : Closeab
         this.additionalTypes.addAll(additionalInputTypes.map { AdditionalType(it, inputType = true) })
 
         val builder = GraphQLSchema.newSchema()
-        builder.query(generateQueries(this, queries))
+        queryRoot = generateQueries(this, queries)
+        builder.query(queryRoot)
         builder.mutation(generateMutations(this, mutations))
         builder.subscription(generateSubscriptions(this, subscriptions))
         builder.additionalTypes(generateAdditionalTypes())

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/operations/QueryRoot.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/operations/QueryRoot.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2021 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.generator.operations
+
+/**
+ * Empty object representing the root query object
+ */
+class QueryRoot


### PR DESCRIPTION
### :pencil: Description
Still WIP. Demo of how we could return the query root object from a mutation field. This would actually be a backwards compatible feature addition. I would just want to clean some things up and add tests

![Screen Shot 2021-05-29 at 12 00 10 PM](https://user-images.githubusercontent.com/2446877/120082049-9943dc00-c075-11eb-93fb-c68ebfff7a23.png)


### :link: Related Issues
https://github.com/ExpediaGroup/graphql-kotlin/discussions/1169