### PR TITLE
[build] update to build on Java 11 with targetJVM 1.8

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -12,10 +12,6 @@ jobs:
   build:
     timeout-minutes: 30
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        # test against latest update of each major Java version, as well as specific updates of LTS versions
-        java: [ 8, 11.0.x ]
 
     steps:
       - uses: actions/checkout@v2
@@ -23,18 +19,18 @@ jobs:
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@v1
 
-      - name: Set up Java ${{ matrix.java }}
+      - name: Set up Java 11
         uses: actions/setup-java@v1
         with:
-          java-version: ${{ matrix.java }}
+          java-version: 11
 
       - name: Set up Gradle cache
         uses: actions/cache@v1
         with:
           path: ~/.gradle/caches
-          key: ${{ runner.os }}-${{ matrix.java }}-gradle-${{ hashFiles('**/*.gradle.kts') }}
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle.kts') }}
           restore-keys: |
-            ${{ runner.os }}-${{ matrix.java }}-gradle-
+            ${{ runner.os }}-gradle-
 
       - name: Build libraries with Gradle
         run: ./gradlew clean build
@@ -43,7 +39,7 @@ jobs:
         uses: actions/upload-artifact@v2
         if: failure()
         with:
-          name: build-reports-${{ matrix.java }}
+          name: build-reports
           path: |
             ./**/build/reports
             plugins/graphql-kotlin-maven-plugin/build/integration/**/build.log
@@ -58,7 +54,7 @@ jobs:
         uses: actions/upload-artifact@v2
         if: failure()
         with:
-          name: build-examples-reports-${{ matrix.java }}
+          name: build-examples-reports
           path: ./examples/**/build/reports
           retention-days: 7
 

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -13,10 +13,6 @@ jobs:
   build:
     timeout-minutes: 30
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        # test against latest update of each major Java version, as well as specific updates of LTS versions
-        java: [ 8, 11.0.x ]
 
     steps:
       - uses: actions/checkout@v2
@@ -24,27 +20,27 @@ jobs:
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@v1
 
-      - name: Set up Java ${{ matrix.java }}
+      - name: Set up Java 11
         uses: actions/setup-java@v1
         with:
-          java-version: ${{ matrix.java }}
+          java-version: 11
 
       - name: Set up Gradle cache
         uses: actions/cache@v1
         with:
           path: ~/.gradle/caches
-          key: ${{ runner.os }}-${{ matrix.java }}-gradle-${{ hashFiles('**/*.gradle.kts') }}
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle.kts') }}
           restore-keys: |
-            ${{ runner.os }}-${{ matrix.java }}-gradle-
+            ${{ runner.os }}-gradle-
 
       # Used by maven-plugin integration tests
       - name: Set up Maven cache
         uses: actions/cache@v1
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-${{ matrix.java }}-maven-${{ hashFiles('**/pom.xml') }}
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            ${{ runner.os }}-${{ matrix.java }}-maven-
+            ${{ runner.os }}-maven-
 
       - name: Build library with Gradle
         run: ./gradlew clean build
@@ -53,7 +49,7 @@ jobs:
         uses: actions/upload-artifact@v2
         if: failure()
         with:
-          name: build-reports-${{ matrix.java }}
+          name: build-reports
           path: |
             ./**/build/reports
             plugins/graphql-kotlin-maven-plugin/build/integration/**/build.log
@@ -68,6 +64,6 @@ jobs:
         uses: actions/upload-artifact@v2
         if: failure()
         with:
-          name: build-examples-reports-${{ matrix.java }}
+          name: build-examples-reports
           path: ./examples/**/build/reports
           retention-days: 7

--- a/.github/workflows/release-code.yml
+++ b/.github/workflows/release-code.yml
@@ -15,11 +15,10 @@ jobs:
 
       - uses: gradle/wrapper-validation-action@v1
 
-      - name: Set up Java 1.8
+      - name: Set up Java 11
         uses: actions/setup-java@v1
-        # dokka doesn't support Java 11
         with:
-          java-version: 1.8
+          java-version: 11
 
       - name: Build library with Gradle
         run: ./gradlew clean build
@@ -41,7 +40,7 @@ jobs:
         uses: actions/upload-artifact@v2
         if: failure()
         with:
