### PR TITLE
Add local schema file support to Gradle plugin extension

### DIFF
--- a/plugins/graphql-kotlin-gradle-plugin/README.md
+++ b/plugins/graphql-kotlin-gradle-plugin/README.md
@@ -32,7 +32,7 @@ graphql {
       allowDeprecatedFields = false
       // List of custom GraphQL scalar to converter mapping containing information about corresponding Java type and converter that should be used to serialize/deserialize values.
       customScalars = listOf(GraphQLScalar("UUID", "java.util.UUID", "com.example.UUIDScalarConverter"))
-      // GraphQL server endpoint that will be used to for running introspection queries. Alternatively you can download schema directly from `sdlEndpoint`.
+      // GraphQL server endpoint that will be used to for running introspection queries. Alternatively you can download schema directly from `sdlEndpoint` or specify local `schemaFileName`.
       endpoint = "http://localhost:8080/graphql"
       // Optional HTTP headers to be specified on an introspection query or SDL request.
       headers = mapOf("X-Custom-Header" to "Custom-Header-Value")
@@ -44,7 +44,9 @@ graphql {
       queryFiles = listOf(file("${project.projectDir}/src/main/resources/queries/MyQuery.graphql"))
       // JSON serializer that will be used to generate the data classes.
       serializer = GraphQLSerializer.JACKSON
-      // GraphQL server SDL endpoint that will be used to download schema. Alternatively you can run introspection query against `endpoint`.
+      // GraphQL schema file location. Can be used instead of `endpoint` or `sdlEndpoint`.
+      schemaFileName = "${project.projectDir}/src/main/resources/myLocalSchema.graphql"
+      // GraphQL server SDL endpoint that will be used to download schema. Alternatively you can run introspection query against `endpoint` or specify local `schemaFileName`.
       sdlEndpoint = "http://localhost:8080/sdl"
       // Timeout configuration for introspection query/downloading SDL
       timeout {

--- a/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePlugin.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePlugin.kt
@@ -115,8 +115,11 @@ class GraphQLGradlePlugin : Plugin<Project> {
                         generateClientTask.dependsOn(downloadSDLTask.path)
                         generateClientTask.schemaFile.convention(downloadSDLTask.outputFile)
                     }
+                    extension.clientExtension.schemaFile != null -> {
+                        generateClientTask.schemaFile.fileValue(extension.clientExtension.schemaFile)
+                    }
                     else -> {
-                        throw RuntimeException("Invalid GraphQL client extension configuration - missing required endpoint/sdlEndpoint property")
+                        throw RuntimeException("Invalid GraphQL client extension configuration - missing required endpoint/sdlEndpoint/schemaFile property")
                     }
                 }
             }

--- a/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePlugin.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePlugin.kt
@@ -115,11 +115,11 @@ class GraphQLGradlePlugin : Plugin<Project> {
                         generateClientTask.dependsOn(downloadSDLTask.path)
                         generateClientTask.schemaFile.convention(downloadSDLTask.outputFile)
                     }
-                    extension.clientExtension.schemaFile != null -> {
-                        generateClientTask.schemaFile.fileValue(extension.clientExtension.schemaFile)
+                    extension.clientExtension.schemaFileName != null -> {
+                        generateClientTask.schemaFileName.convention(extension.clientExtension.schemaFileName)
                     }
                     else -> {
-                        throw RuntimeException("Invalid GraphQL client extension configuration - missing required endpoint/sdlEndpoint/schemaFile property")
+                        throw RuntimeException("Invalid GraphQL client extension configuration - missing required endpoint/sdlEndpoint/schemaFileName property")
                     }
                 }
             }

