### PR TITLE
Update dokka to 1.5

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -41,7 +41,7 @@ wireMockVersion = 2.28.1
 
 # plugin versions
 detektVersion = 1.17.1
-dokkaVersion = 1.4.30
+dokkaVersion = 1.5.0
 jacocoVersion = 0.8.7
 ktlintVersion = 0.41.0
 ktlintPluginVersion = 10.1.0


### PR DESCRIPTION
### :pencil: Description
Kotlinx.html is now publishing to Maven central and we have removed deps on Jcenter so we need to make sure we are using the latest version to get the one in maven central

### :link: Related Issues
https://github.com/Kotlin/dokka/releases/tag/v1.5.0
https://github.com/ExpediaGroup/graphql-kotlin/runs/3146969635?check_suite_focus=true#step:6:38