### PR TITLE
[client] verify selection sets specify all required inputs

### DIFF
--- a/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/exceptions/MissingArgumentException.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/exceptions/MissingArgumentException.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2021 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.plugin.client.generator.exceptions
+
+/**
+ * Exception thrown when specified query file contains invalid selection set that is missing some required parameters.
+ */
+internal class MissingArgumentException(operationName: String, typeName: String, fieldName: String, missingArguments: List<String>) :
+    RuntimeException("Operation $operationName specifies invalid selection set for $typeName - $fieldName selection does not specify $missingArguments required arguments")

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/invalid/missing_argument/MissingArgumentQuery.graphql
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/invalid/missing_argument/MissingArgumentQuery.graphql
@@ -1,0 +1,3 @@
+query MissingArgumentQuery {
+  inputObjectQuery
+}

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/invalid/missing_argument/exception.txt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/invalid/missing_argument/exception.txt
@@ -1,0 +1,1 @@
+MissingArgumentException


### PR DESCRIPTION
### :pencil: Description

Inputs to queries/mutations are either hard coded inside the queries OR provided through variables. As such we never checked for field definition inputs as we only generate simple POJOs that represent the output type results.

This PR adds logic to calculate all required field definition inputs and verifies that selection set specifies them all.

### :link: Related Issues

Resolves: https://github.com/ExpediaGroup/graphql-kotlin/issues/1237
