### PR TITLE
[client] add @Generated annotation

### DIFF
--- a/clients/graphql-kotlin-client/src/main/kotlin/com/expediagroup/graphql/client/Generated.kt
+++ b/clients/graphql-kotlin-client/src/main/kotlin/com/expediagroup/graphql/client/Generated.kt
@@ -1,0 +1,12 @@
+package com.expediagroup.graphql.client
+
+/**
+ * Annotation to automatically exclude auto-generated client code from JaCoCo reports.
+ *
+ * Starting with JaCoCo 8.3, classes and methods annotated with `@Generated` annotation that has RUNTIME retention will be excluded from
+ * code coverage report. We are using custom annotation instead of `javax.annotation.Generated` or `javax.annotation.processing.Generated`
+ * as their retention policy is just SOURCE.
+ */
+@Target(allowedTargets = [AnnotationTarget.CLASS])
+@Retention(value = AnnotationRetention.RUNTIME)
+annotation class Generated

--- a/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/GraphQLClientGenerator.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/GraphQLClientGenerator.kt
@@ -16,6 +16,7 @@
 
 package com.expediagroup.graphql.plugin.client.generator
 
+import com.expediagroup.graphql.client.Generated
 import com.expediagroup.graphql.plugin.client.generator.exceptions.MultipleOperationsInFileException
 import com.expediagroup.graphql.plugin.client.generator.exceptions.SchemaUnavailableException
 import com.expediagroup.graphql.plugin.client.generator.types.generateGraphQLObjectTypeSpec
