### PR TITLE
getValuesFromDataLoader helper function

### DIFF
--- a/servers/graphql-kotlin-server/src/main/kotlin/com/expediagroup/graphql/server/extensions/dataFetchingEnvironmentExtensions.kt
+++ b/servers/graphql-kotlin-server/src/main/kotlin/com/expediagroup/graphql/server/extensions/dataFetchingEnvironmentExtensions.kt
@@ -18,7 +18,6 @@ package com.expediagroup.graphql.server.extensions
 
 import com.expediagroup.graphql.server.exception.MissingDataLoaderException
 import graphql.schema.DataFetchingEnvironment
-import org.dataloader.DataLoader
 import java.util.concurrent.CompletableFuture
 
 /**

--- a/servers/graphql-kotlin-server/src/main/kotlin/com/expediagroup/graphql/server/extensions/dataFetchingEnvironmentExtensions.kt
+++ b/servers/graphql-kotlin-server/src/main/kotlin/com/expediagroup/graphql/server/extensions/dataFetchingEnvironmentExtensions.kt
@@ -18,6 +18,7 @@ package com.expediagroup.graphql.server.extensions
 
 import com.expediagroup.graphql.server.exception.MissingDataLoaderException
 import graphql.schema.DataFetchingEnvironment
+import org.dataloader.DataLoader
 import java.util.concurrent.CompletableFuture
 
 /**
@@ -25,6 +26,17 @@ import java.util.concurrent.CompletableFuture
  * The provided key should be the cache key object used to save the value for that particular data loader.
  */
 fun <K, V> DataFetchingEnvironment.getValueFromDataLoader(dataLoaderName: String, key: K): CompletableFuture<V> {
-    val loader = this.getDataLoader<K, V>(dataLoaderName) ?: throw MissingDataLoaderException(dataLoaderName)
+    val loader = getLoaderName<K, V>(dataLoaderName)
     return loader.load(key, this.getContext())
 }
+
+/**
+* Helper method to get values from a registered DataLoader.
+*/
+fun <K, V> DataFetchingEnvironment.getValuesFromDataLoader(dataLoaderName: String, keys: List<K>): CompletableFuture<List<V>> {
+    val loader = getLoaderName<K, V>(dataLoaderName)
+    return loader.loadMany(keys, listOf(this.getContext()))
+}
+
+private fun <K, V> DataFetchingEnvironment.getLoaderName(dataLoaderName: String) =
+    this.getDataLoader<K, V>(dataLoaderName) ?: throw MissingDataLoaderException(dataLoaderName)

--- a/servers/graphql-kotlin-server/src/test/kotlin/com/expediagroup/graphql/server/extensions/DataFetchingEnvironmentExtensionsKtTest.kt
+++ b/servers/graphql-kotlin-server/src/test/kotlin/com/expediagroup/graphql/server/extensions/DataFetchingEnvironmentExtensionsKtTest.kt
@@ -42,6 +42,22 @@ class DataFetchingEnvironmentExtensionsKtTest {
     }
 
     @Test
+    fun `getting values from a dataloader based on a list of keys`() {
+        val dataFetchingEnvironment: DataFetchingEnvironment = mockk {
+            every { getContext<Any>() } returns mockk()
+            every { getDataLoader<String, String>("foo") } returns mockk {
+                every { loadMany(listOf("bar"), any()) } returns CompletableFuture.completedFuture(listOf("123"))
+            }
+        }
+
+        val result: CompletableFuture<List<String>> = dataFetchingEnvironment.getValuesFromDataLoader("foo", listOf("bar"))
+
+        assertEquals(1, result.get().size)
+        assertEquals("123", result.get().first())
+    }
+
+
+    @Test
     fun `getting a dataloader throws exception when name not found`() {
         val dataFetchingEnvironment: DataFetchingEnvironment = mockk {
             every { getContext<Any>() } returns mockk()

--- a/servers/graphql-kotlin-server/src/test/kotlin/com/expediagroup/graphql/server/extensions/DataFetchingEnvironmentExtensionsKtTest.kt
+++ b/servers/graphql-kotlin-server/src/test/kotlin/com/expediagroup/graphql/server/extensions/DataFetchingEnvironmentExtensionsKtTest.kt
@@ -56,7 +56,6 @@ class DataFetchingEnvironmentExtensionsKtTest {
         assertEquals("123", result.get().first())
     }
 
-
     @Test
     fun `getting a dataloader throws exception when name not found`() {
         val dataFetchingEnvironment: DataFetchingEnvironment = mockk {


### PR DESCRIPTION
### :pencil: Description
Added `getValuesFromDataLoader` helper function to make it easier to call `loadMany`. This works very similar to `getValueFromDataLoader`, but accepts a list of keys and returns a list of values. `getLoaderName` is created because both functions lookup the DataLoader instance the same way.


### :link: Related Issues
