### PR TITLE
[generator] validate GraphQL type names

### DIFF
--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/exceptions/InvalidGraphQLEnumValueException.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/exceptions/InvalidGraphQLEnumValueException.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2021 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.generator.exceptions
+
+import kotlin.reflect.KClass
+
+/**
+ * Thrown when Enum value contains non-alphanumeric ASCII or underscore characters.
+ */
+class InvalidGraphQLEnumValueException(kClass: KClass<*>, name: String) :
+    GraphQLKotlinException("The enum $kClass specifies invalid GraphQL $name enum value, only alphanumeric ASCII characters with underscores are allowed")

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/exceptions/InvalidGraphQLNameException.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/exceptions/InvalidGraphQLNameException.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2021 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.generator.exceptions
+
+import kotlin.reflect.KClass
+
+/**
+ * Thrown when Object, Input Object, Interface, Union or Enum name contains non-alphanumeric ASCII or underscore characters.
+ */
+class InvalidGraphQLNameException(kClass: KClass<*>, name: String) :
+    GraphQLKotlinException("The class $kClass specifies invalid GraphQL $name name, only alphanumeric ASCII characters with underscores are allowed")

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/filters/callableFilters.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/filters/callableFilters.kt
@@ -18,6 +18,7 @@ package com.expediagroup.graphql.generator.internal.filters
 
 import com.expediagroup.graphql.generator.internal.extensions.isGraphQLIgnored
 import com.expediagroup.graphql.generator.internal.extensions.isPublic
+import com.expediagroup.graphql.generator.internal.types.utils.validGraphQLNameRegex
 import kotlin.reflect.KCallable
 
 private typealias CallableFilter = (KCallable<*>) -> Boolean