--- a/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLPluginExtension.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLPluginExtension.kt
@@ -55,12 +55,12 @@ open class GraphQLPluginExtension {
 }
 
 open class GraphQLPluginClientExtension {
-    /** GraphQL server endpoint that will be used to for running introspection queries. Alternatively you can download schema directly from [sdlEndpoint]. */
+    /** GraphQL server endpoint that will be used to for running introspection queries. Alternatively you can download schema directly from [sdlEndpoint] or specify local [schemaFileName]. */
     var endpoint: String? = null
-    /** GraphQL server SDL endpoint that will be used to download schema. Alternatively you can run introspection query against [endpoint]. */
+    /** GraphQL server SDL endpoint that will be used to download schema. Alternatively you can run introspection query against [endpoint] or specify local [schemaFileName]. */
     var sdlEndpoint: String? = null
     /** GraphQL schema file location. Can be used instead of [endpoint] or [sdlEndpoint]. */
-    var schemaFile: File? = null
+    var schemaFileName: String? = null
     /** Target package name to be used for generated classes. */
     var packageName: String? = null
     /** Optional HTTP headers to be specified on an introspection query or SDL request. */

--- a/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLPluginExtension.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLPluginExtension.kt
@@ -59,6 +59,8 @@ open class GraphQLPluginClientExtension {
     var endpoint: String? = null
     /** GraphQL server SDL endpoint that will be used to download schema. Alternatively you can run introspection query against [endpoint]. */
     var sdlEndpoint: String? = null
+    /** GraphQL schema file location. Can be used instead of [endpoint] or [sdlEndpoint]. */
+    var schemaFile: File? = null
     /** Target package name to be used for generated classes. */
     var packageName: String? = null
     /** Optional HTTP headers to be specified on an introspection query or SDL request. */

--- a/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePluginIT.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePluginIT.kt
@@ -87,7 +87,7 @@ class GraphQLGradlePluginIT : GraphQLGradlePluginAbstractIT() {
             |
             |graphql {
             |  client {
-            |    schemaFile = File("src/main/resources/schema.graphql")
+            |    schemaFileName = "src/main/resources/schema.graphql"
             |    packageName = "com.example.generated"
             |  }
             |}

--- a/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePluginIT.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePluginIT.kt
@@ -87,7 +87,7 @@ class GraphQLGradlePluginIT : GraphQLGradlePluginAbstractIT() {
             |
             |graphql {
             |  client {
-            |    schemaFileName = "src/main/resources/schema.graphql"
+            |    schemaFileName = "${'$'}{project.projectDir}/src/main/resources/schema.graphql"
             |    packageName = "com.example.generated"
             |  }
             |}

--- a/website/docs/plugins/gradle-plugin-tasks.mdx
+++ b/website/docs/plugins/gradle-plugin-tasks.mdx
@@ -118,7 +118,7 @@ graphql {
     allowDeprecatedFields = false
     // List of custom GraphQL scalar to converter mapping containing information about corresponding Java type and converter that should be used to serialize/deserialize values.
     customScalars = listOf(GraphQLScalar("UUID", "java.util.UUID", "com.example.UUIDScalarConverter"))
-    // GraphQL server endpoint that will be used to for running introspection queries. Alternatively you can download schema directly from `sdlEndpoint`.
+    // GraphQL server endpoint that will be used to for running introspection queries. Alternatively you can download schema directly from `sdlEndpoint` or specify local `schemaFileName`.
     endpoint = "http://localhost:8080/graphql"
     // Optional HTTP headers to be specified on an introspection query or SDL request.
     headers = mapOf("X-Custom-Header" to "Custom-Header-Value")
@@ -130,7 +130,9 @@ graphql {
     queryFiles = listOf(file("${project.projectDir}/src/main/resources/queries/MyQuery.graphql"))
     // JSON serializer that will be used to generate the data classes.
     serializer = GraphQLSerializer.JACKSON
-    // GraphQL server SDL endpoint that will be used to download schema. Alternatively you can run introspection query against `endpoint`.
+    // GraphQL schema file location. Can be used instead of `endpoint` or `sdlEndpoint`.
+    schemaFileName = "${project.projectDir}/src/main/resources/myLocalSchema.graphql"
+    // GraphQL server SDL endpoint that will be used to download schema. Alternatively you can run introspection query against `endpoint` or specify local `schemaFileName`.
     sdlEndpoint = "http://localhost:8080/sdl"
     // Timeout configuration for introspection query/downloading SDL
     timeout {
@@ -164,7 +166,7 @@ graphql {
         allowDeprecatedFields = false
         // List of custom GraphQL scalar to converter mapping containing information about corresponding Java type and converter that should be used to serialize/deserialize values.
         customScalars = [new GraphQLScalar("UUID", "java.util.UUID", "com.example.UUIDScalarConverter")]
-        // GraphQL server endpoint that will be used to for running introspection queries. Alternatively you can download schema directly from `sdlEndpoint`.
+        // GraphQL server endpoint that will be used to for running introspection queries. Alternatively you can download schema directly from `sdlEndpoint` or specify local `schemaFileName`.
         endpoint = "http://localhost:8080/graphql"
         // Optional HTTP headers to be specified on an introspection query or SDL request.
         headers = ["X-Custom-Header" : "My-Custom-Header-Value"]
@@ -176,7 +178,9 @@ graphql {
         queryFiles = [file("${project.projectDir}/src/main/resources/queries/MyQuery.graphql")]
         // JSON serializer that will be used to generate the data classes.
         serializer = GraphQLSerializer.JACKSON
-        // GraphQL server SDL endpoint that will be used to download schema. Alternatively you can run introspection query against `endpoint`.
+        // GraphQL schema file location. Can be used instead of `endpoint` or `sdlEndpoint`.
+        schemaFileName = "${project.projectDir}/src/main/resources/myLocalSchema.graphql"
+        // GraphQL server SDL endpoint that will be used to download schema. Alternatively you can run introspection query against `endpoint` or specify local `schemaFileName`.
         sdlEndpoint = "http://localhost:8080/sdl"
         // Timeout configuration for introspection query/downloading SDL
         timeout { t ->


### PR DESCRIPTION
### :pencil: Description

Update Gradle plugin to allow client generation by specifying local schema file in the extension. Using extension with local schema file is equivalent to configuring the `GraphQLGenerateClientTask` directly.

### :link: Related Issues

https://github.com/ExpediaGroup/graphql-kotlin/pull/1136: Allow schema to be on the classpath
https://github.com/ExpediaGroup/graphql-kotlin/pull/1190: Add local schema file support to Gradle plugin