@@ -122,6 +123,7 @@ class GraphQLClientGenerator(
                 .initializer("%N", queryConstProp)
                 .build()
             val operationTypeSpec = TypeSpec.classBuilder(capitalizedOperationName)
+                .addAnnotation(Generated::class)
                 .addSuperinterface(ClassName(CORE_TYPES_PACKAGE, "GraphQLClientRequest").parameterizedBy(kotlinResultTypeName))
                 .addProperty(queryProperty)
 

--- a/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/types/generateGraphQLCustomScalarConverters.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/types/generateGraphQLCustomScalarConverters.kt
@@ -16,6 +16,7 @@
 
 package com.expediagroup.graphql.plugin.client.generator.types
 
+import com.expediagroup.graphql.client.Generated
 import com.expediagroup.graphql.plugin.client.generator.GraphQLClientGeneratorContext
 import com.expediagroup.graphql.plugin.client.generator.GraphQLSerializer
 import com.expediagroup.graphql.plugin.client.generator.ScalarConverterInfo
@@ -69,6 +70,7 @@ private fun generateGraphQLCustomScalarJacksonConverters(
     val serializeConverterName = "${customScalarName}ToAnyConverter"
     val serializerConverterTypeSpec = TypeSpec.classBuilder(serializeConverterName)
         .superclass(StdConverter::class.asTypeName().parameterizedBy(scalarClassName, ANY))
+        .addAnnotation(Generated::class)
         .addProperty(converter)
         .addFunction(
             FunSpec.builder("convert")
@@ -83,6 +85,7 @@ private fun generateGraphQLCustomScalarJacksonConverters(
     val deserializeConverterName = "AnyTo${customScalarName}Converter"
     val deserializerConverterTypeSpec = TypeSpec.classBuilder(deserializeConverterName)
         .superclass(StdConverter::class.asTypeName().parameterizedBy(ANY, scalarClassName))
+        .addAnnotation(Generated::class)
         .addProperty(converter)
         .addFunction(
             FunSpec.builder("convert")
@@ -110,6 +113,7 @@ private fun generateGraphQLCustomScalarKSerializer(
     val serializerName = "${customScalarName}Serializer"
     val serializerTypeSpec = TypeSpec.objectBuilder(serializerName)
         .addSuperinterface(KSerializer::class.asTypeName().parameterizedBy(scalarClassName))
+        .addAnnotation(Generated::class)
 
     val converter = PropertySpec.builder("converter", converterClassName)
         .initializer("%T()", converterClassName)

--- a/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/types/generateGraphQLEnumTypeSpec.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/types/generateGraphQLEnumTypeSpec.kt
@@ -16,6 +16,7 @@
 
 package com.expediagroup.graphql.plugin.client.generator.types
 
+import com.expediagroup.graphql.client.Generated
 import com.expediagroup.graphql.plugin.client.generator.GraphQLClientGeneratorContext
 import com.expediagroup.graphql.plugin.client.generator.GraphQLSerializer
 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue
@@ -35,6 +36,7 @@ internal const val UNKNOWN_VALUE = "__UNKNOWN_VALUE"
  */
 internal fun generateGraphQLEnumTypeSpec(context: GraphQLClientGeneratorContext, enumDefinition: EnumTypeDefinition): TypeSpec {
     val enumTypeSpecBuilder = TypeSpec.enumBuilder(enumDefinition.name)
+        .addAnnotation(Generated::class)
     enumDefinition.description?.content?.let { kdoc ->
         enumTypeSpecBuilder.addKdoc("%L", kdoc)
     }

--- a/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/types/generateGraphQLInputObjectTypeSpec.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/types/generateGraphQLInputObjectTypeSpec.kt
@@ -16,6 +16,7 @@
 
 package com.expediagroup.graphql.plugin.client.generator.types
 
+import com.expediagroup.graphql.client.Generated
 import com.expediagroup.graphql.plugin.client.generator.GraphQLClientGeneratorContext
 import com.expediagroup.graphql.plugin.client.generator.GraphQLSerializer
 import com.expediagroup.graphql.plugin.client.generator.isOptionalInputSupported
@@ -36,6 +37,7 @@ import kotlinx.serialization.Serializable
 internal fun generateGraphQLInputObjectTypeSpec(context: GraphQLClientGeneratorContext, inputObjectDefinition: InputObjectTypeDefinition): TypeSpec {
     val inputObjectTypeSpecBuilder = TypeSpec.classBuilder(inputObjectDefinition.name)
         .addModifiers(KModifier.DATA)
+        .addAnnotation(Generated::class)
     inputObjectDefinition.description?.content?.let { kdoc ->
         inputObjectTypeSpecBuilder.addKdoc("%L", kdoc)
     }

--- a/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/types/generateGraphQLObjectTypeSpec.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/types/generateGraphQLObjectTypeSpec.kt
@@ -16,6 +16,7 @@
 
 package com.expediagroup.graphql.plugin.client.generator.types
 
+import com.expediagroup.graphql.client.Generated
 import com.expediagroup.graphql.plugin.client.generator.GraphQLClientGeneratorContext
 import com.expediagroup.graphql.plugin.client.generator.GraphQLSerializer
 import com.expediagroup.graphql.plugin.client.generator.exceptions.InvalidSelectionSetException
@@ -47,6 +48,7 @@ internal fun generateGraphQLObjectTypeSpec(
     val typeName = objectNameOverride ?: objectDefinition.name
     val objectTypeSpecBuilder = TypeSpec.classBuilder(typeName)
         .addModifiers(KModifier.DATA)
+        .addAnnotation(Generated::class)
     objectDefinition.description?.content?.let { kdoc ->
         objectTypeSpecBuilder.addKdoc("%L", kdoc)
     }

--- a/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/types/generateInterfaceTypeSpec.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/types/generateInterfaceTypeSpec.kt
@@ -16,6 +16,7 @@
 
 package com.expediagroup.graphql.plugin.client.generator.types
 
+import com.expediagroup.graphql.client.Generated
 import com.expediagroup.graphql.plugin.client.generator.GraphQLClientGeneratorContext
 import com.expediagroup.graphql.plugin.client.generator.GraphQLSerializer
 import com.expediagroup.graphql.plugin.client.generator.exceptions.InvalidFragmentException
@@ -63,10 +64,13 @@ internal fun generateInterfaceTypeSpec(
     val interfaceTypeSpec = if (context.serializer == GraphQLSerializer.KOTLINX) {
         TypeSpec.classBuilder(interfaceName)
             .addModifiers(KModifier.SEALED)
+            .addAnnotation(Generated::class)
             .addAnnotation(Serializable::class)
     } else {
         TypeSpec.interfaceBuilder(interfaceName)
+            .addAnnotation(Generated::class)
     }
+
     if (kdoc != null) {
         interfaceTypeSpec.addKdoc("%L", kdoc)
     }
@@ -181,14 +185,10 @@ private fun updateImplementationTypeSpecWithSuperInformation(
     val commonPropertyNames = commonProperties.map { it.name }
     val implementationTypeSpec = context.typeSpecs[implementationClassName]!!
 
-    val builder = TypeSpec.classBuilder(implementationTypeSpec.name!!)
-        .addModifiers(implementationTypeSpec.modifiers)
-        .addKdoc("%L", implementationTypeSpec.kdoc)
-
+    val builder = implementationTypeSpec.toBuilder()
     val superClassName = ClassName("${context.packageName}.${context.operationName.lowercase()}", interfaceName)
     if (context.serializer == GraphQLSerializer.KOTLINX) {
-        builder.addAnnotation(Serializable::class)
-            .addAnnotation(
+        builder.addAnnotation(
                 AnnotationSpec.builder(SerialName::class)
                     .addMember("value = %S", implementationName)
                     .build()

--- a/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/types/generateInterfaceTypeSpec.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/types/generateInterfaceTypeSpec.kt
@@ -193,7 +193,7 @@ private fun updateImplementationTypeSpecWithSuperInformation(
                 .addMember("value = %S", implementationName)
                 .build()
         )
-        .superclass(superClassName)
+            .superclass(superClassName)
     } else {
         builder.addSuperinterface(superClassName)
     }

--- a/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/types/generateInterfaceTypeSpec.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/types/generateInterfaceTypeSpec.kt
@@ -189,11 +189,11 @@ private fun updateImplementationTypeSpecWithSuperInformation(
     val superClassName = ClassName("${context.packageName}.${context.operationName.lowercase()}", interfaceName)
     if (context.serializer == GraphQLSerializer.KOTLINX) {
         builder.addAnnotation(
-                AnnotationSpec.builder(SerialName::class)
-                    .addMember("value = %S", implementationName)
-                    .build()
-            )
-            .superclass(superClassName)
+            AnnotationSpec.builder(SerialName::class)
+                .addMember("value = %S", implementationName)
+                .build()
+        )
+        .superclass(superClassName)
     } else {
         builder.addSuperinterface(superClassName)
     }

--- a/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/types/generateVariableTypeSpec.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/types/generateVariableTypeSpec.kt
@@ -16,6 +16,7 @@
 
 package com.expediagroup.graphql.plugin.client.generator.types
 
+import com.expediagroup.graphql.client.Generated
 import com.expediagroup.graphql.plugin.client.generator.GraphQLClientGeneratorContext
 import com.expediagroup.graphql.plugin.client.generator.GraphQLSerializer
 import com.expediagroup.graphql.plugin.client.generator.isOptionalInputSupported
@@ -36,6 +37,7 @@ import kotlinx.serialization.Serializable
 internal fun generateVariableTypeSpec(context: GraphQLClientGeneratorContext, variableDefinitions: List<VariableDefinition>): TypeSpec? {
     val variableTypeSpec = TypeSpec.classBuilder("Variables")
         .addModifiers(KModifier.DATA)
+        .addAnnotation(Generated::class)
     if (context.serializer == GraphQLSerializer.KOTLINX) {
         variableTypeSpec.addAnnotation(Serializable::class)
     }

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/alias/AliasQuery.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/alias/AliasQuery.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated
 
+import com.expediagroup.graphql.client.Generated
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
 import kotlin.Boolean
 import kotlin.String
@@ -8,6 +9,7 @@ import kotlin.reflect.KClass
 public const val ALIAS_QUERY: String =
     "query AliasQuery {\n  first: inputObjectQuery(criteria: { min: 1.0, max: 5.0 } )\n  second: inputObjectQuery(criteria: { min: 5.0, max: 10.0 } )\n}"
 
+@Generated
 public class AliasQuery : GraphQLClientRequest<AliasQuery.Result> {
   public override val query: String = ALIAS_QUERY
 
@@ -15,6 +17,7 @@ public class AliasQuery : GraphQLClientRequest<AliasQuery.Result> {
 
   public override fun responseType(): KClass<AliasQuery.Result> = AliasQuery.Result::class
 
+  @Generated
   public data class Result(
     /**
      * Query that accepts some input arguments

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/documentation/DocumentationQuery.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/documentation/DocumentationQuery.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated
 
+import com.expediagroup.graphql.client.Generated
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
 import com.expediagroup.graphql.generated.documentationquery.DocObject
 import kotlin.String
@@ -8,6 +9,7 @@ import kotlin.reflect.KClass
 public const val DOCUMENTATION_QUERY: String =
     "query DocumentationQuery {\n  docQuery {\n    id\n  }\n}"
 
+@Generated
 public class DocumentationQuery : GraphQLClientRequest<DocumentationQuery.Result> {
   public override val query: String = DOCUMENTATION_QUERY
 
@@ -16,6 +18,7 @@ public class DocumentationQuery : GraphQLClientRequest<DocumentationQuery.Result
   public override fun responseType(): KClass<DocumentationQuery.Result> =
       DocumentationQuery.Result::class
 
+  @Generated
   public data class Result(
     /**
      * Query to test doc strings

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/documentation/documentationquery/DocObject.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/documentation/documentationquery/DocObject.kt
@@ -1,10 +1,12 @@
 package com.expediagroup.graphql.generated.documentationquery
 
+import com.expediagroup.graphql.client.Generated
 import kotlin.Int
 
 /**
  * Doc object with % and $ floating around
  */
+@Generated
 public data class DocObject(
   /**
    * An id with a comment containing % and $ as well

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/input_hard_coded/HardCodedInputQuery.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/input_hard_coded/HardCodedInputQuery.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated
 
+import com.expediagroup.graphql.client.Generated
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
 import kotlin.Boolean
 import kotlin.String
@@ -8,6 +9,7 @@ import kotlin.reflect.KClass
 public const val HARD_CODED_INPUT_QUERY: String =
     "query HardCodedInputQuery {\n  inputObjectQuery(criteria: { min: 1.0, max: 5.0 } )\n}"
 
+@Generated
 public class HardCodedInputQuery : GraphQLClientRequest<HardCodedInputQuery.Result> {
   public override val query: String = HARD_CODED_INPUT_QUERY
 
@@ -16,6 +18,7 @@ public class HardCodedInputQuery : GraphQLClientRequest<HardCodedInputQuery.Resu
   public override fun responseType(): KClass<HardCodedInputQuery.Result> =
       HardCodedInputQuery.Result::class
 
+  @Generated
   public data class Result(
     /**
      * Query that accepts some input arguments

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/input_lists/InputListQuery.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/input_lists/InputListQuery.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated
 
+import com.expediagroup.graphql.client.Generated
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
 import kotlin.String
 import kotlin.collections.List
@@ -8,6 +9,7 @@ import kotlin.reflect.KClass
 public const val INPUT_LIST_QUERY: String =
     "query InputListQuery(${'$'}nullableIds: [String], ${'$'}nullableIdList: [String!], ${'$'}nonNullableIds: [String!]!) {\n  listInputQuery(nullableIds: ${'$'}nulllableIds, nonNullableIds: ${'$'}nonNullableIds)\n}"
 
+@Generated
 public class InputListQuery(
   public override val variables: InputListQuery.Variables
 ) : GraphQLClientRequest<InputListQuery.Result> {
@@ -17,12 +19,14 @@ public class InputListQuery(
 
   public override fun responseType(): KClass<InputListQuery.Result> = InputListQuery.Result::class
 
+  @Generated
   public data class Variables(
     public val nullableIds: List<String?>? = null,
     public val nullableIdList: List<String>? = null,
     public val nonNullableIds: List<String>
   )
 
+  @Generated
   public data class Result(
     /**
      * Query accepting list input

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/input_self_reference/SelfReferencingInputQuery.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/input_self_reference/SelfReferencingInputQuery.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated
 
+import com.expediagroup.graphql.client.Generated
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
 import com.expediagroup.graphql.generated.inputs.ComplexArgumentInput
 import kotlin.Boolean
@@ -9,6 +10,7 @@ import kotlin.reflect.KClass
 public const val SELF_REFERENCING_INPUT_QUERY: String =
     "query SelfReferencingInputQuery(${'$'}input: ComplexArgumentInput) {\n  complexInputObjectQuery(criteria: ${'$'}input)\n}"
 
+@Generated
 public class SelfReferencingInputQuery(
   public override val variables: SelfReferencingInputQuery.Variables
 ) : GraphQLClientRequest<SelfReferencingInputQuery.Result> {
@@ -19,10 +21,12 @@ public class SelfReferencingInputQuery(
   public override fun responseType(): KClass<SelfReferencingInputQuery.Result> =
       SelfReferencingInputQuery.Result::class
 
+  @Generated
   public data class Variables(
     public val input: ComplexArgumentInput? = null
   )
 
+  @Generated
   public data class Result(
     /**
      * Query that accepts self referencing input object

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/input_self_reference/inputs/ComplexArgumentInput.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/input_self_reference/inputs/ComplexArgumentInput.kt
@@ -1,10 +1,12 @@
 package com.expediagroup.graphql.generated.inputs
 
+import com.expediagroup.graphql.client.Generated
 import kotlin.Float
 
 /**
  * Self referencing input object
  */
+@Generated
 public data class ComplexArgumentInput(
   /**
    * Maximum value for test criteria

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/interface_diff_selection_sets/DifferentSelectionSetQuery.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/interface_diff_selection_sets/DifferentSelectionSetQuery.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated
 
+import com.expediagroup.graphql.client.Generated
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
 import com.expediagroup.graphql.generated.differentselectionsetquery.BasicInterface
 import com.expediagroup.graphql.generated.differentselectionsetquery.BasicInterface2
@@ -9,6 +10,7 @@ import kotlin.reflect.KClass
 public const val DIFFERENT_SELECTION_SET_QUERY: String =
     "query DifferentSelectionSetQuery {\n  first: interfaceQuery {\n    __typename\n    id\n    name\n    ... on FirstInterfaceImplementation {\n      intValue\n    }\n    ... on SecondInterfaceImplementation {\n      floatValue\n    }\n  }\n  second: interfaceQuery {\n    __typename\n    name\n    ... on FirstInterfaceImplementation {\n      intValue\n    }\n    ... on SecondInterfaceImplementation {\n      floatValue\n    }\n  }\n}"
 
+@Generated
 public class DifferentSelectionSetQuery : GraphQLClientRequest<DifferentSelectionSetQuery.Result> {
   public override val query: String = DIFFERENT_SELECTION_SET_QUERY
 
@@ -17,6 +19,7 @@ public class DifferentSelectionSetQuery : GraphQLClientRequest<DifferentSelectio
   public override fun responseType(): KClass<DifferentSelectionSetQuery.Result> =
       DifferentSelectionSetQuery.Result::class
 
+  @Generated
   public data class Result(
     /**
      * Query returning an interface

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/interface_diff_selection_sets/differentselectionsetquery/BasicInterface.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/interface_diff_selection_sets/differentselectionsetquery/BasicInterface.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated.differentselectionsetquery
 
+import com.expediagroup.graphql.client.Generated
 import com.fasterxml.jackson.`annotation`.JsonSubTypes
 import com.fasterxml.jackson.`annotation`.JsonTypeInfo
 import com.fasterxml.jackson.`annotation`.JsonTypeInfo.As.PROPERTY
@@ -11,6 +12,7 @@ import kotlin.String
 /**
  * Very basic interface
  */
+@Generated
 @JsonTypeInfo(
   use = JsonTypeInfo.Id.NAME,
   include = JsonTypeInfo.As.PROPERTY,
@@ -35,6 +37,7 @@ public interface BasicInterface {
 /**
  * Example interface implementation where value is an integer
  */
+@Generated
 public data class FirstInterfaceImplementation(
   /**
    * Unique identifier of the first implementation
@@ -53,6 +56,7 @@ public data class FirstInterfaceImplementation(
 /**
  * Example interface implementation where value is a float
  */
+@Generated
 public data class SecondInterfaceImplementation(
   /**
    * Unique identifier of the second implementation

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/interface_diff_selection_sets/differentselectionsetquery/BasicInterface2.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/interface_diff_selection_sets/differentselectionsetquery/BasicInterface2.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated.differentselectionsetquery
 
+import com.expediagroup.graphql.client.Generated
 import com.fasterxml.jackson.`annotation`.JsonSubTypes
 import com.fasterxml.jackson.`annotation`.JsonTypeInfo
 import com.fasterxml.jackson.`annotation`.JsonTypeInfo.As.PROPERTY
@@ -11,6 +12,7 @@ import kotlin.String
 /**
  * Very basic interface
  */
+@Generated
 @JsonTypeInfo(
   use = JsonTypeInfo.Id.NAME,
   include = JsonTypeInfo.As.PROPERTY,
@@ -30,6 +32,7 @@ public interface BasicInterface2 {
 /**
  * Example interface implementation where value is an integer
  */
+@Generated
 public data class FirstInterfaceImplementation2(
   /**
    * Name of the first implementation
@@ -44,6 +47,7 @@ public data class FirstInterfaceImplementation2(
 /**
  * Example interface implementation where value is a float
  */
+@Generated
 public data class SecondInterfaceImplementation2(
   /**
    * Name of the second implementation

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/interface_impl_diff_selection_sets/DifferentSelectionSetQuery.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/interface_impl_diff_selection_sets/DifferentSelectionSetQuery.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated
 
+import com.expediagroup.graphql.client.Generated
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
 import com.expediagroup.graphql.generated.differentselectionsetquery.BasicInterface
 import com.expediagroup.graphql.generated.differentselectionsetquery.BasicInterface2
@@ -9,6 +10,7 @@ import kotlin.reflect.KClass
 public const val DIFFERENT_SELECTION_SET_QUERY: String =
     "query DifferentSelectionSetQuery {\n  first: interfaceQuery {\n    __typename\n    id\n    ... on FirstInterfaceImplementation {\n      intValue\n    }\n    ... on SecondInterfaceImplementation {\n      floatValue\n    }\n  }\n  second: interfaceQuery {\n    __typename\n    id\n    ... on FirstInterfaceImplementation {\n      name\n      intValue\n    }\n    ... on SecondInterfaceImplementation {\n      name\n      floatValue\n    }\n  }\n}"
 
+@Generated
 public class DifferentSelectionSetQuery : GraphQLClientRequest<DifferentSelectionSetQuery.Result> {
   public override val query: String = DIFFERENT_SELECTION_SET_QUERY
 
@@ -17,6 +19,7 @@ public class DifferentSelectionSetQuery : GraphQLClientRequest<DifferentSelectio
   public override fun responseType(): KClass<DifferentSelectionSetQuery.Result> =
       DifferentSelectionSetQuery.Result::class
 
+  @Generated
   public data class Result(
     /**
      * Query returning an interface

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/interface_impl_diff_selection_sets/differentselectionsetquery/BasicInterface.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/interface_impl_diff_selection_sets/differentselectionsetquery/BasicInterface.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated.differentselectionsetquery
 
+import com.expediagroup.graphql.client.Generated
 import com.fasterxml.jackson.`annotation`.JsonSubTypes
 import com.fasterxml.jackson.`annotation`.JsonTypeInfo
 import com.fasterxml.jackson.`annotation`.JsonTypeInfo.As.PROPERTY
@@ -10,6 +11,7 @@ import kotlin.Int
 /**
  * Very basic interface
  */
+@Generated
 @JsonTypeInfo(
   use = JsonTypeInfo.Id.NAME,
   include = JsonTypeInfo.As.PROPERTY,
@@ -29,6 +31,7 @@ public interface BasicInterface {
 /**
  * Example interface implementation where value is an integer
  */
+@Generated
 public data class FirstInterfaceImplementation(
   /**
    * Unique identifier of the first implementation
@@ -43,6 +46,7 @@ public data class FirstInterfaceImplementation(
 /**
  * Example interface implementation where value is a float
  */
+@Generated
 public data class SecondInterfaceImplementation(
   /**
    * Unique identifier of the second implementation

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/interface_impl_diff_selection_sets/differentselectionsetquery/BasicInterface2.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/interface_impl_diff_selection_sets/differentselectionsetquery/BasicInterface2.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated.differentselectionsetquery
 
+import com.expediagroup.graphql.client.Generated
 import com.fasterxml.jackson.`annotation`.JsonSubTypes
 import com.fasterxml.jackson.`annotation`.JsonTypeInfo
 import com.fasterxml.jackson.`annotation`.JsonTypeInfo.As.PROPERTY
@@ -11,6 +12,7 @@ import kotlin.String
 /**
  * Very basic interface
  */
+@Generated
 @JsonTypeInfo(
   use = JsonTypeInfo.Id.NAME,
   include = JsonTypeInfo.As.PROPERTY,
@@ -30,6 +32,7 @@ public interface BasicInterface2 {
 /**
  * Example interface implementation where value is an integer
  */
+@Generated
 public data class FirstInterfaceImplementation2(
   /**
    * Unique identifier of the first implementation
@@ -48,6 +51,7 @@ public data class FirstInterfaceImplementation2(
 /**
  * Example interface implementation where value is a float
  */
+@Generated
 public data class SecondInterfaceImplementation2(
   /**
    * Unique identifier of the second implementation

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/interface_named_fragments/InterfaceWithNamedFragmentsQuery.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/interface_named_fragments/InterfaceWithNamedFragmentsQuery.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated
 
+import com.expediagroup.graphql.client.Generated
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
 import com.expediagroup.graphql.generated.interfacewithnamedfragmentsquery.BasicInterface
 import kotlin.String
@@ -8,6 +9,7 @@ import kotlin.reflect.KClass
 public const val INTERFACE_WITH_NAMED_FRAGMENTS_QUERY: String =
     "query InterfaceWithNamedFragmentsQuery {\n  interfaceQuery {\n    __typename\n    id\n    name\n    ... firstInterfaceImplFields\n    ... secondInterfaceImplFields\n  }\n}\n\nfragment firstInterfaceImplFields on FirstInterfaceImplementation {\n  id\n  name\n  intValue\n}\nfragment secondInterfaceImplFields on SecondInterfaceImplementation {\n  id\n  name\n  floatValue\n}"
 
+@Generated
 public class InterfaceWithNamedFragmentsQuery :
     GraphQLClientRequest<InterfaceWithNamedFragmentsQuery.Result> {
   public override val query: String = INTERFACE_WITH_NAMED_FRAGMENTS_QUERY
@@ -17,6 +19,7 @@ public class InterfaceWithNamedFragmentsQuery :
   public override fun responseType(): KClass<InterfaceWithNamedFragmentsQuery.Result> =
       InterfaceWithNamedFragmentsQuery.Result::class
 
+  @Generated
   public data class Result(
     /**
      * Query returning an interface

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/interface_named_fragments/interfacewithnamedfragmentsquery/BasicInterface.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/interface_named_fragments/interfacewithnamedfragmentsquery/BasicInterface.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated.interfacewithnamedfragmentsquery
 
+import com.expediagroup.graphql.client.Generated
 import com.fasterxml.jackson.`annotation`.JsonSubTypes
 import com.fasterxml.jackson.`annotation`.JsonTypeInfo
 import com.fasterxml.jackson.`annotation`.JsonTypeInfo.As.PROPERTY
@@ -11,6 +12,7 @@ import kotlin.String
 /**
  * Very basic interface
  */
+@Generated
 @JsonTypeInfo(
   use = JsonTypeInfo.Id.NAME,
   include = JsonTypeInfo.As.PROPERTY,
@@ -35,6 +37,7 @@ public interface BasicInterface {
 /**
  * Example interface implementation where value is an integer
  */
+@Generated
 public data class FirstInterfaceImplementation(
   /**
    * Unique identifier of the first implementation
@@ -53,6 +56,7 @@ public data class FirstInterfaceImplementation(
 /**
  * Example interface implementation where value is a float
  */
+@Generated
 public data class SecondInterfaceImplementation(
   /**
    * Unique identifier of the second implementation

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/mutation/SimpleMutation.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/mutation/SimpleMutation.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated
 
+import com.expediagroup.graphql.client.Generated
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
 import com.expediagroup.graphql.generated.inputs.SimpleArgumentInput
 import com.expediagroup.graphql.generated.simplemutation.BasicObject
@@ -9,6 +10,7 @@ import kotlin.reflect.KClass
 public const val SIMPLE_MUTATION: String =
     "mutation SimpleMutation(${'$'}input: SimpleArgumentInput!) {\n  simpleMutation(update: ${'$'}input) {\n    id\n    name\n  }\n}"
 
+@Generated
 public class SimpleMutation(
   public override val variables: SimpleMutation.Variables
 ) : GraphQLClientRequest<SimpleMutation.Result> {
@@ -18,10 +20,12 @@ public class SimpleMutation(
 
   public override fun responseType(): KClass<SimpleMutation.Result> = SimpleMutation.Result::class
 
+  @Generated
   public data class Variables(
     public val input: SimpleArgumentInput
   )
 
+  @Generated
   public data class Result(
     /**
      * Example of a muation

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/mutation/inputs/SimpleArgumentInput.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/mutation/inputs/SimpleArgumentInput.kt
@@ -1,11 +1,13 @@
 package com.expediagroup.graphql.generated.inputs
 
+import com.expediagroup.graphql.client.Generated
 import kotlin.Float
 import kotlin.String
 
 /**
  * Test input object
  */
+@Generated
 public data class SimpleArgumentInput(
   /**
    * Maximum value for test criteria

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/mutation/simplemutation/BasicObject.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/mutation/simplemutation/BasicObject.kt
@@ -1,11 +1,13 @@
 package com.expediagroup.graphql.generated.simplemutation
 
+import com.expediagroup.graphql.client.Generated
 import kotlin.Int
 import kotlin.String
 
 /**
  * Some basic description
  */
+@Generated
 public data class BasicObject(
   public val id: Int,
   /**

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/object_diff_selection_set/DifferentSelectionsQuery.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/object_diff_selection_set/DifferentSelectionsQuery.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated
 
+import com.expediagroup.graphql.client.Generated
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
 import com.expediagroup.graphql.generated.differentselectionsquery.ComplexObject
 import com.expediagroup.graphql.generated.differentselectionsquery.ComplexObject2
@@ -9,6 +10,7 @@ import kotlin.reflect.KClass
 public const val DIFFERENT_SELECTIONS_QUERY: String =
     "query DifferentSelectionsQuery {\n  first: complexObjectQuery {\n    id\n    name\n  }\n  second: complexObjectQuery {\n    id\n    name\n    details {\n      id\n      value\n    }\n  }\n}"
 
+@Generated
 public class DifferentSelectionsQuery : GraphQLClientRequest<DifferentSelectionsQuery.Result> {
   public override val query: String = DIFFERENT_SELECTIONS_QUERY
 
@@ -17,6 +19,7 @@ public class DifferentSelectionsQuery : GraphQLClientRequest<DifferentSelections
   public override fun responseType(): KClass<DifferentSelectionsQuery.Result> =
       DifferentSelectionsQuery.Result::class
 
+  @Generated
   public data class Result(
     /**
      * Query returning an object that references another object

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/object_diff_selection_set/differentselectionsquery/ComplexObject.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/object_diff_selection_set/differentselectionsquery/ComplexObject.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated.differentselectionsquery
 
+import com.expediagroup.graphql.client.Generated
 import kotlin.Int
 import kotlin.String
 
@@ -8,6 +9,7 @@ import kotlin.String
  * This is a second line of the paragraph.
  * This is final line of the description.
  */
+@Generated
 public data class ComplexObject(
   /**
    * Some unique identifier

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/object_diff_selection_set/differentselectionsquery/ComplexObject2.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/object_diff_selection_set/differentselectionsquery/ComplexObject2.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated.differentselectionsquery
 
+import com.expediagroup.graphql.client.Generated
 import kotlin.Int
 import kotlin.String
 
@@ -8,6 +9,7 @@ import kotlin.String
  * This is a second line of the paragraph.
  * This is final line of the description.
  */
+@Generated
 public data class ComplexObject2(
   /**
    * Some unique identifier

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/object_diff_selection_set/differentselectionsquery/DetailsObject.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/object_diff_selection_set/differentselectionsquery/DetailsObject.kt
@@ -1,11 +1,13 @@
 package com.expediagroup.graphql.generated.differentselectionsquery
 
+import com.expediagroup.graphql.client.Generated
 import kotlin.Int
 import kotlin.String
 
 /**
  * Inner type object description
  */
+@Generated
 public data class DetailsObject(
   /**
    * Unique identifier

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/object_diff_sub_selection/DifferentSubselectionQuery.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/object_diff_sub_selection/DifferentSubselectionQuery.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated
 
+import com.expediagroup.graphql.client.Generated
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
 import com.expediagroup.graphql.generated.differentsubselectionquery.ComplexObject
 import com.expediagroup.graphql.generated.differentsubselectionquery.ComplexObject2
@@ -9,6 +10,7 @@ import kotlin.reflect.KClass
 public const val DIFFERENT_SUBSELECTION_QUERY: String =
     "query DifferentSubselectionQuery {\n  first: complexObjectQuery {\n    id\n    name\n    details {\n      id\n      value\n      flag\n    }\n  }\n  second: complexObjectQuery {\n    id\n    name\n    details {\n      id\n      value\n    }\n  }\n}"
 
+@Generated
 public class DifferentSubselectionQuery : GraphQLClientRequest<DifferentSubselectionQuery.Result> {
   public override val query: String = DIFFERENT_SUBSELECTION_QUERY
 
@@ -17,6 +19,7 @@ public class DifferentSubselectionQuery : GraphQLClientRequest<DifferentSubselec
   public override fun responseType(): KClass<DifferentSubselectionQuery.Result> =
       DifferentSubselectionQuery.Result::class
 
+  @Generated
   public data class Result(
     /**
      * Query returning an object that references another object

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/object_diff_sub_selection/differentsubselectionquery/ComplexObject.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/object_diff_sub_selection/differentsubselectionquery/ComplexObject.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated.differentsubselectionquery
 
+import com.expediagroup.graphql.client.Generated
 import kotlin.Int
 import kotlin.String
 
@@ -8,6 +9,7 @@ import kotlin.String
  * This is a second line of the paragraph.
  * This is final line of the description.
  */
+@Generated
 public data class ComplexObject(
   /**
    * Some unique identifier

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/object_diff_sub_selection/differentsubselectionquery/ComplexObject2.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/object_diff_sub_selection/differentsubselectionquery/ComplexObject2.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated.differentsubselectionquery
 
+import com.expediagroup.graphql.client.Generated
 import kotlin.Int
 import kotlin.String
 
@@ -8,6 +9,7 @@ import kotlin.String
  * This is a second line of the paragraph.
  * This is final line of the description.
  */
+@Generated
 public data class ComplexObject2(
   /**
    * Some unique identifier

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/object_diff_sub_selection/differentsubselectionquery/DetailsObject.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/object_diff_sub_selection/differentsubselectionquery/DetailsObject.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated.differentsubselectionquery
 
+import com.expediagroup.graphql.client.Generated
 import kotlin.Boolean
 import kotlin.Int
 import kotlin.String
@@ -7,6 +8,7 @@ import kotlin.String
 /**
  * Inner type object description
  */
+@Generated
 public data class DetailsObject(
   /**
    * Unique identifier

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/object_diff_sub_selection/differentsubselectionquery/DetailsObject2.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/object_diff_sub_selection/differentsubselectionquery/DetailsObject2.kt
@@ -1,11 +1,13 @@
 package com.expediagroup.graphql.generated.differentsubselectionquery
 
+import com.expediagroup.graphql.client.Generated
 import kotlin.Int
 import kotlin.String
 
 /**
  * Inner type object description
  */
+@Generated
 public data class DetailsObject2(
   /**
    * Unique identifier

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/object_list/ListQuery.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/object_list/ListQuery.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated
 
+import com.expediagroup.graphql.client.Generated
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
 import com.expediagroup.graphql.generated.listquery.BasicObject
 import kotlin.String
@@ -8,6 +9,7 @@ import kotlin.reflect.KClass
 
 public const val LIST_QUERY: String = "query ListQuery {\n  listQuery {\n    id\n    name\n  }\n}"
 
+@Generated
 public class ListQuery : GraphQLClientRequest<ListQuery.Result> {
   public override val query: String = LIST_QUERY
 
@@ -15,6 +17,7 @@ public class ListQuery : GraphQLClientRequest<ListQuery.Result> {
 
   public override fun responseType(): KClass<ListQuery.Result> = ListQuery.Result::class
 
+  @Generated
   public data class Result(
     /**
      * Query returning list of simple objects

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/object_list/listquery/BasicObject.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/object_list/listquery/BasicObject.kt
@@ -1,11 +1,13 @@
 package com.expediagroup.graphql.generated.listquery
 
+import com.expediagroup.graphql.client.Generated
 import kotlin.Int
 import kotlin.String
 
 /**
  * Some basic description
  */
+@Generated
 public data class BasicObject(
   public val id: Int,
   /**

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/object_named_fragments/ObjectWithNamedFragmentQuery.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/object_named_fragments/ObjectWithNamedFragmentQuery.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated
 
+import com.expediagroup.graphql.client.Generated
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
 import com.expediagroup.graphql.generated.objectwithnamedfragmentquery.ComplexObject
 import kotlin.String
@@ -8,6 +9,7 @@ import kotlin.reflect.KClass
 public const val OBJECT_WITH_NAMED_FRAGMENT_QUERY: String =
     "query ObjectWithNamedFragmentQuery {\n  complexObjectQuery {\n    ...complexObjectFields\n  }\n}\n\nfragment complexObjectFields on ComplexObject {\n  id\n  name\n  details {\n    ...detailObjectFields\n  }\n}\n\nfragment detailObjectFields on DetailsObject {\n  value\n}"
 
+@Generated
 public class ObjectWithNamedFragmentQuery :
     GraphQLClientRequest<ObjectWithNamedFragmentQuery.Result> {
   public override val query: String = OBJECT_WITH_NAMED_FRAGMENT_QUERY
@@ -17,6 +19,7 @@ public class ObjectWithNamedFragmentQuery :
   public override fun responseType(): KClass<ObjectWithNamedFragmentQuery.Result> =
       ObjectWithNamedFragmentQuery.Result::class
 
+  @Generated
   public data class Result(
     /**
      * Query returning an object that references another object

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/object_named_fragments/objectwithnamedfragmentquery/ComplexObject.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/object_named_fragments/objectwithnamedfragmentquery/ComplexObject.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated.objectwithnamedfragmentquery
 
+import com.expediagroup.graphql.client.Generated
 import kotlin.Int
 import kotlin.String
 
@@ -8,6 +9,7 @@ import kotlin.String
  * This is a second line of the paragraph.
  * This is final line of the description.
  */
+@Generated
 public data class ComplexObject(
   /**
    * Some unique identifier

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/object_named_fragments/objectwithnamedfragmentquery/DetailsObject.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/object_named_fragments/objectwithnamedfragmentquery/DetailsObject.kt
@@ -1,10 +1,12 @@
 package com.expediagroup.graphql.generated.objectwithnamedfragmentquery
 
+import com.expediagroup.graphql.client.Generated
 import kotlin.String
 
 /**
  * Inner type object description
  */
+@Generated
 public data class DetailsObject(
   /**
    * Actual detail value

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/object_self_reference/NestedQuery.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/object_self_reference/NestedQuery.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated
 
+import com.expediagroup.graphql.client.Generated
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
 import com.expediagroup.graphql.generated.nestedquery.NestedObject
 import kotlin.String
@@ -8,6 +9,7 @@ import kotlin.reflect.KClass
 public const val NESTED_QUERY: String =
     "query NestedQuery {\n  nestedObjectQuery {\n    id\n    name\n    children {\n      name\n      children {\n        id\n        name\n        children {\n          id\n          name\n        }\n      }\n    }\n  }\n}"
 
+@Generated
 public class NestedQuery : GraphQLClientRequest<NestedQuery.Result> {
   public override val query: String = NESTED_QUERY
 
@@ -15,6 +17,7 @@ public class NestedQuery : GraphQLClientRequest<NestedQuery.Result> {
 
   public override fun responseType(): KClass<NestedQuery.Result> = NestedQuery.Result::class
 
+  @Generated
   public data class Result(
     /**
      * Query returning object referencing itself

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/object_self_reference/nestedquery/NestedObject.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/object_self_reference/nestedquery/NestedObject.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated.nestedquery
 
+import com.expediagroup.graphql.client.Generated
 import kotlin.Int
 import kotlin.String
 import kotlin.collections.List
@@ -7,6 +8,7 @@ import kotlin.collections.List
 /**
  * Example of an object self-referencing itself
  */
+@Generated
 public data class NestedObject(
   /**
    * Unique identifier

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/object_self_reference/nestedquery/NestedObject2.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/object_self_reference/nestedquery/NestedObject2.kt
@@ -1,11 +1,13 @@
 package com.expediagroup.graphql.generated.nestedquery
 
+import com.expediagroup.graphql.client.Generated
 import kotlin.String
 import kotlin.collections.List
 
 /**
  * Example of an object self-referencing itself
  */
+@Generated
 public data class NestedObject2(
   /**
    * Name of the object

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/object_self_reference/nestedquery/NestedObject3.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/object_self_reference/nestedquery/NestedObject3.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated.nestedquery
 
+import com.expediagroup.graphql.client.Generated
 import kotlin.Int
 import kotlin.String
 import kotlin.collections.List
@@ -7,6 +8,7 @@ import kotlin.collections.List
 /**
  * Example of an object self-referencing itself
  */
+@Generated
 public data class NestedObject3(
   /**
    * Unique identifier

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/object_self_reference/nestedquery/NestedObject4.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/object_self_reference/nestedquery/NestedObject4.kt
@@ -1,11 +1,13 @@
 package com.expediagroup.graphql.generated.nestedquery
 
+import com.expediagroup.graphql.client.Generated
 import kotlin.Int
 import kotlin.String
 
 /**
  * Example of an object self-referencing itself
  */
+@Generated
 public data class NestedObject4(
   /**
    * Unique identifier

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/operation_name_missing/AnonymousQuery.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/operation_name_missing/AnonymousQuery.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated
 
+import com.expediagroup.graphql.client.Generated
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
 import com.expediagroup.graphql.generated.anonymousquery.ScalarWrapper
 import kotlin.String
@@ -7,11 +8,13 @@ import kotlin.reflect.KClass
 
 public const val ANONYMOUS_QUERY: String = "query {\n  scalarQuery {\n    name\n  }\n}"
 
+@Generated
 public class AnonymousQuery : GraphQLClientRequest<AnonymousQuery.Result> {
   public override val query: String = ANONYMOUS_QUERY
 
   public override fun responseType(): KClass<AnonymousQuery.Result> = AnonymousQuery.Result::class
 
+  @Generated
   public data class Result(
     /**
      * Query that returns wrapper object with all supported scalar types

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/operation_name_missing/anonymousquery/ScalarWrapper.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/operation_name_missing/anonymousquery/ScalarWrapper.kt
@@ -1,10 +1,12 @@
 package com.expediagroup.graphql.generated.anonymousquery
 
+import com.expediagroup.graphql.client.Generated
 import kotlin.String
 
 /**
  * Wrapper that holds all supported scalar types
  */
+@Generated
 public data class ScalarWrapper(
   /**
    * UTF-8 character sequence

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/operation_name_unchanged/MiXEDcaSEQuery.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/operation_name_unchanged/MiXEDcaSEQuery.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated
 
+import com.expediagroup.graphql.client.Generated
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
 import com.expediagroup.graphql.generated.mixedcasequery.ScalarWrapper
 import kotlin.String
@@ -8,6 +9,7 @@ import kotlin.reflect.KClass
 public const val MI_XE_DCA_SE_QUERY: String =
     "query miXEDcaSEQuery {\n  scalarQuery {\n    name\n  }\n}"
 
+@Generated
 public class MiXEDcaSEQuery : GraphQLClientRequest<MiXEDcaSEQuery.Result> {
   public override val query: String = MI_XE_DCA_SE_QUERY
 
@@ -15,6 +17,7 @@ public class MiXEDcaSEQuery : GraphQLClientRequest<MiXEDcaSEQuery.Result> {
 
   public override fun responseType(): KClass<MiXEDcaSEQuery.Result> = MiXEDcaSEQuery.Result::class
 
+  @Generated
   public data class Result(
     /**
      * Query that returns wrapper object with all supported scalar types

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/operation_name_unchanged/mixedcasequery/ScalarWrapper.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/operation_name_unchanged/mixedcasequery/ScalarWrapper.kt
@@ -1,10 +1,12 @@
 package com.expediagroup.graphql.generated.mixedcasequery
 
+import com.expediagroup.graphql.client.Generated
 import kotlin.String
 
 /**
  * Wrapper that holds all supported scalar types
  */
+@Generated
 public data class ScalarWrapper(
   /**
    * UTF-8 character sequence

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/reuse_list_types/ReusedListTypesQuery.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/reuse_list_types/ReusedListTypesQuery.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated
 
+import com.expediagroup.graphql.client.Generated
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
 import com.expediagroup.graphql.generated.reusedlisttypesquery.BasicObject
 import com.expediagroup.graphql.generated.reusedlisttypesquery.BasicObject2
@@ -13,6 +14,7 @@ import kotlin.reflect.KClass
 public const val REUSED_LIST_TYPES_QUERY: String =
     "query ReusedListTypesQuery {\n  first: listQuery {\n    id\n    name\n  }\n  second: listQuery {\n    name\n  }\n  third: listQuery {\n    id\n    name\n  }\n  firstComplex: complexObjectQuery {\n    id\n    name\n    basicList {\n      id\n      name\n    }\n  }\n  secondComplex: complexObjectQuery {\n    id\n    name\n    basicList {\n      id\n      name\n    }\n  }\n  thirdComplex: complexObjectQuery {\n    id\n    name\n    basicList {\n      name\n    }\n  }\n  fourthComplex: complexObjectQuery {\n    id\n    basicList {\n      id\n    }\n  }\n}"
 
+@Generated
 public class ReusedListTypesQuery : GraphQLClientRequest<ReusedListTypesQuery.Result> {
   public override val query: String = REUSED_LIST_TYPES_QUERY
 
@@ -21,6 +23,7 @@ public class ReusedListTypesQuery : GraphQLClientRequest<ReusedListTypesQuery.Re
   public override fun responseType(): KClass<ReusedListTypesQuery.Result> =
       ReusedListTypesQuery.Result::class
 
+  @Generated
   public data class Result(
     /**
      * Query returning list of simple objects

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/reuse_list_types/reusedlisttypesquery/BasicObject.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/reuse_list_types/reusedlisttypesquery/BasicObject.kt
@@ -1,11 +1,13 @@
 package com.expediagroup.graphql.generated.reusedlisttypesquery
 
+import com.expediagroup.graphql.client.Generated
 import kotlin.Int
 import kotlin.String
 
 /**
  * Some basic description
  */
+@Generated
 public data class BasicObject(
   public val id: Int,
   /**

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/reuse_list_types/reusedlisttypesquery/BasicObject2.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/reuse_list_types/reusedlisttypesquery/BasicObject2.kt
@@ -1,10 +1,12 @@
 package com.expediagroup.graphql.generated.reusedlisttypesquery
 
+import com.expediagroup.graphql.client.Generated
 import kotlin.String
 
 /**
  * Some basic description
  */
+@Generated
 public data class BasicObject2(
   /**
    * Object name

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/reuse_list_types/reusedlisttypesquery/BasicObject3.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/reuse_list_types/reusedlisttypesquery/BasicObject3.kt
@@ -1,10 +1,12 @@
 package com.expediagroup.graphql.generated.reusedlisttypesquery
 
+import com.expediagroup.graphql.client.Generated
 import kotlin.Int
 
 /**
  * Some basic description
  */
+@Generated
 public data class BasicObject3(
   public val id: Int
 )

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/reuse_list_types/reusedlisttypesquery/ComplexObject.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/reuse_list_types/reusedlisttypesquery/ComplexObject.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated.reusedlisttypesquery
 
+import com.expediagroup.graphql.client.Generated
 import kotlin.Int
 import kotlin.String
 import kotlin.collections.List
@@ -9,6 +10,7 @@ import kotlin.collections.List
  * This is a second line of the paragraph.
  * This is final line of the description.
  */
+@Generated
 public data class ComplexObject(
   /**
    * Some unique identifier

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/reuse_list_types/reusedlisttypesquery/ComplexObject2.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/reuse_list_types/reusedlisttypesquery/ComplexObject2.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated.reusedlisttypesquery
 
+import com.expediagroup.graphql.client.Generated
 import kotlin.Int
 import kotlin.String
 import kotlin.collections.List
@@ -9,6 +10,7 @@ import kotlin.collections.List
  * This is a second line of the paragraph.
  * This is final line of the description.
  */
+@Generated
 public data class ComplexObject2(
   /**
    * Some unique identifier

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/reuse_list_types/reusedlisttypesquery/ComplexObject3.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/reuse_list_types/reusedlisttypesquery/ComplexObject3.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated.reusedlisttypesquery
 
+import com.expediagroup.graphql.client.Generated
 import kotlin.Int
 import kotlin.collections.List
 
@@ -8,6 +9,7 @@ import kotlin.collections.List
  * This is a second line of the paragraph.
  * This is final line of the description.
  */
+@Generated
 public data class ComplexObject3(
   /**
    * Some unique identifier

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/reuse_types/ReusedTypesQuery.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/reuse_types/ReusedTypesQuery.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated
 
+import com.expediagroup.graphql.client.Generated
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
 import com.expediagroup.graphql.generated.reusedtypesquery.ComplexObject
 import com.expediagroup.graphql.generated.reusedtypesquery.ComplexObject2
@@ -10,6 +11,7 @@ import kotlin.reflect.KClass
 public const val REUSED_TYPES_QUERY: String =
     "query ReusedTypesQuery {\n  first: complexObjectQuery {\n    id\n    name\n  }\n  second: complexObjectQuery {\n    id\n    name\n    details {\n      id\n      value\n    }\n  }\n  third: complexObjectQuery {\n    id\n    name\n    details {\n      id\n    }\n  }\n  fourth: complexObjectQuery {\n    id\n    name\n  }\n  fifth: complexObjectQuery {\n    id\n    name\n    details {\n      id\n      value\n    }\n  }\n}"
 
+@Generated
 public class ReusedTypesQuery : GraphQLClientRequest<ReusedTypesQuery.Result> {
   public override val query: String = REUSED_TYPES_QUERY
 
@@ -18,6 +20,7 @@ public class ReusedTypesQuery : GraphQLClientRequest<ReusedTypesQuery.Result> {
   public override fun responseType(): KClass<ReusedTypesQuery.Result> =
       ReusedTypesQuery.Result::class
 
+  @Generated
   public data class Result(
     /**
      * Query returning an object that references another object

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/reuse_types/reusedtypesquery/ComplexObject.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/reuse_types/reusedtypesquery/ComplexObject.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated.reusedtypesquery
 
+import com.expediagroup.graphql.client.Generated
 import kotlin.Int
 import kotlin.String
 
@@ -8,6 +9,7 @@ import kotlin.String
  * This is a second line of the paragraph.
  * This is final line of the description.
  */
+@Generated
 public data class ComplexObject(
   /**
    * Some unique identifier

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/reuse_types/reusedtypesquery/ComplexObject2.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/reuse_types/reusedtypesquery/ComplexObject2.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated.reusedtypesquery
 
+import com.expediagroup.graphql.client.Generated
 import kotlin.Int
 import kotlin.String
 
@@ -8,6 +9,7 @@ import kotlin.String
  * This is a second line of the paragraph.
  * This is final line of the description.
  */
+@Generated
 public data class ComplexObject2(
   /**
    * Some unique identifier

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/reuse_types/reusedtypesquery/ComplexObject3.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/reuse_types/reusedtypesquery/ComplexObject3.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated.reusedtypesquery
 
+import com.expediagroup.graphql.client.Generated
 import kotlin.Int
 import kotlin.String
 
@@ -8,6 +9,7 @@ import kotlin.String
  * This is a second line of the paragraph.
  * This is final line of the description.
  */
+@Generated
 public data class ComplexObject3(
   /**
    * Some unique identifier

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/reuse_types/reusedtypesquery/DetailsObject.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/reuse_types/reusedtypesquery/DetailsObject.kt
@@ -1,11 +1,13 @@
 package com.expediagroup.graphql.generated.reusedtypesquery
 
+import com.expediagroup.graphql.client.Generated
 import kotlin.Int
 import kotlin.String
 
 /**
  * Inner type object description
  */
+@Generated
 public data class DetailsObject(
   /**
    * Unique identifier

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/reuse_types/reusedtypesquery/DetailsObject2.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/reuse_types/reusedtypesquery/DetailsObject2.kt
@@ -1,10 +1,12 @@
 package com.expediagroup.graphql.generated.reusedtypesquery
 
+import com.expediagroup.graphql.client.Generated
 import kotlin.Int
 
 /**
  * Inner type object description
  */
+@Generated
 public data class DetailsObject2(
   /**
    * Unique identifier

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/scalar_typealias/ScalarAliasQuery.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/scalar_typealias/ScalarAliasQuery.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated
 
+import com.expediagroup.graphql.client.Generated
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
 import com.expediagroup.graphql.generated.scalaraliasquery.ScalarWrapper
 import kotlin.String
@@ -8,6 +9,7 @@ import kotlin.reflect.KClass
 public const val SCALAR_ALIAS_QUERY: String =
     "query ScalarAliasQuery {\n  scalarQuery {\n    id\n    custom\n  }\n}"
 
+@Generated
 public class ScalarAliasQuery : GraphQLClientRequest<ScalarAliasQuery.Result> {
   public override val query: String = SCALAR_ALIAS_QUERY
 
@@ -16,6 +18,7 @@ public class ScalarAliasQuery : GraphQLClientRequest<ScalarAliasQuery.Result> {
   public override fun responseType(): KClass<ScalarAliasQuery.Result> =
       ScalarAliasQuery.Result::class
 
+  @Generated
   public data class Result(
     /**
      * Query that returns wrapper object with all supported scalar types

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/scalar_typealias/scalaraliasquery/ScalarWrapper.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/scalar_typealias/scalaraliasquery/ScalarWrapper.kt
@@ -1,11 +1,13 @@
 package com.expediagroup.graphql.generated.scalaraliasquery
 
+import com.expediagroup.graphql.client.Generated
 import com.expediagroup.graphql.generated.ID
 import com.expediagroup.graphql.generated.UUID
 
 /**
  * Wrapper that holds all supported scalar types
  */
+@Generated
 public data class ScalarWrapper(
   /**
    * ID represents unique identifier that is not intended to be human readable

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/union_diff_selection_set/DifferentSelectionSetQuery.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/union_diff_selection_set/DifferentSelectionSetQuery.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated
 
+import com.expediagroup.graphql.client.Generated
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
 import com.expediagroup.graphql.generated.differentselectionsetquery.BasicUnion
 import com.expediagroup.graphql.generated.differentselectionsetquery.BasicUnion2
@@ -9,6 +10,7 @@ import kotlin.reflect.KClass
 public const val DIFFERENT_SELECTION_SET_QUERY: String =
     "query DifferentSelectionSetQuery {\n  first: unionQuery {\n    __typename\n    ... on BasicObject {\n      id\n    }\n    ... on ComplexObject {\n      id\n    }\n  }\n  second: unionQuery {\n    __typename\n    ... on BasicObject {\n      name\n    }\n    ... on ComplexObject {\n      name\n    }\n  }\n}"
 
+@Generated
 public class DifferentSelectionSetQuery : GraphQLClientRequest<DifferentSelectionSetQuery.Result> {
   public override val query: String = DIFFERENT_SELECTION_SET_QUERY
 
@@ -17,6 +19,7 @@ public class DifferentSelectionSetQuery : GraphQLClientRequest<DifferentSelectio
   public override fun responseType(): KClass<DifferentSelectionSetQuery.Result> =
       DifferentSelectionSetQuery.Result::class
 
+  @Generated
   public data class Result(
     /**
      * Query returning union

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/union_diff_selection_set/differentselectionsetquery/BasicUnion.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/union_diff_selection_set/differentselectionsetquery/BasicUnion.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated.differentselectionsetquery
 
+import com.expediagroup.graphql.client.Generated
 import com.fasterxml.jackson.`annotation`.JsonSubTypes
 import com.fasterxml.jackson.`annotation`.JsonTypeInfo
 import com.fasterxml.jackson.`annotation`.JsonTypeInfo.As.PROPERTY
@@ -9,6 +10,7 @@ import kotlin.Int
 /**
  * Very basic union of BasicObject and ComplexObject
  */
+@Generated
 @JsonTypeInfo(
   use = JsonTypeInfo.Id.NAME,
   include = JsonTypeInfo.As.PROPERTY,
@@ -22,6 +24,7 @@ public interface BasicUnion
 /**
  * Some basic description
  */
+@Generated
 public data class BasicObject(
   public val id: Int
 ) : BasicUnion
@@ -31,6 +34,7 @@ public data class BasicObject(
  * This is a second line of the paragraph.
  * This is final line of the description.
  */
+@Generated
 public data class ComplexObject(
   /**
    * Some unique identifier

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/union_diff_selection_set/differentselectionsetquery/BasicUnion2.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/union_diff_selection_set/differentselectionsetquery/BasicUnion2.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated.differentselectionsetquery
 
+import com.expediagroup.graphql.client.Generated
 import com.fasterxml.jackson.`annotation`.JsonSubTypes
 import com.fasterxml.jackson.`annotation`.JsonTypeInfo
 import com.fasterxml.jackson.`annotation`.JsonTypeInfo.As.PROPERTY
@@ -9,6 +10,7 @@ import kotlin.String
 /**
  * Very basic union of BasicObject and ComplexObject
  */
+@Generated
 @JsonTypeInfo(
   use = JsonTypeInfo.Id.NAME,
   include = JsonTypeInfo.As.PROPERTY,
@@ -23,6 +25,7 @@ public interface BasicUnion2
 /**
  * Some basic description
  */
+@Generated
 public data class BasicObject2(
   /**
    * Object name
@@ -35,6 +38,7 @@ public data class BasicObject2(
  * This is a second line of the paragraph.
  * This is final line of the description.
  */
+@Generated
 public data class ComplexObject2(
   /**
    * Some object name

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/union_diff_selection_set2/DifferentSelectionSetQuery.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/union_diff_selection_set2/DifferentSelectionSetQuery.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated
 
+import com.expediagroup.graphql.client.Generated
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
 import com.expediagroup.graphql.generated.differentselectionsetquery.BasicUnion
 import com.expediagroup.graphql.generated.differentselectionsetquery.ComplexObject2
@@ -9,6 +10,7 @@ import kotlin.reflect.KClass
 public const val DIFFERENT_SELECTION_SET_QUERY: String =
     "query DifferentSelectionSetQuery {\n  unionQuery {\n    __typename\n    ... on BasicObject {\n      id\n      name\n    }\n    ... on ComplexObject {\n      id\n      name\n      optional\n    }\n  }\n  complexObjectQuery {\n    id\n    name\n    details {\n      value\n    }\n  }\n}"
 
+@Generated
 public class DifferentSelectionSetQuery : GraphQLClientRequest<DifferentSelectionSetQuery.Result> {
   public override val query: String = DIFFERENT_SELECTION_SET_QUERY
 
@@ -17,6 +19,7 @@ public class DifferentSelectionSetQuery : GraphQLClientRequest<DifferentSelectio
   public override fun responseType(): KClass<DifferentSelectionSetQuery.Result> =
       DifferentSelectionSetQuery.Result::class
 
+  @Generated
   public data class Result(
     /**
      * Query returning union

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/union_diff_selection_set2/differentselectionsetquery/BasicUnion.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/union_diff_selection_set2/differentselectionsetquery/BasicUnion.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated.differentselectionsetquery
 
+import com.expediagroup.graphql.client.Generated
 import com.fasterxml.jackson.`annotation`.JsonSubTypes
 import com.fasterxml.jackson.`annotation`.JsonTypeInfo
 import com.fasterxml.jackson.`annotation`.JsonTypeInfo.As.PROPERTY
@@ -10,6 +11,7 @@ import kotlin.String
 /**
  * Very basic union of BasicObject and ComplexObject
  */
+@Generated
 @JsonTypeInfo(
   use = JsonTypeInfo.Id.NAME,
   include = JsonTypeInfo.As.PROPERTY,
@@ -23,6 +25,7 @@ public interface BasicUnion
 /**
  * Some basic description
  */
+@Generated
 public data class BasicObject(
   public val id: Int,
   /**
@@ -36,6 +39,7 @@ public data class BasicObject(
  * This is a second line of the paragraph.
  * This is final line of the description.
  */
+@Generated
 public data class ComplexObject(
   /**
    * Some unique identifier

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/union_diff_selection_set2/differentselectionsetquery/ComplexObject2.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/union_diff_selection_set2/differentselectionsetquery/ComplexObject2.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated.differentselectionsetquery
 
+import com.expediagroup.graphql.client.Generated
 import kotlin.Int
 import kotlin.String
 
@@ -8,6 +9,7 @@ import kotlin.String
  * This is a second line of the paragraph.
  * This is final line of the description.
  */
+@Generated
 public data class ComplexObject2(
   /**
    * Some unique identifier

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/union_diff_selection_set2/differentselectionsetquery/DetailsObject.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/union_diff_selection_set2/differentselectionsetquery/DetailsObject.kt
@@ -1,10 +1,12 @@
 package com.expediagroup.graphql.generated.differentselectionsetquery
 
+import com.expediagroup.graphql.client.Generated
 import kotlin.String
 
 /**
  * Inner type object description
  */
+@Generated
 public data class DetailsObject(
   /**
    * Actual detail value

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/union_named_fragments/UnionQueryWithNamedFragments.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/union_named_fragments/UnionQueryWithNamedFragments.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated
 
+import com.expediagroup.graphql.client.Generated
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
 import com.expediagroup.graphql.generated.unionquerywithnamedfragments.BasicUnion
 import kotlin.String
@@ -8,6 +9,7 @@ import kotlin.reflect.KClass
 public const val UNION_QUERY_WITH_NAMED_FRAGMENTS: String =
     "query UnionQueryWithNamedFragments {\n  unionQuery {\n    ... basicObjectFields\n    ... complexObjectFields\n  }\n}\n\nfragment basicObjectFields on BasicObject {\n  __typename\n  id\n  name\n}\nfragment complexObjectFields on ComplexObject {\n  __typename\n  id\n  name\n  optional\n}"
 
+@Generated
 public class UnionQueryWithNamedFragments :
     GraphQLClientRequest<UnionQueryWithNamedFragments.Result> {
   public override val query: String = UNION_QUERY_WITH_NAMED_FRAGMENTS
@@ -17,6 +19,7 @@ public class UnionQueryWithNamedFragments :
   public override fun responseType(): KClass<UnionQueryWithNamedFragments.Result> =
       UnionQueryWithNamedFragments.Result::class
 
+  @Generated
   public data class Result(
     /**
      * Query returning union

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/union_named_fragments/unionquerywithnamedfragments/BasicUnion.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/union_named_fragments/unionquerywithnamedfragments/BasicUnion.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated.unionquerywithnamedfragments
 
+import com.expediagroup.graphql.client.Generated
 import com.fasterxml.jackson.`annotation`.JsonSubTypes
 import com.fasterxml.jackson.`annotation`.JsonTypeInfo
 import com.fasterxml.jackson.`annotation`.JsonTypeInfo.As.PROPERTY
@@ -10,6 +11,7 @@ import kotlin.String
 /**
  * Very basic union of BasicObject and ComplexObject
  */
+@Generated
 @JsonTypeInfo(
   use = JsonTypeInfo.Id.NAME,
   include = JsonTypeInfo.As.PROPERTY,
@@ -23,6 +25,7 @@ public interface BasicUnion
 /**
  * Some basic description
  */
+@Generated
 public data class BasicObject(
   public val id: Int,
   /**
@@ -36,6 +39,7 @@ public data class BasicObject(
  * This is a second line of the paragraph.
  * This is final line of the description.
  */
+@Generated
 public data class ComplexObject(
   /**
    * Some unique identifier

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/custom_scalars/CustomScalarQuery.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/custom_scalars/CustomScalarQuery.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated
 
+import com.expediagroup.graphql.client.Generated
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
 import com.expediagroup.graphql.generated.customscalarquery.ScalarWrapper
 import kotlin.String
@@ -8,6 +9,7 @@ import kotlin.reflect.KClass
 public const val CUSTOM_SCALAR_QUERY: String =
     "query CustomScalarQuery {\n  scalarQuery {\n    custom\n    customList\n  }\n}"
 
+@Generated
 public class CustomScalarQuery : GraphQLClientRequest<CustomScalarQuery.Result> {
   public override val query: String = CUSTOM_SCALAR_QUERY
 
@@ -16,6 +18,7 @@ public class CustomScalarQuery : GraphQLClientRequest<CustomScalarQuery.Result> 
   public override fun responseType(): KClass<CustomScalarQuery.Result> =
       CustomScalarQuery.Result::class
 
+  @Generated
   public data class Result(
     /**
      * Query that returns wrapper object with all supported scalar types

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/custom_scalars/customscalarquery/ScalarWrapper.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/custom_scalars/customscalarquery/ScalarWrapper.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated.customscalarquery
 
+import com.expediagroup.graphql.client.Generated
 import com.expediagroup.graphql.generated.scalars.AnyToUUIDConverter
 import com.expediagroup.graphql.generated.scalars.UUIDToAnyConverter
 import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
@@ -10,6 +11,7 @@ import kotlin.collections.List
 /**
  * Wrapper that holds all supported scalar types
  */
+@Generated
 public data class ScalarWrapper(
   /**
    * Custom scalar

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/custom_scalars/scalars/AnyToUUIDConverter.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/custom_scalars/scalars/AnyToUUIDConverter.kt
@@ -1,10 +1,12 @@
 package com.expediagroup.graphql.generated.scalars
 
+import com.expediagroup.graphql.client.Generated
 import com.expediagroup.graphql.plugin.client.generator.UUIDScalarConverter
 import com.fasterxml.jackson.databind.util.StdConverter
 import java.util.UUID
 import kotlin.Any
 
+@Generated
 public class AnyToUUIDConverter : StdConverter<Any, UUID>() {
   private val converter: UUIDScalarConverter = UUIDScalarConverter()
 

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/custom_scalars/scalars/UUIDToAnyConverter.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/custom_scalars/scalars/UUIDToAnyConverter.kt
@@ -1,10 +1,12 @@
 package com.expediagroup.graphql.generated.scalars
 
+import com.expediagroup.graphql.client.Generated
 import com.expediagroup.graphql.plugin.client.generator.UUIDScalarConverter
 import com.fasterxml.jackson.databind.util.StdConverter
 import java.util.UUID
 import kotlin.Any
 
+@Generated
 public class UUIDToAnyConverter : StdConverter<UUID, Any>() {
   private val converter: UUIDScalarConverter = UUIDScalarConverter()
 

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/enums/EnumQuery.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/enums/EnumQuery.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated
 
+import com.expediagroup.graphql.client.Generated
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
 import com.expediagroup.graphql.generated.enums.CustomEnum
 import com.expediagroup.graphql.generated.enums.OtherEnum
@@ -8,6 +9,7 @@ import kotlin.reflect.KClass
 
 public const val ENUM_QUERY: String = "query EnumQuery {\n  enumQuery\n  otherEnumQuery\n}"
 
+@Generated
 public class EnumQuery : GraphQLClientRequest<EnumQuery.Result> {
   public override val query: String = ENUM_QUERY
 
@@ -15,6 +17,7 @@ public class EnumQuery : GraphQLClientRequest<EnumQuery.Result> {
 
   public override fun responseType(): KClass<EnumQuery.Result> = EnumQuery.Result::class
 
+  @Generated
   public data class Result(
     /**
      * Query that returns enum value

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/enums/enums/CustomEnum.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/enums/enums/CustomEnum.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated.enums
 
+import com.expediagroup.graphql.client.Generated
 import com.fasterxml.jackson.`annotation`.JsonEnumDefaultValue
 import com.fasterxml.jackson.`annotation`.JsonProperty
 import kotlin.Deprecated
@@ -7,6 +8,7 @@ import kotlin.Deprecated
 /**
  * Custom enum description
  */
+@Generated
 public enum class CustomEnum {
   /**
    * First enum value

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/enums/enums/OtherEnum.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/enums/enums/OtherEnum.kt
@@ -1,10 +1,12 @@
 package com.expediagroup.graphql.generated.enums
 
+import com.expediagroup.graphql.client.Generated
 import com.fasterxml.jackson.`annotation`.JsonEnumDefaultValue
 
 /**
  * Other enum description
  */
+@Generated
 public enum class OtherEnum {
   FIRST,
   SECOND,

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/interface/InterfaceWithInlineFragmentsQuery.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/interface/InterfaceWithInlineFragmentsQuery.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated
 
+import com.expediagroup.graphql.client.Generated
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
 import com.expediagroup.graphql.generated.interfacewithinlinefragmentsquery.BasicInterface
 import kotlin.String
@@ -8,6 +9,7 @@ import kotlin.reflect.KClass
 public const val INTERFACE_WITH_INLINE_FRAGMENTS_QUERY: String =
     "query InterfaceWithInlineFragmentsQuery {\n  interfaceQuery {\n    __typename\n    id\n    name\n    ... on FirstInterfaceImplementation {\n      intValue\n    }\n    ... on SecondInterfaceImplementation {\n      floatValue\n    }\n  }\n}"
 
+@Generated
 public class InterfaceWithInlineFragmentsQuery :
     GraphQLClientRequest<InterfaceWithInlineFragmentsQuery.Result> {
   public override val query: String = INTERFACE_WITH_INLINE_FRAGMENTS_QUERY
@@ -17,6 +19,7 @@ public class InterfaceWithInlineFragmentsQuery :
   public override fun responseType(): KClass<InterfaceWithInlineFragmentsQuery.Result> =
       InterfaceWithInlineFragmentsQuery.Result::class
 
+  @Generated
   public data class Result(
     /**
      * Query returning an interface

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/interface/interfacewithinlinefragmentsquery/BasicInterface.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/interface/interfacewithinlinefragmentsquery/BasicInterface.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated.interfacewithinlinefragmentsquery
 
+import com.expediagroup.graphql.client.Generated
 import com.fasterxml.jackson.`annotation`.JsonSubTypes
 import com.fasterxml.jackson.`annotation`.JsonTypeInfo
 import com.fasterxml.jackson.`annotation`.JsonTypeInfo.As.PROPERTY
@@ -11,6 +12,7 @@ import kotlin.String
 /**
  * Very basic interface
  */
+@Generated
 @JsonTypeInfo(
   use = JsonTypeInfo.Id.NAME,
   include = JsonTypeInfo.As.PROPERTY,
@@ -35,6 +37,7 @@ public interface BasicInterface {
 /**
  * Example interface implementation where value is an integer
  */
+@Generated
 public data class FirstInterfaceImplementation(
   /**
    * Unique identifier of the first implementation
@@ -53,6 +56,7 @@ public data class FirstInterfaceImplementation(
 /**
  * Example interface implementation where value is a float
  */
+@Generated
 public data class SecondInterfaceImplementation(
   /**
    * Unique identifier of the second implementation

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/object/ComplexObjectQuery.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/object/ComplexObjectQuery.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated
 
+import com.expediagroup.graphql.client.Generated
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
 import com.expediagroup.graphql.generated.complexobjectquery.ComplexObject
 import kotlin.String
@@ -8,6 +9,7 @@ import kotlin.reflect.KClass
 public const val COMPLEX_OBJECT_QUERY: String =
     "query ComplexObjectQuery {\n  complexObjectQuery {\n    id\n    name\n    optional\n    details {\n      id\n      flag\n      value\n    }\n  }\n}"
 
+@Generated
 public class ComplexObjectQuery : GraphQLClientRequest<ComplexObjectQuery.Result> {
   public override val query: String = COMPLEX_OBJECT_QUERY
 
@@ -16,6 +18,7 @@ public class ComplexObjectQuery : GraphQLClientRequest<ComplexObjectQuery.Result
   public override fun responseType(): KClass<ComplexObjectQuery.Result> =
       ComplexObjectQuery.Result::class
 
+  @Generated
   public data class Result(
     /**
      * Query returning an object that references another object

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/object/complexobjectquery/ComplexObject.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/object/complexobjectquery/ComplexObject.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated.complexobjectquery
 
+import com.expediagroup.graphql.client.Generated
 import kotlin.Int
 import kotlin.String
 
@@ -8,6 +9,7 @@ import kotlin.String
  * This is a second line of the paragraph.
  * This is final line of the description.
  */
+@Generated
 public data class ComplexObject(
   /**
    * Some unique identifier

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/object/complexobjectquery/DetailsObject.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/object/complexobjectquery/DetailsObject.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated.complexobjectquery
 
+import com.expediagroup.graphql.client.Generated
 import kotlin.Boolean
 import kotlin.Int
 import kotlin.String
@@ -7,6 +8,7 @@ import kotlin.String
 /**
  * Inner type object description
  */
+@Generated
 public data class DetailsObject(
   /**
    * Unique identifier

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/union/UnionQueryWithInlineFragments.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/union/UnionQueryWithInlineFragments.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated
 
+import com.expediagroup.graphql.client.Generated
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
 import com.expediagroup.graphql.generated.unionquerywithinlinefragments.BasicUnion
 import kotlin.String
@@ -8,6 +9,7 @@ import kotlin.reflect.KClass
 public const val UNION_QUERY_WITH_INLINE_FRAGMENTS: String =
     "query UnionQueryWithInlineFragments {\n  unionQuery {\n    __typename\n    ... on BasicObject {\n      id\n      name\n    }\n    ... on ComplexObject {\n      id\n      name\n      optional\n    }\n  }\n}"
 
+@Generated
 public class UnionQueryWithInlineFragments :
     GraphQLClientRequest<UnionQueryWithInlineFragments.Result> {
   public override val query: String = UNION_QUERY_WITH_INLINE_FRAGMENTS
@@ -17,6 +19,7 @@ public class UnionQueryWithInlineFragments :
   public override fun responseType(): KClass<UnionQueryWithInlineFragments.Result> =
       UnionQueryWithInlineFragments.Result::class
 
+  @Generated
   public data class Result(
     /**
      * Query returning union

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/union/unionquerywithinlinefragments/BasicUnion.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/union/unionquerywithinlinefragments/BasicUnion.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated.unionquerywithinlinefragments
 
+import com.expediagroup.graphql.client.Generated
 import com.fasterxml.jackson.`annotation`.JsonSubTypes
 import com.fasterxml.jackson.`annotation`.JsonTypeInfo
 import com.fasterxml.jackson.`annotation`.JsonTypeInfo.As.PROPERTY
@@ -10,6 +11,7 @@ import kotlin.String
 /**
  * Very basic union of BasicObject and ComplexObject
  */
+@Generated
 @JsonTypeInfo(
   use = JsonTypeInfo.Id.NAME,
   include = JsonTypeInfo.As.PROPERTY,
@@ -23,6 +25,7 @@ public interface BasicUnion
 /**
  * Some basic description
  */
+@Generated
 public data class BasicObject(
   public val id: Int,
   /**
@@ -36,6 +39,7 @@ public data class BasicObject(
  * This is a second line of the paragraph.
  * This is final line of the description.
  */
+@Generated
 public data class ComplexObject(
   /**
    * Some unique identifier

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/variables/JacksonInputQuery.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/variables/JacksonInputQuery.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated
 
+import com.expediagroup.graphql.client.Generated
 import com.expediagroup.graphql.client.jackson.types.OptionalInput
 import com.expediagroup.graphql.client.jackson.types.OptionalInput.Undefined
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
@@ -11,6 +12,7 @@ import kotlin.reflect.KClass
 public const val JACKSON_INPUT_QUERY: String =
     "query JacksonInputQuery(${'$'}input: SimpleArgumentInput) {\n  inputObjectQuery(criteria: ${'$'}input)\n}"
 
+@Generated
 public class JacksonInputQuery(
   public override val variables: JacksonInputQuery.Variables
 ) : GraphQLClientRequest<JacksonInputQuery.Result> {
@@ -21,10 +23,12 @@ public class JacksonInputQuery(
   public override fun responseType(): KClass<JacksonInputQuery.Result> =
       JacksonInputQuery.Result::class
 
+  @Generated
   public data class Variables(
     public val input: OptionalInput<SimpleArgumentInput> = OptionalInput.Undefined
   )
 
+  @Generated
   public data class Result(
     /**
      * Query that accepts some input arguments

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/variables/inputs/SimpleArgumentInput.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/variables/inputs/SimpleArgumentInput.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated.inputs
 
+import com.expediagroup.graphql.client.Generated
 import com.expediagroup.graphql.client.jackson.types.OptionalInput
 import com.expediagroup.graphql.client.jackson.types.OptionalInput.Undefined
 import kotlin.Float
@@ -8,6 +9,7 @@ import kotlin.String
 /**
  * Test input object
  */
+@Generated
 public data class SimpleArgumentInput(
   /**
    * Maximum value for test criteria

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/custom_scalars/CustomScalarQuery.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/custom_scalars/CustomScalarQuery.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated
 
+import com.expediagroup.graphql.client.Generated
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
 import com.expediagroup.graphql.generated.customscalarquery.ScalarWrapper
 import kotlin.String
@@ -9,6 +10,7 @@ import kotlinx.serialization.Serializable
 public const val CUSTOM_SCALAR_QUERY: String =
     "query CustomScalarQuery {\n  first: scalarQuery {\n    ... scalarSelections\n  }\n  second: scalarQuery {\n    ... scalarSelections\n  }\n}\nfragment scalarSelections on ScalarWrapper {\n  count\n  custom\n  customList\n  id\n}"
 
+@Generated
 @Serializable
 public class CustomScalarQuery : GraphQLClientRequest<CustomScalarQuery.Result> {
   public override val query: String = CUSTOM_SCALAR_QUERY
@@ -18,6 +20,7 @@ public class CustomScalarQuery : GraphQLClientRequest<CustomScalarQuery.Result> 
   public override fun responseType(): KClass<CustomScalarQuery.Result> =
       CustomScalarQuery.Result::class
 
+  @Generated
   @Serializable
   public data class Result(
     /**

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/custom_scalars/customscalarquery/ScalarWrapper.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/custom_scalars/customscalarquery/ScalarWrapper.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated.customscalarquery
 
+import com.expediagroup.graphql.client.Generated
 import com.expediagroup.graphql.generated.ID
 import com.expediagroup.graphql.generated.scalars.UUIDSerializer
 import java.util.UUID
@@ -10,6 +11,7 @@ import kotlinx.serialization.Serializable
 /**
  * Wrapper that holds all supported scalar types
  */
+@Generated
 @Serializable
 public data class ScalarWrapper(
   /**

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/custom_scalars/scalars/UUIDSerializer.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/custom_scalars/scalars/UUIDSerializer.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated.scalars
 
+import com.expediagroup.graphql.client.Generated
 import com.expediagroup.graphql.plugin.client.generator.UUIDScalarConverter
 import java.util.UUID
 import kotlin.Unit
@@ -12,6 +13,7 @@ import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.JsonDecoder
 import kotlinx.serialization.json.jsonPrimitive
 
+@Generated
 public object UUIDSerializer : KSerializer<UUID> {
   private val converter: UUIDScalarConverter = UUIDScalarConverter()
 

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/deprecated_opt_in/DeprecatedOptInQuery.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/deprecated_opt_in/DeprecatedOptInQuery.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated
 
+import com.expediagroup.graphql.client.Generated
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
 import kotlin.Deprecated
 import kotlin.String
@@ -9,6 +10,7 @@ import kotlinx.serialization.Serializable
 public const val DEPRECATED_OPT_IN_QUERY: String =
     "query DeprecatedOptInQuery {\n  deprecatedQuery\n}"
 
+@Generated
 @Serializable
 public class DeprecatedOptInQuery : GraphQLClientRequest<DeprecatedOptInQuery.Result> {
   public override val query: String = DEPRECATED_OPT_IN_QUERY
@@ -18,6 +20,7 @@ public class DeprecatedOptInQuery : GraphQLClientRequest<DeprecatedOptInQuery.Re
   public override fun responseType(): KClass<DeprecatedOptInQuery.Result> =
       DeprecatedOptInQuery.Result::class
 
+  @Generated
   @Serializable
   public data class Result(
     /**

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/enums/EnumQuery.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/enums/EnumQuery.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated
 
+import com.expediagroup.graphql.client.Generated
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
 import com.expediagroup.graphql.generated.enums.CustomEnum
 import com.expediagroup.graphql.generated.enums.OtherEnum
@@ -9,6 +10,7 @@ import kotlinx.serialization.Serializable
 
 public const val ENUM_QUERY: String = "query EnumQuery {\n  enumQuery\n  otherEnumQuery\n}"
 
+@Generated
 @Serializable
 public class EnumQuery : GraphQLClientRequest<EnumQuery.Result> {
   public override val query: String = ENUM_QUERY
@@ -17,6 +19,7 @@ public class EnumQuery : GraphQLClientRequest<EnumQuery.Result> {
 
   public override fun responseType(): KClass<EnumQuery.Result> = EnumQuery.Result::class
 
+  @Generated
   @Serializable
   public data class Result(
     /**

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/enums/enums/CustomEnum.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/enums/enums/CustomEnum.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated.enums
 
+import com.expediagroup.graphql.client.Generated
 import kotlin.Deprecated
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -7,6 +8,7 @@ import kotlinx.serialization.Serializable
 /**
  * Custom enum description
  */
+@Generated
 @Serializable
 public enum class CustomEnum {
   /**

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/enums/enums/OtherEnum.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/enums/enums/OtherEnum.kt
@@ -1,10 +1,12 @@
 package com.expediagroup.graphql.generated.enums
 
+import com.expediagroup.graphql.client.Generated
 import kotlinx.serialization.Serializable
 
 /**
  * Other enum description
  */
+@Generated
 @Serializable
 public enum class OtherEnum {
   FIRST,

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/interface/InterfaceWithInlineFragmentsQuery.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/interface/InterfaceWithInlineFragmentsQuery.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated
 
+import com.expediagroup.graphql.client.Generated
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
 import com.expediagroup.graphql.generated.interfacewithinlinefragmentsquery.BasicInterface
 import kotlin.String
@@ -9,6 +10,7 @@ import kotlinx.serialization.Serializable
 public const val INTERFACE_WITH_INLINE_FRAGMENTS_QUERY: String =
     "query InterfaceWithInlineFragmentsQuery {\n  interfaceQuery {\n    __typename\n    id\n    name\n    ... on FirstInterfaceImplementation {\n      intValue\n    }\n    ... on SecondInterfaceImplementation {\n      floatValue\n    }\n  }\n}"
 
+@Generated
 @Serializable
 public class InterfaceWithInlineFragmentsQuery :
     GraphQLClientRequest<InterfaceWithInlineFragmentsQuery.Result> {
@@ -19,6 +21,7 @@ public class InterfaceWithInlineFragmentsQuery :
   public override fun responseType(): KClass<InterfaceWithInlineFragmentsQuery.Result> =
       InterfaceWithInlineFragmentsQuery.Result::class
 
+  @Generated
   @Serializable
   public data class Result(
     /**

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/interface/interfacewithinlinefragmentsquery/BasicInterface.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/interface/interfacewithinlinefragmentsquery/BasicInterface.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated.interfacewithinlinefragmentsquery
 
+import com.expediagroup.graphql.client.Generated
 import kotlin.Float
 import kotlin.Int
 import kotlin.String
@@ -9,6 +10,7 @@ import kotlinx.serialization.Serializable
 /**
  * Very basic interface
  */
+@Generated
 @Serializable
 public sealed class BasicInterface {
   /**
@@ -25,6 +27,7 @@ public sealed class BasicInterface {
 /**
  * Example interface implementation where value is an integer
  */
+@Generated
 @Serializable
 @SerialName(value = "FirstInterfaceImplementation")
 public data class FirstInterfaceImplementation(
@@ -45,6 +48,7 @@ public data class FirstInterfaceImplementation(
 /**
  * Example interface implementation where value is a float
  */
+@Generated
 @Serializable
 @SerialName(value = "SecondInterfaceImplementation")
 public data class SecondInterfaceImplementation(

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/multiple_queries/FirstQuery.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/multiple_queries/FirstQuery.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated
 
+import com.expediagroup.graphql.client.Generated
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
 import com.expediagroup.graphql.generated.enums.CustomEnum
 import com.expediagroup.graphql.generated.firstquery.BasicInterface
@@ -14,6 +15,7 @@ import kotlinx.serialization.Serializable
 public const val FIRST_QUERY: String =
     "query FirstQuery(${'$'}input: ComplexArgumentInput) {\n  complexInputObjectQuery(criteria: ${'$'}input)\n  complexObjectQuery {\n    id\n    name\n    optional\n    details {\n      id\n      flag\n      value\n    }\n  }\n  enumQuery\n  interfaceQuery {\n    __typename\n    id\n    name\n    ... on FirstInterfaceImplementation {\n      intValue\n    }\n    ... on SecondInterfaceImplementation {\n      floatValue\n    }\n  }\n  scalarQuery {\n    count\n    custom\n    id\n  }\n}"
 
+@Generated
 @Serializable
 public class FirstQuery(
   public override val variables: FirstQuery.Variables
@@ -24,11 +26,13 @@ public class FirstQuery(
 
   public override fun responseType(): KClass<FirstQuery.Result> = FirstQuery.Result::class
 
+  @Generated
   @Serializable
   public data class Variables(
     public val input: ComplexArgumentInput? = null
   )
 
+  @Generated
   @Serializable
   public data class Result(
     /**

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/multiple_queries/SecondQuery.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/multiple_queries/SecondQuery.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated
 
+import com.expediagroup.graphql.client.Generated
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
 import com.expediagroup.graphql.generated.enums.CustomEnum
 import com.expediagroup.graphql.generated.inputs.ComplexArgumentInput
@@ -14,6 +15,7 @@ import kotlinx.serialization.Serializable
 public const val SECOND_QUERY: String =
     "query SecondQuery(${'$'}input: ComplexArgumentInput) {\n  complexInputObjectQuery(criteria: ${'$'}input)\n  complexObjectQuery {\n    id\n    name\n  }\n  enumQuery\n  interfaceQuery {\n    __typename\n    id\n    name\n    ... on FirstInterfaceImplementation {\n      intValue\n    }\n    ... on SecondInterfaceImplementation {\n      floatValue\n    }\n  }\n  scalarQuery {\n    count\n    custom\n    id\n  }\n}"
 
+@Generated
 @Serializable
 public class SecondQuery(
   public override val variables: SecondQuery.Variables
@@ -24,11 +26,13 @@ public class SecondQuery(
 
   public override fun responseType(): KClass<SecondQuery.Result> = SecondQuery.Result::class
 
+  @Generated
   @Serializable
   public data class Variables(
     public val input: ComplexArgumentInput? = null
   )
 
+  @Generated
   @Serializable
   public data class Result(
     /**

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/multiple_queries/enums/CustomEnum.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/multiple_queries/enums/CustomEnum.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated.enums
 
+import com.expediagroup.graphql.client.Generated
 import kotlin.Deprecated
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -7,6 +8,7 @@ import kotlinx.serialization.Serializable
 /**
  * Custom enum description
  */
+@Generated
 @Serializable
 public enum class CustomEnum {
   /**

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/multiple_queries/firstquery/BasicInterface.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/multiple_queries/firstquery/BasicInterface.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated.firstquery
 
+import com.expediagroup.graphql.client.Generated
 import kotlin.Float
 import kotlin.Int
 import kotlin.String
@@ -9,6 +10,7 @@ import kotlinx.serialization.Serializable
 /**
  * Very basic interface
  */
+@Generated
 @Serializable
 public sealed class BasicInterface {
   /**
@@ -25,6 +27,7 @@ public sealed class BasicInterface {
 /**
  * Example interface implementation where value is an integer
  */
+@Generated
 @Serializable
 @SerialName(value = "FirstInterfaceImplementation")
 public data class FirstInterfaceImplementation(
@@ -45,6 +48,7 @@ public data class FirstInterfaceImplementation(
 /**
  * Example interface implementation where value is a float
  */
+@Generated
 @Serializable
 @SerialName(value = "SecondInterfaceImplementation")
 public data class SecondInterfaceImplementation(

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/multiple_queries/firstquery/ComplexObject.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/multiple_queries/firstquery/ComplexObject.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated.firstquery
 
+import com.expediagroup.graphql.client.Generated
 import kotlin.Int
 import kotlin.String
 import kotlinx.serialization.Serializable
@@ -9,6 +10,7 @@ import kotlinx.serialization.Serializable
  * This is a second line of the paragraph.
  * This is final line of the description.
  */
+@Generated
 @Serializable
 public data class ComplexObject(
   /**

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/multiple_queries/firstquery/DetailsObject.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/multiple_queries/firstquery/DetailsObject.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated.firstquery
 
+import com.expediagroup.graphql.client.Generated
 import kotlin.Boolean
 import kotlin.Int
 import kotlin.String
@@ -8,6 +9,7 @@ import kotlinx.serialization.Serializable
 /**
  * Inner type object description
  */
+@Generated
 @Serializable
 public data class DetailsObject(
   /**

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/multiple_queries/firstquery/ScalarWrapper.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/multiple_queries/firstquery/ScalarWrapper.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated.firstquery
 
+import com.expediagroup.graphql.client.Generated
 import com.expediagroup.graphql.generated.ID
 import com.expediagroup.graphql.generated.scalars.UUIDSerializer
 import java.util.UUID
@@ -9,6 +10,7 @@ import kotlinx.serialization.Serializable
 /**
  * Wrapper that holds all supported scalar types
  */
+@Generated
 @Serializable
 public data class ScalarWrapper(
   /**

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/multiple_queries/inputs/ComplexArgumentInput.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/multiple_queries/inputs/ComplexArgumentInput.kt
@@ -1,11 +1,13 @@
 package com.expediagroup.graphql.generated.inputs
 
+import com.expediagroup.graphql.client.Generated
 import kotlin.Float
 import kotlinx.serialization.Serializable
 
 /**
  * Self referencing input object
  */
+@Generated
 @Serializable
 public data class ComplexArgumentInput(
   /**

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/multiple_queries/scalars/UUIDSerializer.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/multiple_queries/scalars/UUIDSerializer.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated.scalars
 
+import com.expediagroup.graphql.client.Generated
 import com.expediagroup.graphql.plugin.client.generator.UUIDScalarConverter
 import java.util.UUID
 import kotlin.Unit
@@ -12,6 +13,7 @@ import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.JsonDecoder
 import kotlinx.serialization.json.jsonPrimitive
 
+@Generated
 public object UUIDSerializer : KSerializer<UUID> {
   private val converter: UUIDScalarConverter = UUIDScalarConverter()
 

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/multiple_queries/secondquery/BasicInterface.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/multiple_queries/secondquery/BasicInterface.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated.secondquery
 
+import com.expediagroup.graphql.client.Generated
 import kotlin.Float
 import kotlin.Int
 import kotlin.String
@@ -9,6 +10,7 @@ import kotlinx.serialization.Serializable
 /**
  * Very basic interface
  */
+@Generated
 @Serializable
 public sealed class BasicInterface {
   /**
@@ -25,6 +27,7 @@ public sealed class BasicInterface {
 /**
  * Example interface implementation where value is an integer
  */
+@Generated
 @Serializable
 @SerialName(value = "FirstInterfaceImplementation")
 public data class FirstInterfaceImplementation(
@@ -45,6 +48,7 @@ public data class FirstInterfaceImplementation(
 /**
  * Example interface implementation where value is a float
  */
+@Generated
 @Serializable
 @SerialName(value = "SecondInterfaceImplementation")
 public data class SecondInterfaceImplementation(

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/multiple_queries/secondquery/ComplexObject.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/multiple_queries/secondquery/ComplexObject.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated.secondquery
 
+import com.expediagroup.graphql.client.Generated
 import kotlin.Int
 import kotlin.String
 import kotlinx.serialization.Serializable
@@ -9,6 +10,7 @@ import kotlinx.serialization.Serializable
  * This is a second line of the paragraph.
  * This is final line of the description.
  */
+@Generated
 @Serializable
 public data class ComplexObject(
   /**

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/multiple_queries/secondquery/ScalarWrapper.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/multiple_queries/secondquery/ScalarWrapper.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated.secondquery
 
+import com.expediagroup.graphql.client.Generated
 import com.expediagroup.graphql.generated.ID
 import com.expediagroup.graphql.generated.scalars.UUIDSerializer
 import java.util.UUID
@@ -9,6 +10,7 @@ import kotlinx.serialization.Serializable
 /**
  * Wrapper that holds all supported scalar types
  */
+@Generated
 @Serializable
 public data class ScalarWrapper(
   /**

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/object/ComplexObjectQuery.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/object/ComplexObjectQuery.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated
 
+import com.expediagroup.graphql.client.Generated
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
 import com.expediagroup.graphql.generated.complexobjectquery.ComplexObject
 import kotlin.String
@@ -9,6 +10,7 @@ import kotlinx.serialization.Serializable
 public const val COMPLEX_OBJECT_QUERY: String =
     "query ComplexObjectQuery {\n  complexObjectQuery {\n    id\n    name\n    optional\n    details {\n      id\n      flag\n      value\n    }\n  }\n}"
 
+@Generated
 @Serializable
 public class ComplexObjectQuery : GraphQLClientRequest<ComplexObjectQuery.Result> {
   public override val query: String = COMPLEX_OBJECT_QUERY
@@ -18,6 +20,7 @@ public class ComplexObjectQuery : GraphQLClientRequest<ComplexObjectQuery.Result
   public override fun responseType(): KClass<ComplexObjectQuery.Result> =
       ComplexObjectQuery.Result::class
 
+  @Generated
   @Serializable
   public data class Result(
     /**

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/object/complexobjectquery/ComplexObject.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/object/complexobjectquery/ComplexObject.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated.complexobjectquery
 
+import com.expediagroup.graphql.client.Generated
 import kotlin.Int
 import kotlin.String
 import kotlinx.serialization.Serializable
@@ -9,6 +10,7 @@ import kotlinx.serialization.Serializable
  * This is a second line of the paragraph.
  * This is final line of the description.
  */
+@Generated
 @Serializable
 public data class ComplexObject(
   /**

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/object/complexobjectquery/DetailsObject.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/object/complexobjectquery/DetailsObject.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated.complexobjectquery
 
+import com.expediagroup.graphql.client.Generated
 import kotlin.Boolean
 import kotlin.Int
 import kotlin.String
@@ -8,6 +9,7 @@ import kotlinx.serialization.Serializable
 /**
  * Inner type object description
  */
+@Generated
 @Serializable
 public data class DetailsObject(
   /**

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/union/UnionQueryWithInlineFragments.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/union/UnionQueryWithInlineFragments.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated
 
+import com.expediagroup.graphql.client.Generated
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
 import com.expediagroup.graphql.generated.unionquerywithinlinefragments.BasicUnion
 import kotlin.String
@@ -9,6 +10,7 @@ import kotlinx.serialization.Serializable
 public const val UNION_QUERY_WITH_INLINE_FRAGMENTS: String =
     "query UnionQueryWithInlineFragments {\n  unionQuery {\n    __typename\n    ... on BasicObject {\n      id\n      name\n    }\n    ... on ComplexObject {\n      id\n      name\n      optional\n    }\n  }\n}"
 
+@Generated
 @Serializable
 public class UnionQueryWithInlineFragments :
     GraphQLClientRequest<UnionQueryWithInlineFragments.Result> {
@@ -19,6 +21,7 @@ public class UnionQueryWithInlineFragments :
   public override fun responseType(): KClass<UnionQueryWithInlineFragments.Result> =
       UnionQueryWithInlineFragments.Result::class
 
+  @Generated
   @Serializable
   public data class Result(
     /**

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/union/unionquerywithinlinefragments/BasicUnion.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/union/unionquerywithinlinefragments/BasicUnion.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated.unionquerywithinlinefragments
 
+import com.expediagroup.graphql.client.Generated
 import kotlin.Int
 import kotlin.String
 import kotlinx.serialization.SerialName
@@ -8,12 +9,14 @@ import kotlinx.serialization.Serializable
 /**
  * Very basic union of BasicObject and ComplexObject
  */
+@Generated
 @Serializable
 public sealed class BasicUnion
 
 /**
  * Some basic description
  */
+@Generated
 @Serializable
 @SerialName(value = "BasicObject")
 public data class BasicObject(
@@ -29,6 +32,7 @@ public data class BasicObject(
  * This is a second line of the paragraph.
  * This is final line of the description.
  */
+@Generated
 @Serializable
 @SerialName(value = "ComplexObject")
 public data class ComplexObject(

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/variables/KotlinXInputQuery.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/variables/KotlinXInputQuery.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated
 
+import com.expediagroup.graphql.client.Generated
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
 import com.expediagroup.graphql.generated.inputs.SimpleArgumentInput
 import kotlin.Boolean
@@ -10,6 +11,7 @@ import kotlinx.serialization.Serializable
 public const val KOTLIN_X_INPUT_QUERY: String =
     "query KotlinXInputQuery(${'$'}input: SimpleArgumentInput) {\n  inputObjectQuery(criteria: ${'$'}input)\n}"
 
+@Generated
 @Serializable
 public class KotlinXInputQuery(
   public override val variables: KotlinXInputQuery.Variables
@@ -21,11 +23,13 @@ public class KotlinXInputQuery(
   public override fun responseType(): KClass<KotlinXInputQuery.Result> =
       KotlinXInputQuery.Result::class
 
+  @Generated
   @Serializable
   public data class Variables(
     public val input: SimpleArgumentInput? = null
   )
 
+  @Generated
   @Serializable
   public data class Result(
     /**

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/variables/inputs/SimpleArgumentInput.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/variables/inputs/SimpleArgumentInput.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.generated.inputs
 
+import com.expediagroup.graphql.client.Generated
 import kotlin.Float
 import kotlin.String
 import kotlinx.serialization.Serializable
@@ -7,6 +8,7 @@ import kotlinx.serialization.Serializable
 /**
  * Test input object
  */
+@Generated
 @Serializable
 public data class SimpleArgumentInput(
   /**

--- a/plugins/graphql-kotlin-gradle-plugin/src/integration/client-generator/jacoco/build.gradle.kts
+++ b/plugins/graphql-kotlin-gradle-plugin/src/integration/client-generator/jacoco/build.gradle.kts
@@ -1,0 +1,70 @@
+import com.expediagroup.graphql.plugin.gradle.graphql
+
+buildscript {
+    repositories {
+        mavenLocal {
+            content {
+                includeGroup("com.expediagroup")
+            }
+        }
+    }
+
+    val graphQLKotlinVersion = System.getenv("GRAPHQL_KOTLIN_VERSION") ?: "5.0.0-SNAPSHOT"
+    dependencies {
+        classpath("com.expediagroup:graphql-kotlin-gradle-plugin:$graphQLKotlinVersion")
+    }
+}
+
+plugins {
+    kotlin("jvm") version "1.5.30"
+    jacoco
+}
+
+apply(plugin = "com.expediagroup.graphql")
+
+repositories {
+    mavenCentral()
+    mavenLocal {
+        content {
+            includeGroup("com.expediagroup")
+        }
+    }
+}
+
+val graphQLKotlinVersion = System.getenv("GRAPHQL_KOTLIN_VERSION") ?: "5.0.0-SNAPSHOT"
+val junitVersion = System.getenv("JUNIT_VERSION") ?: "5.7.2"
+val mockkVersion = System.getenv("MOCKK_VERSION") ?: "1.11.0"
+dependencies {
+    implementation("com.expediagroup:graphql-kotlin-spring-client:$graphQLKotlinVersion")
+    testImplementation("org.junit.jupiter:junit-jupiter-api:$junitVersion")
+    testImplementation("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
+    testImplementation("io.mockk:mockk:1.11.0")
+}
+
+graphql {
+    client {
+        schemaFile = file("${project.projectDir}/schema.graphql")
+        packageName = "com.expediagroup.jacoco.generated"
+    }
+}
+
+tasks {
+    check {
+        dependsOn(jacocoTestCoverageVerification)
+    }
+    jacocoTestCoverageVerification {
+        violationRules {
+            rule {
+                limit {
+                    counter = "INSTRUCTION"
+                    value = "COVEREDRATIO"
+                    minimum = "0.99".toBigDecimal()
+                }
+            }
+        }
+    }
+    test {
+        useJUnitPlatform()
+        finalizedBy(jacocoTestReport)
+    }
+}

--- a/plugins/graphql-kotlin-gradle-plugin/src/integration/client-generator/jacoco/schema.graphql
+++ b/plugins/graphql-kotlin-gradle-plugin/src/integration/client-generator/jacoco/schema.graphql
@@ -1,0 +1,147 @@
+schema {
+  query: Query
+  mutation: Mutation
+}
+"Directs the executor to include this field or fragment only when the `if` argument is true"
+directive @include(
+  "Included when true."
+  if: Boolean!
+) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+"Directs the executor to skip this field or fragment when the `if`'argument is true."
+directive @skip(
+  "Skipped when true."
+  if: Boolean!
+) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+"Marks the field or enum value as deprecated"
+directive @deprecated(
+  "The reason for the deprecation"
+  reason: String! = "No longer supported"
+) on FIELD_DEFINITION | ENUM_VALUE
+"Very basic interface"
+interface BasicInterface {
+  "Unique identifier of an interface"
+  id: Int!
+  "Name field"
+  name: String!
+}
+"Very basic union of BasicObject and ComplexObject"
+union BasicUnion = BasicObject | ComplexObject
+"Some basic description"
+type BasicObject {
+  id: Int!
+  "Object name"
+  name: String!
+}
+"""
+Multi line description of a complex type.
+This is a second line of the paragraph.
+This is final line of the description.
+"""
+type ComplexObject {
+  "Some additional details"
+  details: DetailsObject!
+  "Some unique identifier"
+  id: Int!
+  "Some object name"
+  name: String!
+  """
+  Optional value
+  Second line of the description
+  """
+  optional: String
+}
+"Inner type object description"
+type DetailsObject {
+  "Boolean flag"
+  flag: Boolean!
+  "Unique identifier"
+  id: Int!
+  "Actual detail value"
+  value: String!
+}
+"Example interface implementation where value is an integer"
+type FirstInterfaceImplementation implements BasicInterface {
+  "Unique identifier of the first implementation"
+  id: Int!
+  "Custom field integer value"
+  intValue: Int!
+  "Name of the first implementation"
+  name: String!
+}
+type Mutation {
+  "Example of a muation"
+  simpleMutation(update: SimpleArgumentInput!): BasicObject!
+}
+"Example of an object self-referencing itself"
+type NestedObject {
+  "Children elements"
+  children: [NestedObject!]!
+  "Unique identifier"
+  id: Int!
+  "Name of the object"
+  name: String!
+}
+type Query {
+  "Query returning an object that references another object"
+  complexObjectQuery: ComplexObject!
+  "Deprecated query that should not be used anymore"
+  deprecatedQuery: String! @deprecated(reason : "old query should not be used")
+  "Query that returns enum value"
+  enumQuery: CustomEnum!
+  "Query that accepts some input arguments"
+  inputObjectQuery(criteria: SimpleArgumentInput!): Boolean!
+  "Query returning an interface"
+  interfaceQuery: BasicInterface!
+  "Query returning list of simple objects"
+  listQuery: [BasicObject!]!
+  "Query returning object referencing itself"
+  nestedObjectQuery: NestedObject!
+  "Query that returns wrapper object with all supported scalar types"
+  scalarQuery: ScalarWrapper!
+  "Query returning union"
+  unionQuery: BasicUnion!
+}
+"Wrapper that holds all supported scalar types"
+type ScalarWrapper {
+  "A signed 32-bit nullable integer value"
+  count: Int
+  "Custom scalar"
+  custom: UUID!
+  "ID represents unique identifier that is not intended to be human readable"
+  id: ID!
+  "UTF-8 character sequence"
+  name: String!
+  "A nullable signed double-precision floating-point value"
+  rating: Float
+  "Either true or false"
+  valid: Boolean!
+}
+"Example interface implementation where value is a float"
+type SecondInterfaceImplementation implements BasicInterface {
+  "Custom field float value"
+  floatValue: Float!
+  "Unique identifier of the second implementation"
+  id: Int!
+  "Name of the second implementation"
+  name: String!
+}
+"Custom enum description"
+enum CustomEnum {
+  "First enum value"
+  ONE
+  "Third enum value"
+  THREE @deprecated(reason : "only goes up to two")
+  "Second enum value"
+  TWO
+}
+"Custom scalar representing UUID"
+scalar UUID
+"Test input object"
+input SimpleArgumentInput {
+  "Maximum value for test criteria"
+  max: Float
+  "Minimum value for test criteria"
+  min: Float
+  "New value to be set"
+  newName: String
+}

--- a/plugins/graphql-kotlin-gradle-plugin/src/integration/client-generator/jacoco/settings.gradle.kts
+++ b/plugins/graphql-kotlin-gradle-plugin/src/integration/client-generator/jacoco/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "jacoco-coverage-test"

--- a/plugins/graphql-kotlin-gradle-plugin/src/integration/client-generator/jacoco/src/main/kotlin/com/expediagroup/jacoco/Foo.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/integration/client-generator/jacoco/src/main/kotlin/com/expediagroup/jacoco/Foo.kt
@@ -1,0 +1,12 @@
+package com.expediagroup.jacoco
+
+import com.expediagroup.graphql.client.spring.GraphQLWebClient
+import com.expediagroup.jacoco.generated.JacocoQuery
+
+class Foo(private val client: GraphQLWebClient) {
+
+    suspend fun query(): JacocoQuery.Result? {
+        val query = JacocoQuery()
+        return client.execute(query).data
+    }
+}

--- a/plugins/graphql-kotlin-gradle-plugin/src/integration/client-generator/jacoco/src/main/resources/JacocoQuery.graphql
+++ b/plugins/graphql-kotlin-gradle-plugin/src/integration/client-generator/jacoco/src/main/resources/JacocoQuery.graphql
@@ -1,0 +1,11 @@
+query JacocoQuery {
+  enumQuery
+  scalarQuery {
+    count
+    custom
+    id
+    name
+    rating
+    valid
+  }
+}

--- a/plugins/graphql-kotlin-gradle-plugin/src/integration/client-generator/jacoco/src/test/kotlin/com/expediagroup/jacoco/FooTest.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/integration/client-generator/jacoco/src/test/kotlin/com/expediagroup/jacoco/FooTest.kt
@@ -1,0 +1,22 @@
+package com.expediagroup.jacoco
+
+import com.expediagroup.graphql.client.jackson.types.JacksonGraphQLResponse
+import com.expediagroup.graphql.client.spring.GraphQLWebClient
+import com.expediagroup.graphql.client.types.GraphQLClientRequest
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+class FooTest {
+
+    @Test
+    fun `simple test for 0`() = runBlocking {
+        val mockkClient = mockk<GraphQLWebClient> {
+            coEvery { execute(any<GraphQLClientRequest<String>>(), any()) } returns JacksonGraphQLResponse(data = "Bar")
+        }
+        val foo = Foo(mockkClient)
+        Assertions.assertEquals("Bar", foo.query())
+    }
+}

--- a/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGenerateClientIT.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGenerateClientIT.kt
@@ -19,7 +19,6 @@ package com.expediagroup.graphql.plugin.gradle
 import com.expediagroup.graphql.plugin.gradle.tasks.GENERATE_CLIENT_TASK_NAME
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
-import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
 import org.junit.jupiter.api.io.TempDir
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
@@ -28,29 +27,36 @@ import java.io.File
 import java.nio.file.Path
 import kotlin.test.assertEquals
 
-class GraphQLGradlePluginAndroidIT {
+class GraphQLGenerateClientIT {
 
     @ParameterizedTest
-    @MethodSource("androidTests")
-    @EnabledIfEnvironmentVariable(named = "ANDROID_SDK_ROOT", matches = ".+")
-    fun `verify gradle plugin can be applied on android projects`(sourceDirectory: File, @TempDir tempDir: Path) {
+    @MethodSource("generateClientTests")
+    fun `verify gradle plugin can generate client code`(sourceDirectory: File, @TempDir tempDir: Path) {
         val testProjectDirectory = tempDir.toFile()
         sourceDirectory.copyRecursively(testProjectDirectory)
 
-        val androidPluginVersion = System.getProperty("androidPluginVersion") ?: "4.2.2"
+        val junitVersion = System.getProperty("junitVersion") ?: "5.7.2"
         val kotlinVersion = System.getProperty("kotlinVersion") ?: "1.5.21"
+        val mockkVersion = System.getProperty("mockkVersion") ?: "1.11.0"
         val buildResult = GradleRunner.create()
             .withProjectDir(testProjectDirectory)
             .withPluginClasspath()
-            .withArguments("build", "--stacktrace", "-PGRAPHQL_KOTLIN_VERSION=$DEFAULT_PLUGIN_VERSION", "-PKOTLIN_VERSION=$kotlinVersion", "-PANDROID_PLUGIN_VERSION=$androidPluginVersion")
+            .withArguments(
+                "build",
+                "--stacktrace",
+                "-PGRAPHQL_KOTLIN_VERSION=$DEFAULT_PLUGIN_VERSION",
+                "-PKOTLIN_VERSION=$kotlinVersion",
+                "-PJUNIT_VERSION=$junitVersion",
+                "-PMOCKK_VERSION=$mockkVersion"
+            )
             .forwardOutput()
             .build()
 
-        assertEquals(TaskOutcome.SUCCESS, buildResult.task(":app:$GENERATE_CLIENT_TASK_NAME")?.outcome)
+        assertEquals(TaskOutcome.SUCCESS, buildResult.task(":$GENERATE_CLIENT_TASK_NAME")?.outcome)
     }
 
     companion object {
         @JvmStatic
-        fun androidTests(): List<Arguments> = locateTestCaseArguments("src/integration/android")
+        fun generateClientTests(): List<Arguments> = locateTestCaseArguments("src/integration/client-generator")
     }
 }

--- a/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/parameterizedTestUtils.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/parameterizedTestUtils.kt
@@ -1,0 +1,11 @@
+package com.expediagroup.graphql.plugin.gradle
+
+import org.junit.jupiter.params.provider.Arguments
+import java.io.File
+
+internal fun locateTestCaseArguments(directory: String) = File(directory)
+    .listFiles()
+    ?.filter { it.isDirectory }
+    ?.map {
+        Arguments.of(it)
+    } ?: emptyList()

--- a/website/docs/client/client-customization.mdx
+++ b/website/docs/client/client-customization.mdx
@@ -174,12 +174,14 @@ Custom scalar fields will then be automatically converted to a `java.util.UUID` 
 Following converters will be generated under `com.example.generated.scalars` package.
 
 ```kotlin
+@Generated
 public class AnyToUUIDConverter : StdConverter<Any, UUID>() {
   private val converter: UUIDScalarConverter = UUIDScalarConverter()
 
   public override fun convert(`value`: Any): UUID = converter.toScalar(value)
 }
 
+@Generated
 public class UUIDToAnyConverter : StdConverter<UUID, Any>() {
   private val converter: UUIDScalarConverter = UUIDScalarConverter()
 
@@ -190,6 +192,7 @@ public class UUIDToAnyConverter : StdConverter<UUID, Any>() {
 Custom scalars fields will then be annotated with Jackson annotations referencing the above converters.
 
 ```kotlin
+@Generated
 public data class Result(
   @JsonSerialize(converter = UUIDToAnyConverter::class)
   @JsonDeserialize(converter = AnyToUUIDConverter::class)
@@ -206,6 +209,7 @@ public data class Result(
 Following serializer will be generated under `com.example.generated.scalars` package.
 
 ```kotlin
+@Generated
 public object UUIDSerializer : KSerializer<UUID> {
   private val converter: UUIDScalarConverter = UUIDScalarConverter()
 
@@ -228,6 +232,7 @@ public object UUIDSerializer : KSerializer<UUID> {
 Custom scalars fields will then be annotated with `@Serializable` annotation referencing the above serializer.
 
 ```kotlin
+@Generated
 @Serializable
 public data class Result(
   @Serializable(with = UUIDSerializer::class)

--- a/website/docs/client/client-features.mdx
+++ b/website/docs/client/client-features.mdx
@@ -78,6 +78,7 @@ Which will generate following data models
 <TabItem value="jackson">
 
 ```kotlin
+@Generated
 @JsonTypeInfo(
   use = JsonTypeInfo.Id.NAME,
   include = JsonTypeInfo.As.PROPERTY,
@@ -92,12 +93,14 @@ interface BasicInterface {
   abstract val name: String
 }
 
+@Generated
 data class FirstInterfaceImplementation(
   override val id: Int,
   override val name: String,
   val intValue: Int
 ) : BasicInterface
 
+@Generated
 data class SecondInterfaceImplementation(
   override val id: Int,
   override val name: String,
@@ -109,12 +112,14 @@ data class SecondInterfaceImplementation(
 <TabItem value="kotlinx">
 
 ```kotlin
+@Generated
 @Serializable
 sealed class BasicInterface {
   abstract val id: Int
   abstract val name: String
 }
 
+@Generated
 @Serializable
 @SerialName(value = "FirstInterfaceImplementation")
 data class FirstInterfaceImplementation(
@@ -123,6 +128,7 @@ data class FirstInterfaceImplementation(
   val intValue: Int
 ) : BasicInterface()
 
+@Generated
 @Serializable
 @SerialName(value = "SecondInterfaceImplementation")
 data class SecondInterfaceImplementation(
@@ -164,6 +170,7 @@ Will result in a corresponding auto generated data class
 /**
  * Some basic description
  */
+ @Generated
 data class BasicObject(
   /**
    * Unique identifier

--- a/website/docs/client/client-overview.mdx
+++ b/website/docs/client/client-overview.mdx
@@ -173,12 +173,14 @@ Plugins will generate following client code
 ```kotlin
 package com.example.generated
 
+import com.expediagroup.graphql.client.Generated
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
 import kotlin.String
 import kotlin.reflect.KClass
 
 const val HELLO_WORLD_QUERY: String = "query HelloWorldQuery {\n    helloWorld\n}"
 
+@Generated
 class HelloWorldQuery: GraphQLClientRequest<HelloWorldQuery.Result> {
     override val query: String = HELLO_WORLD_QUERY
 
@@ -186,6 +188,7 @@ class HelloWorldQuery: GraphQLClientRequest<HelloWorldQuery.Result> {
 
     override fun responseType(): KClass<HelloWorldQuery.Result> = HelloWorldQuery.Result::class
 
+    @Generated
     data class Result(
         val helloWorld: String
     }


### PR DESCRIPTION
### :pencil: Description

Update client generation logic to automatically apply `@com.expediagroup.graphql.client.Generated` annotation to all auto-generated classes. This doesn't change any functionality but is a meta-information for JaCoCo to automatically exclude those classes from coverage reports.

### :link: Related Issues