@@ -30,5 +31,6 @@ private val isNotGraphQLIgnored: CallableFilter = { it.isGraphQLIgnored().not() 
 private val isBlacklistedFunction: CallableFilter = { blacklistFunctions.contains(it.name) }
 private val isComponentFunction: CallableFilter = { it.name.matches(componentFunctionRegex) }
 private val isNotBlacklistedFunction: CallableFilter = { isBlacklistedFunction(it).not() && isComponentFunction(it).not() }
+private val isValidFunctionName: CallableFilter = { it.name.matches(validGraphQLNameRegex) }
 
-internal val functionFilters: List<CallableFilter> = listOf(isPublic, isNotGraphQLIgnored, isNotBlacklistedFunction)
+internal val functionFilters: List<CallableFilter> = listOf(isPublic, isNotGraphQLIgnored, isValidFunctionName, isNotBlacklistedFunction)

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/filters/propertyFilters.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/filters/propertyFilters.kt
@@ -20,6 +20,7 @@ import com.expediagroup.graphql.generator.internal.extensions.isGraphQLIgnored
 import com.expediagroup.graphql.generator.internal.extensions.isPropertyGraphQLIgnored
 import com.expediagroup.graphql.generator.internal.extensions.isPublic
 import com.expediagroup.graphql.generator.internal.extensions.qualifiedName
+import com.expediagroup.graphql.generator.internal.types.utils.validGraphQLNameRegex
 import kotlin.reflect.KClass
 import kotlin.reflect.KProperty
 import kotlin.reflect.full.memberProperties
@@ -32,6 +33,7 @@ private val blacklistTypes: List<String> = listOf("kotlin.reflect.KClass")
 private val isPropertyPublic: PropertyFilter = { prop, _ -> prop.isPublic() }
 private val isPropertyNotGraphQLIgnored: PropertyFilter = { prop, parentClass -> prop.isPropertyGraphQLIgnored(parentClass).not() }
 private val isNotBlacklistedType: PropertyFilter = { prop, _ -> blacklistTypes.contains(prop.returnType.qualifiedName).not() }
+private val isValidPropertyName: PropertyFilter = { prop, _ -> prop.name.matches(validGraphQLNameRegex) }
 
 private val isNotIgnoredFromSuperClass: PropertyFilter = { prop, parentClass ->
     val superPropsIgnored = parentClass.supertypes
@@ -48,4 +50,4 @@ private val isNotIgnoredFromSuperClass: PropertyFilter = { prop, parentClass ->
 }
 
 private val basicPropertyFilters = listOf(isPropertyPublic, isNotBlacklistedType)
-internal val propertyFilters: List<PropertyFilter> = basicPropertyFilters + isPropertyNotGraphQLIgnored + isNotIgnoredFromSuperClass
+internal val propertyFilters: List<PropertyFilter> = basicPropertyFilters + isPropertyNotGraphQLIgnored + isNotIgnoredFromSuperClass + isValidPropertyName

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateEnum.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateEnum.kt
@@ -23,15 +23,19 @@ import com.expediagroup.graphql.generator.internal.extensions.getGraphQLDescript
 import com.expediagroup.graphql.generator.internal.extensions.getGraphQLName
 import com.expediagroup.graphql.generator.internal.extensions.getSimpleName
 import com.expediagroup.graphql.generator.internal.extensions.safeCast
+import com.expediagroup.graphql.generator.internal.types.utils.validateGraphQLEnumValue
+import com.expediagroup.graphql.generator.internal.types.utils.validateGraphQLName
 import graphql.introspection.Introspection.DirectiveLocation
 import graphql.schema.GraphQLEnumType
 import graphql.schema.GraphQLEnumValueDefinition
 import kotlin.reflect.KClass
 
 internal fun generateEnum(generator: SchemaGenerator, kClass: KClass<out Enum<*>>): GraphQLEnumType {
-    val enumBuilder = GraphQLEnumType.newEnum()
+    val name = kClass.getSimpleName()
+    validateGraphQLName(name, kClass)
 
-    enumBuilder.name(kClass.getSimpleName())
+    val enumBuilder = GraphQLEnumType.newEnum()
+    enumBuilder.name(name)
     enumBuilder.description(kClass.getGraphQLDescription())
 
     generateDirectives(generator, kClass, DirectiveLocation.ENUM).forEach {
@@ -49,6 +53,8 @@ private fun getEnumValueDefinition(generator: SchemaGenerator, enum: Enum<*>, kC
     val valueField = kClass.java.getField(enum.name)
 
     val name = valueField.getGraphQLName()
+    validateGraphQLEnumValue(name, kClass)
+
     valueBuilder.name(name)
     valueBuilder.value(name)
 

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateInputObject.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateInputObject.kt
@@ -22,6 +22,7 @@ import com.expediagroup.graphql.generator.internal.extensions.getGraphQLDescript
 import com.expediagroup.graphql.generator.internal.extensions.getSimpleName
 import com.expediagroup.graphql.generator.internal.extensions.getValidProperties
 import com.expediagroup.graphql.generator.internal.extensions.safeCast
+import com.expediagroup.graphql.generator.internal.types.utils.validateGraphQLName
 import com.expediagroup.graphql.generator.internal.types.utils.validateObjectLocation
 import graphql.introspection.Introspection.DirectiveLocation
 import graphql.schema.GraphQLInputObjectType
@@ -30,9 +31,11 @@ import kotlin.reflect.KClass
 internal fun generateInputObject(generator: SchemaGenerator, kClass: KClass<*>): GraphQLInputObjectType {
     validateObjectLocation(kClass, GraphQLValidObjectLocations.Locations.INPUT_OBJECT)
 
-    val builder = GraphQLInputObjectType.newInputObject()
+    val name = kClass.getSimpleName(isInputClass = true)
+    validateGraphQLName(name, kClass)
 
-    builder.name(kClass.getSimpleName(isInputClass = true))
+    val builder = GraphQLInputObjectType.newInputObject()
+    builder.name(name)
     builder.description(kClass.getGraphQLDescription())
 
     generateDirectives(generator, kClass, DirectiveLocation.INPUT_OBJECT).forEach {

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateInterface.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateInterface.kt
@@ -25,6 +25,7 @@ import com.expediagroup.graphql.generator.internal.extensions.getValidProperties
 import com.expediagroup.graphql.generator.internal.extensions.getValidSuperclasses
 import com.expediagroup.graphql.generator.internal.extensions.safeCast
 import com.expediagroup.graphql.generator.internal.state.AdditionalType
+import com.expediagroup.graphql.generator.internal.types.utils.validateGraphQLName
 import graphql.TypeResolutionEnvironment
 import graphql.introspection.Introspection.DirectiveLocation
 import graphql.schema.GraphQLInterfaceType
@@ -33,9 +34,11 @@ import kotlin.reflect.KClass
 import kotlin.reflect.full.createType
 
 internal fun generateInterface(generator: SchemaGenerator, kClass: KClass<*>): GraphQLInterfaceType {
-    val builder = GraphQLInterfaceType.newInterface()
+    val name = kClass.getSimpleName()
+    validateGraphQLName(name, kClass)
 
-    builder.name(kClass.getSimpleName())
+    val builder = GraphQLInterfaceType.newInterface()
+    builder.name(name)
     builder.description(kClass.getGraphQLDescription())
 
     generateDirectives(generator, kClass, DirectiveLocation.INTERFACE).forEach {

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateObject.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateObject.kt
@@ -25,6 +25,7 @@ import com.expediagroup.graphql.generator.internal.extensions.getValidFunctions
 import com.expediagroup.graphql.generator.internal.extensions.getValidProperties
 import com.expediagroup.graphql.generator.internal.extensions.getValidSuperclasses
 import com.expediagroup.graphql.generator.internal.extensions.safeCast
+import com.expediagroup.graphql.generator.internal.types.utils.validateGraphQLName
 import com.expediagroup.graphql.generator.internal.types.utils.validateObjectLocation
 import graphql.introspection.Introspection.DirectiveLocation
 import graphql.schema.GraphQLInterfaceType
@@ -36,9 +37,10 @@ import kotlin.reflect.full.createType
 internal fun generateObject(generator: SchemaGenerator, kClass: KClass<*>): GraphQLObjectType {
     validateObjectLocation(kClass, GraphQLValidObjectLocations.Locations.OBJECT)
 
-    val builder = GraphQLObjectType.newObject()
-
     val name = kClass.getSimpleName()
+    validateGraphQLName(name, kClass)
+
+    val builder = GraphQLObjectType.newObject()
     builder.name(name)
     builder.description(kClass.getGraphQLDescription())
 

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateUnion.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateUnion.kt
@@ -22,6 +22,7 @@ import com.expediagroup.graphql.generator.extensions.unwrapType
 import com.expediagroup.graphql.generator.internal.extensions.getGraphQLDescription
 import com.expediagroup.graphql.generator.internal.extensions.getSimpleName
 import com.expediagroup.graphql.generator.internal.extensions.safeCast
+import com.expediagroup.graphql.generator.internal.types.utils.validateGraphQLName
 import graphql.TypeResolutionEnvironment
 import graphql.introspection.Introspection.DirectiveLocation
 import graphql.schema.GraphQLObjectType
@@ -32,15 +33,18 @@ import kotlin.reflect.full.createType
 
 internal fun generateUnion(generator: SchemaGenerator, kClass: KClass<*>, unionAnnotation: GraphQLUnion? = null): GraphQLUnionType {
     return if (unionAnnotation != null) {
-        generateUnionFromAnnotation(generator, unionAnnotation)
+        generateUnionFromAnnotation(generator, unionAnnotation, kClass)
     } else {
         generateUnionFromKClass(generator, kClass)
     }
 }
 
-private fun generateUnionFromAnnotation(generator: SchemaGenerator, unionAnnotation: GraphQLUnion): GraphQLUnionType {
+private fun generateUnionFromAnnotation(generator: SchemaGenerator, unionAnnotation: GraphQLUnion, kClass: KClass<*>): GraphQLUnionType {
+    val unionName = unionAnnotation.name
+    validateGraphQLName(unionName, kClass)
+
     val builder = GraphQLUnionType.newUnionType()
-    builder.name(unionAnnotation.name)
+    builder.name(unionName)
     builder.description(unionAnnotation.description)
 
     val possibleTypes = unionAnnotation.possibleTypes.toList()
@@ -51,6 +55,8 @@ private fun generateUnionFromAnnotation(generator: SchemaGenerator, unionAnnotat
 private fun generateUnionFromKClass(generator: SchemaGenerator, kClass: KClass<*>): GraphQLUnionType {
     val builder = GraphQLUnionType.newUnionType()
     val name = kClass.getSimpleName()
+    validateGraphQLName(name, kClass)
+
     builder.name(name)
     builder.description(kClass.getGraphQLDescription())
 

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/utils/validateName.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/utils/validateName.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.generator.internal.types.utils
+
+import com.expediagroup.graphql.generator.exceptions.InvalidGraphQLEnumValueException
+import com.expediagroup.graphql.generator.exceptions.InvalidGraphQLNameException
+import kotlin.reflect.KClass
+
+internal val validGraphQLNameRegex = Regex("[_A-Za-z][_0-9A-Za-z]*")
+
+/**
+ * Throws an exception if passed in name is not a valid GraphQL name.
+ */
+internal fun validateGraphQLName(name: String, kClass: KClass<*>) {
+    if (!name.matches(validGraphQLNameRegex)) {
+        throw InvalidGraphQLNameException(kClass, name)
+    }
+}
+
+/**
+ * Throws an exception if passed in enum value is not a valid GraphQL name.
+ */
+internal fun validateGraphQLEnumValue(enumValue: String, enumKClass: KClass<*>) {
+    if (!enumValue.matches(validGraphQLNameRegex)) {
+        throw InvalidGraphQLEnumValueException(enumKClass, enumValue)
+    }
+}

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/filters/CallableFiltersTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/filters/CallableFiltersTest.kt
@@ -31,6 +31,7 @@ internal class CallableFiltersTest {
         assertTrue(isValidFunction(MyClass::publicFunction))
         assertFalse(isValidFunction(MyClass::ignoredFunction))
         assertFalse(isValidFunction(MyClass::privateFunction))
+        assertFalse(isValidFunction(MyClass::`invalid$Name`))
     }
 
     @Test
@@ -50,6 +51,8 @@ internal class CallableFiltersTest {
 
         @Suppress("Detekt.FunctionOnlyReturningConstant")
         internal fun privateFunction() = 0
+
+        fun `invalid$Name`() = privateFunction()
     }
 
     private fun isValidFunction(function: KFunction<*>): Boolean = functionFilters.all { it(function) }

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/filters/PropertyFiltersTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/filters/PropertyFiltersTest.kt
@@ -33,8 +33,8 @@ internal class PropertyFiltersTest {
         assertFalse(isValidProperty(MyClass::kClass, MyDataClass::class))
         assertTrue(isValidProperty(MyDataClass::id, MyDataClass::class))
         assertFalse(isValidProperty(MyDataClass::ignoredProperty, MyDataClass::class))
-        assertFalse(isValidProperty(MyDataClass::ignoredProperty, MyDataClass::class))
         assertFalse(isValidProperty(MyClass::foo, MyClass::class))
+        assertFalse(isValidProperty(MyClass::`$invalidPropertyName`, MyClass::class))
     }
 
     internal data class MyDataClass(
@@ -60,6 +60,8 @@ internal class PropertyFiltersTest {
         @GraphQLIgnore
         internal val ignoredProperty: Int = 0
         override val foo: Int = 5
+
+        val `$invalidPropertyName`: Int = 0
     }
 
     private fun isValidProperty(property: KProperty<*>, parentClass: KClass<*>): Boolean = propertyFilters.all { it(property, parentClass) }

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/types/GenerateEnumTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/types/GenerateEnumTest.kt
@@ -18,10 +18,13 @@ package com.expediagroup.graphql.generator.internal.types
 
 import com.expediagroup.graphql.generator.annotations.GraphQLDescription
 import com.expediagroup.graphql.generator.annotations.GraphQLName
+import com.expediagroup.graphql.generator.exceptions.InvalidGraphQLEnumValueException
+import com.expediagroup.graphql.generator.exceptions.InvalidGraphQLNameException
 import com.expediagroup.graphql.generator.test.utils.CustomDirective
 import com.expediagroup.graphql.generator.test.utils.SimpleDirective
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
@@ -53,6 +56,12 @@ class GenerateEnumTest : TypeTestHelper() {
     @Suppress("Detekt.UnusedPrivateClass")
     @GraphQLName("MyTestEnumRenamed")
     enum class MyTestEnumCustomName
+
+    enum class `Invalid$EnumName`
+
+    enum class InvalidEnum {
+        FOO, FOO_BAR, `FOO$BAR`
+    }
 
     @Test
     fun enumType() {
@@ -129,5 +138,19 @@ class GenerateEnumTest : TypeTestHelper() {
         val gqlEnum = assertNotNull(generateEnum(generator, MyTestEnum::class))
 
         assertNotNull(gqlEnum.getValue("customFour"))
+    }
+
+    @Test
+    fun `Enum generation will fail if it has invalid name`() {
+        assertFailsWith<InvalidGraphQLNameException> {
+            generateEnum(generator, `Invalid$EnumName`::class)
+        }
+    }
+
+    @Test
+    fun `Enum generation will fail if it has invalid value`() {
+        assertFailsWith<InvalidGraphQLEnumValueException> {
+            generateEnum(generator, `InvalidEnum`::class)
+        }
     }
 }

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/types/GenerateInputObjectTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/types/GenerateInputObjectTest.kt
@@ -19,6 +19,7 @@ package com.expediagroup.graphql.generator.internal.types
 import com.expediagroup.graphql.generator.annotations.GraphQLDescription
 import com.expediagroup.graphql.generator.annotations.GraphQLName
 import com.expediagroup.graphql.generator.annotations.GraphQLValidObjectLocations
+import com.expediagroup.graphql.generator.exceptions.InvalidGraphQLNameException
 import com.expediagroup.graphql.generator.exceptions.InvalidObjectLocationException
 import com.expediagroup.graphql.generator.test.utils.SimpleDirective
 import org.junit.jupiter.api.Test
@@ -52,6 +53,8 @@ class GenerateInputObjectTest : TypeTestHelper() {
     class OutputOnly {
         val myField: String = "car"
     }
+
+    class `Invalid$InputTypeName`
 
     @Test
     fun `Test naming`() {
@@ -103,6 +106,13 @@ class GenerateInputObjectTest : TypeTestHelper() {
     fun `output only objects throw an exception`() {
         assertFailsWith(InvalidObjectLocationException::class) {
             generateInputObject(generator, OutputOnly::class)
+        }
+    }
+
+    @Test
+    fun `Generation of output object will fail if it specifies invalid name`() {
+        assertFailsWith(InvalidGraphQLNameException::class) {
+            generateInputObject(generator, `Invalid$InputTypeName`::class)
         }
     }
 }

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/types/GenerateInterfaceTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/types/GenerateInterfaceTest.kt
@@ -18,15 +18,37 @@ package com.expediagroup.graphql.generator.internal.types
 
 import com.expediagroup.graphql.generator.annotations.GraphQLDescription
 import com.expediagroup.graphql.generator.annotations.GraphQLName
+import com.expediagroup.graphql.generator.exceptions.InvalidGraphQLNameException
 import com.expediagroup.graphql.generator.internal.extensions.getSimpleName
 import com.expediagroup.graphql.generator.test.utils.SimpleDirective
 import graphql.schema.GraphQLInterfaceType
 import org.junit.jupiter.api.Test
 import kotlin.math.PI
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 
 class GenerateInterfaceTest : TypeTestHelper() {
+
+    @Suppress("Detekt.UnusedPrivateClass")
+    @GraphQLDescription("The truth")
+    @SimpleDirective
+    interface HappyInterface
+
+    @Suppress("Detekt.UnusedPrivateClass")
+    @GraphQLName("HappyInterfaceRenamed")
+    interface HappyInterfaceCustomName
+
+    abstract class Shape(val area: Double)
+    class Circle(radius: Double) : Shape(PI * radius * radius)
+    class Square(sideLength: Double) : Shape(sideLength * sideLength)
+
+    sealed class Pet(val name: String) {
+        class Dog(name: String, val goodBoysReceived: Int) : Pet(name)
+        class Cat(name: String, val livesRemaining: Int) : Pet(name)
+    }
+
+    interface `Invalid$IntefaceName`
 
     @Test
     fun `Test naming`() {
@@ -73,21 +95,10 @@ class GenerateInterfaceTest : TypeTestHelper() {
         assertNotNull(generator.additionalTypes.find { it.kType.getSimpleName() == "Dog" })
     }
 
-    @Suppress("Detekt.UnusedPrivateClass")
-    @GraphQLDescription("The truth")
-    @SimpleDirective
-    interface HappyInterface
-
-    @Suppress("Detekt.UnusedPrivateClass")
-    @GraphQLName("HappyInterfaceRenamed")
-    interface HappyInterfaceCustomName
-
-    abstract class Shape(val area: Double)
-    class Circle(radius: Double) : Shape(PI * radius * radius)
-    class Square(sideLength: Double) : Shape(sideLength * sideLength)
-
-    sealed class Pet(val name: String) {
-        class Dog(name: String, val goodBoysReceived: Int) : Pet(name)
-        class Cat(name: String, val livesRemaining: Int) : Pet(name)
+    @Test
+    fun `Generation of interface will fail if it specifies invalid name override`() {
+        assertFailsWith(InvalidGraphQLNameException::class) {
+            generateInterface(generator, `Invalid$IntefaceName`::class)
+        }
     }
 }

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/types/GenerateObjectTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/types/GenerateObjectTest.kt
@@ -20,6 +20,7 @@ import com.expediagroup.graphql.generator.annotations.GraphQLDescription
 import com.expediagroup.graphql.generator.annotations.GraphQLDirective
 import com.expediagroup.graphql.generator.annotations.GraphQLName
 import com.expediagroup.graphql.generator.annotations.GraphQLValidObjectLocations
+import com.expediagroup.graphql.generator.exceptions.InvalidGraphQLNameException
 import com.expediagroup.graphql.generator.exceptions.InvalidObjectLocationException
 import graphql.Scalars
 import graphql.introspection.Introspection
@@ -59,6 +60,11 @@ class GenerateObjectTest : TypeTestHelper() {
     class OutputOnly {
         val myField: String = "car"
     }
+
+    class `Invalid$OutputTypeName`
+
+    @GraphQLName("Invalid\$Name")
+    class InvalidOutputTypeNameOverride
 
     @Test
     fun `Test naming`() {
@@ -117,6 +123,20 @@ class GenerateObjectTest : TypeTestHelper() {
     fun `output only objects throw an exception`() {
         assertFailsWith(InvalidObjectLocationException::class) {
             generateInputObject(generator, OutputOnly::class)
+        }
+    }
+
+    @Test
+    fun `Generation of output object will fail if it specifies invalid name`() {
+        assertFailsWith(InvalidGraphQLNameException::class) {
+            generateInputObject(generator, `Invalid$OutputTypeName`::class)
+        }
+    }
+
+    @Test
+    fun `Generation of output object will fail if it specifies invalid name override`() {
+        assertFailsWith(InvalidGraphQLNameException::class) {
+            generateInputObject(generator, InvalidOutputTypeNameOverride::class)
         }
     }
 }

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/types/GenerateUnionTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/types/GenerateUnionTest.kt
@@ -19,6 +19,7 @@ package com.expediagroup.graphql.generator.internal.types
 import com.expediagroup.graphql.generator.annotations.GraphQLDescription
 import com.expediagroup.graphql.generator.annotations.GraphQLName
 import com.expediagroup.graphql.generator.annotations.GraphQLUnion
+import com.expediagroup.graphql.generator.exceptions.InvalidGraphQLNameException
 import com.expediagroup.graphql.generator.test.utils.SimpleDirective
 import graphql.schema.GraphQLObjectType
 import graphql.schema.GraphQLUnionType
@@ -64,7 +65,12 @@ class GenerateUnionTest : TypeTestHelper() {
 
         @GraphQLUnion(name = "EmptyUnion", possibleTypes = [])
         fun emptyUnion(): Any = StrawBerryCake()
+
+        @GraphQLUnion(name = "Invalid\$Name", possibleTypes = [StrawBerryCake::class])
+        fun invalidUnion(): Any = StrawBerryCake()
     }
+
+    interface `Invalid$UnionName`
 
     @Test
     fun `Test simple case`() {
@@ -128,6 +134,21 @@ class GenerateUnionTest : TypeTestHelper() {
     fun `custom union annotation throws if possible types is empty`() {
         val annotation = AnnotationUnion::emptyUnion.annotations.first() as GraphQLUnion
         assertFailsWith(graphql.AssertException::class) {
+            generateUnion(generator, Any::class, annotation)
+        }
+    }
+
+    @Test
+    fun `Union generation will fail if it has an invalid name`() {
+        assertFailsWith<InvalidGraphQLNameException> {
+            generateUnion(generator, `Invalid$UnionName`::class)
+        }
+    }
+
+    @Test
+    fun `Union generation will fail if annotation specifies an invalid name`() {
+        val annotation = AnnotationUnion::invalidUnion.annotations.first() as GraphQLUnion
+        assertFailsWith<InvalidGraphQLNameException> {
             generateUnion(generator, Any::class, annotation)
         }
     }


### PR DESCRIPTION
### :pencil: Description

Java/Kotlin allows to declare classes/functions and properties using any alphanumeric Unicode (+ underscore) as well as allows special usage of `$` within the names. GraphQL does support Unicode characters but only in comments and returned String values. GraphQL type names can only contain alphanumeric ASCII characters (+ underscore).

Adding validation logic to filter out invalid function/property names and also fail generation if any of the GraphQL types (object, input object, interface, union, enum or enum value) specifies invalid name.

See:
* https://docs.oracle.com/javase/specs/jls/se16/html/jls-3.html#jls-3.8
* https://spec.graphql.org/June2018/#sec-Source-Text

### :link: Related Issues

Resolves: https://github.com/ExpediaGroup/graphql-kotlin/issues/1246