### PR TITLE
Drop Jackson, avoid duplicate deserialization

### DIFF
--- a/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/server/spring/Application.kt
+++ b/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/server/spring/Application.kt
@@ -24,7 +24,6 @@ import com.expediagroup.graphql.examples.server.spring.execution.SpringDataFetch
 import com.expediagroup.graphql.examples.server.spring.hooks.CustomSchemaGeneratorHooks
 import com.expediagroup.graphql.generator.directives.KotlinDirectiveWiringFactory
 import com.expediagroup.graphql.server.spring.subscriptions.ApolloSubscriptionHooks
-import com.fasterxml.jackson.databind.ObjectMapper
 import graphql.execution.DataFetcherExceptionHandler
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
@@ -43,9 +42,8 @@ class Application {
     @Bean
     fun dataFetcherFactoryProvider(
         springDataFetcherFactory: SpringDataFetcherFactory,
-        objectMapper: ObjectMapper,
         applicationContext: ApplicationContext
-    ) = CustomDataFetcherFactoryProvider(springDataFetcherFactory, objectMapper, applicationContext)
+    ) = CustomDataFetcherFactoryProvider(springDataFetcherFactory, applicationContext)
 
     @Bean
     fun dataFetcherExceptionHandler(): DataFetcherExceptionHandler = CustomDataFetcherExceptionHandler()

--- a/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/server/spring/execution/CustomDataFetcherFactoryProvider.kt
+++ b/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/server/spring/execution/CustomDataFetcherFactoryProvider.kt
@@ -17,7 +17,6 @@
 package com.expediagroup.graphql.examples.server.spring.execution
 
 import com.expediagroup.graphql.generator.execution.SimpleKotlinDataFetcherFactoryProvider
-import com.fasterxml.jackson.databind.ObjectMapper
 import graphql.schema.DataFetcherFactory
 import org.springframework.context.ApplicationContext
 import kotlin.reflect.KClass
