### PR TITLE
[plugin] update generateClientTasks to correctly monitor inputs

### DIFF
--- a/plugins/graphql-kotlin-gradle-plugin/README.md
+++ b/plugins/graphql-kotlin-gradle-plugin/README.md
@@ -32,7 +32,7 @@ graphql {
       allowDeprecatedFields = false
       // List of custom GraphQL scalar to converter mapping containing information about corresponding Java type and converter that should be used to serialize/deserialize values.
       customScalars = listOf(GraphQLScalar("UUID", "java.util.UUID", "com.example.UUIDScalarConverter"))
-      // GraphQL server endpoint that will be used to for running introspection queries. Alternatively you can download schema directly from `sdlEndpoint` or specify local `schemaFileName`.
+      // GraphQL server endpoint that will be used to for running introspection queries. Alternatively you can download schema directly from `sdlEndpoint` or specify local `schemaFile`.
       endpoint = "http://localhost:8080/graphql"
       // Optional HTTP headers to be specified on an introspection query or SDL request.
       headers = mapOf("X-Custom-Header" to "Custom-Header-Value")
@@ -42,9 +42,9 @@ graphql {
       queryFileDirectory = "${project.projectDir}/src/main/resources/queries"
       // Optional list of query files to be processed, takes precedence over queryFileDirectory
       queryFiles = listOf(file("${project.projectDir}/src/main/resources/queries/MyQuery.graphql"))
-      // GraphQL schema file location. Can be used instead of `endpoint` or `sdlEndpoint`.
-      schemaFileName = "${project.projectDir}/src/main/resources/myLocalSchema.graphql"
-      // GraphQL server SDL endpoint that will be used to download schema. Alternatively you can run introspection query against `endpoint` or specify local `schemaFileName`.
+      // GraphQL schema file. Can be used instead of `endpoint` or `sdlEndpoint`.
+      schemaFile = file("${project.projectDir}/src/main/resources/myLocalSchema.graphql")
+      // GraphQL server SDL endpoint that will be used to download schema. Alternatively you can run introspection query against `endpoint` or specify local `schemaFile`.
       sdlEndpoint = "http://localhost:8080/sdl"
       // JSON serializer that will be used to generate the data classes.
       serializer = GraphQLSerializer.JACKSON
@@ -106,8 +106,7 @@ resulting generated code will be automatically added to the project main source 
 | `queryFiles` | FileCollection | | List of query files to be processed. Instead of a list of files to be processed you can specify `queryFileDirectory` directory instead. If this property is specified it will take precedence over the corresponding directory property. |
 | `queryFileDirectory` | Directory | | Directory file containing GraphQL queries. Instead of specifying a directory you can also specify list of query file by using `queryFiles` property instead.<br/>**Default value is:** `src/main/resources`. |
 | `serializer` | GraphQLSerializer | | JSON serializer that will be used to generate the data classes.<br/>**Default value is:** `GraphQLSerializer.JACKSON`. |
-| `schemaFile` | File | `schemaFileName` or `schemaFile` has to be provided | GraphQL schema file that will be used to generate client code. |
-| `schemaFileName` | String | `schemaFileName` or `schemaFile` has to be provided | Path to GraphQL schema file that will be used to generate client code.<br/>**Command line property is**: `schemaFileName`. |
+| `schemaFile` | File | yes | GraphQL schema file that will be used to generate client code. |
 | `useOptionalInputWrapper` | Boolean | | Boolean opt-in flag to wrap nullable arguments in `OptionalInput` that distinguish between `null` and undefined/omitted value. Only supported for JACKSON serializer.<br/>**Default value is:** `false`.<br/>**Command line property is**: `useOptionalInputWrapper` |
 
 ### graphqlGenerateSDL
@@ -154,8 +153,7 @@ test source set.
 | `queryFiles` | FileCollection | | List of query files to be processed. Instead of a list of files to be processed you can specify `queryFileDirectory` directory instead. If this property is specified it will take precedence over the corresponding directory property. |
 | `queryFileDirectory` | Directory | | Directory file containing GraphQL queries. Instead of specifying a directory you can also specify list of query file by using `queryFiles` property instead.<br/>**Default value is:** `src/test/resources`. |
 | `serializer` | GraphQLSerializer | | JSON serializer that will be used to generate the data classes.<br/>**Default value is:** `GraphQLSerializer.JACKSON`. |
-| `schemaFile` | File | `schemaFileName` or `schemaFile` has to be provided | GraphQL schema file that will be used to generate client code. |
-| `schemaFileName` | String | `schemaFileName` or `schemaFile` has to be provided | Path to GraphQL schema file that will be used to generate client code.<br/>**Command line property is**: `schemaFileName`. |
+| `schemaFile` | File | yes | GraphQL schema file that will be used to generate client code. |
 | `useOptionalInputWrapper` | Boolean | | Boolean opt-in flag to wrap nullable arguments in `OptionalInput` that distinguish between `null` and undefined/omitted value. Only supported for JACKSON serializer.<br/>**Default value is:** `false`.<br/>**Command line property is**: `useOptionalInputWrapper` |
 
 ### graphqlIntrospectSchema

--- a/plugins/graphql-kotlin-gradle-plugin/README.md
+++ b/plugins/graphql-kotlin-gradle-plugin/README.md
@@ -42,12 +42,12 @@ graphql {
       queryFileDirectory = "${project.projectDir}/src/main/resources/queries"
       // Optional list of query files to be processed, takes precedence over queryFileDirectory
       queryFiles = listOf(file("${project.projectDir}/src/main/resources/queries/MyQuery.graphql"))
-      // JSON serializer that will be used to generate the data classes.
-      serializer = GraphQLSerializer.JACKSON
       // GraphQL schema file location. Can be used instead of `endpoint` or `sdlEndpoint`.
       schemaFileName = "${project.projectDir}/src/main/resources/myLocalSchema.graphql"
       // GraphQL server SDL endpoint that will be used to download schema. Alternatively you can run introspection query against `endpoint` or specify local `schemaFileName`.
       sdlEndpoint = "http://localhost:8080/sdl"
+      // JSON serializer that will be used to generate the data classes.
+      serializer = GraphQLSerializer.JACKSON
       // Timeout configuration for introspection query/downloading SDL
       timeout {
           // Connect timeout in milliseconds
@@ -104,7 +104,7 @@ resulting generated code will be automatically added to the project main source 
 | `customScalars` | List<GraphQLScalar> | | List of custom GraphQL scalar to converter mapping containing information about corresponding Java type and converter that should be used to serialize/deserialize values. |
 | `packageName` | String | yes | Target package name for generated code.<br/>**Command line property is**: `packageName`. |
 | `queryFiles` | FileCollection | | List of query files to be processed. Instead of a list of files to be processed you can specify `queryFileDirectory` directory instead. If this property is specified it will take precedence over the corresponding directory property. |
-| `queryFileDirectory` | String | | Directory file containing GraphQL queries. Instead of specifying a directory you can also specify list of query file by using `queryFiles` property instead.<br/>**Default value is:** `src/main/resources`.<br/>**Command line property is**: `queryFileDirectory`. |
+| `queryFileDirectory` | Directory | | Directory file containing GraphQL queries. Instead of specifying a directory you can also specify list of query file by using `queryFiles` property instead.<br/>**Default value is:** `src/main/resources`. |
 | `serializer` | GraphQLSerializer | | JSON serializer that will be used to generate the data classes.<br/>**Default value is:** `GraphQLSerializer.JACKSON`. |
 | `schemaFile` | File | `schemaFileName` or `schemaFile` has to be provided | GraphQL schema file that will be used to generate client code. |
 | `schemaFileName` | String | `schemaFileName` or `schemaFile` has to be provided | Path to GraphQL schema file that will be used to generate client code.<br/>**Command line property is**: `schemaFileName`. |
@@ -152,7 +152,7 @@ test source set.
 | `customScalars` | List<GraphQLScalar> | | List of custom GraphQL scalar to converter mapping containing information about corresponding Java type and converter that should be used to serialize/deserialize values. |
 | `packageName` | String | yes | Target package name for generated code.<br/>**Command line property is**: `packageName`. |
 | `queryFiles` | FileCollection | | List of query files to be processed. Instead of a list of files to be processed you can specify `queryFileDirectory` directory instead. If this property is specified it will take precedence over the corresponding directory property. |
-| `queryFileDirectory` | String | | Directory file containing GraphQL queries. Instead of specifying a directory you can also specify list of query file by using `queryFiles` property instead.<br/>**Default value is:** `src/test/resources`.<br/>**Command line property is**: `queryFileDirectory`. |
+| `queryFileDirectory` | Directory | | Directory file containing GraphQL queries. Instead of specifying a directory you can also specify list of query file by using `queryFiles` property instead.<br/>**Default value is:** `src/test/resources`. |
 | `serializer` | GraphQLSerializer | | JSON serializer that will be used to generate the data classes.<br/>**Default value is:** `GraphQLSerializer.JACKSON`. |
 | `schemaFile` | File | `schemaFileName` or `schemaFile` has to be provided | GraphQL schema file that will be used to generate client code. |
 | `schemaFileName` | String | `schemaFileName` or `schemaFile` has to be provided | Path to GraphQL schema file that will be used to generate client code.<br/>**Command line property is**: `schemaFileName`. |

--- a/plugins/graphql-kotlin-gradle-plugin/src/integration/android/androidGraphQLClient/app/build.gradle.kts
+++ b/plugins/graphql-kotlin-gradle-plugin/src/integration/android/androidGraphQLClient/app/build.gradle.kts
@@ -25,7 +25,7 @@ dependencies {
 
 graphql {
     client {
-        schemaFileName = "${project.projectDir}/schema.graphql"
+        schemaFile = file("${project.projectDir}/schema.graphql")
         packageName = "com.expediagroup.android.generated"
         serializer = com.expediagroup.graphql.plugin.gradle.config.GraphQLSerializer.KOTLINX
     }

--- a/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePlugin.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePlugin.kt
@@ -111,8 +111,8 @@ class GraphQLGradlePlugin : Plugin<Project> {
                         generateClientTask.dependsOn(downloadSDLTask.path)
                         generateClientTask.schemaFile.convention(downloadSDLTask.outputFile)
                     }
-                    extension.clientExtension.schemaFileName != null -> {
-                        generateClientTask.schemaFileName.convention(extension.clientExtension.schemaFileName)
+                    extension.clientExtension.schemaFile != null -> {
+                        generateClientTask.schemaFile.set(extension.clientExtension.schemaFile)
                     }
                     else -> {
                         throw RuntimeException("Invalid GraphQL client extension configuration - missing required endpoint/sdlEndpoint/schemaFileName property")

--- a/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePlugin.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePlugin.kt
@@ -30,6 +30,7 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.tasks.SourceSetContainer
+import java.io.File
 
 private const val PLUGIN_EXTENSION_NAME = "graphql"
 private const val GENERATE_CLIENT_CONFIGURATION = "graphqlClient"
@@ -87,7 +88,7 @@ class GraphQLGradlePlugin : Plugin<Project> {
                 generateClientTask.customScalars.convention(extension.clientExtension.customScalars)
                 val queryFileDirectory = extension.clientExtension.queryFileDirectory
                 if (queryFileDirectory != null) {
-                    generateClientTask.queryFileDirectory.convention(queryFileDirectory)
+                    generateClientTask.queryFileDirectory.set(File(queryFileDirectory))
                 }
                 generateClientTask.queryFiles.setFrom(extension.clientExtension.queryFiles)
                 generateClientTask.serializer.convention(extension.clientExtension.serializer)

--- a/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLPluginExtension.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLPluginExtension.kt
@@ -55,12 +55,12 @@ open class GraphQLPluginExtension {
 }
 
 open class GraphQLPluginClientExtension {
-    /** GraphQL server endpoint that will be used to for running introspection queries. Alternatively you can download schema directly from [sdlEndpoint] or specify local [schemaFileName]. */
+    /** GraphQL server endpoint that will be used to for running introspection queries. Alternatively you can download schema directly from [sdlEndpoint] or specify local [schemaFile]. */
     var endpoint: String? = null
-    /** GraphQL server SDL endpoint that will be used to download schema. Alternatively you can run introspection query against [endpoint] or specify local [schemaFileName]. */
+    /** GraphQL server SDL endpoint that will be used to download schema. Alternatively you can run introspection query against [endpoint] or specify local [schemaFile]. */
     var sdlEndpoint: String? = null
-    /** GraphQL schema file location. Can be used instead of [endpoint] or [sdlEndpoint]. */
-    var schemaFileName: String? = null
+    /** GraphQL schema file. Can be used instead of [endpoint] or [sdlEndpoint]. */
+    var schemaFile: File? = null
     /** Target package name to be used for generated classes. */
     var packageName: String? = null
     /** Optional HTTP headers to be specified on an introspection query or SDL request. */

--- a/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/AbstractGenerateClientTask.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/AbstractGenerateClientTask.kt
@@ -50,23 +50,11 @@ abstract class AbstractGenerateClientTask : DefaultTask() {
     val pluginClasspath: ConfigurableFileCollection = project.objects.fileCollection()
 
     /**
-     * Path to GraphQL schema file that will be used to generate client code.
-     *
-     * **Required Property**: [schemaFileName] or [schemaFile] has to be provided.
-     * **Command line property is**: `schemaFileName`.
-     */
-    @Input
-    @Optional
-    @Option(option = "schemaFileName", description = "path to GraphQL schema file that will be used to generate the client code")
-    val schemaFileName: Property<String> = project.objects.property(String::class.java)
-
-    /**
      * GraphQL schema file that will be used to generate client code.
      *
-     * **Required Property**: [schemaFileName] or [schemaFile] has to be provided.
+     * **Required Property**
      */
     @InputFile
-    @Optional
     val schemaFile: RegularFileProperty = project.objects.fileProperty()
 
     /**
@@ -152,10 +140,8 @@ abstract class AbstractGenerateClientTask : DefaultTask() {
 
         val graphQLSchemaPath = when {
             schemaFile.isPresent -> schemaFile.get().asFile.path
-            schemaFileName.isPresent -> schemaFileName.get()
             else -> throw RuntimeException("schema not available")
         }
-
         val targetPackage = packageName.orNull ?: throw RuntimeException("package not specified")
         val targetQueryFiles: List<File> = when {
             queryFiles.files.isNotEmpty() -> queryFiles.files.toList()

--- a/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/GraphQLGenerateClientTask.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/GraphQLGenerateClientTask.kt
@@ -27,7 +27,7 @@ abstract class GraphQLGenerateClientTask : AbstractGenerateClientTask() {
     init {
         description = "Generate HTTP client from the specified GraphQL queries."
 
-        queryFileDirectory.convention("${project.projectDir}/src/main/resources")
+        queryFileDirectory.convention(project.layout.projectDirectory.dir("src/main/resources"))
         outputDirectory.convention(project.layout.buildDirectory.dir("generated/source/graphql/main"))
     }
 }

--- a/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/GraphQLGenerateTestClientTask.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/GraphQLGenerateTestClientTask.kt
@@ -27,7 +27,7 @@ abstract class GraphQLGenerateTestClientTask : AbstractGenerateClientTask() {
     init {
         description = "Generate HTTP test client from the specified GraphQL queries."
 
-        queryFileDirectory.convention("${project.projectDir}/src/test/resources")
+        queryFileDirectory.convention(project.layout.projectDirectory.dir("src/test/resources"))
         outputDirectory.convention(project.layout.buildDirectory.dir("generated/source/graphql/test"))
     }
 }

--- a/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePluginAndroidIT.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePluginAndroidIT.kt
@@ -31,7 +31,7 @@ import kotlin.test.assertEquals
 class GraphQLGradlePluginAndroidIT {
 
     @ParameterizedTest
-    @MethodSource("pluginTests")
+    @MethodSource("androidTests")
     @EnabledIfEnvironmentVariable(named = "ANDROID_SDK_ROOT", matches = ".+")
     fun `verify gradle plugin can be applied on android projects`(sourceDirectory: File, @TempDir tempDir: Path) {
         val testProjectDirectory = tempDir.toFile()
@@ -51,7 +51,7 @@ class GraphQLGradlePluginAndroidIT {
 
     companion object {
         @JvmStatic
-        fun pluginTests(): List<Arguments> = locateTestCaseArguments("src/integration/android")
+        fun androidTests(): List<Arguments> = locateTestCaseArguments("src/integration/android")
 
         private fun locateTestCaseArguments(directory: String) = File(directory)
             .listFiles()

--- a/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePluginIT.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePluginIT.kt
@@ -87,7 +87,7 @@ class GraphQLGradlePluginIT : GraphQLGradlePluginAbstractIT() {
             |
             |graphql {
             |  client {
-            |    schemaFileName = "${'$'}{project.projectDir}/src/main/resources/schema.graphql"
+            |    schemaFile = file("${'$'}{project.projectDir}/src/main/resources/schema.graphql")
             |    packageName = "com.example.generated"
             |  }
             |}

--- a/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/GraphQLGenerateClientTaskIT.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/GraphQLGenerateClientTaskIT.kt
@@ -56,7 +56,7 @@ class GraphQLGenerateClientTaskIT : GraphQLGradlePluginAbstractIT() {
             |
             |val graphqlGenerateClient by tasks.getting(GraphQLGenerateClientTask::class) {
             |  packageName.set("com.example.generated")
-            |  schemaFileName.set("${'$'}{project.projectDir}/schema.graphql")
+            |  schemaFile.set(file("${'$'}{project.projectDir}/schema.graphql"))
             |}
             """.trimMargin()
         testProjectDirectory.generateBuildFileForClient(buildFileContents)
@@ -80,7 +80,7 @@ class GraphQLGenerateClientTaskIT : GraphQLGradlePluginAbstractIT() {
             """
             |val graphqlGenerateClient by tasks.getting(GraphQLGenerateClientTask::class) {
             |  packageName.set("com.example.generated")
-            |  schemaFileName.set("${'$'}{project.projectDir}/schema.graphql")
+            |  schemaFile.set(file("${'$'}{project.projectDir}/schema.graphql"))
             |}
             """.trimMargin()
         testProjectDirectory.generateBuildFileForClient(buildFileContents)
@@ -127,7 +127,7 @@ class GraphQLGenerateClientTaskIT : GraphQLGradlePluginAbstractIT() {
             |
             |val graphqlGenerateClient by tasks.getting(GraphQLGenerateClientTask::class) {
             |  packageName.set("com.example.generated")
-            |  schemaFileName.set("${'$'}{project.projectDir}/schema.graphql")
+            |  schemaFile.set(file("${'$'}{project.projectDir}/schema.graphql"))
             |  // optional config
             |  customScalars.add(GraphQLScalar("UUID", "java.util.UUID", "com.example.UUIDScalarConverter"))
             |  allowDeprecatedFields.set(true)
@@ -176,7 +176,7 @@ class GraphQLGenerateClientTaskIT : GraphQLGradlePluginAbstractIT() {
             """
             |val graphqlGenerateTestClient by tasks.getting(GraphQLGenerateTestClientTask::class) {
             |  packageName.set("com.example.generated")
-            |  schemaFileName.set("${'$'}{project.projectDir}/schema.graphql")
+            |  schemaFile.set(file("${'$'}{project.projectDir}/schema.graphql"))
             |}
             |
             |tasks {
@@ -220,7 +220,7 @@ class GraphQLGenerateClientTaskIT : GraphQLGradlePluginAbstractIT() {
             |
             |graphqlGenerateClient {
             |  packageName = "com.example.generated"
-            |  schemaFileName = "${'$'}{project.projectDir}/schema.graphql"
+            |  schemaFile = file("${'$'}{project.projectDir}/schema.graphql")
             |  // optional config
             |  allowDeprecatedFields = true
             |  customScalars.add(new GraphQLScalar("UUID", "java.util.UUID", "com.example.UUIDScalarConverter"))
@@ -272,7 +272,7 @@ class GraphQLGenerateClientTaskIT : GraphQLGradlePluginAbstractIT() {
             |
             |tasks.create("generateClient1", GraphQLGenerateClientTask::class) {
             |  packageName.set("com.example.generated")
-            |  schemaFileName.set("${'$'}{project.projectDir}/schema.graphql")
+            |  schemaFile.set(file("${'$'}{project.projectDir}/schema.graphql"))
             |  // optional config
             |  customScalars.add(GraphQLScalar("UUID", "java.util.UUID", "com.example.UUIDScalarConverter"))
             |  queryFiles.from(
@@ -282,7 +282,7 @@ class GraphQLGenerateClientTaskIT : GraphQLGradlePluginAbstractIT() {
             |
             |tasks.create("generateClient2", GraphQLGenerateClientTask::class) {
             |  packageName.set("com.example.generated2")
-            |  schemaFileName.set("${'$'}{project.projectDir}/schema.graphql")
+            |  schemaFile.set(file("${'$'}{project.projectDir}/schema.graphql"))
             |  // optional config
             |  allowDeprecatedFields.set(true)
             |  queryFiles.from(

--- a/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/GraphQLGenerateClientTaskIT.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/GraphQLGenerateClientTaskIT.kt
@@ -198,6 +198,7 @@ class GraphQLGenerateClientTaskIT : GraphQLGradlePluginAbstractIT() {
             .withProjectDir(testProjectDirectory)
             .withPluginClasspath()
             .withArguments(GENERATE_TEST_CLIENT_TASK_NAME, "test", "--stacktrace")
+            .forwardOutput()
             .build()
 
         assertEquals(TaskOutcome.SUCCESS, buildResult.task(":$GENERATE_TEST_CLIENT_TASK_NAME")?.outcome)

--- a/website/docs/plugins/gradle-plugin-tasks.mdx
+++ b/website/docs/plugins/gradle-plugin-tasks.mdx
@@ -129,12 +129,12 @@ graphql {
     queryFileDirectory = "${project.projectDir}/src/main/resources/queries"
     // Optional list of query files to be processed, takes precedence over queryFileDirectory
     queryFiles = listOf(file("${project.projectDir}/src/main/resources/queries/MyQuery.graphql"))
-    // JSON serializer that will be used to generate the data classes.
-    serializer = GraphQLSerializer.JACKSON
     // GraphQL schema file location. Can be used instead of `endpoint` or `sdlEndpoint`.
     schemaFileName = "${project.projectDir}/src/main/resources/myLocalSchema.graphql"
     // GraphQL server SDL endpoint that will be used to download schema. Alternatively you can run introspection query against `endpoint` or specify local `schemaFileName`.
     sdlEndpoint = "http://localhost:8080/sdl"
+    // JSON serializer that will be used to generate the data classes.
+    serializer = GraphQLSerializer.JACKSON
     // Timeout configuration for introspection query/downloading SDL
     timeout {
         // Connect timeout in milliseconds
@@ -177,12 +177,12 @@ graphql {
         queryFileDirectory = "${project.projectDir}/src/main/resources/queries"
         // Optional list of query files to be processed, takes precedence over queryFileDirectory
         queryFiles = [file("${project.projectDir}/src/main/resources/queries/MyQuery.graphql")]
-        // JSON serializer that will be used to generate the data classes.
-        serializer = GraphQLSerializer.JACKSON
         // GraphQL schema file location. Can be used instead of `endpoint` or `sdlEndpoint`.
         schemaFileName = "${project.projectDir}/src/main/resources/myLocalSchema.graphql"
         // GraphQL server SDL endpoint that will be used to download schema. Alternatively you can run introspection query against `endpoint` or specify local `schemaFileName`.
         sdlEndpoint = "http://localhost:8080/sdl"
+        // JSON serializer that will be used to generate the data classes.
+        serializer = GraphQLSerializer.JACKSON
         // Timeout configuration for introspection query/downloading SDL
         timeout { t ->
             // Connect timeout in milliseconds
@@ -256,7 +256,7 @@ resulting generated code will be automatically added to the project main source 
 | `customScalars` | `List<GraphQLScalar>` | | List of custom GraphQL scalar to converter mappings containing information about corresponding Java type and converter that should be used to serialize/deserialize values. |
 | `packageName` | String | yes | Target package name for generated code.<br/>**Command line property is**: `packageName`. |
 | `queryFiles` | FileCollection | | List of query files to be processed. Instead of a list of files to be processed you can specify `queryFileDirectory` directory instead. If this property is specified it will take precedence over the corresponding directory property. |
-| `queryFileDirectory` | String | | Directory file containing GraphQL queries. Instead of specifying a directory you can also specify list of query file by using `queryFiles` property instead.<br/>**Default value is:** `src/main/resources`.<br/>**Command line property is**: `queryFileDirectory`. |
+| `queryFileDirectory` | Directory | | Directory file containing GraphQL queries. Instead of specifying a directory you can also specify list of query file by using `queryFiles` property instead.<br/>**Default value is:** `src/main/resources`. |
 | `serializer` | GraphQLSerializer | | JSON serializer that will be used to generate the data classes.<br/>**Default value is:** `GraphQLSerializer.JACKSON`. |
 | `schemaFile` | File | `schemaFileName` or `schemaFile` has to be provided | GraphQL schema file that will be used to generate client code. |
 | `schemaFileName` | String | `schemaFileName` or `schemaFile` has to be provided | Path to GraphQL schema file that will be used to generate client code.<br/>**Command line property is**: `schemaFileName`. |                                                                                                                                                     |
@@ -306,7 +306,7 @@ test source set.
 | `customScalars` | `List<GraphQLScalar>` | | List of custom GraphQL scalar to converter mappings containing information about corresponding Java type and converter that should be used to serialize/deserialize values. |
 | `packageName` | String | yes | Target package name for generated code.<br/>**Command line property is**: `packageName`. |
 | `queryFiles` | FileCollection | | List of query files to be processed. Instead of a list of files to be processed you can specify `queryFileDirectory` directory instead. If this property is specified it will take precedence over the corresponding directory property. |
-| `queryFileDirectory` | String | | Directory file containing GraphQL queries. Instead of specifying a directory you can also specify list of query file by using `queryFiles` property instead.<br/>**Default value is:** `src/test/resources`.<br/>**Command line property is**: `queryFileDirectory`. |
+| `queryFileDirectory` | Directory | | Directory file containing GraphQL queries. Instead of specifying a directory you can also specify list of query file by using `queryFiles` property instead.<br/>**Default value is:** `src/test/resources`. |
 | `serializer` | GraphQLSerializer | | JSON serializer that will be used to generate the data classes.<br/>**Default value is:** `GraphQLSerializer.JACKSON`. |
 | `schemaFile` | File | `schemaFileName` or `schemaFile` has to be provided | GraphQL schema file that will be used to generate client code. |
 | `schemaFileName` | String | `schemaFileName` or `schemaFile` has to be provided | Path to GraphQL schema file that will be used to generate client code.<br/>**Command line property is**: `schemaFileName`. |

--- a/website/docs/plugins/gradle-plugin-tasks.mdx
+++ b/website/docs/plugins/gradle-plugin-tasks.mdx
@@ -119,7 +119,7 @@ graphql {
     allowDeprecatedFields = false
     // List of custom GraphQL scalar to converter mapping containing information about corresponding Java type and converter that should be used to serialize/deserialize values.
     customScalars = listOf(GraphQLScalar("UUID", "java.util.UUID", "com.example.UUIDScalarConverter"))
-    // GraphQL server endpoint that will be used to for running introspection queries. Alternatively you can download schema directly from `sdlEndpoint` or specify local `schemaFileName`.
+    // GraphQL server endpoint that will be used to for running introspection queries. Alternatively you can download schema directly from `sdlEndpoint` or specify local `schemaFile`.
     endpoint = "http://localhost:8080/graphql"
     // Optional HTTP headers to be specified on an introspection query or SDL request.
     headers = mapOf("X-Custom-Header" to "Custom-Header-Value")
@@ -129,9 +129,9 @@ graphql {
     queryFileDirectory = "${project.projectDir}/src/main/resources/queries"
     // Optional list of query files to be processed, takes precedence over queryFileDirectory
     queryFiles = listOf(file("${project.projectDir}/src/main/resources/queries/MyQuery.graphql"))
-    // GraphQL schema file location. Can be used instead of `endpoint` or `sdlEndpoint`.
-    schemaFileName = "${project.projectDir}/src/main/resources/myLocalSchema.graphql"
-    // GraphQL server SDL endpoint that will be used to download schema. Alternatively you can run introspection query against `endpoint` or specify local `schemaFileName`.
+    // GraphQL schema file. Can be used instead of `endpoint` or `sdlEndpoint`.
+    schemaFile = file("${project.projectDir}/src/main/resources/myLocalSchema.graphql")
+    // GraphQL server SDL endpoint that will be used to download schema. Alternatively you can run introspection query against `endpoint` or specify local `schemaFile`.
     sdlEndpoint = "http://localhost:8080/sdl"
     // JSON serializer that will be used to generate the data classes.
     serializer = GraphQLSerializer.JACKSON
@@ -167,7 +167,7 @@ graphql {
         allowDeprecatedFields = false
         // List of custom GraphQL scalar to converter mapping containing information about corresponding Java type and converter that should be used to serialize/deserialize values.
         customScalars = [new GraphQLScalar("UUID", "java.util.UUID", "com.example.UUIDScalarConverter")]
-        // GraphQL server endpoint that will be used to for running introspection queries. Alternatively you can download schema directly from `sdlEndpoint` or specify local `schemaFileName`.
+        // GraphQL server endpoint that will be used to for running introspection queries. Alternatively you can download schema directly from `sdlEndpoint` or specify local `schemaFile`.
         endpoint = "http://localhost:8080/graphql"
         // Optional HTTP headers to be specified on an introspection query or SDL request.
         headers = ["X-Custom-Header" : "My-Custom-Header-Value"]
@@ -177,9 +177,9 @@ graphql {
         queryFileDirectory = "${project.projectDir}/src/main/resources/queries"
         // Optional list of query files to be processed, takes precedence over queryFileDirectory
         queryFiles = [file("${project.projectDir}/src/main/resources/queries/MyQuery.graphql")]
-        // GraphQL schema file location. Can be used instead of `endpoint` or `sdlEndpoint`.
-        schemaFileName = "${project.projectDir}/src/main/resources/myLocalSchema.graphql"
-        // GraphQL server SDL endpoint that will be used to download schema. Alternatively you can run introspection query against `endpoint` or specify local `schemaFileName`.
+        // GraphQL schema file. Can be used instead of `endpoint` or `sdlEndpoint`.
+        schemaFile = file("${project.projectDir}/src/main/resources/myLocalSchema.graphql")
+        // GraphQL server SDL endpoint that will be used to download schema. Alternatively you can run introspection query against `endpoint` or specify local `schemaFile`.
         sdlEndpoint = "http://localhost:8080/sdl"
         // JSON serializer that will be used to generate the data classes.
         serializer = GraphQLSerializer.JACKSON
@@ -231,6 +231,11 @@ schema file as `schema.graphql` under build directory. In general, this task pro
 and could be used as an alternative to `graphqlIntrospectSchema` to generate input for the subsequent
 `graphqlGenerateClient` task.
 
+:::info
+This task will always be `UP-TO-DATE` and in order to trigger the re-download of an SDL you need to force rerun it by
+specifying `--rerun-tasks` option or by executing `clean` task.
+:::
+
 **Properties**
 
 | Property               | Type                | Required | Description                                                                                                                                                                                      |
@@ -258,8 +263,7 @@ resulting generated code will be automatically added to the project main source 
 | `queryFiles` | FileCollection | | List of query files to be processed. Instead of a list of files to be processed you can specify `queryFileDirectory` directory instead. If this property is specified it will take precedence over the corresponding directory property. |
 | `queryFileDirectory` | Directory | | Directory file containing GraphQL queries. Instead of specifying a directory you can also specify list of query file by using `queryFiles` property instead.<br/>**Default value is:** `src/main/resources`. |
 | `serializer` | GraphQLSerializer | | JSON serializer that will be used to generate the data classes.<br/>**Default value is:** `GraphQLSerializer.JACKSON`. |
-| `schemaFile` | File | `schemaFileName` or `schemaFile` has to be provided | GraphQL schema file that will be used to generate client code. |
-| `schemaFileName` | String | `schemaFileName` or `schemaFile` has to be provided | Path to GraphQL schema file that will be used to generate client code.<br/>**Command line property is**: `schemaFileName`. |                                                                                                                                                     |
+| `schemaFile` | File | yes | GraphQL schema file that will be used to generate client code. |
 | `useOptionalInputWrapper` | Boolean | | Boolean opt-in flag to wrap nullable arguments in `OptionalInput` that distinguish between `null` and undefined/omitted value. Only supported for JACKSON serializer.<br/>**Default value is:** `false`.<br/>**Command line property is**: `useOptionalInputWrapper` |
 
 By default, this task will generate Jackson compatible data models. See [client serialization documentation](../client/client-serialization.mdx)
@@ -308,8 +312,7 @@ test source set.
 | `queryFiles` | FileCollection | | List of query files to be processed. Instead of a list of files to be processed you can specify `queryFileDirectory` directory instead. If this property is specified it will take precedence over the corresponding directory property. |
 | `queryFileDirectory` | Directory | | Directory file containing GraphQL queries. Instead of specifying a directory you can also specify list of query file by using `queryFiles` property instead.<br/>**Default value is:** `src/test/resources`. |
 | `serializer` | GraphQLSerializer | | JSON serializer that will be used to generate the data classes.<br/>**Default value is:** `GraphQLSerializer.JACKSON`. |
-| `schemaFile` | File | `schemaFileName` or `schemaFile` has to be provided | GraphQL schema file that will be used to generate client code. |
-| `schemaFileName` | String | `schemaFileName` or `schemaFile` has to be provided | Path to GraphQL schema file that will be used to generate client code.<br/>**Command line property is**: `schemaFileName`. |
+| `schemaFile` | File | yes | GraphQL schema file that will be used to generate client code. |
 | `useOptionalInputWrapper` | Boolean | | Boolean opt-in flag to wrap nullable arguments in `OptionalInput` that distinguish between `null` and undefined/omitted value. Only supported for JACKSON serializer.<br/>**Default value is:** `false`.<br/>**Command line property is**: `useOptionalInputWrapper` |
 
 By default, this task will generate Jackson compatible data models. See [client serialization documentation](../client/client-serialization.mdx)
@@ -320,6 +323,11 @@ for details on how to update this process to use `kotlinx.serialization` instead
 Task that executes GraphQL introspection query against specified `endpoint` and saves the underlying schema file as
 `schema.graphql` under build directory. In general, this task provides limited functionality by itself and instead
 should be used to generate input for the subsequent `graphqlGenerateClient` task.
+
+:::info
+This task will always be `UP-TO-DATE` and in order to trigger the re-running of the introspection query you need to force
+rerun it by specifying `--rerun-tasks` option or by executing `clean` task.
+:::
 
 **Properties**
 

--- a/website/docs/plugins/gradle-plugin-usage.mdx
+++ b/website/docs/plugins/gradle-plugin-usage.mdx
@@ -110,15 +110,7 @@ invoke it OR configure it as a dependency of some other task.
 ## Generating Client
 
 GraphQL Kotlin client code is generated based on the provided queries that will be executed against target GraphQL `schemaFile`.
-Separate class is generated for each provided GraphQL query and are saved under specified `packageName`. When using default
-configuration and storing GraphQL queries under `src/main/resources` directories, task can be executed directly from the
-command line by explicitly providing required properties.
-
-```shell script
-$ gradle graphqlGenerateClient --schemaFileName"mySchema.graphql" --packageName="com.example.generated"
-```
-
-Task can also be explicitly configured in your Gradle build file
+Separate class is generated for each provided GraphQL query and are saved under specified `packageName`.
 
 <Tabs
   defaultValue="kotlin"
@@ -136,7 +128,7 @@ import com.expediagroup.graphql.plugin.gradle.tasks.GraphQLGenerateClientTask
 
 val graphqlGenerateClient by tasks.getting(GraphQLGenerateClientTask::class) {
   packageName.set("com.example.generated")
-  schemaFileName.set("mySchema.graphql")
+  schemaFile.set(file("${project.projectDir}/mySchema.graphql"))
 }
 ```
 
@@ -147,7 +139,7 @@ val graphqlGenerateClient by tasks.getting(GraphQLGenerateClientTask::class) {
 //build.gradle
 graphqlGenerateClient {
     packageName = "com.example.generated"
-    schemaFileName = "mySchema.graphql"
+    schemaFile = file("${project.projectDir}/mySchema.graphql")
 }
 ```
 
@@ -201,7 +193,7 @@ import com.expediagroup.graphql.plugin.gradle.tasks.GraphQLGenerateClientTask
 
 val graphqlGenerateClient by tasks.getting(GraphQLGenerateClientTask::class) {
   packageName.set("com.example.generated")
-  schemaFileName.set("mySchema.graphql")
+  schemaFile.set(file("${project.projectDir}/mySchema.graphql"))
   customScalars.add(GraphQLScalar("UUID", "java.util.UUID", "com.example.UUIDScalarConverter"))
 }
 ```
@@ -215,7 +207,7 @@ import com.expediagroup.graphql.plugin.gradle.config.GraphQLScalar
 
 graphqlGenerateClient {
     packageName = "com.example.generated"
-    schemaFileName = "mySchema.graphql"
+    schemaFile = file("${project.projectDir}/mySchema.graphql")
     customScalars.add(new GraphQLScalar("UUID", "java.util.UUID", "com.example.UUIDScalarConverter"))
 }
 ```
@@ -251,7 +243,7 @@ plugins {
 
 val graphqlGenerateClient by tasks.getting(GraphQLGenerateClientTask::class) {
   packageName.set("com.example.generated")
-  schemaFileName.set("mySchema.graphql")
+  schemaFile.set(file("${project.projectDir}/mySchema.graphql"))
   serializer.set(GraphQLSerializer.KOTLINX)
 }
 ```
@@ -270,8 +262,56 @@ plugins {
 
 graphqlGenerateClient {
     packageName = "com.example.generated"
-    schemaFileName = "mySchema.graphql"
+    schemaFile = file("${project.projectDir}/mySchema.graphql")
     serializer = GraphQLSerializer.KOTLINX
+}
+```
+
+</TabItem>
+</Tabs>
+
+## Generating Client using Classpath Schema
+
+Client generation tasks require `schemaFile` to be provided. Using Gradle we can configure tasks to use local schema file,
+load it from an URI or consume it directly from a classpath. See [Gradle TextResourceFactory](https://docs.gradle.org/current/dsl/org.gradle.api.resources.TextResourceFactory.html)
+for additional details.
+
+If `schema.graphql` file is provided in a `my-lib` JAR we can configure our generate client task as follows
+
+<Tabs
+  defaultValue="kotlin"
+  values={[
+    { label: 'Kotlin', value: 'kotlin' },
+    { label: 'Groovy', value: 'groovy' }
+  ]
+  }>
+
+<TabItem value="kotlin">
+
+```kotlin
+// build.gradle.kts
+val graphqlGenerateClient by tasks.getting(GraphQLGenerateClientTask::class) {
+  packageName.set("com.example.generated")
+  val archive = configurations["compileClasspath"].filter {
+      // filter on the jar name.
+      it.name.startsWith("my-lib")
+  }
+  schemaFile.set(resources.text.fromArchive(archive, "schema.graphql").asFile())
+}
+```
+
+</TabItem>
+<TabItem value="groovy">
+
+```groovy
+//build.gradle
+graphqlGenerateClient {
+    packageName = "com.example.generated"
+    val archive = configurations["compileClasspath"].filter {
+        // filter on the jar name.
+        it.name.startsWith("my-lib")
+    }
+    schemaFile = resources.text.fromArchive(archive, "schema.graphql").asFile()
 }
 ```
 
@@ -281,15 +321,7 @@ graphqlGenerateClient {
 ## Generating Test Client
 
 GraphQL Kotlin test client code is generated based on the provided queries that will be executed against target GraphQL `schemaFile`.
-Separate class is generated for each provided GraphQL query and are saved under specified `packageName`. When using default
-configuration and storing GraphQL queries under `src/test/resources` directories, task can be executed directly from the
-command line by explicitly providing required properties.
-
-```shell script
-$ gradle graphqlGenerateTestClient --schemaFileName"mySchema.graphql" --packageName="com.example.generated"
-```
-
-Task can also be explicitly configured in your Gradle build file
+Separate class is generated for each provided GraphQL query and are saved under specified `packageName`.
 
 <Tabs
   defaultValue="kotlin"
@@ -307,7 +339,7 @@ import com.expediagroup.graphql.plugin.gradle.tasks.GraphQLGenerateClientTask
 
 val graphqlGenerateTestClient by tasks.getting(GraphQLGenerateTestClientTask::class) {
   packageName.set("com.example.generated")
-  schemaFileName.set("mySchema.graphql")
+  schemaFile.set(file("${project.projectDir}/mySchema.graphql"))
 }
 ```
 
@@ -318,7 +350,7 @@ val graphqlGenerateTestClient by tasks.getting(GraphQLGenerateTestClientTask::cl
 //build.gradle
 graphqlGenerateTestClient {
     packageName = "com.example.generated"
-    schemaFileName = "mySchema.graphql"
+    schemaFile = file("${project.projectDir}/mySchema.graphql")
 }
 ```
 


### PR DESCRIPTION
### :pencil: Description

By changing `queryFileDirectory` input from a String to a Directory and dropping support for providing schema file path in favor of explicit schema file, Gradle will now be able to correctly monitor task inputs to to determine whether the task is up-to-date.

### :link: Related Issues

Resolves: https://github.com/ExpediaGroup/graphql-kotlin/issues/1232