### PR TITLE
[client] fix Jackson collection serialization

### DIFF
--- a/clients/graphql-kotlin-client-jackson/src/main/kotlin/com/expediagroup/graphql/client/jackson/GraphQLClientJacksonSerializer.kt
+++ b/clients/graphql-kotlin-client-jackson/src/main/kotlin/com/expediagroup/graphql/client/jackson/GraphQLClientJacksonSerializer.kt
@@ -17,6 +17,8 @@
 package com.expediagroup.graphql.client.jackson
 
 import com.expediagroup.graphql.client.jackson.types.JacksonGraphQLResponse
+import com.expediagroup.graphql.client.jackson.types.OptionalInput
+import com.expediagroup.graphql.client.jackson.types.UndefinedFilter
 import com.expediagroup.graphql.client.serializer.GraphQLClientSerializer
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
 import com.fasterxml.jackson.annotation.JsonInclude
@@ -35,7 +37,8 @@ class GraphQLClientJacksonSerializer(private val mapper: ObjectMapper = jacksonO
 
     init {
         mapper.enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE)
-        mapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY)
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL)
+        mapper.configOverride(OptionalInput::class.java).include = JsonInclude.Value.empty().withValueInclusion(JsonInclude.Include.CUSTOM).withValueFilter(UndefinedFilter::class.java)
     }
 
     override fun serialize(request: GraphQLClientRequest<*>): String = mapper.writeValueAsString(request)

--- a/clients/graphql-kotlin-client-jackson/src/main/kotlin/com/expediagroup/graphql/client/jackson/types/OptionalInput.kt
+++ b/clients/graphql-kotlin-client-jackson/src/main/kotlin/com/expediagroup/graphql/client/jackson/types/OptionalInput.kt
@@ -39,3 +39,10 @@ sealed class OptionalInput<out T> {
         override fun toString(): String = "Defined(value=$value)"
     }
 }
+
+/**
+ * Jackson value filter that is used to determine whether to serialize the `OptionalInput` or not.
+ */
+class UndefinedFilter {
+    override fun equals(other: Any?): Boolean = OptionalInput.Undefined == other
+}

--- a/clients/graphql-kotlin-client-jackson/src/test/kotlin/com/expediagroup/graphql/client/jackson/GraphQLClientJacksonSerializerTest.kt
+++ b/clients/graphql-kotlin-client-jackson/src/test/kotlin/com/expediagroup/graphql/client/jackson/GraphQLClientJacksonSerializerTest.kt
@@ -18,7 +18,9 @@ package com.expediagroup.graphql.client.jackson
 
 import com.expediagroup.graphql.client.jackson.data.EnumQuery
 import com.expediagroup.graphql.client.jackson.data.FirstQuery
+import com.expediagroup.graphql.client.jackson.data.InputListQuery
 import com.expediagroup.graphql.client.jackson.data.InputQuery
+import com.expediagroup.graphql.client.jackson.data.OptionalInputQuery
 import com.expediagroup.graphql.client.jackson.data.OtherQuery
 import com.expediagroup.graphql.client.jackson.data.PolymorphicQuery
 import com.expediagroup.graphql.client.jackson.data.ScalarQuery