@@ -29,15 +28,13 @@ import kotlin.reflect.KProperty
  */
 class CustomDataFetcherFactoryProvider(
     private val springDataFetcherFactory: SpringDataFetcherFactory,
-    private val objectMapper: ObjectMapper,
     private val applicationContext: ApplicationContext
-) : SimpleKotlinDataFetcherFactoryProvider(objectMapper) {
+) : SimpleKotlinDataFetcherFactoryProvider() {
 
     override fun functionDataFetcherFactory(target: Any?, kFunction: KFunction<*>) = DataFetcherFactory {
         CustomFunctionDataFetcher(
             target = target,
             fn = kFunction,
-            objectMapper = objectMapper,
             appContext = applicationContext
         )
     }

--- a/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/server/spring/execution/CustomFunctionDataFetcher.kt
+++ b/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/server/spring/execution/CustomFunctionDataFetcher.kt
@@ -17,7 +17,6 @@
 package com.expediagroup.graphql.examples.server.spring.execution
 
 import com.expediagroup.graphql.server.spring.execution.SpringDataFetcher
-import com.fasterxml.jackson.databind.ObjectMapper
 import graphql.schema.DataFetchingEnvironment
 import org.springframework.context.ApplicationContext
 import reactor.core.publisher.Mono
@@ -29,9 +28,8 @@ import kotlin.reflect.KFunction
 class CustomFunctionDataFetcher(
     target: Any?,
     fn: KFunction<*>,
-    objectMapper: ObjectMapper,
     appContext: ApplicationContext
-) : SpringDataFetcher(target, fn, objectMapper, appContext) {
+) : SpringDataFetcher(target, fn, appContext) {
 
     override fun get(environment: DataFetchingEnvironment): Any? = when (val result = super.get(environment)) {
         is Mono<*> -> result.toFuture()

--- a/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/server/spring/model/Widget.kt
+++ b/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/server/spring/model/Widget.kt
@@ -29,6 +29,8 @@ data class Widget(
     @GraphQLDescription("The widget's deprecated value that shouldn't be used")
     val deprecatedValue: Int? = value,
 
+    val listOfValues: List<Int>? = null,
+
     @GraphQLIgnore
     val ignoredField: String? = "ignored",
 

--- a/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/server/spring/mutation/WidgetMutation.kt
+++ b/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/server/spring/mutation/WidgetMutation.kt
@@ -34,4 +34,23 @@ class WidgetMutation : Mutation {
         }
         return widget
     }
+
+    fun processWidgetList(widgets: List<Widget>): List<Widget> {
+        widgets.forEach {
+            if (null == it.value) {
+                it.value = 42
+            }
+        }
+
+        return widgets
+    }
+
+    fun processWidgetArray(widgets: Array<Widget>): Array<Widget> {
+        widgets.forEach {
+            if (null == it.value) {
+                it.value = 42
+            }
+        }
+        return widgets
+    }
 }

--- a/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/server/spring/query/CustomJacksonSerialization.kt
+++ b/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/server/spring/query/CustomJacksonSerialization.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.examples.server.spring.query
+
+import com.expediagroup.graphql.examples.server.spring.hooks.Period
+import com.expediagroup.graphql.server.operations.Query
+import org.springframework.stereotype.Component
+
+@Component
+class CustomJacksonSerialization : Query {
+
+    fun fooInput(input: FooInput): String = "foo is ${input.foo} and range is ${input.range}"
+
+    data class FooInput(
+        val foo: String,
+        val range: Period,
+    )
+}

--- a/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/server/spring/query/ScalarQuery.kt
+++ b/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/server/spring/query/ScalarQuery.kt
@@ -33,6 +33,9 @@ class ScalarQuery : Query {
     fun generateRandomUUID() = UUID.randomUUID()
 
     @GraphQLDescription("Prints a string with a custom scalar as input")
+    fun printUuid(uuid: UUID) = "You sent $uuid"
+
+    @GraphQLDescription("Prints a string with a custom scalar as input")
     fun printUuids(uuids: List<UUID>) = "You sent $uuids"
 
     fun findPersonById(id: ID) = Person(id, "Nelson")

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/exceptions/CouldNotConstructAValidKotlinObject.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/exceptions/CouldNotConstructAValidKotlinObject.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2021 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.generator.exceptions
+
+class CouldNotConstructAValidKotlinObject(input: Any?) : GraphQLKotlinException("Could not convert the input $input to a valid Kotlin object")

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/execution/KotlinDataFetcherFactoryProvider.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/execution/KotlinDataFetcherFactoryProvider.kt
@@ -16,8 +16,6 @@
 
 package com.expediagroup.graphql.generator.execution
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import graphql.schema.DataFetcherFactory
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
@@ -54,7 +52,6 @@ interface KotlinDataFetcherFactoryProvider {
  * to obtain [DataFetcherFactory] that should be used for target function and property resolution.
  */
 open class SimpleKotlinDataFetcherFactoryProvider(
-    private val objectMapper: ObjectMapper = jacksonObjectMapper(),
     private val defaultCoroutineContext: CoroutineContext = EmptyCoroutineContext
 ) : KotlinDataFetcherFactoryProvider {
 
@@ -62,7 +59,6 @@ open class SimpleKotlinDataFetcherFactoryProvider(
         FunctionDataFetcher(
             target = target,
             fn = kFunction,
-            objectMapper = objectMapper,
             defaultCoroutineContext = defaultCoroutineContext
         )
     }

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/execution/convertArgumentToObject.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/execution/convertArgumentToObject.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2021 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.generator.execution
+
+import com.expediagroup.graphql.generator.exceptions.CouldNotConstructAValidKotlinObject
+import com.expediagroup.graphql.generator.internal.extensions.getKClass
+import com.expediagroup.graphql.generator.internal.extensions.getTypeOfFirstArgument
+import com.expediagroup.graphql.generator.internal.extensions.isOptionalInputType
+import graphql.schema.DataFetchingEnvironment
+import kotlin.reflect.KClass
+import kotlin.reflect.KParameter
+import kotlin.reflect.KType
+import kotlin.reflect.full.primaryConstructor
+
+/**
+ * Convert the input object [argumentValue] given from graphql-java to a class we can pass to the Kotlin function.
+ */
+internal fun convertArgumentToObject(
+    param: KParameter,
+    environment: DataFetchingEnvironment,
+    argumentName: String,
+    argumentValue: Any?
+): Any? = when {
+    param.type.isOptionalInputType() -> {
+        when {
+            !environment.containsArgument(argumentName) -> OptionalInput.Undefined
+            argumentValue == null -> OptionalInput.Defined(null)
+            else -> {
+                val paramType = param.type.getTypeOfFirstArgument()
+                val value = convertValue(paramType, argumentValue)
+                OptionalInput.Defined(value)
+            }
+        }
+    }
+    else -> convertValue(param.type, argumentValue)
+}
+
+/**
+ * The value may already be parsed, so we can perform some checks to avoid duplicate deserialization
+ */
+private fun convertValue(
+    paramType: KType,
+    argumentValue: Any?
+): Any? {
+    // The input given is already a list, iterate over each value to return a parsed list
+    if (argumentValue is Iterable<*>) {
+        return argumentValue.map {
+            val wrappedType = paramType.getTypeOfFirstArgument()
+            convertValue(wrappedType, it)
+        }
+    }
+
+    // The input given is already an array, iterate over each value to return a parsed list
+    if (argumentValue is Array<*>) {
+        return argumentValue.map {
+            val wrappedType = paramType.getTypeOfFirstArgument()
+            convertValue(wrappedType, it)
+        }
+    }
+
+    // If the value is a generic map, parse each entry which may have some values already parsed
+    if (argumentValue is Map<*, *>) {
+        @Suppress("UNCHECKED_CAST")
+        return mapToKotlinObject(argumentValue as Map<String, *>, paramType.getKClass())
+    }
+
+    // Value is already parsed so we can return it as-is
+    return argumentValue
+}
+
+/**
+ * At this point all custom scalars have been converted by graphql-java so the only thing left to parse is object maps into the nested Kotlin classes
+ */
+private fun <T : Any> mapToKotlinObject(inputMap: Map<String, *>, targetClass: KClass<T>): T {
+    val targetConstructor = targetClass.primaryConstructor ?: throw CouldNotConstructAValidKotlinObject(targetClass)
+    val params = targetConstructor.parameters
+    val constructorValues = mutableListOf<Any?>()
+
+    params.forEach {
+        val input = inputMap[it.name]
+        if (input is Map<*, *>) {
+            val nestedTarged = it.type.getKClass()
+            @Suppress("UNCHECKED_CAST")
+            val subValue = mapToKotlinObject(input as Map<String, *>, nestedTarged)
+            constructorValues.add(subValue)
+        } else {
+            constructorValues.add(input)
+        }
+    }
+
+    return targetConstructor.call(*constructorValues.toTypedArray())
+}

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/execution/ConvertArgumentToObjectKtTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/execution/ConvertArgumentToObjectKtTest.kt
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2021 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.generator.execution
+
+import graphql.schema.DataFetchingEnvironment
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import kotlin.reflect.full.findParameterByName
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+
+class ConvertArgumentToObjectKtTest {
+
+    @Test
+    fun `string input is parsed`() {
+        val kParam = assertNotNull(TestFunctions::stringInput.findParameterByName("input"))
+        val mockEnv = mockk<DataFetchingEnvironment>()
+        val result = convertArgumentToObject(kParam, mockEnv, "input", "hello")
+        assertEquals("hello", result)
+    }
+
+    @Test
+    fun `pre-parsed object is returned`() {
+        val kParam = assertNotNull(TestFunctions::inputObject.findParameterByName("input"))
+        val mockEnv = mockk<DataFetchingEnvironment>()
+        val result = convertArgumentToObject(kParam, mockEnv, "input", TestInput("hello"))
+        val castResult = assertIs<TestInput>(result)
+        assertEquals("hello", castResult.foo)
+    }
+
+    @Test
+    fun `generic map object is parsed`() {
+        val kParam = assertNotNull(TestFunctions::inputObject.findParameterByName("input"))
+        val mockEnv = mockk<DataFetchingEnvironment>()
+        val inputValue = mapOf(
+            "foo" to "hello",
+            "bar" to "world",
+            "baz" to listOf("!")
+        )
+        val result = convertArgumentToObject(kParam, mockEnv, "input", inputValue)
+        val castResult = assertIs<TestInput>(result)
+        assertEquals("hello", castResult.foo)
+        assertEquals("world", castResult.bar)
+        assertEquals(listOf("!"), castResult.baz)
+    }
+
+    @Test
+    fun `generic map object is parsed and defaults are used`() {
+        val kParam = assertNotNull(TestFunctions::inputObject.findParameterByName("input"))
+        val mockEnv = mockk<DataFetchingEnvironment>()
+        val result = convertArgumentToObject(kParam, mockEnv, "input", mapOf("foo" to "hello"))
+        val castResult = assertIs<TestInput>(result)
+        assertEquals("hello", castResult.foo)
+        assertEquals(null, castResult.bar)
+        assertEquals(null, castResult.baz)
+    }
+
+    @Test
+    fun `list string input is parsed`() {
+        val kParam = assertNotNull(TestFunctions::listStringInput.findParameterByName("input"))
+        val mockEnv = mockk<DataFetchingEnvironment>()
+        val result = convertArgumentToObject(kParam, mockEnv, "input", listOf("hello"))
+        assertEquals(listOf("hello"), result)
+    }
+
+    @Test
+    fun `optional input when undefined is parsed`() {
+        val kParam = assertNotNull(TestFunctions::optionalInput.findParameterByName("input"))
+        val mockEnv = mockk<DataFetchingEnvironment> {
+            every { containsArgument("input") } returns false
+        }
+        val result = convertArgumentToObject(kParam, mockEnv, "input", null)
+        assertEquals(OptionalInput.Undefined, result)
+    }
+
+    @Test
+    fun `optional input with defined null is parsed`() {
+        val kParam = assertNotNull(TestFunctions::optionalInput.findParameterByName("input"))
+        val mockEnv = mockk<DataFetchingEnvironment> {
+            every { containsArgument("input") } returns true
+        }
+        val result = convertArgumentToObject(kParam, mockEnv, "input", null)
+        val castResult = assertIs<OptionalInput.Defined<*>>(result)
+        assertEquals(null, castResult.value)
+    }
+
+    @Test
+    fun `optional input with defined value is parsed`() {
+        val kParam = assertNotNull(TestFunctions::optionalInput.findParameterByName("input"))
+        val mockEnv = mockk<DataFetchingEnvironment> {
+            every { containsArgument("input") } returns true
+        }
+        val result = convertArgumentToObject(kParam, mockEnv, "input", "hello")
+        val castResult = assertIs<OptionalInput.Defined<*>>(result)
+        assertEquals("hello", castResult.value)
+    }
+
+    @Test
+    fun `optional input with object is parsed`() {
+        val kParam = assertNotNull(TestFunctions::optionalInputObject.findParameterByName("input"))
+        val mockEnv = mockk<DataFetchingEnvironment> {
+            every { containsArgument("input") } returns true
+        }
+        val result = convertArgumentToObject(kParam, mockEnv, "input", TestInput("hello"))
+        val castResult = assertIs<OptionalInput.Defined<*>>(result)
+        val castResult2 = assertIs<TestInput>(castResult.value)
+        assertEquals("hello", castResult2.foo)
+    }
+
+    @Test
+    fun `optional input with list object is parsed`() {
+        val kParam = assertNotNull(TestFunctions::optionalInputListObject.findParameterByName("input"))
+        val mockEnv = mockk<DataFetchingEnvironment> {
+            every { containsArgument("input") } returns true
+        }
+        val result = convertArgumentToObject(kParam, mockEnv, "input", listOf(TestInput("hello")))
+        val castResult = assertIs<OptionalInput.Defined<*>>(result)
+        val castResult2 = assertIs<List<TestInput>>(castResult.value)
+        assertEquals("hello", castResult2.firstOrNull()?.foo)
+    }
+
+    class TestFunctions {
+        fun stringInput(input: String): String = TODO()
+        fun listStringInput(input: List<String>): String = TODO()
+        fun inputObject(input: TestInput): String = TODO()
+        fun optionalInput(input: OptionalInput<String>): String = TODO()
+        fun optionalInputObject(input: OptionalInput<TestInput>): String = TODO()
+        fun optionalInputListObject(input: OptionalInput<List<TestInput>>): String = TODO()
+    }
+
+    class TestInput(
+        val foo: String,
+        val bar: String? = null,
+        val baz: List<String>? = null
+    )
+}

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/execution/FunctionDataFetcherTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/execution/FunctionDataFetcherTest.kt
@@ -74,6 +74,11 @@ class FunctionDataFetcherTest {
             is OptionalInput.Undefined -> "input was UNDEFINED"
             is OptionalInput.Defined -> "first input was ${input.value?.first()?.field1}"
         }
+
+        fun optionalListInputObjects(input: OptionalInput<List<MyInputClass>>): String = when (input) {
+            is OptionalInput.Undefined -> "input was UNDEFINED"
+            is OptionalInput.Defined -> "first input was ${input.value?.first()?.field1}"
+        }
     }
 
     @GraphQLName("MyInputClassRenamed")
@@ -179,7 +184,7 @@ class FunctionDataFetcherTest {
     }
 
     @Test
-    fun `list can be converted by the object mapper`() {
+    fun `list inputs can be converted by the object mapper`() {
         val dataFetcher = FunctionDataFetcher(target = MyClass(), fn = MyClass::printList)
         val mockEnvironmet: DataFetchingEnvironment = mockk {
             every { arguments } returns mapOf("items" to listOf("foo", "bar"))
@@ -286,7 +291,18 @@ class FunctionDataFetcherTest {
     fun `optional array of input objects is deserialized correctly`() {
         val dataFetcher = FunctionDataFetcher(target = MyClass(), fn = MyClass::optionalArrayInputObjects)
         val mockEnvironmet: DataFetchingEnvironment = mockk {
-            every { arguments } returns mapOf("input" to arrayListOf(linkedMapOf("jacksonField" to "foo")))
+            every { arguments } returns mapOf("input" to arrayOf(linkedMapOf("jacksonField" to "foo")))
+            every { containsArgument("input") } returns true
+        }
+        val result = dataFetcher.get(mockEnvironmet)
+        assertEquals(expected = "first input was foo", actual = result)
+    }
+
+    @Test
+    fun `optional list of input objects is deserialized correctly`() {
+        val dataFetcher = FunctionDataFetcher(target = MyClass(), fn = MyClass::optionalListInputObjects)
+        val mockEnvironmet: DataFetchingEnvironment = mockk {
+            every { arguments } returns mapOf("input" to listOf(linkedMapOf("jacksonField" to "foo")))
             every { containsArgument("input") } returns true
         }
         val result = dataFetcher.get(mockEnvironmet)

--- a/servers/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/server/spring/GraphQLExecutionConfiguration.kt
+++ b/servers/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/server/spring/GraphQLExecutionConfiguration.kt
@@ -21,7 +21,6 @@ import com.expediagroup.graphql.server.execution.DataLoaderRegistryFactory
 import com.expediagroup.graphql.server.execution.DefaultDataLoaderRegistryFactory
 import com.expediagroup.graphql.server.execution.KotlinDataLoader
 import com.expediagroup.graphql.server.spring.execution.SpringKotlinDataFetcherFactoryProvider
-import com.fasterxml.jackson.databind.ObjectMapper
 import graphql.execution.DataFetcherExceptionHandler
 import graphql.execution.SimpleDataFetcherExceptionHandler
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
@@ -44,8 +43,8 @@ class GraphQLExecutionConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    fun dataFetcherFactoryProvider(objectMapper: ObjectMapper, applicationContext: ApplicationContext): KotlinDataFetcherFactoryProvider =
-        SpringKotlinDataFetcherFactoryProvider(objectMapper, applicationContext)
+    fun dataFetcherFactoryProvider(applicationContext: ApplicationContext): KotlinDataFetcherFactoryProvider =
+        SpringKotlinDataFetcherFactoryProvider(applicationContext)
 
     @Bean
     @ConditionalOnMissingBean

--- a/servers/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/server/spring/execution/SpringDataFetcher.kt
+++ b/servers/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/server/spring/execution/SpringDataFetcher.kt
@@ -17,7 +17,6 @@
 package com.expediagroup.graphql.server.spring.execution
 
 import com.expediagroup.graphql.generator.execution.FunctionDataFetcher
-import com.fasterxml.jackson.databind.ObjectMapper
 import graphql.schema.DataFetchingEnvironment
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Qualifier
@@ -34,9 +33,8 @@ import kotlin.reflect.jvm.javaType
 open class SpringDataFetcher(
     target: Any?,
     fn: KFunction<*>,
-    objectMapper: ObjectMapper,
     private val applicationContext: ApplicationContext
-) : FunctionDataFetcher(target, fn, objectMapper) {
+) : FunctionDataFetcher(target, fn) {
 
     @ExperimentalStdlibApi
     override fun mapParameterToValue(param: KParameter, environment: DataFetchingEnvironment): Pair<KParameter, Any?>? =

--- a/servers/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/server/spring/execution/SpringKotlinDataFetcherFactoryProvider.kt
+++ b/servers/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/server/spring/execution/SpringKotlinDataFetcherFactoryProvider.kt
@@ -17,7 +17,6 @@
 package com.expediagroup.graphql.server.spring.execution
 
 import com.expediagroup.graphql.generator.execution.SimpleKotlinDataFetcherFactoryProvider
-import com.fasterxml.jackson.databind.ObjectMapper
 import graphql.schema.DataFetcherFactory
 import org.springframework.context.ApplicationContext
 import kotlin.reflect.KFunction
@@ -27,9 +26,8 @@ import kotlin.reflect.KFunction
  * This allows you to use Spring beans as function arugments and they will be populated by the data fetcher.
  */
 class SpringKotlinDataFetcherFactoryProvider(
-    private val objectMapper: ObjectMapper,
     private val applicationContext: ApplicationContext
-) : SimpleKotlinDataFetcherFactoryProvider(objectMapper) {
+) : SimpleKotlinDataFetcherFactoryProvider() {
     override fun functionDataFetcherFactory(target: Any?, kFunction: KFunction<*>): DataFetcherFactory<Any?> =
-        DataFetcherFactory { SpringDataFetcher(target, kFunction, objectMapper, applicationContext) }
+        DataFetcherFactory { SpringDataFetcher(target, kFunction, applicationContext) }
 }

--- a/servers/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/server/spring/execution/SpringDataFetcherTest.kt
+++ b/servers/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/server/spring/execution/SpringDataFetcherTest.kt
@@ -17,7 +17,6 @@
 package com.expediagroup.graphql.server.spring.execution
 
 import com.expediagroup.graphql.generator.annotations.GraphQLIgnore
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import graphql.schema.DataFetchingEnvironment
 import io.mockk.every
 import io.mockk.mockk
@@ -31,7 +30,6 @@ import kotlin.test.assertFailsWith
 
 class SpringDataFetcherTest {
 
-    private val objectMapper = jacksonObjectMapper()
     private val context: ApplicationContext = mockk {
         every { getBean(MyService::class.java) } returns MyService()
         every { getBean(NotService::class.java) } throws NoSuchBeanDefinitionException(NotService::class.java)
@@ -45,7 +43,6 @@ class SpringDataFetcherTest {
         val dataFetcher = SpringDataFetcher(
             target = MyQuery(),
             fn = MyQuery::callService,
-            objectMapper = objectMapper,
             applicationContext = context
         )
 
@@ -59,7 +56,6 @@ class SpringDataFetcherTest {
         val dataFetcher = SpringDataFetcher(
             target = MyQuery(),
             fn = MyQuery::callServiceNoAnnotation,
-            objectMapper = objectMapper,
             applicationContext = context
         )
 
@@ -73,7 +69,6 @@ class SpringDataFetcherTest {
         val dataFetcher = SpringDataFetcher(
             target = MyQuery(),
             fn = MyQuery::callNotService,
-            objectMapper = objectMapper,
             applicationContext = context
         )
 
@@ -87,7 +82,6 @@ class SpringDataFetcherTest {
         val dataFetcher = SpringDataFetcher(
             target = MyQuery(),
             fn = MyQuery::callNotServiceNoAnnotation,
-            objectMapper = objectMapper,
             applicationContext = context
         )
 


### PR DESCRIPTION
### :pencil: Description
Remove Jackson for converting input objects to Kotlin function arguments. graphql-java will have already run scalar coercion so the only thing we have to handle is List and Map. With Kotlin reflection we can get access to the function argument `KClass` and therefore call the constructor for that class.

This removes the need to use Jackson at all and means that we don't double deserialize objects

We are changing the public API by removing the need to have `objectMapper` as an argument. We could keep that around for backwards compatibility of others extending the logic if we wanted, but that might not be needed

### :link: Related Issues
Should help resolve https://github.com/ExpediaGroup/graphql-kotlin/issues/1220

I still need to more testing