### PR TITLE
Add GraphQLAbstractType to support custom schema types from libraries

### DIFF
--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/annotations/GraphQLAbstractType.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/annotations/GraphQLAbstractType.kt
@@ -1,0 +1,6 @@
+package com.expediagroup.graphql.generator.annotations
+
+import kotlin.reflect.KClass
+
+@Target(AnnotationTarget.PROPERTY, AnnotationTarget.FUNCTION)
+annotation class GraphQLAbstractType(val possibleTypes: Array<KClass<*>>, val name: String, val description: String)

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/extensions/kClassExtensions.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/extensions/kClassExtensions.kt
@@ -61,8 +61,10 @@ internal fun KClass<*>.isInterface(): Boolean =
     this.java.isInterface || this.isAbstract || this.isSealed
 
 internal fun KClass<*>.isUnion(): Boolean =
-    this.isInterface() && this.declaredMemberProperties.isEmpty() && this.declaredMemberFunctions.isEmpty()
+    (this.isInterface() && this.declaredMemberProperties.isEmpty() && this.declaredMemberFunctions.isEmpty())  || this.isAny()
 
+internal fun KClass<*>.isAny(): Boolean =
+    qualifiedName?.startsWith("kotlin.Any") == true
 /**
  * Do not add interfaces as additional types if it expects all the types
  * to be input types. The isInteface() check works for both

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/extensions/kClassExtensions.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/extensions/kClassExtensions.kt
@@ -61,10 +61,8 @@ internal fun KClass<*>.isInterface(): Boolean =
     this.java.isInterface || this.isAbstract || this.isSealed
 
 internal fun KClass<*>.isUnion(): Boolean =
-    (this.isInterface() && this.declaredMemberProperties.isEmpty() && this.declaredMemberFunctions.isEmpty())  || this.isAny()
+    (this.isInterface() && this.declaredMemberProperties.isEmpty() && this.declaredMemberFunctions.isEmpty())  || this.isInstance(Any::class)
 
-internal fun KClass<*>.isAny(): Boolean =
-    qualifiedName?.startsWith("kotlin.Any") == true
 /**
  * Do not add interfaces as additional types if it expects all the types
  * to be input types. The isInteface() check works for both

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/state/TypesCache.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/state/TypesCache.kt
@@ -86,7 +86,7 @@ internal class TypesCache(private val supportedPackages: List<String>) : Closeab
         return when {
             kClass.isListType() -> null
             kClass.isSubclassOf(Enum::class) -> kClass.getSimpleName()
-            kClass.qualifiedName?.startsWith("kotlin.Any") == true -> null
+            kClass.isInstance(Any::class) -> null
             isTypeNotSupported(type) -> throw TypeNotSupportedException(type, supportedPackages)
             else -> type.getSimpleName(cacheKey.inputType)
         }

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/state/TypesCache.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/state/TypesCache.kt
@@ -86,6 +86,7 @@ internal class TypesCache(private val supportedPackages: List<String>) : Closeab
         return when {
             kClass.isListType() -> null
             kClass.isSubclassOf(Enum::class) -> kClass.getSimpleName()
+            kClass.qualifiedName?.startsWith("kotlin.Any") == true -> null
             isTypeNotSupported(type) -> throw TypeNotSupportedException(type, supportedPackages)
             else -> type.getSimpleName(cacheKey.inputType)
         }

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateFunction.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateFunction.kt
@@ -51,7 +51,7 @@ internal fun generateFunction(generator: SchemaGenerator, fn: KFunction<*>, pare
 
     val typeFromHooks = generator.config.hooks.willResolveMonad(fn.returnType)
     val returnType = getWrappedReturnType(typeFromHooks)
-    val graphQLOutputType = generateGraphQLType(generator = generator, type = returnType).safeCast<GraphQLOutputType>()
+    val graphQLOutputType = generateGraphQLType(generator = generator, type = returnType, annotations = fn.annotations).safeCast<GraphQLOutputType>()
     val graphQLType = builder.type(graphQLOutputType).build()
     val coordinates = FieldCoordinates.coordinates(parentName, functionName)
 

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateProperty.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateProperty.kt
@@ -18,6 +18,7 @@ package com.expediagroup.graphql.generator.internal.types
 
 import com.expediagroup.graphql.generator.SchemaGenerator
 import com.expediagroup.graphql.generator.directives.deprecatedDirectiveWithReason
+import com.expediagroup.graphql.generator.internal.extensions.getPropertyAnnotations
 import com.expediagroup.graphql.generator.internal.extensions.getPropertyDeprecationReason
 import com.expediagroup.graphql.generator.internal.extensions.getPropertyDescription
 import com.expediagroup.graphql.generator.internal.extensions.getPropertyName
@@ -32,7 +33,7 @@ import kotlin.reflect.KProperty
 
 internal fun generateProperty(generator: SchemaGenerator, prop: KProperty<*>, parentClass: KClass<*>): GraphQLFieldDefinition {
     val typeFromHooks = generator.config.hooks.willResolveMonad(prop.returnType)
-    val propertyType = generateGraphQLType(generator, type = typeFromHooks)
+    val propertyType = generateGraphQLType(generator, type = typeFromHooks, annotations = prop.getPropertyAnnotations(parentClass))
         .safeCast<GraphQLOutputType>()
 
     val propertyName = prop.getPropertyName(parentClass)

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateUnion.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateUnion.kt
@@ -21,7 +21,6 @@ import com.expediagroup.graphql.generator.annotations.GraphQLAbstractType
 import com.expediagroup.graphql.generator.extensions.unwrapType
 import com.expediagroup.graphql.generator.internal.extensions.getGraphQLDescription
 import com.expediagroup.graphql.generator.internal.extensions.getSimpleName
-import com.expediagroup.graphql.generator.internal.extensions.isAny
 import com.expediagroup.graphql.generator.internal.extensions.safeCast
 import graphql.GraphQLException
 import graphql.TypeResolutionEnvironment
@@ -45,7 +44,7 @@ private fun generateUnionFromAbstractTypeAnnotation(generator: SchemaGenerator, 
     builder.name(abstractTypeAnnotation.name)
 
     val possibleTypes = abstractTypeAnnotation.possibleTypes.toList()
-    val types = if (kClass.isAny() || (possibleTypes.isNotEmpty() && generator.classScanner.getSubTypesOf(kClass).containsAll(possibleTypes))) {
+    val types = if (kClass.isInstance(Any::class) || (possibleTypes.isNotEmpty() && generator.classScanner.getSubTypesOf(kClass).containsAll(possibleTypes))) {
         possibleTypes
     } else {
         throw GraphQLException("The specified possible types are not all subtypes of ${kClass.qualifiedName}") // TODO: throw correct exception

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateUnion.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateUnion.kt
@@ -17,10 +17,13 @@
 package com.expediagroup.graphql.generator.internal.types
 
 import com.expediagroup.graphql.generator.SchemaGenerator
+import com.expediagroup.graphql.generator.annotations.GraphQLAbstractType
 import com.expediagroup.graphql.generator.extensions.unwrapType
 import com.expediagroup.graphql.generator.internal.extensions.getGraphQLDescription
 import com.expediagroup.graphql.generator.internal.extensions.getSimpleName
+import com.expediagroup.graphql.generator.internal.extensions.isAny
 import com.expediagroup.graphql.generator.internal.extensions.safeCast
+import graphql.GraphQLException
 import graphql.TypeResolutionEnvironment
 import graphql.introspection.Introspection.DirectiveLocation
 import graphql.schema.GraphQLObjectType
@@ -29,7 +32,29 @@ import graphql.schema.GraphQLUnionType
 import kotlin.reflect.KClass
 import kotlin.reflect.full.createType
 
-internal fun generateUnion(generator: SchemaGenerator, kClass: KClass<*>): GraphQLUnionType {
+internal fun generateUnion(generator: SchemaGenerator, kClass: KClass<*>, abstractTypeAnnotation: GraphQLAbstractType?): GraphQLUnionType {
+    return if (abstractTypeAnnotation != null) {
+        generateUnionFromAbstractTypeAnnotation(generator, kClass, abstractTypeAnnotation)
+    } else {
+        generateUnionFromKClass(generator, kClass)
+    }
+}
+
+private fun generateUnionFromAbstractTypeAnnotation(generator: SchemaGenerator, kClass: KClass<*>, abstractTypeAnnotation: GraphQLAbstractType): GraphQLUnionType {
+    val builder = GraphQLUnionType.newUnionType()
+    builder.name(abstractTypeAnnotation.name)
+
+    val possibleTypes = abstractTypeAnnotation.possibleTypes.toList()
+    val types = if (kClass.isAny() || (possibleTypes.isNotEmpty() && generator.classScanner.getSubTypesOf(kClass).containsAll(possibleTypes))) {
+        possibleTypes
+    } else {
+        throw GraphQLException("The specified possible types are not all subtypes of ${kClass.qualifiedName}") // TODO: throw correct exception
+    }
+
+    return createUnion(generator, builder, types)
+}
+
+private fun generateUnionFromKClass(generator: SchemaGenerator, kClass: KClass<*>): GraphQLUnionType {
     val builder = GraphQLUnionType.newUnionType()
     builder.name(kClass.getSimpleName())
     builder.description(kClass.getGraphQLDescription())
@@ -38,8 +63,13 @@ internal fun generateUnion(generator: SchemaGenerator, kClass: KClass<*>): Graph
         builder.withDirective(it)
     }
 
-    generator.classScanner.getSubTypesOf(kClass)
-        .map { generateGraphQLType(generator, it.createType()) }
+    val types = generator.classScanner.getSubTypesOf(kClass)
+
+    return createUnion(generator, builder, types)
+}
+
+private fun createUnion(generator: SchemaGenerator, builder: GraphQLUnionType.Builder, types: List<KClass<*>>): GraphQLUnionType {
+    types.map { generateGraphQLType(generator, it.createType()) }
         .forEach {
             when (val unwrappedType = it.unwrapType()) {
                 is GraphQLTypeReference -> builder.possibleType(unwrappedType)


### PR DESCRIPTION
### :pencil: Description
Since the schema can be generated from code you can use existing Kotlin classes from common libraries to define shared models. However if you want to declare an object defined in the library as implementing some new interface or union in your service it is not possible, since we can't modify the class definition to add Kotlin code to it.


These changes would allow us to use `Any` as the return type in the schema but then, through annotations, modify the schema return type to match the new class we want to use.


For example in an SDL-First world you could have this Kotlin class defined in some library

```kotlin
data class SharedModel(val foo: String)
```

And then write your schema as the following

```graphql
interface CustomServiceInterface {
  foo: String!
}

type SharedModel implements CustomServiceInterface {
  foo: String!
}

type CustomServiceModel implements CustomServiceInterface {
  foo: String!
  bar: String!
}

union CustomServiceUnion = SharedModel | CustomServiceModel
```

But this is not currently possible in the full code-generation approach

### :link: Related Issues
