### PR TITLE
Fix deprecations and compile warnings

### DIFF
--- a/clients/graphql-kotlin-client-serialization/src/test/kotlin/com/expediagroup/graphql/client/serialization/types/serializers/AnyKSerializerTest.kt
+++ b/clients/graphql-kotlin-client-serialization/src/test/kotlin/com/expediagroup/graphql/client/serialization/types/serializers/AnyKSerializerTest.kt
@@ -17,6 +17,7 @@
 package com.expediagroup.graphql.client.serialization.types.serializers
 
 import com.expediagroup.graphql.client.serialization.serializers.AnyKSerializer
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
@@ -57,6 +58,7 @@ class AnyKSerializerTest {
     """.trimMargin()
 
     @Test
+    @ExperimentalSerializationApi
     fun `verify serialization logic`() {
         val json = Json {
             prettyPrint = true

--- a/clients/graphql-kotlin-client-serialization/src/test/kotlin/com/expediagroup/graphql/client/serialization/types/serializers/GraphQLErrorPathSerializerTest.kt
+++ b/clients/graphql-kotlin-client-serialization/src/test/kotlin/com/expediagroup/graphql/client/serialization/types/serializers/GraphQLErrorPathSerializerTest.kt
@@ -17,6 +17,7 @@
 package com.expediagroup.graphql.client.serialization.types.serializers
 
 import com.expediagroup.graphql.client.serialization.serializers.GraphQLErrorPathSerializer
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
@@ -41,6 +42,7 @@ class GraphQLErrorPathSerializerTest {
     """.trimMargin()
 
     @Test
+    @ExperimentalSerializationApi
     fun `verify serialization`() {
         val json = Json {
             prettyPrint = true

--- a/clients/graphql-kotlin-ktor-client/src/test/kotlin/com/expediagroup/graphql/client/ktor/GraphQLKtorClientTest.kt
+++ b/clients/graphql-kotlin-ktor-client/src/test/kotlin/com/expediagroup/graphql/client/ktor/GraphQLKtorClientTest.kt
@@ -22,11 +22,11 @@ import com.expediagroup.graphql.client.jackson.types.JacksonGraphQLResponse
 import com.expediagroup.graphql.client.jackson.types.JacksonGraphQLSourceLocation
 import com.expediagroup.graphql.client.serialization.GraphQLClientKotlinxSerializer
 import com.expediagroup.graphql.client.serialization.serializers.AnyKSerializer
-import com.expediagroup.graphql.client.types.GraphQLClientRequest
-import com.expediagroup.graphql.client.types.GraphQLClientResponse
 import com.expediagroup.graphql.client.serialization.types.KotlinxGraphQLError
 import com.expediagroup.graphql.client.serialization.types.KotlinxGraphQLResponse
 import com.expediagroup.graphql.client.serialization.types.KotlinxGraphQLSourceLocation
+import com.expediagroup.graphql.client.types.GraphQLClientRequest
+import com.expediagroup.graphql.client.types.GraphQLClientResponse
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.MappingBuilder

--- a/clients/graphql-kotlin-spring-client/src/test/kotlin/com/expediagroup/graphql/client/spring/GraphQLWebClientTest.kt
+++ b/clients/graphql-kotlin-spring-client/src/test/kotlin/com/expediagroup/graphql/client/spring/GraphQLWebClientTest.kt
@@ -17,8 +17,8 @@
 package com.expediagroup.graphql.client.spring
 
 import com.expediagroup.graphql.client.jackson.GraphQLClientJacksonSerializer
-import com.expediagroup.graphql.client.jackson.types.JacksonGraphQLResponse
 import com.expediagroup.graphql.client.jackson.types.JacksonGraphQLError
+import com.expediagroup.graphql.client.jackson.types.JacksonGraphQLResponse
 import com.expediagroup.graphql.client.jackson.types.JacksonGraphQLSourceLocation
 import com.expediagroup.graphql.client.serialization.GraphQLClientKotlinxSerializer
 import com.expediagroup.graphql.client.serialization.serializers.AnyKSerializer

--- a/examples/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/server/spring/directives/CustomDirectiveWiringFactory.kt
+++ b/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/server/spring/directives/CustomDirectiveWiringFactory.kt
@@ -20,7 +20,6 @@ import com.expediagroup.graphql.generator.directives.KotlinDirectiveWiringFactor
 import com.expediagroup.graphql.generator.directives.KotlinSchemaDirectiveEnvironment
 import com.expediagroup.graphql.generator.directives.KotlinSchemaDirectiveWiring
 import graphql.schema.GraphQLDirectiveContainer
-import java.util.Locale
 import kotlin.reflect.KClass
 
 class CustomDirectiveWiringFactory : KotlinDirectiveWiringFactory(manualWiring = mapOf<String, KotlinSchemaDirectiveWiring>("lowercase" to LowercaseSchemaDirectiveWiring())) {
@@ -28,15 +27,11 @@ class CustomDirectiveWiringFactory : KotlinDirectiveWiringFactory(manualWiring =
     private val stringEvalDirectiveWiring = StringEvalSchemaDirectiveWiring()
     private val caleOnlyDirectiveWiring = SpecificValueOnlySchemaDirectiveWiring()
 
-    override fun getSchemaDirectiveWiring(environment: KotlinSchemaDirectiveEnvironment<GraphQLDirectiveContainer>): KotlinSchemaDirectiveWiring? = when {
-        environment.directive.name == getDirectiveName(StringEval::class) -> stringEvalDirectiveWiring
-        environment.directive.name == getDirectiveName(SpecificValueOnly::class) -> caleOnlyDirectiveWiring
+    override fun getSchemaDirectiveWiring(environment: KotlinSchemaDirectiveEnvironment<GraphQLDirectiveContainer>): KotlinSchemaDirectiveWiring? = when (environment.directive.name) {
+        getDirectiveName(StringEval::class) -> stringEvalDirectiveWiring
+        getDirectiveName(SpecificValueOnly::class) -> caleOnlyDirectiveWiring
         else -> null
     }
 }
 
-internal fun getDirectiveName(kClass: KClass<out Annotation>): String = kClass.simpleName!!.replaceFirstChar {
-    it.lowercase(
-        Locale.getDefault()
-    )
-}
+internal fun getDirectiveName(kClass: KClass<out Annotation>): String = kClass.simpleName!!.replaceFirstChar { it.lowercase() }

--- a/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/server/spring/directives/CustomDirectiveWiringFactory.kt
+++ b/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/server/spring/directives/CustomDirectiveWiringFactory.kt
@@ -20,6 +20,7 @@ import com.expediagroup.graphql.generator.directives.KotlinDirectiveWiringFactor
 import com.expediagroup.graphql.generator.directives.KotlinSchemaDirectiveEnvironment
 import com.expediagroup.graphql.generator.directives.KotlinSchemaDirectiveWiring
 import graphql.schema.GraphQLDirectiveContainer
+import java.util.Locale
 import kotlin.reflect.KClass
 
 class CustomDirectiveWiringFactory : KotlinDirectiveWiringFactory(manualWiring = mapOf<String, KotlinSchemaDirectiveWiring>("lowercase" to LowercaseSchemaDirectiveWiring())) {
@@ -34,4 +35,8 @@ class CustomDirectiveWiringFactory : KotlinDirectiveWiringFactory(manualWiring =
     }
 }
 
-internal fun getDirectiveName(kClass: KClass<out Annotation>): String = kClass.simpleName!!.decapitalize()
+internal fun getDirectiveName(kClass: KClass<out Annotation>): String = kClass.simpleName!!.replaceFirstChar {
+    it.lowercase(
+        Locale.getDefault()
+    )
+}

--- a/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/server/spring/directives/LowercaseSchemaDirectiveWiring.kt
+++ b/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/server/spring/directives/LowercaseSchemaDirectiveWiring.kt
@@ -20,23 +20,16 @@ import com.expediagroup.graphql.generator.directives.KotlinFieldDirectiveEnviron
 import com.expediagroup.graphql.generator.directives.KotlinSchemaDirectiveWiring
 import graphql.schema.DataFetcher
 import graphql.schema.DataFetcherFactories
-import graphql.schema.DataFetchingEnvironment
 import graphql.schema.GraphQLFieldDefinition
-import java.util.Locale
-import java.util.function.BiFunction
 
 class LowercaseSchemaDirectiveWiring : KotlinSchemaDirectiveWiring {
 
     override fun onField(environment: KotlinFieldDirectiveEnvironment): GraphQLFieldDefinition {
         val field = environment.element
         val originalDataFetcher: DataFetcher<*> = environment.getDataFetcher()
-
-        val lowerCaseFetcher = DataFetcherFactories.wrapDataFetcher(
-            originalDataFetcher,
-            BiFunction<DataFetchingEnvironment, Any, Any> { _, value ->
-                value.toString().lowercase(Locale.getDefault())
-            }
-        )
+        val lowerCaseFetcher = DataFetcherFactories.wrapDataFetcher(originalDataFetcher) { _, value ->
+            value.toString().lowercase()
+        }
         environment.setDataFetcher(lowerCaseFetcher)
         return field
     }

--- a/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/server/spring/directives/LowercaseSchemaDirectiveWiring.kt
+++ b/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/server/spring/directives/LowercaseSchemaDirectiveWiring.kt
@@ -22,6 +22,7 @@ import graphql.schema.DataFetcher
 import graphql.schema.DataFetcherFactories
 import graphql.schema.DataFetchingEnvironment
 import graphql.schema.GraphQLFieldDefinition
+import java.util.Locale
 import java.util.function.BiFunction
 
 class LowercaseSchemaDirectiveWiring : KotlinSchemaDirectiveWiring {
@@ -32,7 +33,9 @@ class LowercaseSchemaDirectiveWiring : KotlinSchemaDirectiveWiring {
 
         val lowerCaseFetcher = DataFetcherFactories.wrapDataFetcher(
             originalDataFetcher,
-            BiFunction<DataFetchingEnvironment, Any, Any> { _, value -> value.toString().toLowerCase() }
+            BiFunction<DataFetchingEnvironment, Any, Any> { _, value ->
+                value.toString().lowercase(Locale.getDefault())
+            }
         )
         environment.setDataFetcher(lowerCaseFetcher)
         return field

--- a/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/server/spring/directives/StringEvalSchemaDirectiveWiring.kt
+++ b/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/server/spring/directives/StringEvalSchemaDirectiveWiring.kt
@@ -23,6 +23,7 @@ import graphql.schema.DataFetcher
 import graphql.schema.DataFetchingEnvironmentImpl.newDataFetchingEnvironment
 import graphql.schema.GraphQLArgument
 import graphql.schema.GraphQLFieldDefinition
+import java.util.Locale
 
 class StringEvalSchemaDirectiveWiring : KotlinSchemaDirectiveWiring {
     private val directiveName = getDirectiveName(StringEval::class)
@@ -37,7 +38,7 @@ class StringEvalSchemaDirectiveWiring : KotlinSchemaDirectiveWiring {
                 dataEnv.getArgument(it.name) as String?
             }.forEach { (graphQLArgumentType, value) ->
                 if (graphQLArgumentType.getDirective(directiveName).getArgument(StringEval::lowerCase.name).value as Boolean) {
-                    newArguments[graphQLArgumentType.name] = value?.toLowerCase()
+                    newArguments[graphQLArgumentType.name] = value?.lowercase(Locale.getDefault())
                 }
                 if (value.isNullOrEmpty()) {
                     newArguments[graphQLArgumentType.name] = graphQLArgumentType.defaultValue

--- a/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/server/spring/directives/StringEvalSchemaDirectiveWiring.kt
+++ b/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/server/spring/directives/StringEvalSchemaDirectiveWiring.kt
@@ -23,7 +23,6 @@ import graphql.schema.DataFetcher
 import graphql.schema.DataFetchingEnvironmentImpl.newDataFetchingEnvironment
 import graphql.schema.GraphQLArgument
 import graphql.schema.GraphQLFieldDefinition
-import java.util.Locale
 
 class StringEvalSchemaDirectiveWiring : KotlinSchemaDirectiveWiring {
     private val directiveName = getDirectiveName(StringEval::class)
@@ -38,7 +37,7 @@ class StringEvalSchemaDirectiveWiring : KotlinSchemaDirectiveWiring {
                 dataEnv.getArgument(it.name) as String?
             }.forEach { (graphQLArgumentType, value) ->
                 if (graphQLArgumentType.getDirective(directiveName).getArgument(StringEval::lowerCase.name).value as Boolean) {
-                    newArguments[graphQLArgumentType.name] = value?.lowercase(Locale.getDefault())
+                    newArguments[graphQLArgumentType.name] = value?.lowercase()
                 }
                 if (value.isNullOrEmpty()) {
                     newArguments[graphQLArgumentType.name] = graphQLArgumentType.defaultValue

--- a/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/server/spring/hooks/CustomSchemaGeneratorHooks.kt
+++ b/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/server/spring/hooks/CustomSchemaGeneratorHooks.kt
@@ -18,7 +18,6 @@ package com.expediagroup.graphql.examples.server.spring.hooks
 
 import com.expediagroup.graphql.generator.directives.KotlinDirectiveWiringFactory
 import com.expediagroup.graphql.generator.hooks.SchemaGeneratorHooks
-import graphql.Scalars
 import graphql.language.StringValue
 import graphql.schema.Coercing
 import graphql.schema.CoercingParseLiteralException
@@ -28,7 +27,6 @@ import graphql.schema.GraphQLScalarType
 import graphql.schema.GraphQLType
 import org.springframework.beans.factory.BeanFactoryAware
 import reactor.core.publisher.Mono
-import java.math.BigDecimal
 import java.util.UUID
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
@@ -45,7 +43,6 @@ class CustomSchemaGeneratorHooks(override val wiringFactory: KotlinDirectiveWiri
      */
     override fun willGenerateGraphQLType(type: KType): GraphQLType? = when (type.classifier) {
         UUID::class -> graphqlUUIDType
-        BigDecimal::class -> Scalars.GraphQLBigDecimal
         else -> null
     }
 

--- a/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/server/spring/query/ScalarQuery.kt
+++ b/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/server/spring/query/ScalarQuery.kt
@@ -21,9 +21,7 @@ import com.expediagroup.graphql.generator.annotations.GraphQLDescription
 import com.expediagroup.graphql.generator.scalars.ID
 import com.expediagroup.graphql.server.operations.Query
 import org.springframework.stereotype.Component
-import java.math.BigDecimal
 import java.util.UUID
-import kotlin.random.Random
 
 /**
  * Simple query that exposes custom scalar.
@@ -41,7 +39,4 @@ class ScalarQuery : Query {
 
     @GraphQLDescription("generates random GraphQL ID")
     fun generateRandomId() = ID(UUID.randomUUID().toString())
-
-    @GraphQLDescription("generates random BigDecimal")
-    fun generateRandomBigDecimal(): BigDecimal = BigDecimal(Random.nextLong())
 }

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateDirective.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateDirective.kt
@@ -25,6 +25,7 @@ import graphql.introspection.Introspection.DirectiveLocation
 import graphql.schema.GraphQLArgument
 import graphql.schema.GraphQLDirective
 import java.lang.reflect.Field
+import java.util.Locale
 import kotlin.reflect.KAnnotatedElement
 import kotlin.reflect.KClass
 import kotlin.reflect.KProperty
@@ -104,7 +105,7 @@ private fun generateDirectiveArgument(prop: KProperty<*>, directiveInfo: Directi
         .build()
 }
 
-private fun String.normalizeDirectiveName() = this.decapitalize()
+private fun String.normalizeDirectiveName() = this.replaceFirstChar { it.lowercase(Locale.getDefault()) }
 
 private fun Annotation.getDirectiveInfo(): DirectiveInfo? = this.annotationClass.annotations
     .filterIsInstance(GraphQLDirectiveAnnotation::class.java)

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateDirective.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateDirective.kt
@@ -25,7 +25,6 @@ import graphql.introspection.Introspection.DirectiveLocation
 import graphql.schema.GraphQLArgument
 import graphql.schema.GraphQLDirective
 import java.lang.reflect.Field
-import java.util.Locale
 import kotlin.reflect.KAnnotatedElement
 import kotlin.reflect.KClass
 import kotlin.reflect.KProperty
@@ -105,7 +104,7 @@ private fun generateDirectiveArgument(prop: KProperty<*>, directiveInfo: Directi
         .build()
 }
 
-private fun String.normalizeDirectiveName() = this.replaceFirstChar { it.lowercase(Locale.getDefault()) }
+private fun String.normalizeDirectiveName() = this.replaceFirstChar { it.lowercase() }
 
 private fun Annotation.getDirectiveInfo(): DirectiveInfo? = this.annotationClass.annotations
     .filterIsInstance(GraphQLDirectiveAnnotation::class.java)

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateUnion.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateUnion.kt
@@ -45,7 +45,7 @@ private fun generateUnionFromAnnotation(generator: SchemaGenerator, unionAnnotat
 
     val possibleTypes = unionAnnotation.possibleTypes.toList()
 
-    return createUnion(generator, builder, possibleTypes, unionAnnotation.name)
+    return createUnion(generator, builder, possibleTypes)
 }
 
 private fun generateUnionFromKClass(generator: SchemaGenerator, kClass: KClass<*>): GraphQLUnionType {
@@ -60,10 +60,10 @@ private fun generateUnionFromKClass(generator: SchemaGenerator, kClass: KClass<*
 
     val types = generator.classScanner.getSubTypesOf(kClass)
 
-    return createUnion(generator, builder, types, name)
+    return createUnion(generator, builder, types)
 }
 
-private fun createUnion(generator: SchemaGenerator, builder: GraphQLUnionType.Builder, types: List<KClass<*>>, name: String): GraphQLUnionType {
+private fun createUnion(generator: SchemaGenerator, builder: GraphQLUnionType.Builder, types: List<KClass<*>>): GraphQLUnionType {
     types.map { generateGraphQLType(generator, it.createType()) }
         .forEach {
             when (val unwrappedType = it.unwrapType()) {

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/directives/KotlinDirectiveWiringFactoryTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/directives/KotlinDirectiveWiringFactoryTest.kt
@@ -28,6 +28,7 @@ import graphql.schema.GraphQLObjectType
 import graphql.schema.GraphQLTypeReference
 import io.mockk.mockk
 import org.junit.jupiter.api.Test
+import java.util.Locale
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotEquals
@@ -58,7 +59,7 @@ class KotlinDirectiveWiringFactoryTest {
 
         private fun getNewDescription(original: String?) = when {
             null != newDescription -> newDescription
-            lowerCase -> original?.toLowerCase()
+            lowerCase -> original?.lowercase(Locale.getDefault())
             else -> original
         }
     }
@@ -207,7 +208,7 @@ class KotlinDirectiveWiringFactoryTest {
         assertNotEquals(original, actual)
 
         val updatedField = actual as? GraphQLFieldDefinition
-        assertEquals(overwrittenDescription.toLowerCase(), updatedField?.description)
+        assertEquals(overwrittenDescription.lowercase(Locale.getDefault()), updatedField?.description)
     }
 
     @Test

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/directives/KotlinDirectiveWiringFactoryTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/directives/KotlinDirectiveWiringFactoryTest.kt
@@ -59,7 +59,7 @@ class KotlinDirectiveWiringFactoryTest {
 
         private fun getNewDescription(original: String?) = when {
             null != newDescription -> newDescription
-            lowerCase -> original?.lowercase(Locale.getDefault())
+            lowerCase -> original?.lowercase()
             else -> original
         }
     }
@@ -208,7 +208,7 @@ class KotlinDirectiveWiringFactoryTest {
         assertNotEquals(original, actual)
 
         val updatedField = actual as? GraphQLFieldDefinition
-        assertEquals(overwrittenDescription.lowercase(Locale.getDefault()), updatedField?.description)
+        assertEquals(overwrittenDescription.lowercase(), updatedField?.description)
     }
 
     @Test

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/directives/KotlinDirectiveWiringFactoryTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/directives/KotlinDirectiveWiringFactoryTest.kt
@@ -28,7 +28,6 @@ import graphql.schema.GraphQLObjectType
 import graphql.schema.GraphQLTypeReference
 import io.mockk.mockk
 import org.junit.jupiter.api.Test
-import java.util.Locale
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotEquals

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/extensions/AnnotationExtensionsTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/extensions/AnnotationExtensionsTest.kt
@@ -45,12 +45,14 @@ class AnnotationExtensionsTest {
 
     @Test
     fun `verify @GraphQLName on classes`() {
+        @Suppress("DEPRECATION")
         assertEquals(expected = "WithAnnotationsCustomName", actual = WithAnnotations::class.getGraphQLName())
         assertNull(NoAnnotations::class.getGraphQLName())
     }
 
     @Test
     fun `verify @GraphQLName on fields`() {
+        @Suppress("DEPRECATION")
         val fieldName = WithAnnotations::class.findMemberProperty("id")?.getGraphQLName()
         assertEquals(expected = "newName", actual = fieldName)
         assertNull(NoAnnotations::class.findMemberProperty("id")?.getGraphQLName())
@@ -58,13 +60,16 @@ class AnnotationExtensionsTest {
 
     @Test
     fun `verify @GraphQLDescrption on classes`() {
+        @Suppress("DEPRECATION")
         assertEquals(expected = "class description", actual = WithAnnotations::class.getGraphQLDescription())
         assertNull(NoAnnotations::class.getGraphQLDescription())
     }
 
     @Test
     fun `verify @Deprecated`() {
+        @Suppress("DEPRECATION")
         val classDeprecation = WithAnnotations::class.getDeprecationReason()
+        @Suppress("DEPRECATION")
         val classPropertyDeprecation = WithAnnotations::class.findMemberProperty("id")?.getDeprecationReason()
 
         assertEquals(expected = "class deprecated", actual = classDeprecation)
@@ -75,6 +80,7 @@ class AnnotationExtensionsTest {
 
     @Test
     fun `verify @GraphQLIgnore`() {
+        @Suppress("DEPRECATION")
         assertTrue(WithAnnotations::class.isGraphQLIgnored())
         assertFalse(NoAnnotations::class.isGraphQLIgnored())
     }

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/extensions/KPropertyExtensionsKtTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/extensions/KPropertyExtensionsKtTest.kt
@@ -50,7 +50,9 @@ class KPropertyExtensionsKtTest {
 
     @Test
     fun isPropertyGraphQLIgnored() {
+        @Suppress("DEPRECATION")
         assertTrue(MyDataClass::propertyAnnotation.isPropertyGraphQLIgnored(MyDataClass::class))
+        @Suppress("DEPRECATION")
         assertTrue(MyDataClass::constructorAnnotation.isPropertyGraphQLIgnored(MyDataClass::class))
         assertTrue(MyDataClass::getterAnnotation.isPropertyGraphQLIgnored(MyDataClass::class))
         assertFalse(MyDataClass::noAnnotations.isPropertyGraphQLIgnored(MyDataClass::class))
@@ -58,21 +60,27 @@ class KPropertyExtensionsKtTest {
 
     @Test
     fun getPropertyDeprecationReason() {
+        @Suppress("DEPRECATION")
         assertEquals("property deprecated", MyDataClass::propertyAnnotation.getPropertyDeprecationReason(MyDataClass::class))
+        @Suppress("DEPRECATION")
         assertEquals("constructor deprecated", MyDataClass::constructorAnnotation.getPropertyDeprecationReason(MyDataClass::class))
         assertEquals(null, MyDataClass::noAnnotations.getPropertyDeprecationReason(MyDataClass::class))
     }
 
     @Test
     fun getPropertyDescription() {
+        @Suppress("DEPRECATION")
         assertEquals("property description", MyDataClass::propertyAnnotation.getPropertyDescription(MyDataClass::class))
+        @Suppress("DEPRECATION")
         assertEquals("constructor description", MyDataClass::constructorAnnotation.getPropertyDescription(MyDataClass::class))
         assertEquals(null, MyDataClass::noAnnotations.getPropertyDescription(MyDataClass::class))
     }
 
     @Test
     fun getPropertyName() {
+        @Suppress("DEPRECATION")
         assertEquals("nameOnProperty", MyDataClass::propertyAnnotation.getPropertyName(MyDataClass::class))
+        @Suppress("DEPRECATION")
         assertEquals("nameOnConstructor", MyDataClass::constructorAnnotation.getPropertyName(MyDataClass::class))
         assertEquals("noAnnotations", MyDataClass::noAnnotations.getPropertyName(MyDataClass::class))
     }

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/types/GenerateFunctionTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/types/GenerateFunctionTest.kt
@@ -127,6 +127,7 @@ class GenerateFunctionTest : TypeTestHelper() {
 
     @Test
     fun `Functions can be deprecated`() {
+        @Suppress("DEPRECATION")
         val kFunction = Happy::sketch
         val result = generateFunction(generator, kFunction, "Query", target = null, abstract = false)
         assertTrue(result.isDeprecated)

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/types/GeneratePropertyTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/types/GeneratePropertyTest.kt
@@ -112,6 +112,7 @@ class GeneratePropertyTest : TypeTestHelper() {
 
     @Test
     fun `Test deprecation`() {
+        @Suppress("DEPRECATION")
         val prop = ClassWithProperties::dessert
         val result = generateProperty(generator, prop, ClassWithProperties::class)
 
@@ -121,6 +122,7 @@ class GeneratePropertyTest : TypeTestHelper() {
 
     @Test
     fun `Test deprecation with replacement`() {
+        @Suppress("DEPRECATION")
         val prop = ClassWithProperties::healthyFood
         val result = generateProperty(generator, prop, ClassWithProperties::class)
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generateClient.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generateClient.kt
@@ -18,8 +18,8 @@ package com.expediagroup.graphql.plugin.client
 
 import com.expediagroup.graphql.plugin.client.generator.GraphQLClientGenerator
 import com.expediagroup.graphql.plugin.client.generator.GraphQLClientGeneratorConfig
-import com.expediagroup.graphql.plugin.client.generator.GraphQLSerializer
 import com.expediagroup.graphql.plugin.client.generator.GraphQLScalar
+import com.expediagroup.graphql.plugin.client.generator.GraphQLSerializer
 import com.squareup.kotlinpoet.FileSpec
 import java.io.File
 

--- a/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/GraphQLClientGenerator.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/GraphQLClientGenerator.kt
@@ -95,9 +95,9 @@ class GraphQLClientGenerator(
         }
 
         val fileSpecs = mutableListOf<FileSpec>()
-        val operationFileSpec = FileSpec.builder(packageName = config.packageName, fileName = queryFile.nameWithoutExtension.capitalizeWithDefaultLocale())
+        val operationFileSpec = FileSpec.builder(packageName = config.packageName, fileName = queryFile.nameWithoutExtension.capitalizeFirstChar())
         operationDefinitions.forEach { operationDefinition ->
-            val capitalizedOperationName = operationDefinition.name?.capitalizeWithDefaultLocale() ?: queryFile.nameWithoutExtension.capitalizeWithDefaultLocale()
+            val capitalizedOperationName = operationDefinition.name?.capitalizeFirstChar() ?: queryFile.nameWithoutExtension.capitalizeFirstChar()
             val context = GraphQLClientGeneratorContext(
                 packageName = config.packageName,
                 graphQLSchema = graphQLSchema,
@@ -233,8 +233,7 @@ class GraphQLClientGenerator(
  * This is the reccommended approach now with the deprecation of String.capitalize from the
  * Kotlin stdlib in version 1.5.
  */
-internal fun String.capitalizeWithDefaultLocale(): String =
-    replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() }
+internal fun String.capitalizeFirstChar(): String = replaceFirstChar { if (it.isLowerCase()) it.uppercaseChar() else it }
 
 internal fun String.toUpperUnderscore(): String {
     val builder = StringBuilder()

--- a/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/GraphQLClientGenerator.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/GraphQLClientGenerator.kt
@@ -36,6 +36,7 @@ import graphql.schema.idl.SchemaParser
 import graphql.schema.idl.TypeDefinitionRegistry
 import kotlinx.serialization.Serializable
 import java.io.File
+import java.util.Locale
 
 private const val CORE_TYPES_PACKAGE = "com.expediagroup.graphql.client.types"
 
@@ -94,9 +95,9 @@ class GraphQLClientGenerator(
         }
 
         val fileSpecs = mutableListOf<FileSpec>()
-        val operationFileSpec = FileSpec.builder(packageName = config.packageName, fileName = queryFile.nameWithoutExtension.capitalize())
+        val operationFileSpec = FileSpec.builder(packageName = config.packageName, fileName = queryFile.nameWithoutExtension.capitalizeWithDefaultLocale())
         operationDefinitions.forEach { operationDefinition ->
-            val capitalizedOperationName = operationDefinition.name?.capitalize() ?: queryFile.nameWithoutExtension.capitalize()
+            val capitalizedOperationName = operationDefinition.name?.capitalizeWithDefaultLocale() ?: queryFile.nameWithoutExtension.capitalizeWithDefaultLocale()
             val context = GraphQLClientGeneratorContext(
                 packageName = config.packageName,
                 graphQLSchema = graphQLSchema,
@@ -205,7 +206,7 @@ class GraphQLClientGenerator(
 
     private fun findRootType(operationDefinition: OperationDefinition): ObjectTypeDefinition {
         val operationNames = if (graphQLSchema.schemaDefinition().isPresent) {
-            graphQLSchema.schemaDefinition().get().operationTypeDefinitions.associateBy({ it.name.toUpperCase() }, { it.typeName.name })
+            graphQLSchema.schemaDefinition().get().operationTypeDefinitions.associateBy({ it.name.uppercase(Locale.getDefault()) }, { it.typeName.name })
         } else {
             mapOf(
                 OperationDefinition.Operation.QUERY.name to "Query",
@@ -228,6 +229,13 @@ class GraphQLClientGenerator(
     }
 }
 
+/**
+ * This is the reccommended approach now with the deprecation of String.capitalize from the
+ * Kotlin stdlib in version 1.5.
+ */
+internal fun String.capitalizeWithDefaultLocale(): String =
+    replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() }
+
 internal fun String.toUpperUnderscore(): String {
     val builder = StringBuilder()
     val nameCharArray = this.toCharArray()
@@ -237,7 +245,7 @@ internal fun String.toUpperUnderscore(): String {
                 builder.append("_")
             }
         }
-        builder.append(c.toUpperCase())
+        builder.append(c.uppercaseChar())
     }
     return builder.toString()
 }

--- a/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/GraphQLClientGenerator.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/GraphQLClientGenerator.kt
@@ -36,7 +36,6 @@ import graphql.schema.idl.SchemaParser
 import graphql.schema.idl.TypeDefinitionRegistry
 import kotlinx.serialization.Serializable
 import java.io.File
-import java.util.Locale
 
 private const val CORE_TYPES_PACKAGE = "com.expediagroup.graphql.client.types"
 
@@ -206,7 +205,7 @@ class GraphQLClientGenerator(
 
     private fun findRootType(operationDefinition: OperationDefinition): ObjectTypeDefinition {
         val operationNames = if (graphQLSchema.schemaDefinition().isPresent) {
-            graphQLSchema.schemaDefinition().get().operationTypeDefinitions.associateBy({ it.name.uppercase(Locale.getDefault()) }, { it.typeName.name })
+            graphQLSchema.schemaDefinition().get().operationTypeDefinitions.associateBy({ it.name.uppercase() }, { it.typeName.name })
         } else {
             mapOf(
                 OperationDefinition.Operation.QUERY.name to "Query",

--- a/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/types/generateGraphQLEnumTypeSpec.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/types/generateGraphQLEnumTypeSpec.kt
@@ -54,7 +54,7 @@ internal fun generateGraphQLEnumTypeSpec(context: GraphQLClientGeneratorContext,
                     .build()
             )
         }
-        val enumName = enumValueDefinition.name.toUpperCase(Locale.US)
+        val enumName = enumValueDefinition.name.uppercase(Locale.US)
         if (enumName != enumValueDefinition.name) {
             if (context.serializer == GraphQLSerializer.JACKSON) {
                 enumValueTypeSpecBuilder.addAnnotation(

--- a/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/types/generateGraphQLEnumTypeSpec.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/types/generateGraphQLEnumTypeSpec.kt
@@ -27,7 +27,6 @@ import graphql.language.EnumTypeDefinition
 import graphql.language.StringValue
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import java.util.Locale
 
 internal const val UNKNOWN_VALUE = "__UNKNOWN_VALUE"
 
@@ -54,7 +53,7 @@ internal fun generateGraphQLEnumTypeSpec(context: GraphQLClientGeneratorContext,
                     .build()
             )
         }
-        val enumName = enumValueDefinition.name.uppercase(Locale.US)
+        val enumName = enumValueDefinition.name.uppercase()
         if (enumName != enumValueDefinition.name) {
             if (context.serializer == GraphQLSerializer.JACKSON) {
                 enumValueTypeSpecBuilder.addAnnotation(

--- a/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/types/generateInterfaceTypeSpec.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/types/generateInterfaceTypeSpec.kt
@@ -40,6 +40,7 @@ import graphql.language.Selection
 import graphql.language.SelectionSet
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import java.util.Locale
 
 /**
  * Generate interface [TypeSpec] based on the available field definitions and selection set. Generates all implementing classes as well.
@@ -185,7 +186,7 @@ private fun updateImplementationTypeSpecWithSuperInformation(
         .addModifiers(implementationTypeSpec.modifiers)
         .addKdoc("%L", implementationTypeSpec.kdoc)
 
-    val superClassName = ClassName("${context.packageName}.${context.operationName.toLowerCase()}", interfaceName)
+    val superClassName = ClassName("${context.packageName}.${context.operationName.lowercase(Locale.getDefault())}", interfaceName)
     if (context.serializer == GraphQLSerializer.KOTLINX) {
         builder.addAnnotation(Serializable::class)
             .addAnnotation(

--- a/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/types/generateInterfaceTypeSpec.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/types/generateInterfaceTypeSpec.kt
@@ -186,7 +186,7 @@ private fun updateImplementationTypeSpecWithSuperInformation(
         .addModifiers(implementationTypeSpec.modifiers)
         .addKdoc("%L", implementationTypeSpec.kdoc)
 
-    val superClassName = ClassName("${context.packageName}.${context.operationName.lowercase(Locale.getDefault())}", interfaceName)
+    val superClassName = ClassName("${context.packageName}.${context.operationName.lowercase()}", interfaceName)
     if (context.serializer == GraphQLSerializer.KOTLINX) {
         builder.addAnnotation(Serializable::class)
             .addAnnotation(

--- a/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/types/generateInterfaceTypeSpec.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/types/generateInterfaceTypeSpec.kt
@@ -40,7 +40,6 @@ import graphql.language.Selection
 import graphql.language.SelectionSet
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import java.util.Locale
 
 /**
  * Generate interface [TypeSpec] based on the available field definitions and selection set. Generates all implementing classes as well.

--- a/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/types/generateTypeName.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/types/generateTypeName.kt
@@ -47,7 +47,6 @@ import graphql.language.Type
 import graphql.language.TypeDefinition
 import graphql.language.UnionTypeDefinition
 import kotlinx.serialization.Serializable
-import java.util.Locale
 
 /**
  * Generate [TypeName] reference to a Kotlin class representation of an underlying GraphQL type.
@@ -183,7 +182,7 @@ internal fun generateClassName(
     graphQLType: NamedNode<*>,
     selectionSet: SelectionSet? = null,
     nameOverride: String? = null,
-    packageName: String = "${context.packageName}.${context.operationName.lowercase(Locale.getDefault())}"
+    packageName: String = "${context.packageName}.${context.operationName.lowercase()}"
 ): ClassName {
     val typeName = nameOverride ?: graphQLType.name
     val className = ClassName(packageName, typeName)

--- a/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/types/generateTypeName.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/types/generateTypeName.kt
@@ -47,6 +47,7 @@ import graphql.language.Type
 import graphql.language.TypeDefinition
 import graphql.language.UnionTypeDefinition
 import kotlinx.serialization.Serializable
+import java.util.Locale
 
 /**
  * Generate [TypeName] reference to a Kotlin class representation of an underlying GraphQL type.
@@ -182,7 +183,7 @@ internal fun generateClassName(
     graphQLType: NamedNode<*>,
     selectionSet: SelectionSet? = null,
     nameOverride: String? = null,
-    packageName: String = "${context.packageName}.${context.operationName.toLowerCase()}"
+    packageName: String = "${context.packageName}.${context.operationName.lowercase(Locale.getDefault())}"
 ): ClassName {
     val typeName = nameOverride ?: graphQLType.name
     val className = ClassName(packageName, typeName)

--- a/plugins/client/graphql-kotlin-client-generator/src/test/kotlin/com/expediagroup/graphql/plugin/client/DownloadSchemaTest.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/kotlin/com/expediagroup/graphql/plugin/client/DownloadSchemaTest.kt
@@ -25,7 +25,6 @@ import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 import graphql.schema.idl.errors.SchemaProblem
 import io.ktor.client.features.ClientRequestException
 import io.ktor.client.features.HttpRequestTimeoutException
-import io.ktor.util.KtorExperimentalAPI
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
@@ -44,7 +43,6 @@ class DownloadSchemaTest {
     }
 
     @Test
-    @KtorExperimentalAPI
     fun `verify can download SDL`() {
         val expectedSchema =
             """
@@ -95,7 +93,6 @@ class DownloadSchemaTest {
     }
 
     @Test
-    @KtorExperimentalAPI
     fun `verify downloadSchema will throw exception if URL is not valid`() {
         assertThrows<UnknownHostException> {
             runBlocking {
@@ -105,7 +102,6 @@ class DownloadSchemaTest {
     }
 
     @Test
-    @KtorExperimentalAPI
     fun `verify downloadSchema will throw exception if downloaded SDL is not valid schema`() {
         stubFor(
             get("/whatever").willReturn(
@@ -124,7 +120,6 @@ class DownloadSchemaTest {
     }
 
     @Test
-    @KtorExperimentalAPI
     fun `verify downloadSchema will throw exception if unable to download schema`() {
         stubFor(
             get("/sdl").willReturn(aResponse().withStatus(404))
@@ -137,7 +132,6 @@ class DownloadSchemaTest {
     }
 
     @Test
-    @KtorExperimentalAPI
     fun `verify downloadSchema will respect timeout setting`() {
         stubFor(
             get("/sdl").willReturn(

--- a/plugins/client/graphql-kotlin-client-generator/src/test/kotlin/com/expediagroup/graphql/plugin/client/IntrospectSchemaTest.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/kotlin/com/expediagroup/graphql/plugin/client/IntrospectSchemaTest.kt
@@ -21,7 +21,6 @@ import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 import io.ktor.client.features.ClientRequestException
 import io.ktor.client.features.HttpRequestTimeoutException
-import io.ktor.util.KtorExperimentalAPI
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
@@ -40,7 +39,6 @@ class IntrospectSchemaTest {
     }
 
     @Test
-    @KtorExperimentalAPI
     fun `verify can run introspection query and generate valid schema`() {
         val expectedSchema =
             """
@@ -106,7 +104,6 @@ class IntrospectSchemaTest {
     }
 
     @Test
-    @KtorExperimentalAPI
     fun `verify introspectSchema will throw exception if unable to run query`() {
         WireMock.stubFor(
             WireMock.post("/graphql")
@@ -120,7 +117,6 @@ class IntrospectSchemaTest {
     }
 
     @Test
-    @KtorExperimentalAPI
     fun `verify introspectSchema will respect timeout setting`() {
         WireMock.stubFor(
             WireMock.post("/graphql")
@@ -138,7 +134,6 @@ class IntrospectSchemaTest {
     }
 
     @Test
-    @KtorExperimentalAPI
     fun `verify introspectSchema will throw exception if URL is not valid`() {
         assertThrows<UnknownHostException> {
             runBlocking {

--- a/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLPluginExtension.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLPluginExtension.kt
@@ -16,8 +16,8 @@
 
 package com.expediagroup.graphql.plugin.gradle
 
-import com.expediagroup.graphql.plugin.gradle.config.GraphQLSerializer
 import com.expediagroup.graphql.plugin.gradle.config.GraphQLScalar
+import com.expediagroup.graphql.plugin.gradle.config.GraphQLSerializer
 import com.expediagroup.graphql.plugin.gradle.config.TimeoutConfiguration
 import org.gradle.api.Action
 import java.io.File

--- a/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/actions/GenerateClientAction.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/actions/GenerateClientAction.kt
@@ -17,8 +17,8 @@
 package com.expediagroup.graphql.plugin.gradle.actions
 
 import com.expediagroup.graphql.plugin.client.generateClient
-import com.expediagroup.graphql.plugin.client.generator.GraphQLSerializer
 import com.expediagroup.graphql.plugin.client.generator.GraphQLScalar
+import com.expediagroup.graphql.plugin.client.generator.GraphQLSerializer
 import com.expediagroup.graphql.plugin.gradle.parameters.GenerateClientParameters
 import org.gradle.workers.WorkAction
 

--- a/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/parameters/GenerateClientParameters.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/parameters/GenerateClientParameters.kt
@@ -16,8 +16,8 @@
 
 package com.expediagroup.graphql.plugin.gradle.parameters
 
-import com.expediagroup.graphql.plugin.gradle.config.GraphQLSerializer
 import com.expediagroup.graphql.plugin.gradle.config.GraphQLScalar
+import com.expediagroup.graphql.plugin.gradle.config.GraphQLSerializer
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.workers.WorkParameters

--- a/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/AbstractGenerateClientTask.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/AbstractGenerateClientTask.kt
@@ -17,8 +17,8 @@
 package com.expediagroup.graphql.plugin.gradle.tasks
 
 import com.expediagroup.graphql.plugin.gradle.actions.GenerateClientAction
-import com.expediagroup.graphql.plugin.gradle.config.GraphQLSerializer
 import com.expediagroup.graphql.plugin.gradle.config.GraphQLScalar
+import com.expediagroup.graphql.plugin.gradle.config.GraphQLSerializer
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty

--- a/plugins/graphql-kotlin-maven-plugin/pom.xml
+++ b/plugins/graphql-kotlin-maven-plugin/pom.xml
@@ -131,7 +131,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-invoker-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>3.2.2</version>
                 <configuration>
                     <cloneProjectsTo>${project.build.outputDirectory}/integration</cloneProjectsTo>
                     <filterProperties>

--- a/servers/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/server/spring/GraphQLRoutesConfiguration.kt
+++ b/servers/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/server/spring/GraphQLRoutesConfiguration.kt
@@ -25,6 +25,7 @@ import org.springframework.web.reactive.function.server.bodyValueAndAwait
 import org.springframework.web.reactive.function.server.buildAndAwait
 import org.springframework.web.reactive.function.server.coRouter
 import org.springframework.web.reactive.function.server.json
+import java.util.Locale
 
 /**
  * Default route configuration for GraphQL endpoints.
@@ -64,5 +65,5 @@ class GraphQLRoutesConfiguration(
     }
 
     private fun requestContainsHeader(headers: ServerRequest.Headers, headerName: String, headerValue: String): Boolean =
-        headers.header(headerName).map { it.toLowerCase() }.contains(headerValue.toLowerCase())
+        headers.header(headerName).map { it.lowercase(Locale.getDefault()) }.contains(headerValue.lowercase(Locale.getDefault()))
 }

--- a/servers/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/server/spring/GraphQLRoutesConfiguration.kt
+++ b/servers/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/server/spring/GraphQLRoutesConfiguration.kt
@@ -25,7 +25,6 @@ import org.springframework.web.reactive.function.server.bodyValueAndAwait
 import org.springframework.web.reactive.function.server.buildAndAwait
 import org.springframework.web.reactive.function.server.coRouter
 import org.springframework.web.reactive.function.server.json
-import java.util.Locale
 
 /**
  * Default route configuration for GraphQL endpoints.
@@ -65,5 +64,5 @@ class GraphQLRoutesConfiguration(
     }
 
     private fun requestContainsHeader(headers: ServerRequest.Headers, headerName: String, headerValue: String): Boolean =
-        headers.header(headerName).map { it.lowercase(Locale.getDefault()) }.contains(headerValue.lowercase(Locale.getDefault()))
+        headers.header(headerName).map { it.lowercase() }.contains(headerValue.lowercase())
 }

--- a/servers/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/server/spring/subscriptions/ApolloSubscriptionProtocolHandlerTest.kt
+++ b/servers/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/server/spring/subscriptions/ApolloSubscriptionProtocolHandlerTest.kt
@@ -27,9 +27,9 @@ import com.expediagroup.graphql.server.spring.subscriptions.SubscriptionOperatio
 import com.expediagroup.graphql.server.spring.subscriptions.SubscriptionOperationMessage.ServerMessages.GQL_CONNECTION_KEEP_ALIVE
 import com.expediagroup.graphql.server.spring.subscriptions.SubscriptionOperationMessage.ServerMessages.GQL_DATA
 import com.expediagroup.graphql.server.spring.subscriptions.SubscriptionOperationMessage.ServerMessages.GQL_ERROR
-import com.expediagroup.graphql.server.types.GraphQLServerError
 import com.expediagroup.graphql.server.types.GraphQLRequest
 import com.expediagroup.graphql.server.types.GraphQLResponse
+import com.expediagroup.graphql.server.types.GraphQLServerError
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.mockk.coEvery
 import io.mockk.every

--- a/website/docs/client/client-customization.mdx
+++ b/website/docs/client/client-customization.mdx
@@ -3,6 +3,7 @@ id: client-customization
 title: Client Customization
 ---
 
+
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 

--- a/website/docs/client/client-features.mdx
+++ b/website/docs/client/client-features.mdx
@@ -3,6 +3,7 @@ id: client-features
 title: Client Features
 ---
 
+
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 

--- a/website/docs/client/client-overview.mdx
+++ b/website/docs/client/client-overview.mdx
@@ -3,6 +3,7 @@ id: client-overview
 title: Client Overview
 ---
 
+
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 

--- a/website/docs/client/client-serialization.mdx
+++ b/website/docs/client/client-serialization.mdx
@@ -3,6 +3,7 @@ id: client-serialization
 title: Client Serialization
 ---
 
+
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 

--- a/website/docs/getting-started.mdx
+++ b/website/docs/getting-started.mdx
@@ -4,6 +4,7 @@ title: Getting Started
 slug: /
 ---
 
+
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 

--- a/website/docs/plugins/gradle-plugin-tasks.mdx
+++ b/website/docs/plugins/gradle-plugin-tasks.mdx
@@ -4,6 +4,7 @@ title: Gradle Plugin Tasks
 sidebar_label: Tasks
 ---
 
+
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 

--- a/website/docs/plugins/gradle-plugin-usage.mdx
+++ b/website/docs/plugins/gradle-plugin-usage.mdx
@@ -4,6 +4,7 @@ title: Gradle Plugin Usage
 sidebar_label: Usage
 ---
 
+
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 

--- a/website/docs/plugins/hooks-provider.mdx
+++ b/website/docs/plugins/hooks-provider.mdx
@@ -3,6 +3,7 @@ id: hooks-provider
 title: Schema Generator Hooks Provider
 ---
 
+
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 

--- a/website/docs/schema-generator/federation/apollo-federation.mdx
+++ b/website/docs/schema-generator/federation/apollo-federation.mdx
@@ -3,6 +3,7 @@ id: apollo-federation
 title: Apollo Federation
 ---
 
+
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 

--- a/website/docs/schema-generator/schema-generator-getting-started.mdx
+++ b/website/docs/schema-generator/schema-generator-getting-started.mdx
@@ -3,6 +3,7 @@ id: schema-generator-getting-started
 title: Getting Started
 ---
 
+
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 

--- a/website/docs/server/spring-server/spring-overview.mdx
+++ b/website/docs/server/spring-server/spring-overview.mdx
@@ -3,6 +3,7 @@ id: spring-overview
 title: Spring Server Overview
 ---
 
+
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 

--- a/website/src/theme/DocVersionSuggestions/index.js
+++ b/website/src/theme/DocVersionSuggestions/index.js
@@ -7,8 +7,8 @@
 import React from 'react';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Link from '@docusaurus/Link';
-import { useActivePlugin, useActiveVersion, useDocVersionSuggestions } from '@theme/hooks/useDocs';
-import { useDocsPreferredVersion } from '@docusaurus/theme-common';
+import {useActivePlugin, useActiveVersion, useDocVersionSuggestions} from '@theme/hooks/useDocs';
+import {useDocsPreferredVersion} from '@docusaurus/theme-common';
 
 const getVersionMainDoc = version => version.docs.find(doc => doc.id === version.mainDocId);
 

--- a/website/static/img/kotlin-logo.svg
+++ b/website/static/img/kotlin-logo.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 19.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 60 60" style="enable-background:new 0 0 60 60;" xml:space="preserve">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px"
+     viewBox="0 0 60 60" style="enable-background:new 0 0 60 60;" xml:space="preserve">
 <g>
 
 		<linearGradient id="XMLID_3_" gradientUnits="userSpaceOnUse" x1="15.9594" y1="-13.0143" x2="44.3068" y2="15.3332" gradientTransform="matrix(1 0 0 -1 0 61)">

--- a/website/versioned_docs/version-4.x.x/client/client-customization.mdx
+++ b/website/versioned_docs/version-4.x.x/client/client-customization.mdx
@@ -3,6 +3,7 @@ id: client-customization
 title: Client Customization
 ---
 
+
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 

--- a/website/versioned_docs/version-4.x.x/client/client-features.mdx
+++ b/website/versioned_docs/version-4.x.x/client/client-features.mdx
@@ -3,6 +3,7 @@ id: client-features
 title: Client Features
 ---
 
+
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 

--- a/website/versioned_docs/version-4.x.x/client/client-overview.mdx
+++ b/website/versioned_docs/version-4.x.x/client/client-overview.mdx
@@ -3,6 +3,7 @@ id: client-overview
 title: Client Overview
 ---
 
+
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 

--- a/website/versioned_docs/version-4.x.x/client/client-serialization.mdx
+++ b/website/versioned_docs/version-4.x.x/client/client-serialization.mdx
@@ -3,6 +3,7 @@ id: client-serialization
 title: Client Serialization
 ---
 
+
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 

--- a/website/versioned_docs/version-4.x.x/getting-started.mdx
+++ b/website/versioned_docs/version-4.x.x/getting-started.mdx
@@ -4,6 +4,7 @@ title: Getting Started
 slug: /
 ---
 
+
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 

--- a/website/versioned_docs/version-4.x.x/plugins/gradle-plugin-tasks.mdx
+++ b/website/versioned_docs/version-4.x.x/plugins/gradle-plugin-tasks.mdx
@@ -4,6 +4,7 @@ title: Gradle Plugin Tasks
 sidebar_label: Tasks
 ---
 
+
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 

--- a/website/versioned_docs/version-4.x.x/plugins/gradle-plugin-usage.mdx
+++ b/website/versioned_docs/version-4.x.x/plugins/gradle-plugin-usage.mdx
@@ -4,6 +4,7 @@ title: Gradle Plugin Usage
 sidebar_label: Usage
 ---
 
+
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 

--- a/website/versioned_docs/version-4.x.x/plugins/hooks-provider.mdx
+++ b/website/versioned_docs/version-4.x.x/plugins/hooks-provider.mdx
@@ -3,6 +3,7 @@ id: hooks-provider
 title: Schema Generator Hooks Provider
 ---
 
+
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 

--- a/website/versioned_docs/version-4.x.x/schema-generator/federation/apollo-federation.mdx
+++ b/website/versioned_docs/version-4.x.x/schema-generator/federation/apollo-federation.mdx
@@ -3,6 +3,7 @@ id: apollo-federation
 title: Apollo Federation
 ---
 
+
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 

--- a/website/versioned_docs/version-4.x.x/schema-generator/schema-generator-getting-started.mdx
+++ b/website/versioned_docs/version-4.x.x/schema-generator/schema-generator-getting-started.mdx
@@ -3,6 +3,7 @@ id: schema-generator-getting-started
 title: Getting Started
 ---
 
+
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 

--- a/website/versioned_docs/version-4.x.x/server/spring-server/spring-overview.mdx
+++ b/website/versioned_docs/version-4.x.x/server/spring-server/spring-overview.mdx
@@ -3,6 +3,7 @@ id: spring-overview
 title: Spring Server Overview
 ---
 
+
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 


### PR DESCRIPTION
### :pencil: Description
With the update to Kotlin 1.5 there are some new deprecations and that we can fix and updating Gradle to use the same kotlin version under the hood

### :link: Related Issues
https://docs.gradle.org/7.1.1/userguide/upgrading_version_7.html#changes_7.1.1