@@ -259,6 +261,63 @@ class GraphQLClientJacksonSerializerTest {
             |}
         """.trimMargin()
 
+        val serialized = serializer.serialize(query)
+        assertEquals(testMapper.readTree(rawQuery), testMapper.readTree(serialized))
+    }
+
+    @Test
+    fun `verify list serialization`() {
+        val query = InputListQuery(
+            variables = InputListQuery.Variables(
+                nonNullableIds = listOf("ABC")
+            )
+        )
+        val rawQuery =
+            """{
+            |  "query": "INPUT_LIST_QUERY",
+            |  "operationName": "InputListQuery",
+            |  "variables": {
+            |    "nonNullableIds": ["ABC"]
+            |  }
+            |}
+        """.trimMargin()
+        val serialized = serializer.serialize(query)
+        assertEquals(testMapper.readTree(rawQuery), testMapper.readTree(serialized))
+    }
+
+    @Test
+    fun `verify nullable list serialization`() {
+        val query = InputListQuery(
+            variables = InputListQuery.Variables(
+                nullableIds = listOf("XYZ", null),
+                nullableIdList = null,
+                nonNullableIds = listOf()
+            )
+        )
+        val rawQuery =
+            """{
+            |  "query": "INPUT_LIST_QUERY",
+            |  "operationName": "InputListQuery",
+            |  "variables": {
+            |    "nullableIds": ["XYZ", null],
+            |    "nonNullableIds": []
+            |  }
+            |}
+        """.trimMargin()
+        val serialized = serializer.serialize(query)
+        assertEquals(testMapper.readTree(rawQuery), testMapper.readTree(serialized))
+    }
+
+    @Test
+    fun `verify unspecified optional input serialization results in empty variables`() {
+        val query = OptionalInputQuery(variables = OptionalInputQuery.Variables())
+        val rawQuery =
+            """{
+            |  "query": "OPTIONAL_INPUT_QUERY",
+            |  "operationName": "OptionalInputQuery",
+            |  "variables": {}
+            |}
+        """.trimMargin()
         val serialized = serializer.serialize(query)
         assertEquals(testMapper.readTree(rawQuery), testMapper.readTree(serialized))
     }

--- a/clients/graphql-kotlin-client-jackson/src/test/kotlin/com/expediagroup/graphql/client/jackson/data/InputListQuery.kt
+++ b/clients/graphql-kotlin-client-jackson/src/test/kotlin/com/expediagroup/graphql/client/jackson/data/InputListQuery.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2021 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.client.jackson.data
+
+import com.expediagroup.graphql.client.types.GraphQLClientRequest
+import kotlin.String
+import kotlin.collections.List
+import kotlin.reflect.KClass
+
+class InputListQuery(
+    override val variables: Variables
+) : GraphQLClientRequest<InputListQuery.Result> {
+    override val query: String = "INPUT_LIST_QUERY"
+
+    override val operationName: String = "InputListQuery"
+
+    override fun responseType(): KClass<Result> = Result::class
+
+    data class Variables(
+        val nullableIds: List<String?>? = null,
+        val nullableIdList: List<String>? = null,
+        val nonNullableIds: List<String>
+    )
+
+    data class Result(
+        val inputListQuery: String?
+    )
+}

--- a/clients/graphql-kotlin-client-jackson/src/test/kotlin/com/expediagroup/graphql/client/jackson/data/OptionalInputQuery.kt
+++ b/clients/graphql-kotlin-client-jackson/src/test/kotlin/com/expediagroup/graphql/client/jackson/data/OptionalInputQuery.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2021 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.client.jackson.data
+
+import com.expediagroup.graphql.client.jackson.types.OptionalInput
+import com.expediagroup.graphql.client.types.GraphQLClientRequest
+import kotlin.reflect.KClass
+
+class OptionalInputQuery(
+    override val variables: Variables
+) : GraphQLClientRequest<OptionalInputQuery.Result> {
+    override val query: String = "OPTIONAL_INPUT_QUERY"
+
+    override val operationName: String = "OptionalInputQuery"
+
+    override fun responseType(): KClass<Result> = Result::class
+
+    data class Variables(
+        val optional: String? = null
+    )
+
+    data class Result(
+        val stringResult: String
+    )
+}

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/input_lists/InputListQuery.graphql
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/input_lists/InputListQuery.graphql
@@ -1,0 +1,3 @@
+query InputListQuery($nullableIds: [String], $nullableIdList: [String!], $nonNullableIds: [String!]!) {
+  listInputQuery(nullableIds: $nulllableIds, nonNullableIds: $nonNullableIds)
+}

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/input_lists/InputListQuery.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/input_lists/InputListQuery.kt
@@ -1,0 +1,32 @@
+package com.expediagroup.graphql.generated
+
+import com.expediagroup.graphql.client.types.GraphQLClientRequest
+import kotlin.String
+import kotlin.collections.List
+import kotlin.reflect.KClass
+
+public const val INPUT_LIST_QUERY: String =
+    "query InputListQuery(${'$'}nullableIds: [String], ${'$'}nullableIdList: [String!], ${'$'}nonNullableIds: [String!]!) {\n  listInputQuery(nullableIds: ${'$'}nulllableIds, nonNullableIds: ${'$'}nonNullableIds)\n}"
+
+public class InputListQuery(
+  public override val variables: InputListQuery.Variables
+) : GraphQLClientRequest<InputListQuery.Result> {
+  public override val query: String = INPUT_LIST_QUERY
+
+  public override val operationName: String = "InputListQuery"
+
+  public override fun responseType(): KClass<InputListQuery.Result> = InputListQuery.Result::class
+
+  public data class Variables(
+    public val nullableIds: List<String?>? = null,
+    public val nullableIdList: List<String>? = null,
+    public val nonNullableIds: List<String>
+  )
+
+  public data class Result(
+    /**
+     * Query accepting list input
+     */
+    public val listInputQuery: String?
+  )
+}

--- a/plugins/client/graphql-kotlin-client-generator/src/test/resources/testSchema.graphql
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/resources/testSchema.graphql
@@ -100,6 +100,8 @@ type Query {
   interfaceQuery: BasicInterface!
   "Query returning list of simple objects"
   listQuery: [BasicObject!]!
+  "Query accepting list input"
+  listInputQuery(nullableIds: [String], nullableIdList: [String!], nonNullableIds: [String!]!): String
   "Query returning object referencing itself"
   nestedObjectQuery: NestedObject!
   "Query that returns wrapper object with all supported scalar types"

--- a/website/docs/client/client-features.mdx
+++ b/website/docs/client/client-features.mdx
@@ -198,3 +198,46 @@ val secondQuery = SecondQuery(variables = SecondQuery.Variables(foo = "baz"))
 
 val results: List<GraphQLResponse<*>> = client.execute(listOf(firstQuery, secondQuery))
 ```
+
+## Optional Input Support (Jackson only)
+
+In the GraphQL world, input types can be optional which means that the client can specify a value, specify a `null` value
+OR don't specify any value. This is in contrast with the JVM world where objects can either have some specific value or
+don't have any value (i.e. are `null`). By default, GraphQL Kotlin Client treats `null` Kotlin values as unspecified, which
+means it will skip all `null` values when serializing the request, e.g. given following query
+
+```graphql
+query OptionalInputQuery($optionalValue: String) {
+  optional(value: $optionalValue)
+```
+
+GraphQL Kotlin plugins will generate corresponding POJO that defines `Variables` as
+
+```kotlin
+public data class Variables(
+  public val optionalValue: String? = null
+)
+```
+
+Regardless whether we specify `optionalValue` as `null` or rely on the default value, this field won't be serialized,
+i.e. variables will be serialized as an empty JSON object `{}`.
+
+By specifying `useOptionalInputWrapper = true` plugin configuration option, we can opt-in to a behavior that supports
+three states - defined, `null` or undefined. Generated code will then use `OptionalInput` wrapper to represent those states.
+See [Gradle](../plugins/gradle-plugin-tasks) and [Maven](../plugins/maven-plugin-goals) plugin for configuration details.
+
+```kotlin
+public data class Variables(
+  public val optionalValue: OptionalInput<String> = OptionalInput.Undefined
+)
+
+// usage
+// - same behavior as default null, serialized as {}
+val undefinedVariables = Variables(optionalValue = OptionalInput.Undefined)
+
+// - serialized as {"optionalValue": null}
+val nullVariables = Variables(optionalValue = OptionalInput.Defined(null))
+
+// - serialized as {"optionalValue": "foo"}
+val definedVariables = Variables(optionalValue = OptionalInput.Defined("foo")
+```

--- a/website/docs/schema-generator/execution/optional-undefined-arguments.md
+++ b/website/docs/schema-generator/execution/optional-undefined-arguments.md
@@ -43,7 +43,7 @@ value in `Defined` class, i.e. `OptionalInput<String>` will appear as nullable `
 Optional input types can be represented as nullable parameters in Kotlin
 
 ```kotlin
-fun optionalInput(value: String?): String? = value
+fun optionalInput(value: String? = null): String? = value
 ```
 
 ```graphql
@@ -54,14 +54,14 @@ query OptionalInputQuery {
 }
 ```
 
-By default, if an optional input value is not specified, then the execution engine will set the argument in Kotlin to `null`.
-This means that you can not tell, by just the value alone, whether the request did not contain any argument or the client
-explicitly passed in `null`.
+By default, if an optional input value is not specified, then the execution engine will fallback to the argument default
+value (in our example above `null`). This means that you can not tell, by just the value alone, whether the request did
+not contain any argument or the client explicitly passed in the default value.
 
 Instead, you can inspect all passed in arguments using the [DataFetchingEnvironment](./data-fetching-environment.md).
 
 ```kotlin
-fun optionalInput(value: String?, dataFetchingEnvironment: DataFetchingEnvironment): String =
+fun optionalInput(value: String? = null, dataFetchingEnvironment: DataFetchingEnvironment): String =
     if (dataFetchingEnvironment.containsArgument("value")) {
         "The value was $value"
     } else {


### PR DESCRIPTION
### :pencil: Description

When we introduced support for handling optional inputs in Jackson, we broke serialization of empty arrays. `JsonInclude.Include.NON_EMPTY` serialization strategy skips serializing any `null`, absent (from optionals) and empty (collections, strings, etc) values.

Updated default serialization policy to `NON_NULL` and set custom serialization policy for `OptionalInput` fields to rely on a value filter that checks whether input is `Undefined`.

### :link: Related Issues

Resolves: https://github.com/ExpediaGroup/graphql-kotlin/issues/1248



