### PR TITLE
[generator] remove extended scalars

### DIFF
--- a/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/server/spring/subscriptions/SimpleSubscription.kt
+++ b/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/server/spring/subscriptions/SimpleSubscription.kt
@@ -40,7 +40,7 @@ class SimpleSubscription : Subscription {
     fun singleValueSubscription(): Flux<Int> = Flux.just(1)
 
     @GraphQLDescription("Returns a random number every second")
-    fun counter(limit: Long? = null): Flux<Int> {
+    fun counter(limit: Int? = null): Flux<Int> {
         val flux = Flux.interval(Duration.ofSeconds(1)).map {
             val value = Random.nextInt()
             logger.info("Returning $value from counter")
@@ -48,7 +48,7 @@ class SimpleSubscription : Subscription {
         }
 
         return if (limit != null) {
-            flux.take(limit)
+            flux.take(limit.toLong())
         } else {
             flux
         }

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateScalar.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateScalar.kt
@@ -22,8 +22,6 @@ import com.expediagroup.graphql.generator.internal.extensions.safeCast
 import com.expediagroup.graphql.generator.scalars.ID
 import graphql.Scalars
 import graphql.schema.GraphQLScalarType
-import java.math.BigDecimal
-import java.math.BigInteger
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
 
@@ -38,13 +36,8 @@ internal fun generateScalar(generator: SchemaGenerator, type: KType): GraphQLSca
 
 private val defaultScalarsMap = mapOf(
     Int::class to Scalars.GraphQLInt,
-    Long::class to Scalars.GraphQLLong,
-    Short::class to Scalars.GraphQLShort,
     Float::class to Scalars.GraphQLFloat,
     Double::class to Scalars.GraphQLFloat,
-    BigDecimal::class to Scalars.GraphQLBigDecimal,
-    BigInteger::class to Scalars.GraphQLBigInteger,
-    Char::class to Scalars.GraphQLChar,
     String::class to Scalars.GraphQLString,
     Boolean::class to Scalars.GraphQLBoolean,
     ID::class to Scalars.GraphQLID

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/types/GenerateScalarTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/types/GenerateScalarTest.kt
@@ -20,8 +20,6 @@ import com.expediagroup.graphql.generator.scalars.ID
 import graphql.Scalars
 import graphql.schema.GraphQLScalarType
 import org.junit.jupiter.api.Test
-import java.math.BigDecimal
-import java.math.BigInteger
 import kotlin.reflect.KType
 import kotlin.reflect.full.createType
 import kotlin.test.assertEquals
@@ -31,13 +29,8 @@ class GenerateScalarTest : TypeTestHelper() {
     @Test
     fun `test all types`() {
         verify(Int::class.createType(), Scalars.GraphQLInt)
-        verify(Long::class.createType(), Scalars.GraphQLLong)
-        verify(Short::class.createType(), Scalars.GraphQLShort)
         verify(Float::class.createType(), Scalars.GraphQLFloat)
         verify(Double::class.createType(), Scalars.GraphQLFloat)
-        verify(BigDecimal::class.createType(), Scalars.GraphQLBigDecimal)
-        verify(BigInteger::class.createType(), Scalars.GraphQLBigInteger)
-        verify(Char::class.createType(), Scalars.GraphQLChar)
         verify(String::class.createType(), Scalars.GraphQLString)
         verify(Boolean::class.createType(), Scalars.GraphQLBoolean)
         verify(ID::class.createType(), Scalars.GraphQLID)


### PR DESCRIPTION
### :pencil: Description

Extended scalars were deprecated in `graphql-java` v15 in favor of separate `graphql-java-extended-scalars` project. Extended scalars are problematic as clients have to explicitly know how to handle them and what they represent. Due to the all the drawbacks, instead of automatically providing support for deprecated functionality, users should explicitly opt-in into this functionality by using custom hooks.

### :link: Related Issues
