### PR TITLE
Add local schema file support to Gradle plugin

### DIFF
--- a/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePlugin.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePlugin.kt
@@ -115,8 +115,11 @@ class GraphQLGradlePlugin : Plugin<Project> {
                         generateClientTask.dependsOn(downloadSDLTask.path)
                         generateClientTask.schemaFile.convention(downloadSDLTask.outputFile)
                     }
+                    extension.clientExtension.schemaFile != null -> {
+                        generateClientTask.schemaFile.fileValue(extension.clientExtension.schemaFile)
+                    }
                     else -> {
-                        throw RuntimeException("Invalid GraphQL client extension configuration - missing required endpoint/sdlEndpoint property")
+                        throw RuntimeException("Invalid GraphQL client extension configuration - missing required endpoint/sdlEndpoint/schemaFile property")
                     }
                 }
             }

--- a/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLPluginExtension.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLPluginExtension.kt
@@ -59,6 +59,8 @@ open class GraphQLPluginClientExtension {
     var endpoint: String? = null
     /** GraphQL server SDL endpoint that will be used to download schema. Alternatively you can run introspection query against [endpoint]. */
     var sdlEndpoint: String? = null
+    /** GraphQL schema file location. Can be used instead of [endpoint] or [sdlEndpoint]. */
+    var schemaFile: File? = null
     /** Target package name to be used for generated classes. */
     var packageName: String? = null
     /** Optional HTTP headers to be specified on an introspection query or SDL request. */


### PR DESCRIPTION
### :pencil: Description
Add support to the Gradle plugin for client generation from a local schema file.

### :link: Related Issues

#1136: Allow schema to be on the classpath