-          name: build-reports-${{ matrix.java }}
+          name: build-reports
           path: |
             ./**/build/reports
             plugins/graphql-kotlin-maven-plugin/build/integration/**/build.log

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -108,7 +108,7 @@ subprojects {
         val dokka = named("dokkaJavadoc", DokkaTask::class)
         val javadocJar by registering(Jar::class) {
             archiveClassifier.set("javadoc")
-            from("$buildDir/javadoc")
+            from("$buildDir/dokka/javadoc")
             dependsOn(dokka)
         }
         publishing {

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/extensions/KClassExtensionsTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/extensions/KClassExtensionsTest.kt
@@ -294,25 +294,12 @@ open class KClassExtensionsTest {
         assertFalse(invalidAnnotationUnion.returnType.getKClass().isUnion(invalidAnnotationUnion.annotations))
     }
 
-    // TODO remove JUnit condition once we only build artifacts using Java 11
-    //  BLOCKED: in order to publish to Maven Central we need to generate javadoc jar, blocked until Dokka https://github.com/Kotlin/dokka/issues/294 is resolved
-    //  ISSUE: with Kotlin 1.3.40+ there is bug on JRE 1.8 that results in incorrect simple name of the anonymous classes, see https://youtrack.jetbrains.com/issue/KT-23072
     @Test
-    @EnabledOnJre(JRE.JAVA_11)
     fun `test class simple name`() {
         assertEquals("MyTestClass", MyTestClass::class.getSimpleName())
         assertFailsWith(CouldNotGetNameOfKClassException::class) {
             object { }::class.getSimpleName()
         }
-    }
-
-    // TODO remove this JUnit once we only build artifacts using Java 11
-    //  BLOCKED: in order to publish to Maven Central we need to generate javadoc jar, blocked until Dokka https://github.com/Kotlin/dokka/issues/294 is resolved
-    //  ISSUE: with Kotlin 1.3.40+ there is bug on JRE 1.8 that results in incorrect simple name of the anonymous classes, see https://youtrack.jetbrains.com/issue/KT-23072
-    @Test
-    @EnabledOnJre(JRE.JAVA_8)
-    fun `test class simple name on JRE 8`() {
-        assertEquals("MyTestClass", MyTestClass::class.getSimpleName())
     }
 
     @Test

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/extensions/KClassExtensionsTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/extensions/KClassExtensionsTest.kt
@@ -23,8 +23,6 @@ import com.expediagroup.graphql.generator.exceptions.CouldNotGetNameOfKClassExce
 import com.expediagroup.graphql.generator.hooks.NoopSchemaGeneratorHooks
 import com.expediagroup.graphql.generator.hooks.SchemaGeneratorHooks
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.condition.EnabledOnJre
-import org.junit.jupiter.api.condition.JRE
 import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
 import kotlin.reflect.KProperty

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/extensions/KTypeExtensionsKtTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/extensions/KTypeExtensionsKtTest.kt
@@ -145,27 +145,13 @@ class KTypeExtensionsKtTest {
         }
     }
 
-    // TODO remove JUnit condition once we only build artifacts using Java 11
-    //  BLOCKED: in order to publish to Maven Central we need to generate javadoc jar, blocked until Dokka https://github.com/Kotlin/dokka/issues/294 is resolved
-    //  ISSUE: with Kotlin 1.3.40+ there is bug on JRE 1.8 that results in incorrect simple name of the anonymous classes, see https://youtrack.jetbrains.com/issue/KT-23072
     @Test
-    @EnabledOnJre(JRE.JAVA_11)
     fun getSimpleName() {
         assertEquals("MyClass", MyClass::class.starProjectedType.getSimpleName())
         assertEquals("MyClassInput", MyClass::class.starProjectedType.getSimpleName(isInputType = true))
         assertFailsWith(CouldNotGetNameOfKClassException::class) {
             object {}::class.starProjectedType.getSimpleName()
         }
-    }
-
-    // TODO remove this JUnit once we only build artifacts using Java 11
-    //  BLOCKED: in order to publish to Maven Central we need to generate javadoc jar, blocked until Dokka https://github.com/Kotlin/dokka/issues/294 is resolved
-    //  ISSUE: with Kotlin 1.3.40+ there is bug on JRE 1.8 that results in incorrect simple name of the anonymous classes, see https://youtrack.jetbrains.com/issue/KT-23072
-    @Test
-    @EnabledOnJre(JRE.JAVA_8)
-    fun getSimpleNameJava8() {
-        assertEquals("MyClass", MyClass::class.starProjectedType.getSimpleName())
-        assertEquals("MyClassInput", MyClass::class.starProjectedType.getSimpleName(isInputType = true))
     }
 
     @Test

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/extensions/KTypeExtensionsKtTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/extensions/KTypeExtensionsKtTest.kt
@@ -21,8 +21,6 @@ import com.expediagroup.graphql.generator.exceptions.InvalidWrappedTypeException
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.condition.EnabledOnJre
-import org.junit.jupiter.api.condition.JRE
 import kotlin.reflect.KType
 import kotlin.reflect.KTypeProjection
 import kotlin.reflect.full.createType


### PR DESCRIPTION
### :pencil: Description

New version of Dokka supports Java 9+ so we can just run a single build using current LTS (11) with targetJVM 1.8

### :link: Related Issues
