### PR TITLE
Backport GraphQLUnion to 4.x.x

### DIFF
--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/annotations/GraphQLUnion.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/annotations/GraphQLUnion.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Expedia, Inc
+ * Copyright 2021 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-package com.expediagroup.graphql.generator.internal.state
+package com.expediagroup.graphql.generator.annotations
 
-import kotlin.reflect.KType
+import kotlin.reflect.KClass
 
-internal data class TypesCacheKey(
-    val type: KType,
-    val inputType: Boolean = false,
-    val name: String? = null
+@Target(AnnotationTarget.PROPERTY, AnnotationTarget.FUNCTION)
+annotation class GraphQLUnion(
+    val name: String,
+    val possibleTypes: Array<KClass<*>>,
+    val description: String = ""
 )

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/exceptions/InvalidCustomUnionException.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/exceptions/InvalidCustomUnionException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Expedia, Inc
+ * Copyright 2021 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,12 +14,9 @@
  * limitations under the License.
  */
 
-package com.expediagroup.graphql.generator.internal.state
+package com.expediagroup.graphql.generator.exceptions
 
 import kotlin.reflect.KType
 
-internal data class TypesCacheKey(
-    val type: KType,
-    val inputType: Boolean = false,
-    val name: String? = null
-)
+class InvalidCustomUnionException(returnType: KType) :
+    GraphQLKotlinException("The custom union annotation was used but the return type was $returnType instead of Any")

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/extensions/annotationExtensions.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/extensions/annotationExtensions.kt
@@ -19,6 +19,7 @@ package com.expediagroup.graphql.generator.internal.extensions
 import com.expediagroup.graphql.generator.annotations.GraphQLDescription
 import com.expediagroup.graphql.generator.annotations.GraphQLIgnore
 import com.expediagroup.graphql.generator.annotations.GraphQLName
+import com.expediagroup.graphql.generator.annotations.GraphQLUnion
 import kotlin.reflect.KAnnotatedElement
 import kotlin.reflect.full.findAnnotation
 
@@ -30,7 +31,9 @@ internal fun KAnnotatedElement.getDeprecationReason(): String? = this.findAnnota
 
 internal fun KAnnotatedElement.isGraphQLIgnored(): Boolean = this.findAnnotation<GraphQLIgnore>() != null
 
-internal fun Deprecated.getReason(): String? {
+internal fun List<Annotation>.getUnionAnnotation(): GraphQLUnion? = this.filterIsInstance(GraphQLUnion::class.java).firstOrNull()
+
+internal fun Deprecated.getReason(): String {
     val builder = StringBuilder()
     builder.append(this.message)
 

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/extensions/kClassExtensions.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/extensions/kClassExtensions.kt
@@ -60,8 +60,11 @@ internal fun KClass<*>.findConstructorParameter(name: String): KParameter? =
 internal fun KClass<*>.isInterface(): Boolean =
     this.java.isInterface || this.isAbstract || this.isSealed
 
-internal fun KClass<*>.isUnion(): Boolean =
-    this.isInterface() && this.declaredMemberProperties.isEmpty() && this.declaredMemberFunctions.isEmpty()
+internal fun KClass<*>.isUnion(fieldAnnotations: List<Annotation> = emptyList()): Boolean = this.isDeclaredUnion() || this.isAnnotationUnion(fieldAnnotations)
+
+private fun KClass<*>.isDeclaredUnion() = this.isInterface() && this.declaredMemberProperties.isEmpty() && this.declaredMemberFunctions.isEmpty()
+
+internal fun KClass<*>.isAnnotationUnion(fieldAnnotations: List<Annotation>): Boolean = this.isInstance(Any::class) && fieldAnnotations.getUnionAnnotation() != null
 
 /**
  * Do not add interfaces as additional types if it expects all the types

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/state/TypesCache.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/state/TypesCache.kt
@@ -16,10 +16,14 @@
 
 package com.expediagroup.graphql.generator.internal.state
 
+import com.expediagroup.graphql.generator.annotations.GraphQLUnion
 import com.expediagroup.graphql.generator.exceptions.ConflictingTypesException
+import com.expediagroup.graphql.generator.exceptions.InvalidCustomUnionException
 import com.expediagroup.graphql.generator.exceptions.TypeNotSupportedException
 import com.expediagroup.graphql.generator.internal.extensions.getKClass
 import com.expediagroup.graphql.generator.internal.extensions.getSimpleName
+import com.expediagroup.graphql.generator.internal.extensions.getUnionAnnotation
+import com.expediagroup.graphql.generator.internal.extensions.isAnnotationUnion
 import com.expediagroup.graphql.generator.internal.extensions.isListType
 import com.expediagroup.graphql.generator.internal.extensions.qualifiedName
 import graphql.schema.GraphQLNamedType
@@ -35,6 +39,11 @@ internal class TypesCache(private val supportedPackages: List<String>) : Closeab
 
     private val cache: MutableMap<String, KGraphQLType> = mutableMapOf()
     private val typesUnderConstruction: MutableSet<TypesCacheKey> = mutableSetOf()
+
+    internal fun get(type: KType, inputType: Boolean, annotations: List<Annotation>): GraphQLNamedType? {
+        val cacheKey = generateCacheKey(type, inputType, annotations)
+        return get(cacheKey)
+    }
 
     @Throws(ConflictingTypesException::class)
     internal fun get(cacheKey: TypesCacheKey): GraphQLNamedType? {
@@ -64,6 +73,28 @@ internal class TypesCache(private val supportedPackages: List<String>) : Closeab
         return null
     }
 
+    private fun generateCacheKey(type: KType, inputType: Boolean, annotations: List<Annotation> = emptyList()): TypesCacheKey {
+        if (type.getKClass().isListType()) {
+            return TypesCacheKey(type, inputType)
+        }
+
+        val unionAnnotation = annotations.getUnionAnnotation()
+
+        return if (unionAnnotation != null) {
+            if (type.getKClass().isAnnotationUnion(annotations)) {
+                TypesCacheKey(type = type, inputType = inputType, name = getCustomUnionNameKey(unionAnnotation))
+            } else {
+                throw InvalidCustomUnionException(type)
+            }
+        } else {
+            TypesCacheKey(type = type, inputType = inputType)
+        }
+    }
+
+    private fun getCustomUnionNameKey(union: GraphQLUnion): String {
+        return union.name + union.possibleTypes.joinToString(prefix = "[", postfix = "]", separator = ",") { it.getSimpleName() }
+    }
+
     /**
      * Clear the cache of all saved values
      */
@@ -80,25 +111,29 @@ internal class TypesCache(private val supportedPackages: List<String>) : Closeab
      * Enums do not have a different name for input and output.
      */
     private fun getCacheKeyString(cacheKey: TypesCacheKey): String? {
-        val type = cacheKey.type
-        val kClass = type.getKClass()
+        return if (cacheKey.name != null) {
+            cacheKey.name
+        } else {
+            val type = cacheKey.type
+            val kClass = type.getKClass()
 
-        return when {
-            kClass.isListType() -> null
-            kClass.isSubclassOf(Enum::class) -> kClass.getSimpleName()
-            isTypeNotSupported(type) -> throw TypeNotSupportedException(type, supportedPackages)
-            else -> type.getSimpleName(cacheKey.inputType)
+            when {
+                kClass.isListType() -> null
+                kClass.isSubclassOf(Enum::class) -> kClass.getSimpleName()
+                isTypeNotSupported(type) -> throw TypeNotSupportedException(type, supportedPackages)
+                else -> type.getSimpleName(cacheKey.inputType)
+            }
         }
     }
 
     private fun isTypeNotSupported(type: KType): Boolean = supportedPackages.none { type.qualifiedName.startsWith(it) }
 
-    internal fun buildIfNotUnderConstruction(kClass: KClass<*>, inputType: Boolean, build: (KClass<*>) -> GraphQLType): GraphQLType {
+    internal fun buildIfNotUnderConstruction(kClass: KClass<*>, inputType: Boolean, annotations: List<Annotation>, build: (KClass<*>) -> GraphQLType): GraphQLType {
         if (kClass.isListType()) {
             return build(kClass)
         }
 
-        val cacheKey = TypesCacheKey(kClass.starProjectedType, inputType)
+        val cacheKey = generateCacheKey(kClass.starProjectedType, inputType, annotations)
         val cachedType = get(cacheKey)
         return when {
             cachedType != null -> cachedType

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateFunction.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateFunction.kt
@@ -51,7 +51,7 @@ internal fun generateFunction(generator: SchemaGenerator, fn: KFunction<*>, pare
 
     val typeFromHooks = generator.config.hooks.willResolveMonad(fn.returnType)
     val returnType = getWrappedReturnType(typeFromHooks)
-    val graphQLOutputType = generateGraphQLType(generator = generator, type = returnType).safeCast<GraphQLOutputType>()
+    val graphQLOutputType = generateGraphQLType(generator = generator, type = returnType, annotations = fn.annotations).safeCast<GraphQLOutputType>()
     val graphQLType = builder.type(graphQLOutputType).build()
     val coordinates = FieldCoordinates.coordinates(parentName, functionName)
 

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateInterface.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateInterface.kt
@@ -61,7 +61,7 @@ internal fun generateInterface(generator: SchemaGenerator, kClass: KClass<*>): G
         .filter { generator.config.hooks.isValidAdditionalType(it, inputType = false) }
         .forEach { generator.additionalTypes.add(AdditionalType(it.createType(), inputType = false)) }
 
-    val interfaceType = builder.build()
+    val interfaceType: GraphQLInterfaceType = builder.build()
     generator.codeRegistry.typeResolver(interfaceType) { env: TypeResolutionEnvironment -> env.schema.getObjectType(env.getObject<Any>().javaClass.kotlin.getSimpleName()) }
     return generator.config.hooks.onRewireGraphQLType(interfaceType).safeCast()
 }

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateList.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateList.kt
@@ -21,7 +21,7 @@ import com.expediagroup.graphql.generator.internal.extensions.getWrappedType
 import graphql.schema.GraphQLList
 import kotlin.reflect.KType
 
-internal fun generateList(generator: SchemaGenerator, type: KType, inputType: Boolean): GraphQLList {
-    val wrappedType = generateGraphQLType(generator, type.getWrappedType(), inputType)
+internal fun generateList(generator: SchemaGenerator, type: KType, inputType: Boolean, annotations: List<Annotation> = emptyList()): GraphQLList {
+    val wrappedType = generateGraphQLType(generator, type.getWrappedType(), inputType, annotations)
     return GraphQLList.list(wrappedType)
 }

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateProperty.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateProperty.kt
@@ -18,6 +18,7 @@ package com.expediagroup.graphql.generator.internal.types
 
 import com.expediagroup.graphql.generator.SchemaGenerator
 import com.expediagroup.graphql.generator.directives.deprecatedDirectiveWithReason
+import com.expediagroup.graphql.generator.internal.extensions.getPropertyAnnotations
 import com.expediagroup.graphql.generator.internal.extensions.getPropertyDeprecationReason
 import com.expediagroup.graphql.generator.internal.extensions.getPropertyDescription
 import com.expediagroup.graphql.generator.internal.extensions.getPropertyName
@@ -32,7 +33,7 @@ import kotlin.reflect.KProperty
 
 internal fun generateProperty(generator: SchemaGenerator, prop: KProperty<*>, parentClass: KClass<*>): GraphQLFieldDefinition {
     val typeFromHooks = generator.config.hooks.willResolveMonad(prop.returnType)
-    val propertyType = generateGraphQLType(generator, type = typeFromHooks)
+    val propertyType = generateGraphQLType(generator, type = typeFromHooks, annotations = prop.getPropertyAnnotations(parentClass))
         .safeCast<GraphQLOutputType>()
 
     val propertyName = prop.getPropertyName(parentClass)

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateUnion.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateUnion.kt
@@ -17,6 +17,7 @@
 package com.expediagroup.graphql.generator.internal.types
 
 import com.expediagroup.graphql.generator.SchemaGenerator
+import com.expediagroup.graphql.generator.annotations.GraphQLUnion
 import com.expediagroup.graphql.generator.extensions.unwrapType
 import com.expediagroup.graphql.generator.internal.extensions.getGraphQLDescription
 import com.expediagroup.graphql.generator.internal.extensions.getSimpleName
@@ -29,17 +30,41 @@ import graphql.schema.GraphQLUnionType
 import kotlin.reflect.KClass
 import kotlin.reflect.full.createType
 
-internal fun generateUnion(generator: SchemaGenerator, kClass: KClass<*>): GraphQLUnionType {
+internal fun generateUnion(generator: SchemaGenerator, kClass: KClass<*>, unionAnnotation: GraphQLUnion? = null): GraphQLUnionType {
+    return if (unionAnnotation != null) {
+        generateUnionFromAnnotation(generator, unionAnnotation)
+    } else {
+        generateUnionFromKClass(generator, kClass)
+    }
+}
+
+private fun generateUnionFromAnnotation(generator: SchemaGenerator, unionAnnotation: GraphQLUnion): GraphQLUnionType {
     val builder = GraphQLUnionType.newUnionType()
-    builder.name(kClass.getSimpleName())
+    builder.name(unionAnnotation.name)
+    builder.description(unionAnnotation.description)
+
+    val possibleTypes = unionAnnotation.possibleTypes.toList()
+
+    return createUnion(generator, builder, possibleTypes, unionAnnotation.name)
+}
+
+private fun generateUnionFromKClass(generator: SchemaGenerator, kClass: KClass<*>): GraphQLUnionType {
+    val builder = GraphQLUnionType.newUnionType()
+    val name = kClass.getSimpleName()
+    builder.name(name)
     builder.description(kClass.getGraphQLDescription())
 
     generateDirectives(generator, kClass, DirectiveLocation.UNION).forEach {
         builder.withDirective(it)
     }
 
-    generator.classScanner.getSubTypesOf(kClass)
-        .map { generateGraphQLType(generator, it.createType()) }
+    val types = generator.classScanner.getSubTypesOf(kClass)
+
+    return createUnion(generator, builder, types, name)
+}
+
+private fun createUnion(generator: SchemaGenerator, builder: GraphQLUnionType.Builder, types: List<KClass<*>>, name: String): GraphQLUnionType {
+    types.map { generateGraphQLType(generator, it.createType()) }
         .forEach {
             when (val unwrappedType = it.unwrapType()) {
                 is GraphQLTypeReference -> builder.possibleType(unwrappedType)
@@ -47,7 +72,7 @@ internal fun generateUnion(generator: SchemaGenerator, kClass: KClass<*>): Graph
             }
         }
 
-    val unionType = builder.build()
+    val unionType: GraphQLUnionType = builder.build()
     generator.codeRegistry.typeResolver(unionType) { env: TypeResolutionEnvironment -> env.schema.getObjectType(env.getObject<Any>().javaClass.kotlin.getSimpleName()) }
-    return generator.config.hooks.onRewireGraphQLType(unionType).safeCast()
+    return generator.config.hooks.onRewireGraphQLType(unionType, null, generator.codeRegistry).safeCast()
 }

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/extensions/KClassExtensionsTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/extensions/KClassExtensionsTest.kt
@@ -18,6 +18,7 @@ package com.expediagroup.graphql.generator.internal.extensions
 
 import com.expediagroup.graphql.generator.annotations.GraphQLIgnore
 import com.expediagroup.graphql.generator.annotations.GraphQLName
+import com.expediagroup.graphql.generator.annotations.GraphQLUnion
 import com.expediagroup.graphql.generator.exceptions.CouldNotGetNameOfKClassException
 import com.expediagroup.graphql.generator.hooks.NoopSchemaGeneratorHooks
 import com.expediagroup.graphql.generator.hooks.SchemaGeneratorHooks
@@ -149,6 +150,17 @@ open class KClassExtensionsTest {
         fun getTest() = 1
     }
 
+    class One(val value: String)
+    class Two(val value: String)
+
+    class TestQuery {
+        @GraphQLUnion(name = "Number", possibleTypes = [One::class, Two::class])
+        fun customUnion(): Any = One("1")
+
+        @GraphQLUnion(name = "InvalidUnion", possibleTypes = [One::class, Two::class])
+        fun invalidCustomUnion(): Int = 1
+    }
+
     private class FilterHooks : SchemaGeneratorHooks {
         override fun isValidProperty(kClass: KClass<*>, property: KProperty<*>) =
             property.name.contains("filteredProperty").not()
@@ -273,9 +285,13 @@ open class KClassExtensionsTest {
     @Test
     fun `test graphql union extension`() {
         assertTrue(TestUnion::class.isUnion())
+        val customAnnotationUnion = TestQuery::customUnion
+        assertTrue(customAnnotationUnion.returnType.getKClass().isUnion(customAnnotationUnion.annotations))
         assertFalse(InvalidPropertyUnionInterface::class.isUnion())
         assertFalse(InvalidFunctionUnionInterface::class.isUnion())
         assertFalse(Pet::class.isUnion())
+        val invalidAnnotationUnion = TestQuery::invalidCustomUnion
+        assertFalse(invalidAnnotationUnion.returnType.getKClass().isUnion(invalidAnnotationUnion.annotations))
     }
 
     // TODO remove JUnit condition once we only build artifacts using Java 11

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/state/TypesCacheTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/state/TypesCacheTest.kt
@@ -16,6 +16,9 @@
 
 package com.expediagroup.graphql.generator.internal.state
 
+import com.expediagroup.graphql.generator.annotations.GraphQLUnion
+import com.expediagroup.graphql.generator.exceptions.InvalidCustomUnionException
+import com.expediagroup.graphql.generator.internal.extensions.getKClass
 import graphql.schema.GraphQLNamedType
 import io.mockk.every
 import io.mockk.mockk
@@ -23,6 +26,7 @@ import org.junit.jupiter.api.Test
 import kotlin.reflect.full.findParameterByName
 import kotlin.reflect.full.starProjectedType
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
@@ -30,7 +34,7 @@ import kotlin.test.assertTrue
 
 class TypesCacheTest {
 
-    internal data class MyType(val id: Int = 0)
+    data class MyType(val id: Int = 0)
 
     private val graphQLType: GraphQLNamedType = mockk {
         every { name } returns "MyType"
@@ -40,7 +44,11 @@ class TypesCacheTest {
         every { name } returns "MySecondType"
     }
 
-    internal class MyClass {
+    private val customUnionGraphQLType: GraphQLNamedType = mockk {
+        every { name } returns "CustomUnion"
+    }
+
+    class MyClass {
         fun listFun(list: List<String>) = list.joinToString(separator = ",") { it }
 
         fun objectListFun(list: List<MyType>) = list.map { it.id.toString() }.joinToString(separator = ",") { it }
@@ -48,6 +56,12 @@ class TypesCacheTest {
         fun arrayFun(array: Array<String>) = array.joinToString(separator = ",") { it }
 
         fun primitiveArrayFun(intArray: IntArray) = intArray.joinToString(separator = ",") { it.toString() }
+
+        @GraphQLUnion(name = "CustomUnion", possibleTypes = [MyType::class, Int::class])
+        fun customUnion(): Any = MyType(1)
+
+        @GraphQLUnion(name = "InvalidUnion", possibleTypes = [MyType::class, Int::class])
+        fun invalidUnion(): String = "foobar"
     }
 
     @Test
@@ -139,6 +153,35 @@ class TypesCacheTest {
     }
 
     @Test
+    fun `custom unions are cached by special name`() {
+        val cache = TypesCache(listOf("com.expediagroup.graphql.generator"))
+        val type = MyClass::customUnion.returnType
+        val annotations = MyClass::customUnion.annotations
+
+        val cacheKey = TypesCacheKey(type = type, name = "CustomUnion[MyType,Int]")
+        val cacheValue = KGraphQLType(type.getKClass(), customUnionGraphQLType)
+
+        assertNull(cache.get(cacheKey))
+        assertNull(cache.get(type = type, inputType = false, annotations = annotations))
+        assertNotNull(cache.put(cacheKey, cacheValue))
+        assertNotNull(cache.get(type = type, inputType = false, annotations = annotations))
+    }
+
+    @Test
+    fun `invalid custom unions throw an exception`() {
+        val cache = TypesCache(listOf("com.expediagroup.graphql.generator"))
+        val type = MyClass::invalidUnion.returnType
+        val annotations = MyClass::invalidUnion.annotations
+
+        val cacheKey = TypesCacheKey(type = type, name = "InvalidUnion[MyType,Int]")
+
+        assertNull(cache.get(cacheKey))
+        assertFailsWith(InvalidCustomUnionException::class) {
+            cache.get(type = type, inputType = false, annotations = annotations)
+        }
+    }
+
+    @Test
     fun `verify doesNotContainGraphQLType()`() {
         val cache = TypesCache(listOf("com.expediagroup.graphql.generator"))
         val cacheKey = TypesCacheKey(MyType::class.starProjectedType, true)
@@ -159,7 +202,7 @@ class TypesCacheTest {
         assertNull(cache.get(cacheKey))
         cache.put(cacheKey, cacheValue)
 
-        val cacheHit = cache.buildIfNotUnderConstruction(MyType::class, false) {
+        val cacheHit = cache.buildIfNotUnderConstruction(MyType::class, false, emptyList()) {
             assertTrue(false, "Should never reach here")
             cacheValue.graphQLType
         }
@@ -174,8 +217,8 @@ class TypesCacheTest {
         val cacheValue = KGraphQLType(MyType::class, graphQLType)
         assertNull(cache.get(cacheKey))
 
-        val cacheHit = cache.buildIfNotUnderConstruction(MyType::class, false) {
-            cache.buildIfNotUnderConstruction(MyType::class, false) {
+        val cacheHit = cache.buildIfNotUnderConstruction(MyType::class, false, emptyList()) {
+            cache.buildIfNotUnderConstruction(MyType::class, false, emptyList()) {
                 assertTrue(false, "Should never reach here")
                 cacheValue.graphQLType
             }

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/test/integration/CustomUnionAnnotationTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/test/integration/CustomUnionAnnotationTest.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2021 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.generator.test.integration
+
+import com.expediagroup.graphql.generator.TopLevelObject
+import com.expediagroup.graphql.generator.annotations.GraphQLUnion
+import com.expediagroup.graphql.generator.extensions.deepName
+import com.expediagroup.graphql.generator.testSchemaConfig
+import com.expediagroup.graphql.generator.toSchema
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFails
+import kotlin.test.assertNotNull
+
+class CustomUnionAnnotationTest {
+
+    @Test
+    fun `custom unions can be defined with a variety of return types`() {
+        val schema = toSchema(testSchemaConfig, listOf(TopLevelObject(Query())))
+        assertNotNull(schema)
+        assertNotNull(schema.getType("One"))
+        assertNotNull(schema.getType("Two"))
+        assertNotNull(schema.getType("Three"))
+        assertNotNull(schema.getType("Four"))
+        assertNotNull(schema.getType("Even"))
+        assertNotNull(schema.getType("Odd"))
+        assertNotNull(schema.getType("Number"))
+        assertEquals("Even!", schema.queryType.getFieldDefinition("even").type.deepName)
+        assertEquals("Odd!", schema.queryType.getFieldDefinition("odd").type.deepName)
+        assertEquals("Number!", schema.queryType.getFieldDefinition("number").type.deepName)
+        assertEquals("[Number!]!", schema.queryType.getFieldDefinition("listNumbers").type.deepName)
+    }
+
+    @Test
+    fun `verify exception is thrown when union returns different types`() {
+        assertFails {
+            toSchema(testSchemaConfig, listOf(TopLevelObject(InvalidQuery())))
+        }
+    }
+
+    @Test
+    fun `verify exception is thrown when custom union return type is not Any`() {
+        assertFails {
+            toSchema(testSchemaConfig, listOf(TopLevelObject(InvalidReturnType())))
+        }
+    }
+
+    class One(val value: String)
+    class Two(val value: String)
+    class Three(val value: String)
+    class Four(val value: String)
+
+    class Query {
+        @GraphQLUnion(name = "Even", possibleTypes = [Two::class, Four::class])
+        fun even(first: Boolean): Any = if (first) Two("2") else Four("4")
+
+        @GraphQLUnion(name = "Odd", possibleTypes = [One::class, Three::class])
+        fun odd(first: Boolean): Any = if (first) One("1") else Three("3")
+
+        @GraphQLUnion(name = "Number", possibleTypes = [One::class, Two::class, Three::class, Four::class])
+        fun number(): Any = One("1")
+
+        @GraphQLUnion(name = "Number", possibleTypes = [One::class, Two::class, Three::class, Four::class])
+        fun listNumbers(): List<Any> = listOf(One("1"), Two("2"))
+    }
+
+    /**
+     * Each union here is valid, but using them together in the same schema means the union "Number"
+     * is defined twice with different definitions and should fail
+     */
+    class InvalidQuery {
+        @GraphQLUnion(name = "Number", possibleTypes = [One::class, Two::class])
+        fun number1(): Any = One("1")
+
+        @GraphQLUnion(name = "Number", possibleTypes = [Three::class, Four::class])
+        fun number2(): Any = Three("1")
+    }
+
+    /**
+     * While it is valid to compile, library users should return Any for the custom
+     * union annotation
+     */
+    class InvalidReturnType {
+        @GraphQLUnion(name = "Number", possibleTypes = [One::class, Two::class])
+        fun number1(): One = One("one")
+
+        fun number2(): One = One("two")
+    }
+}


### PR DESCRIPTION
### :pencil: Description
Since the schema can be generated from code you can use existing Kotlin classes from common libraries to define shared models. However if you want to declare an object defined in the library as implementing some new interface or union in your service it is not possible, since we can't modify the class definition to add Kotlin code to it.


These changes would allow us to use `Any` as the return type in the schema but then, through annotations, modify the schema return type to match the new class we want to use.


For example in an SDL-First world you could have this Kotlin class defined in some library

```kotlin
data class SharedModel(val foo: String)
```

And then write your schema as the following

```graphql
interface CustomServiceInterface {
  foo: String!
}

type SharedModel implements CustomServiceInterface {
  foo: String!
}

type CustomServiceModel implements CustomServiceInterface {
  foo: String!
  bar: String!
}

union CustomServiceUnion = SharedModel | CustomServiceModel
```

But this is not currently possible in the full code-generation approach

### :link: Related Issues
PR into master branch: https://github.com/ExpediaGroup/graphql-kotlin/pull/1194