### PR TITLE
[client] support optional input for kotlinx serialization

### DIFF
--- a/clients/graphql-kotlin-client-jackson/src/test/kotlin/com/expediagroup/graphql/client/jackson/data/EmptyInputQuery.kt
+++ b/clients/graphql-kotlin-client-jackson/src/test/kotlin/com/expediagroup/graphql/client/jackson/data/EmptyInputQuery.kt
@@ -14,26 +14,26 @@
  * limitations under the License.
  */
 
-package com.expediagroup.graphql.client.serialization.data
+package com.expediagroup.graphql.client.jackson.data
 
-import com.expediagroup.graphql.client.serialization.data.polymorphicquery.BasicInterface
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
-import kotlinx.serialization.Required
-import kotlinx.serialization.Serializable
 import kotlin.reflect.KClass
 
-@Serializable
-class PolymorphicQuery : GraphQLClientRequest<PolymorphicQuery.Result> {
-    @Required
-    override val query: String = "POLYMORPHIC_QUERY"
+class EmptyInputQuery(
+    override val variables: Variables
+) : GraphQLClientRequest<EmptyInputQuery.Result> {
 
-    @Required
-    override val operationName: String = "PolymorphicQuery"
+    override val query: String = "EMPTY_INPUT_QUERY"
+
+    override val operationName: String = "EmptyInputQuery"
 
     override fun responseType(): KClass<Result> = Result::class
 
-    @Serializable
+    data class Variables(
+        val nullable: Int? = null
+    )
+
     data class Result(
-        val polymorphicResult: BasicInterface
+        val stringResult: String
     )
 }

--- a/clients/graphql-kotlin-client-jackson/src/test/kotlin/com/expediagroup/graphql/client/jackson/data/InputQuery.kt
+++ b/clients/graphql-kotlin-client-jackson/src/test/kotlin/com/expediagroup/graphql/client/jackson/data/InputQuery.kt
@@ -16,8 +16,9 @@
 
 package com.expediagroup.graphql.client.jackson.data
 
-import com.expediagroup.graphql.client.jackson.types.OptionalInput
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
+import kotlin.String
+import kotlin.collections.List
 import kotlin.reflect.KClass
 
 class InputQuery(
@@ -31,12 +32,14 @@ class InputQuery(
 
     data class Variables(
         val requiredInput: Int,
-        val optionalIntInput: OptionalInput<Int> = OptionalInput.Undefined,
-        val optionalStringInput: OptionalInput<String> = OptionalInput.Undefined,
-        val optionalBooleanInput: OptionalInput<Boolean> = OptionalInput.Undefined
+        val nullableId: Int? = null,
+        val nullableListNullableElements: List<String?>? = null,
+        val nullableListNonNullableElements: List<String>? = null,
+        val nullableElementList: List<String?>,
+        val nonNullableElementList: List<String>
     )
 
     data class Result(
-        val stringResult: String
+        val inputListQuery: String?
     )
 }

--- a/clients/graphql-kotlin-client-jackson/src/test/kotlin/com/expediagroup/graphql/client/jackson/data/OptionalInputQuery.kt
+++ b/clients/graphql-kotlin-client-jackson/src/test/kotlin/com/expediagroup/graphql/client/jackson/data/OptionalInputQuery.kt
@@ -16,6 +16,7 @@
 
 package com.expediagroup.graphql.client.jackson.data
 
+import com.expediagroup.graphql.client.jackson.types.OptionalInput
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
 import kotlin.reflect.KClass
 
@@ -29,7 +30,10 @@ class OptionalInputQuery(
     override fun responseType(): KClass<Result> = Result::class
 
     data class Variables(
-        val optional: String? = null
+        val requiredInput: Int,
+        val optionalIntInput: OptionalInput<Int> = OptionalInput.Undefined,
+        val optionalStringInput: OptionalInput<String> = OptionalInput.Undefined,
+        val optionalBooleanInput: OptionalInput<Boolean> = OptionalInput.Undefined
     )
 
     data class Result(

--- a/clients/graphql-kotlin-client-serialization/build.gradle.kts
+++ b/clients/graphql-kotlin-client-serialization/build.gradle.kts
@@ -20,7 +20,8 @@ tasks {
                 limit {
                     counter = "INSTRUCTION"
                     value = "COVEREDRATIO"
-                    minimum = "0.73".toBigDecimal()
+                    // increase it when https://github.com/Kotlin/kotlinx.serialization/issues/961 is resolved
+                    minimum = "0.70".toBigDecimal()
                 }
             }
         }

--- a/clients/graphql-kotlin-client-serialization/src/main/kotlin/com/expediagroup/graphql/client/serialization/GraphQLClientKotlinxSerializer.kt
+++ b/clients/graphql-kotlin-client-serialization/src/main/kotlin/com/expediagroup/graphql/client/serialization/GraphQLClientKotlinxSerializer.kt
@@ -41,8 +41,7 @@ class GraphQLClientKotlinxSerializer(private val jsonBuilder: JsonBuilder.() -> 
         apply(jsonBuilder)
         classDiscriminator = "__typename"
         coerceInputValues = true
-        // encodeDefaults = false // need this for optional
-        encodeDefaults = true
+        encodeDefaults = false
     }
 
     override fun serialize(request: GraphQLClientRequest<*>): String = json.encodeToString(requestSerializer(request), request)

--- a/clients/graphql-kotlin-client-serialization/src/test/kotlin/com/expediagroup/graphql/client/serialization/data/EmptyInputQuery.kt
+++ b/clients/graphql-kotlin-client-serialization/src/test/kotlin/com/expediagroup/graphql/client/serialization/data/EmptyInputQuery.kt
@@ -16,24 +16,31 @@
 
 package com.expediagroup.graphql.client.serialization.data
 
-import com.expediagroup.graphql.client.serialization.data.polymorphicquery.BasicInterface
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
 import kotlinx.serialization.Required
 import kotlinx.serialization.Serializable
 import kotlin.reflect.KClass
 
 @Serializable
-class PolymorphicQuery : GraphQLClientRequest<PolymorphicQuery.Result> {
-    @Required
-    override val query: String = "POLYMORPHIC_QUERY"
+class EmptyInputQuery(
+    override val variables: Variables
+) : GraphQLClientRequest<EmptyInputQuery.Result> {
 
     @Required
-    override val operationName: String = "PolymorphicQuery"
+    override val query: String = "EMPTY_INPUT_QUERY"
+
+    @Required
+    override val operationName: String = "EmptyInputQuery"
 
     override fun responseType(): KClass<Result> = Result::class
 
     @Serializable
+    data class Variables(
+        val nullable: Int? = null
+    )
+
+    @Serializable
     data class Result(
-        val polymorphicResult: BasicInterface
+        val stringResult: String
     )
 }

--- a/clients/graphql-kotlin-client-serialization/src/test/kotlin/com/expediagroup/graphql/client/serialization/data/EnumQuery.kt
+++ b/clients/graphql-kotlin-client-serialization/src/test/kotlin/com/expediagroup/graphql/client/serialization/data/EnumQuery.kt
@@ -18,6 +18,7 @@ package com.expediagroup.graphql.client.serialization.data
 
 import com.expediagroup.graphql.client.serialization.data.enums.TestEnum
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
+import kotlinx.serialization.Required
 import kotlinx.serialization.Serializable
 import kotlin.reflect.KClass
 
@@ -25,8 +26,10 @@ import kotlin.reflect.KClass
 class EnumQuery(
     override val variables: Variables
 ) : GraphQLClientRequest<EnumQuery.Result> {
+    @Required
     override val query: String = "ENUM_QUERY"
 
+    @Required
     override val operationName: String = "EnumQuery"
 
     override fun responseType(): KClass<Result> = Result::class

--- a/clients/graphql-kotlin-client-serialization/src/test/kotlin/com/expediagroup/graphql/client/serialization/data/FirstQuery.kt
+++ b/clients/graphql-kotlin-client-serialization/src/test/kotlin/com/expediagroup/graphql/client/serialization/data/FirstQuery.kt
@@ -17,6 +17,7 @@
 package com.expediagroup.graphql.client.serialization.data
 
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
+import kotlinx.serialization.Required
 import kotlinx.serialization.Serializable
 import kotlin.reflect.KClass
 
@@ -24,8 +25,10 @@ import kotlin.reflect.KClass
 class FirstQuery(
     override val variables: Variables
 ) : GraphQLClientRequest<FirstQuery.Result> {
+    @Required
     override val query: String = "FIRST_QUERY"
 
+    @Required
     override val operationName: String = "FirstQuery"
 
     override fun responseType(): KClass<Result> = Result::class

--- a/clients/graphql-kotlin-client-serialization/src/test/kotlin/com/expediagroup/graphql/client/serialization/data/InputQuery.kt
+++ b/clients/graphql-kotlin-client-serialization/src/test/kotlin/com/expediagroup/graphql/client/serialization/data/InputQuery.kt
@@ -16,8 +16,8 @@
 
 package com.expediagroup.graphql.client.serialization.data
 
-import com.expediagroup.graphql.client.serialization.types.OptionalInput
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
+import kotlinx.serialization.Required
 import kotlinx.serialization.Serializable
 import kotlin.reflect.KClass
 
@@ -25,8 +25,11 @@ import kotlin.reflect.KClass
 class InputQuery(
     override val variables: Variables
 ) : GraphQLClientRequest<InputQuery.Result> {
+
+    @Required
     override val query: String = "INPUT_QUERY"
 
+    @Required
     override val operationName: String = "InputQuery"
 
     override fun responseType(): KClass<Result> = Result::class
@@ -34,9 +37,11 @@ class InputQuery(
     @Serializable
     data class Variables(
         val requiredInput: Int,
-        val optionalIntInput: OptionalInput<Int> = OptionalInput.Undefined,
-        val optionalStringInput: OptionalInput<String> = OptionalInput.Undefined,
-        val optionalBooleanInput: OptionalInput<Boolean> = OptionalInput.Undefined
+        val nullableId: Int? = null,
+        val nullableListNullableElements: List<String?>? = null,
+        val nullableListNonNullableElements: List<String>? = null,
+        val nullableElementList: List<String?>,
+        val nonNullableElementList: List<String>
     )
 
     @Serializable

--- a/clients/graphql-kotlin-client-serialization/src/test/kotlin/com/expediagroup/graphql/client/serialization/data/OptionalInputQuery.kt
+++ b/clients/graphql-kotlin-client-serialization/src/test/kotlin/com/expediagroup/graphql/client/serialization/data/OptionalInputQuery.kt
@@ -14,29 +14,36 @@
  * limitations under the License.
  */
 
-package com.expediagroup.graphql.client.jackson.data
+package com.expediagroup.graphql.client.serialization.data
 
+import com.expediagroup.graphql.client.serialization.types.OptionalInput
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
-import kotlin.String
-import kotlin.collections.List
+import kotlinx.serialization.Required
+import kotlinx.serialization.Serializable
 import kotlin.reflect.KClass
 
-class InputListQuery(
+@Serializable
+class OptionalInputQuery(
     override val variables: Variables
-) : GraphQLClientRequest<InputListQuery.Result> {
-    override val query: String = "INPUT_LIST_QUERY"
+) : GraphQLClientRequest<OptionalInputQuery.Result> {
+    @Required
+    override val query: String = "OPTIONAL_INPUT_QUERY"
 
-    override val operationName: String = "InputListQuery"
+    @Required
+    override val operationName: String = "OptionalInputQuery"
 
     override fun responseType(): KClass<Result> = Result::class
 
+    @Serializable
     data class Variables(
-        val nullableIds: List<String?>? = null,
-        val nullableIdList: List<String>? = null,
-        val nonNullableIds: List<String>
+        val requiredInput: Int,
+        val optionalIntInput: OptionalInput<Int> = OptionalInput.Undefined,
+        val optionalStringInput: OptionalInput<String> = OptionalInput.Undefined,
+        val optionalBooleanInput: OptionalInput<Boolean> = OptionalInput.Undefined
     )
 
+    @Serializable
     data class Result(
-        val inputListQuery: String?
+        val stringResult: String
     )
 }

--- a/clients/graphql-kotlin-client-serialization/src/test/kotlin/com/expediagroup/graphql/client/serialization/data/OtherQuery.kt
+++ b/clients/graphql-kotlin-client-serialization/src/test/kotlin/com/expediagroup/graphql/client/serialization/data/OtherQuery.kt
@@ -17,13 +17,16 @@
 package com.expediagroup.graphql.client.serialization.data
 
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
+import kotlinx.serialization.Required
 import kotlinx.serialization.Serializable
 import kotlin.reflect.KClass
 
 @Serializable
 class OtherQuery : GraphQLClientRequest<OtherQuery.Result> {
+    @Required
     override val query: String = "OTHER_QUERY"
 
+    @Required
     override val operationName: String = "OtherQuery"
 
     override fun responseType(): KClass<Result> = Result::class

--- a/clients/graphql-kotlin-client-serialization/src/test/kotlin/com/expediagroup/graphql/client/serialization/data/ScalarQuery.kt
+++ b/clients/graphql-kotlin-client-serialization/src/test/kotlin/com/expediagroup/graphql/client/serialization/data/ScalarQuery.kt
@@ -18,6 +18,7 @@ package com.expediagroup.graphql.client.serialization.data
 
 import com.expediagroup.graphql.client.serialization.data.scalars.UUID
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
+import kotlinx.serialization.Required
 import kotlinx.serialization.Serializable
 import kotlin.reflect.KClass
 
@@ -28,8 +29,10 @@ typealias ID = String
 class ScalarQuery(
     override val variables: Variables
 ) : GraphQLClientRequest<ScalarQuery.Result> {
+    @Required
     override val query: String = "SCALAR_QUERY"
 
+    @Required
     override val operationName: String = "ScalarQuery"
 
     override fun responseType(): KClass<Result> = Result::class

--- a/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/GraphQLClientGeneratorConfig.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/GraphQLClientGeneratorConfig.kt
@@ -30,7 +30,7 @@ data class GraphQLClientGeneratorConfig(
     val customScalarMap: Map<String, GraphQLScalar> = emptyMap(),
     /** Type of JSON serializer to be used. */
     val serializer: GraphQLSerializer = GraphQLSerializer.JACKSON,
-    /** Explicit opt-in flag to enable support for optional inputs, only available for JACKSON serializer. */
+    /** Explicit opt-in flag to enable support for optional inputs. */
     val useOptionalInputWrapper: Boolean = false
 )
 

--- a/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/GraphQLClientGeneratorContext.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/GraphQLClientGeneratorContext.kt
@@ -69,5 +69,3 @@ sealed class ScalarConverterInfo {
         val serializerTypeSpec: TypeSpec
     ) : ScalarConverterInfo()
 }
-
-internal fun GraphQLClientGeneratorContext.isOptionalInputSupported() = useOptionalInputWrapper && serializer == GraphQLSerializer.JACKSON

--- a/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/types/generateGraphQLInputObjectTypeSpec.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/types/generateGraphQLInputObjectTypeSpec.kt
@@ -18,14 +18,15 @@ package com.expediagroup.graphql.plugin.client.generator.types
 
 import com.expediagroup.graphql.plugin.client.generator.GraphQLClientGeneratorContext
 import com.expediagroup.graphql.plugin.client.generator.GraphQLSerializer
-import com.expediagroup.graphql.plugin.client.generator.isOptionalInputSupported
 import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.MemberName
 import com.squareup.kotlinpoet.ParameterSpec
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.PropertySpec
+import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.TypeSpec
 import graphql.language.InputObjectTypeDefinition
 import kotlinx.serialization.Serializable
@@ -49,13 +50,7 @@ internal fun generateGraphQLInputObjectTypeSpec(context: GraphQLClientGeneratorC
         val kotlinFieldType = generateTypeName(context, fieldDefinition.type)
         val fieldName = fieldDefinition.name
 
-        val inputFieldType = if (kotlinFieldType.isNullable && context.isOptionalInputSupported()) {
-            ClassName("com.expediagroup.graphql.client.jackson.types", "OptionalInput")
-                .parameterizedBy(kotlinFieldType.copy(nullable = false))
-        } else {
-            kotlinFieldType
-        }
-
+        val inputFieldType = kotlinFieldType.wrapOptionalInputType(context)
         val inputPropertySpecBuilder = PropertySpec.builder(fieldName, inputFieldType)
             .initializer(fieldName)
         fieldDefinition.description?.content?.let { kdoc ->
@@ -67,15 +62,33 @@ internal fun generateGraphQLInputObjectTypeSpec(context: GraphQLClientGeneratorC
 
         val inputParameterSpec = ParameterSpec.builder(inputPropertySpec.name, inputPropertySpec.type)
         if (kotlinFieldType.isNullable) {
-            if (context.isOptionalInputSupported()) {
-                inputParameterSpec.defaultValue("%M", MemberName("com.expediagroup.graphql.client.jackson.types", "OptionalInput.Undefined"))
-            } else {
-                inputParameterSpec.defaultValue("null")
-            }
+            inputParameterSpec.defaultValue(nullableDefaultValueCodeBlock(context))
         }
         constructorBuilder.addParameter(inputParameterSpec.build())
     }
     inputObjectTypeSpecBuilder.primaryConstructor(constructorBuilder.build())
 
     return inputObjectTypeSpecBuilder.build()
+}
+
+internal fun TypeName.wrapOptionalInputType(context: GraphQLClientGeneratorContext): TypeName = if (this.isNullable && context.useOptionalInputWrapper) {
+    if (context.serializer == GraphQLSerializer.JACKSON) {
+        ClassName("com.expediagroup.graphql.client.jackson.types", "OptionalInput")
+            .parameterizedBy(this.copy(nullable = false))
+    } else {
+        ClassName("com.expediagroup.graphql.client.serialization.types", "OptionalInput")
+            .parameterizedBy(this.copy(nullable = false))
+    }
+} else {
+    this
+}
+
+internal fun nullableDefaultValueCodeBlock(context: GraphQLClientGeneratorContext): CodeBlock = if (context.useOptionalInputWrapper) {
+    if (context.serializer == GraphQLSerializer.JACKSON) {
+        CodeBlock.of("%M", MemberName("com.expediagroup.graphql.client.jackson.types", "OptionalInput.Undefined"))
+    } else {
+        CodeBlock.of("%M", MemberName("com.expediagroup.graphql.client.serialization.types", "OptionalInput.Undefined"))
+    }
+} else {
+    CodeBlock.of("null")
 }

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/custom_scalars/CustomScalarQuery.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/custom_scalars/CustomScalarQuery.kt
@@ -4,6 +4,7 @@ import com.expediagroup.graphql.client.types.GraphQLClientRequest
 import com.expediagroup.graphql.generated.customscalarquery.ScalarWrapper
 import kotlin.String
 import kotlin.reflect.KClass
+import kotlinx.serialization.Required
 import kotlinx.serialization.Serializable
 
 public const val CUSTOM_SCALAR_QUERY: String =
@@ -11,8 +12,10 @@ public const val CUSTOM_SCALAR_QUERY: String =
 
 @Serializable
 public class CustomScalarQuery : GraphQLClientRequest<CustomScalarQuery.Result> {
+  @Required
   public override val query: String = CUSTOM_SCALAR_QUERY
 
+  @Required
   public override val operationName: String = "CustomScalarQuery"
 
   public override fun responseType(): KClass<CustomScalarQuery.Result> =

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/deprecated_opt_in/DeprecatedOptInQuery.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/deprecated_opt_in/DeprecatedOptInQuery.kt
@@ -4,6 +4,7 @@ import com.expediagroup.graphql.client.types.GraphQLClientRequest
 import kotlin.Deprecated
 import kotlin.String
 import kotlin.reflect.KClass
+import kotlinx.serialization.Required
 import kotlinx.serialization.Serializable
 
 public const val DEPRECATED_OPT_IN_QUERY: String =
@@ -11,8 +12,10 @@ public const val DEPRECATED_OPT_IN_QUERY: String =
 
 @Serializable
 public class DeprecatedOptInQuery : GraphQLClientRequest<DeprecatedOptInQuery.Result> {
+  @Required
   public override val query: String = DEPRECATED_OPT_IN_QUERY
 
+  @Required
   public override val operationName: String = "DeprecatedOptInQuery"
 
   public override fun responseType(): KClass<DeprecatedOptInQuery.Result> =

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/enums/EnumQuery.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/enums/EnumQuery.kt
@@ -5,14 +5,17 @@ import com.expediagroup.graphql.generated.enums.CustomEnum
 import com.expediagroup.graphql.generated.enums.OtherEnum
 import kotlin.String
 import kotlin.reflect.KClass
+import kotlinx.serialization.Required
 import kotlinx.serialization.Serializable
 
 public const val ENUM_QUERY: String = "query EnumQuery {\n  enumQuery\n  otherEnumQuery\n}"
 
 @Serializable
 public class EnumQuery : GraphQLClientRequest<EnumQuery.Result> {
+  @Required
   public override val query: String = ENUM_QUERY
 
+  @Required
   public override val operationName: String = "EnumQuery"
 
   public override fun responseType(): KClass<EnumQuery.Result> = EnumQuery.Result::class

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/interface/InterfaceWithInlineFragmentsQuery.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/interface/InterfaceWithInlineFragmentsQuery.kt
@@ -4,6 +4,7 @@ import com.expediagroup.graphql.client.types.GraphQLClientRequest
 import com.expediagroup.graphql.generated.interfacewithinlinefragmentsquery.BasicInterface
 import kotlin.String
 import kotlin.reflect.KClass
+import kotlinx.serialization.Required
 import kotlinx.serialization.Serializable
 
 public const val INTERFACE_WITH_INLINE_FRAGMENTS_QUERY: String =
@@ -12,8 +13,10 @@ public const val INTERFACE_WITH_INLINE_FRAGMENTS_QUERY: String =
 @Serializable
 public class InterfaceWithInlineFragmentsQuery :
     GraphQLClientRequest<InterfaceWithInlineFragmentsQuery.Result> {
+  @Required
   public override val query: String = INTERFACE_WITH_INLINE_FRAGMENTS_QUERY
 
+  @Required
   public override val operationName: String = "InterfaceWithInlineFragmentsQuery"
 
   public override fun responseType(): KClass<InterfaceWithInlineFragmentsQuery.Result> =

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/multiple_queries/FirstQuery.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/multiple_queries/FirstQuery.kt
@@ -9,6 +9,7 @@ import com.expediagroup.graphql.generated.inputs.ComplexArgumentInput
 import kotlin.Boolean
 import kotlin.String
 import kotlin.reflect.KClass
+import kotlinx.serialization.Required
 import kotlinx.serialization.Serializable
 
 public const val FIRST_QUERY: String =
@@ -18,8 +19,10 @@ public const val FIRST_QUERY: String =
 public class FirstQuery(
   public override val variables: FirstQuery.Variables
 ) : GraphQLClientRequest<FirstQuery.Result> {
+  @Required
   public override val query: String = FIRST_QUERY
 
+  @Required
   public override val operationName: String = "FirstQuery"
 
   public override fun responseType(): KClass<FirstQuery.Result> = FirstQuery.Result::class

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/multiple_queries/SecondQuery.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/multiple_queries/SecondQuery.kt
@@ -9,6 +9,7 @@ import com.expediagroup.graphql.generated.secondquery.ScalarWrapper
 import kotlin.Boolean
 import kotlin.String
 import kotlin.reflect.KClass
+import kotlinx.serialization.Required
 import kotlinx.serialization.Serializable
 
 public const val SECOND_QUERY: String =
@@ -18,8 +19,10 @@ public const val SECOND_QUERY: String =
 public class SecondQuery(
   public override val variables: SecondQuery.Variables
 ) : GraphQLClientRequest<SecondQuery.Result> {
+  @Required
   public override val query: String = SECOND_QUERY
 
+  @Required
   public override val operationName: String = "SecondQuery"
 
   public override fun responseType(): KClass<SecondQuery.Result> = SecondQuery.Result::class

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/object/ComplexObjectQuery.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/object/ComplexObjectQuery.kt
@@ -4,6 +4,7 @@ import com.expediagroup.graphql.client.types.GraphQLClientRequest
 import com.expediagroup.graphql.generated.complexobjectquery.ComplexObject
 import kotlin.String
 import kotlin.reflect.KClass
+import kotlinx.serialization.Required
 import kotlinx.serialization.Serializable
 
 public const val COMPLEX_OBJECT_QUERY: String =
@@ -11,8 +12,10 @@ public const val COMPLEX_OBJECT_QUERY: String =
 
 @Serializable
 public class ComplexObjectQuery : GraphQLClientRequest<ComplexObjectQuery.Result> {
+  @Required
   public override val query: String = COMPLEX_OBJECT_QUERY
 
+  @Required
   public override val operationName: String = "ComplexObjectQuery"
 
   public override fun responseType(): KClass<ComplexObjectQuery.Result> =

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/union/UnionQueryWithInlineFragments.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/union/UnionQueryWithInlineFragments.kt
@@ -4,6 +4,7 @@ import com.expediagroup.graphql.client.types.GraphQLClientRequest
 import com.expediagroup.graphql.generated.unionquerywithinlinefragments.BasicUnion
 import kotlin.String
 import kotlin.reflect.KClass
+import kotlinx.serialization.Required
 import kotlinx.serialization.Serializable
 
 public const val UNION_QUERY_WITH_INLINE_FRAGMENTS: String =
@@ -12,8 +13,10 @@ public const val UNION_QUERY_WITH_INLINE_FRAGMENTS: String =
 @Serializable
 public class UnionQueryWithInlineFragments :
     GraphQLClientRequest<UnionQueryWithInlineFragments.Result> {
+  @Required
   public override val query: String = UNION_QUERY_WITH_INLINE_FRAGMENTS
 
+  @Required
   public override val operationName: String = "UnionQueryWithInlineFragments"
 
   public override fun responseType(): KClass<UnionQueryWithInlineFragments.Result> =

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/variables/KotlinXInputQuery.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/variables/KotlinXInputQuery.kt
@@ -5,6 +5,7 @@ import com.expediagroup.graphql.generated.inputs.SimpleArgumentInput
 import kotlin.Boolean
 import kotlin.String
 import kotlin.reflect.KClass
+import kotlinx.serialization.Required
 import kotlinx.serialization.Serializable
 
 public const val KOTLIN_X_INPUT_QUERY: String =
@@ -14,8 +15,10 @@ public const val KOTLIN_X_INPUT_QUERY: String =
 public class KotlinXInputQuery(
   public override val variables: KotlinXInputQuery.Variables
 ) : GraphQLClientRequest<KotlinXInputQuery.Result> {
+  @Required
   public override val query: String = KOTLIN_X_INPUT_QUERY
 
+  @Required
   public override val operationName: String = "KotlinXInputQuery"
 
   public override fun responseType(): KClass<KotlinXInputQuery.Result> =

--- a/plugins/graphql-kotlin-gradle-plugin/README.md
+++ b/plugins/graphql-kotlin-gradle-plugin/README.md
@@ -56,7 +56,6 @@ graphql {
           read = 15_000
       }
       // Opt-in flag to wrap nullable arguments in OptionalInput that distinguish between null and undefined value.
-      // Only supported for JACKSON serializer
       useOptionalInputWrapper = false
   }
   schema {
@@ -107,7 +106,7 @@ resulting generated code will be automatically added to the project main source 
 | `queryFileDirectory` | Directory | | Directory file containing GraphQL queries. Instead of specifying a directory you can also specify list of query file by using `queryFiles` property instead.<br/>**Default value is:** `src/main/resources`. |
 | `serializer` | GraphQLSerializer | | JSON serializer that will be used to generate the data classes.<br/>**Default value is:** `GraphQLSerializer.JACKSON`. |
 | `schemaFile` | File | yes | GraphQL schema file that will be used to generate client code. |
-| `useOptionalInputWrapper` | Boolean | | Boolean opt-in flag to wrap nullable arguments in `OptionalInput` that distinguish between `null` and undefined/omitted value. Only supported for JACKSON serializer.<br/>**Default value is:** `false`.<br/>**Command line property is**: `useOptionalInputWrapper` |
+| `useOptionalInputWrapper` | Boolean | | Boolean opt-in flag to wrap nullable arguments in `OptionalInput` that distinguish between `null` and undefined/omitted value. <br/>**Default value is:** `false`.<br/>**Command line property is**: `useOptionalInputWrapper` |
 
 ### graphqlGenerateSDL
 
@@ -154,7 +153,7 @@ test source set.
 | `queryFileDirectory` | Directory | | Directory file containing GraphQL queries. Instead of specifying a directory you can also specify list of query file by using `queryFiles` property instead.<br/>**Default value is:** `src/test/resources`. |
 | `serializer` | GraphQLSerializer | | JSON serializer that will be used to generate the data classes.<br/>**Default value is:** `GraphQLSerializer.JACKSON`. |
 | `schemaFile` | File | yes | GraphQL schema file that will be used to generate client code. |
-| `useOptionalInputWrapper` | Boolean | | Boolean opt-in flag to wrap nullable arguments in `OptionalInput` that distinguish between `null` and undefined/omitted value. Only supported for JACKSON serializer.<br/>**Default value is:** `false`.<br/>**Command line property is**: `useOptionalInputWrapper` |
+| `useOptionalInputWrapper` | Boolean | | Boolean opt-in flag to wrap nullable arguments in `OptionalInput` that distinguish between `null` and undefined/omitted value. <br/>**Default value is:** `false`.<br/>**Command line property is**: `useOptionalInputWrapper` |
 
 ### graphqlIntrospectSchema
 

--- a/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLPluginExtension.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLPluginExtension.kt
@@ -75,7 +75,7 @@ open class GraphQLPluginClientExtension {
     var queryFileDirectory: String? = null
     /** JSON serializer that will be used to generate the data classes. */
     var serializer: GraphQLSerializer = GraphQLSerializer.JACKSON
-    /** Opt-in flag to wrap nullable arguments in OptionalInput that supports both null and undefined. Only supported for JACKSON serializer. */
+    /** Opt-in flag to wrap nullable arguments in OptionalInput that supports both null and undefined. */
     var useOptionalInputWrapper: Boolean = false
 
     /** Connect and read timeout configuration for executing introspection query/download schema */

--- a/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/parameters/GenerateClientParameters.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/parameters/GenerateClientParameters.kt
@@ -42,9 +42,6 @@ interface GenerateClientParameters : WorkParameters {
     val queryFiles: ListProperty<File>
     /** Directory where to save the generated source files. */
     val targetDirectory: Property<File>
-    /**
-     * Explicit opt-in flag to wrap nullable arguments in OptionalInput that supports both null and undefined values.
-     * Only supported for JACKSON serializer.
-     */
+    /** Explicit opt-in flag to wrap nullable arguments in OptionalInput that supports both null and undefined values. */
     val useOptionalInputWrapper: Property<Boolean>
 }

--- a/plugins/graphql-kotlin-maven-plugin/README.md
+++ b/plugins/graphql-kotlin-maven-plugin/README.md
@@ -46,8 +46,7 @@ Plugin should be configured as part of your `pom.xml` build file.
                     <connect>1000</connect>
                     <read>30000</read>
                 </timeoutConfiguration>
-                <!-- Opt-in flag to wrap nullable arguments in OptionalInput that distinguish between null and undefined value.
-                    Only supported for JACKSON serializer. -->
+                <!-- Opt-in flag to wrap nullable arguments in OptionalInput that distinguish between null and undefined value. -->
                 <useOptionalInputWrapper>false</useOptionalInputWrapper>
                 <queryFiles>
                     <queryFile>${project.basedir}/src/main/resources/queries/MyQuery.graphql</queryFile>
@@ -114,7 +113,7 @@ Generate GraphQL client code based on the provided GraphQL schema and target que
 | `queryFiles` | List<File> | | List of query files to be processed. Instead of a list of files to be processed you can also specify `queryFileDirectory` directory containing all the files. If this property is specified it will take precedence over the corresponding directory property. |
 | `serializer` | GraphQLSerializer | | JSON serializer that will be used to generate the data classes.<br/>**Default value is:** `GraphQLSerializer.JACKSON`. |
 | `schemaFile` | String | | GraphQL schema file that will be used to generate client code.<br/>**Default value is**: `${project.build.directory}/schema.graphql`<br/>**User property is**: `graphql.schemaFile`. |
-| `useOptionalInputWrapper` | Boolean | | Boolean opt-in flag to wrap nullable arguments in `OptionalInput` that distinguish between `null` and undefined/omitted value. Only supported for JACKSON serializer.<br/>**Default value is:** `false`.<br/>**User property is**: `graphql.useOptionalInputWrapper` |
+| `useOptionalInputWrapper` | Boolean | | Boolean opt-in flag to wrap nullable arguments in `OptionalInput` that distinguish between `null` and undefined/omitted value.<br/>**Default value is:** `false`.<br/>**User property is**: `graphql.useOptionalInputWrapper` |
 
 **Parameter Details**
 
@@ -182,7 +181,7 @@ Generate GraphQL test client code based on the provided GraphQL schema and targe
 | `queryFiles` | List<File> | | List of query files to be processed. Instead of a list of files to be processed you can also specify `queryFileDirectory` directory containing all the files. If this property is specified it will take precedence over the corresponding directory property. |
 | `serializer` | GraphQLSerializer | | JSON serializer that will be used to generate the data classes.<br/>**Default value is:** `GraphQLSerializer.JACKSON`. |
 | `schemaFile` | String | | GraphQL schema file that will be used to generate client code.<br/>**Default value is**: `${project.build.directory}/schema.graphql`<br/>**User property is**: `graphql.schemaFile`. |
-| `useOptionalInputWrapper` | Boolean | | Boolean opt-in flag to wrap nullable arguments in `OptionalInput` that distinguish between `null` and undefined/omitted value. Only supported for JACKSON serializer.<br/>**Default value is:** `false`.<br/>**User property is**: `graphql.useOptionalInputWrapper` |
+| `useOptionalInputWrapper` | Boolean | | Boolean opt-in flag to wrap nullable arguments in `OptionalInput` that distinguish between `null` and undefined/omitted value.<br/>**Default value is:** `false`.<br/>**User property is**: `graphql.useOptionalInputWrapper` |
 
 **Parameter Details**
 

--- a/plugins/graphql-kotlin-maven-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/maven/GenerateClientAbstractMojo.kt
+++ b/plugins/graphql-kotlin-maven-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/maven/GenerateClientAbstractMojo.kt
@@ -94,7 +94,6 @@ abstract class GenerateClientAbstractMojo : AbstractMojo() {
 
     /**
      * Explicit opt-in flag to wrap nullable arguments in OptionalInput that supports both null and undefined values.
-     * Only supported for JACKSON serializer.
      */
     @Parameter(defaultValue = "\${graphql.useOptionalInputWrapper}", name = "useOptionalInputWrapper")
     private var useOptionalInputWrapper: Boolean = false

--- a/website/docs/client/client-features.mdx
+++ b/website/docs/client/client-features.mdx
@@ -199,12 +199,12 @@ val secondQuery = SecondQuery(variables = SecondQuery.Variables(foo = "baz"))
 val results: List<GraphQLResponse<*>> = client.execute(listOf(firstQuery, secondQuery))
 ```
 
-## Optional Input Support (Jackson only)
+## Optional Input Support
 
 In the GraphQL world, input types can be optional which means that the client can specify a value, specify a `null` value
 OR don't specify any value. This is in contrast with the JVM world where objects can either have some specific value or
 don't have any value (i.e. are `null`). By default, GraphQL Kotlin Client treats `null` Kotlin values as unspecified, which
-means it will skip all `null` values when serializing the request, e.g. given following query
+means they will skip all `null` values when serializing the request, e.g. given following query
 
 ```graphql
 query OptionalInputQuery($optionalValue: String) {

--- a/website/docs/plugins/gradle-plugin-tasks.mdx
+++ b/website/docs/plugins/gradle-plugin-tasks.mdx
@@ -143,7 +143,6 @@ graphql {
         read = 15_000
     }
     // Opt-in flag to wrap nullable arguments in OptionalInput that distinguish between null and undefined value.
-    // Only supported for JACKSON serializer
     useOptionalInputWrapper = false
   }
   schema {
@@ -190,7 +189,6 @@ graphql {
             t.read = 15000
         }
         // Opt-in flag to wrap nullable arguments in OptionalInput that distinguish between null and undefined value.
-        // Only supported for JACKSON serializer
         useOptionalInputWrapper = false
     }
     schema {
@@ -264,7 +262,7 @@ resulting generated code will be automatically added to the project main source 
 | `queryFileDirectory` | Directory | | Directory file containing GraphQL queries. Instead of specifying a directory you can also specify list of query file by using `queryFiles` property instead.<br/>**Default value is:** `src/main/resources`. |
 | `serializer` | GraphQLSerializer | | JSON serializer that will be used to generate the data classes.<br/>**Default value is:** `GraphQLSerializer.JACKSON`. |
 | `schemaFile` | File | yes | GraphQL schema file that will be used to generate client code. |
-| `useOptionalInputWrapper` | Boolean | | Boolean opt-in flag to wrap nullable arguments in `OptionalInput` that distinguish between `null` and undefined/omitted value. Only supported for JACKSON serializer.<br/>**Default value is:** `false`.<br/>**Command line property is**: `useOptionalInputWrapper` |
+| `useOptionalInputWrapper` | Boolean | | Boolean opt-in flag to wrap nullable arguments in `OptionalInput` that distinguish between `null` and undefined/omitted value.<br/>**Default value is:** `false`.<br/>**Command line property is**: `useOptionalInputWrapper` |
 
 By default, this task will generate Jackson compatible data models. See [client serialization documentation](../client/client-serialization.mdx)
 for details on how to update this process to use `kotlinx.serialization` instead.
@@ -313,7 +311,7 @@ test source set.
 | `queryFileDirectory` | Directory | | Directory file containing GraphQL queries. Instead of specifying a directory you can also specify list of query file by using `queryFiles` property instead.<br/>**Default value is:** `src/test/resources`. |
 | `serializer` | GraphQLSerializer | | JSON serializer that will be used to generate the data classes.<br/>**Default value is:** `GraphQLSerializer.JACKSON`. |
 | `schemaFile` | File | yes | GraphQL schema file that will be used to generate client code. |
-| `useOptionalInputWrapper` | Boolean | | Boolean opt-in flag to wrap nullable arguments in `OptionalInput` that distinguish between `null` and undefined/omitted value. Only supported for JACKSON serializer.<br/>**Default value is:** `false`.<br/>**Command line property is**: `useOptionalInputWrapper` |
+| `useOptionalInputWrapper` | Boolean | | Boolean opt-in flag to wrap nullable arguments in `OptionalInput` that distinguish between `null` and undefined/omitted value.<br/>**Default value is:** `false`.<br/>**Command line property is**: `useOptionalInputWrapper` |
 
 By default, this task will generate Jackson compatible data models. See [client serialization documentation](../client/client-serialization.mdx)
 for details on how to update this process to use `kotlinx.serialization` instead.

--- a/website/docs/plugins/maven-plugin-goals.md
+++ b/website/docs/plugins/maven-plugin-goals.md
@@ -72,7 +72,7 @@ Generate GraphQL client code based on the provided GraphQL schema and target que
 | `queryFiles` | `List<File>` | | List of query files to be processed. Instead of a list of files to be processed you can also specify `queryFileDirectory` directory containing all the files. If this property is specified it will take precedence over the corresponding directory property. |
 | `serializer` | GraphQLSerializer | | JSON serializer that will be used to generate the data classes.<br/>**Default value is:** `GraphQLSerializer.JACKSON`. |
 | `schemaFile` | String | | GraphQL schema file that will be used to generate client code.<br/>**Default value is**: `${project.build.directory}/schema.graphql`<br/>**User property is**: `graphql.schemaFile`. |
-| `useOptionalInputWrapper` | Boolean | | Boolean opt-in flag to wrap nullable arguments in `OptionalInput` that distinguish between `null` and undefined/omitted value. Only supported for JACKSON serializer.<br/>**Default value is:** `false`.<br/>**User property is**: `graphql.useOptionalInputWrapper` |
+| `useOptionalInputWrapper` | Boolean | | Boolean opt-in flag to wrap nullable arguments in `OptionalInput` that distinguish between `null` and undefined/omitted value.<br/>**Default value is:** `false`.<br/>**User property is**: `graphql.useOptionalInputWrapper` |
 
 **Parameter Details**
 
@@ -140,7 +140,7 @@ Generate GraphQL test client code based on the provided GraphQL schema and targe
 | `queryFiles` | `List<File>` | | List of query files to be processed. Instead of a list of files to be processed you can also specify `queryFileDirectory` directory containing all the files. If this property is specified it will take precedence over the corresponding directory property. |
 | `serializer` | GraphQLSerializer | | JSON serializer that will be used to generate the data classes.<br/>**Default value is:** `GraphQLSerializer.JACKSON`. |
 | `schemaFile` | String | | GraphQL schema file that will be used to generate client code.<br/>**Default value is**: `${project.build.directory}/schema.graphql`<br/>**User property is**: `graphql.schemaFile`. |
-| `useOptionalInputWrapper` | Boolean | | Boolean opt-in flag to wrap nullable arguments in `OptionalInput` that distinguish between `null` and undefined/omitted value. Only supported for JACKSON serializer.<br/>**Default value is:** `false`.<br/>**User property is**: `graphql.useOptionalInputWrapper` |
+| `useOptionalInputWrapper` | Boolean | | Boolean opt-in flag to wrap nullable arguments in `OptionalInput` that distinguish between `null` and undefined/omitted value.<br/>**Default value is:** `false`.<br/>**User property is**: `graphql.useOptionalInputWrapper` |
 
 **Parameter Details**
 


### PR DESCRIPTION
### :pencil: Description

It appears that using `@Required` annotation works on serialization and deserialization (https://github.com/Kotlin/kotlinx.serialization/blob/master/docs/basic-serialization.md#required-properties) giving us the correct behavior for handling optional input.

This PR also cleans up corresponding serialization tests to ensure we have consistent serialization between Jackson and Kotlinx Serialization.

### :link: Related Issues

Resolves: https://github.com/ExpediaGroup/graphql-kotlin/issues/1151