### PR TITLE
junit fix - bump up the query timeout

### DIFF
--- a/clients/graphql-kotlin-spring-client/src/test/kotlin/com/expediagroup/graphql/client/spring/GraphQLWebClientTest.kt
+++ b/clients/graphql-kotlin-spring-client/src/test/kotlin/com/expediagroup/graphql/client/spring/GraphQLWebClientTest.kt
@@ -201,7 +201,7 @@ class GraphQLWebClientTest {
     @Test
     fun `verifies spring web client instance can be customized`() {
         val expectedResponse = JacksonGraphQLResponse(data = HelloWorldResult("Hello World!"))
-        WireMock.stubFor(stubJacksonResponse(response = expectedResponse, delayMillis = 50))
+        WireMock.stubFor(stubJacksonResponse(response = expectedResponse, delayMillis = 500))
 
         val httpClient: HttpClient = HttpClient.create()
             .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 10)


### PR DESCRIPTION
### :pencil: Description

It looks like runners used for Actions occasionally might be getting busy and as a result our unit test logic does not encounter timeout. Bumping up the WireMock response delay to address it.

### :link: Related Issues
