### PR TITLE
Remove ClassScanner validation at initialization. Closes #1224

### DIFF
--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/SchemaGenerator.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/SchemaGenerator.kt
@@ -54,15 +54,6 @@ open class SchemaGenerator(internal val config: SchemaGeneratorConfig) : Closeab
     internal val directives = ConcurrentHashMap<String, GraphQLDirective>()
 
     /**
-     * Validate that the supported packages contain classes
-     */
-    init {
-        if (classScanner.isEmptyScan()) {
-            throw InvalidPackagesException(config.supportedPackages)
-        }
-    }
-
-    /**
      * Generate a schema given a list of objects to parse for the queries, mutations, and subscriptions.
      */
     open fun generateSchema(


### PR DESCRIPTION
### :pencil: Description
Remove validation of ClassScanner at initialization because it not working when application built with native-image (GraalVM)

### :link: Related Issues
https://github.com/ExpediaGroup/graphql-kotlin/issues/1224
