### PR TITLE
[client] fix handling of custom scalar inputs

### DIFF
--- a/examples/build.gradle.kts
+++ b/examples/build.gradle.kts
@@ -36,8 +36,9 @@ subprojects {
         this.ext[key.toString()] = value
     }
 
-    val kotlinVersion: String by project
+    val icuVersion: String by project
     val junitVersion: String by project
+    val kotlinVersion: String by project
     val kotlinCoroutinesVersion: String by project
 
     val detektVersion: String by project
@@ -51,7 +52,7 @@ subprojects {
         implementation(kotlin("stdlib", kotlinVersion))
         implementation(kotlin("reflect", kotlinVersion))
         implementation("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:$kotlinCoroutinesVersion")
-        implementation("com.ibm.icu:icu4j:69.1")
+        implementation("com.ibm.icu:icu4j:$icuVersion")
         testImplementation(kotlin("test-junit5", kotlinVersion))
         testImplementation("org.junit.jupiter:junit-jupiter-api:$junitVersion")
         testImplementation("org.junit.jupiter:junit-jupiter-engine:$junitVersion")

--- a/examples/client/gradle-client/src/main/kotlin/com/expediagroup/graphql/examples/client/gradle/Application.kt
+++ b/examples/client/gradle-client/src/main/kotlin/com/expediagroup/graphql/examples/client/gradle/Application.kt
@@ -87,7 +87,7 @@ fun main() {
 
     println("additional examples")
     runBlocking {
-        val exampleData = client.execute(ExampleQuery(variables = ExampleQuery.Variables(simpleCriteria = SimpleArgumentInput(max = 1.0f))))
+        val exampleData = client.execute(ExampleQuery(variables = ExampleQuery.Variables(simpleCriteria = SimpleArgumentInput(max = 1.0))))
         println("\tretrieved interface: ${exampleData.data?.interfaceQuery} ")
         println("\tretrieved union: ${exampleData.data?.unionQuery} ")
         println("\tretrieved enum: ${exampleData.data?.enumQuery} ")

--- a/examples/client/maven-client/src/main/kotlin/com/expediagroup/graphql/examples/client/maven/Application.kt
+++ b/examples/client/maven-client/src/main/kotlin/com/expediagroup/graphql/examples/client/maven/Application.kt
@@ -76,7 +76,7 @@ fun main() {
 
     println("additional examples")
     runBlocking {
-        val exampleData = client.execute(ExampleQuery(variables = ExampleQuery.Variables(simpleCriteria = OptionalInput.Defined(SimpleArgumentInput(max = OptionalInput.Defined(1.0f))))))
+        val exampleData = client.execute(ExampleQuery(variables = ExampleQuery.Variables(simpleCriteria = OptionalInput.Defined(SimpleArgumentInput(max = OptionalInput.Defined(1.0))))))
         println("\tretrieved interface: ${exampleData.data?.interfaceQuery} ")
         println("\tretrieved union: ${exampleData.data?.unionQuery} ")
         println("\tretrieved enum: ${exampleData.data?.enumQuery} ")

--- a/gradle.properties
+++ b/gradle.properties
@@ -34,6 +34,7 @@ springVersion = 5.3.9
 
 # test dependency versions
 compileTestingVersion = 1.4.3
+icuVersion=69.1
 junitVersion = 5.7.2
 mockkVersion = 1.12.0
 mustacheVersion = 0.9.10

--- a/plugins/client/graphql-kotlin-client-generator/build.gradle.kts
+++ b/plugins/client/graphql-kotlin-client-generator/build.gradle.kts
@@ -2,6 +2,7 @@ description = "GraphQL Kotlin common utilities to generate a client."
 
 val compileTestingVersion: String by project
 val graphQLJavaVersion: String by project
+val icuVersion: String by project
 val jacksonVersion: String by project
 val junitVersion: String by project
 val kotlinPoetVersion: String by project
@@ -26,6 +27,7 @@ dependencies {
     testImplementation("com.github.tomakehurst:wiremock-jre8:$wireMockVersion")
     testImplementation("com.github.tschuchortdev:kotlin-compile-testing:$compileTestingVersion")
     testImplementation("org.junit.jupiter:junit-jupiter-params:$junitVersion")
+    testImplementation("com.ibm.icu:icu4j:$icuVersion")
 }
 
 tasks {

--- a/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/GraphQLClientGenerator.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/GraphQLClientGenerator.kt
@@ -37,9 +37,11 @@ import graphql.schema.idl.SchemaParser
 import graphql.schema.idl.TypeDefinitionRegistry
 import kotlinx.serialization.Required
 import kotlinx.serialization.Serializable
+import org.slf4j.LoggerFactory
 import java.io.File
 
 private const val CORE_TYPES_PACKAGE = "com.expediagroup.graphql.client.types"
+internal val LOGGER = LoggerFactory.getLogger(GraphQLClientGenerator::class.java)
 
 /**
  * GraphQL client code generator that uses [KotlinPoet](https://github.com/square/kotlinpoet) to generate Kotlin classes based on the specified GraphQL queries.

--- a/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/types/generateTypeName.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/types/generateTypeName.kt
@@ -24,7 +24,7 @@ import com.expediagroup.graphql.plugin.client.generator.extensions.findFragmentD
 import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.BOOLEAN
 import com.squareup.kotlinpoet.ClassName
-import com.squareup.kotlinpoet.FLOAT
+import com.squareup.kotlinpoet.DOUBLE
 import com.squareup.kotlinpoet.INT
 import com.squareup.kotlinpoet.LIST
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
@@ -59,7 +59,7 @@ internal fun generateTypeName(context: GraphQLClientGeneratorContext, graphQLTyp
         is NamedNode<*> -> when (graphQLType.name) {
             Scalars.GraphQLString.name -> STRING
             Scalars.GraphQLInt.name -> INT
-            Scalars.GraphQLFloat.name -> FLOAT
+            Scalars.GraphQLFloat.name -> DOUBLE
             Scalars.GraphQLBoolean.name -> BOOLEAN
             else -> generateCustomClassName(context, graphQLType, selectionSet)
         }

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/input_self_reference/inputs/ComplexArgumentInput.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/input_self_reference/inputs/ComplexArgumentInput.kt
@@ -1,7 +1,7 @@
 package com.expediagroup.graphql.generated.inputs
 
 import com.expediagroup.graphql.client.Generated
-import kotlin.Float
+import kotlin.Double
 
 /**
  * Self referencing input object
@@ -11,11 +11,11 @@ public data class ComplexArgumentInput(
   /**
    * Maximum value for test criteria
    */
-  public val max: Float? = null,
+  public val max: Double? = null,
   /**
    * Minimum value for test criteria
    */
-  public val min: Float? = null,
+  public val min: Double? = null,
   /**
    * Next criteria
    */

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/interface_diff_selection_sets/differentselectionsetquery/BasicInterface.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/interface_diff_selection_sets/differentselectionsetquery/BasicInterface.kt
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.`annotation`.JsonSubTypes
 import com.fasterxml.jackson.`annotation`.JsonTypeInfo
 import com.fasterxml.jackson.`annotation`.JsonTypeInfo.As.PROPERTY
 import com.fasterxml.jackson.`annotation`.JsonTypeInfo.Id.NAME
-import kotlin.Float
+import kotlin.Double
 import kotlin.Int
 import kotlin.String
 
@@ -69,5 +69,5 @@ public data class SecondInterfaceImplementation(
   /**
    * Custom field float value
    */
-  public val floatValue: Float
+  public val floatValue: Double
 ) : BasicInterface

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/interface_diff_selection_sets/differentselectionsetquery/BasicInterface2.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/interface_diff_selection_sets/differentselectionsetquery/BasicInterface2.kt
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.`annotation`.JsonSubTypes
 import com.fasterxml.jackson.`annotation`.JsonTypeInfo
 import com.fasterxml.jackson.`annotation`.JsonTypeInfo.As.PROPERTY
 import com.fasterxml.jackson.`annotation`.JsonTypeInfo.Id.NAME
-import kotlin.Float
+import kotlin.Double
 import kotlin.Int
 import kotlin.String
 
@@ -56,5 +56,5 @@ public data class SecondInterfaceImplementation2(
   /**
    * Custom field float value
    */
-  public val floatValue: Float
+  public val floatValue: Double
 ) : BasicInterface2

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/interface_impl_diff_selection_sets/differentselectionsetquery/BasicInterface.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/interface_impl_diff_selection_sets/differentselectionsetquery/BasicInterface.kt
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.`annotation`.JsonSubTypes
 import com.fasterxml.jackson.`annotation`.JsonTypeInfo
 import com.fasterxml.jackson.`annotation`.JsonTypeInfo.As.PROPERTY
 import com.fasterxml.jackson.`annotation`.JsonTypeInfo.Id.NAME
-import kotlin.Float
+import kotlin.Double
 import kotlin.Int
 
 /**
@@ -55,5 +55,5 @@ public data class SecondInterfaceImplementation(
   /**
    * Custom field float value
    */
-  public val floatValue: Float
+  public val floatValue: Double
 ) : BasicInterface

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/interface_impl_diff_selection_sets/differentselectionsetquery/BasicInterface2.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/interface_impl_diff_selection_sets/differentselectionsetquery/BasicInterface2.kt
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.`annotation`.JsonSubTypes
 import com.fasterxml.jackson.`annotation`.JsonTypeInfo
 import com.fasterxml.jackson.`annotation`.JsonTypeInfo.As.PROPERTY
 import com.fasterxml.jackson.`annotation`.JsonTypeInfo.Id.NAME
-import kotlin.Float
+import kotlin.Double
 import kotlin.Int
 import kotlin.String
 
@@ -64,5 +64,5 @@ public data class SecondInterfaceImplementation2(
   /**
    * Custom field float value
    */
-  public val floatValue: Float
+  public val floatValue: Double
 ) : BasicInterface2

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/interface_named_fragments/interfacewithnamedfragmentsquery/BasicInterface.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/interface_named_fragments/interfacewithnamedfragmentsquery/BasicInterface.kt
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.`annotation`.JsonSubTypes
 import com.fasterxml.jackson.`annotation`.JsonTypeInfo
 import com.fasterxml.jackson.`annotation`.JsonTypeInfo.As.PROPERTY
 import com.fasterxml.jackson.`annotation`.JsonTypeInfo.Id.NAME
-import kotlin.Float
+import kotlin.Double
 import kotlin.Int
 import kotlin.String
 
@@ -69,5 +69,5 @@ public data class SecondInterfaceImplementation(
   /**
    * Custom field float value
    */
-  public val floatValue: Float
+  public val floatValue: Double
 ) : BasicInterface

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/mutation/inputs/SimpleArgumentInput.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/mutation/inputs/SimpleArgumentInput.kt
@@ -1,7 +1,7 @@
 package com.expediagroup.graphql.generated.inputs
 
 import com.expediagroup.graphql.client.Generated
-import kotlin.Float
+import kotlin.Double
 import kotlin.String
 
 /**
@@ -12,11 +12,11 @@ public data class SimpleArgumentInput(
   /**
    * Maximum value for test criteria
    */
-  public val max: Float? = null,
+  public val max: Double? = null,
   /**
    * Minimum value for test criteria
    */
-  public val min: Float? = null,
+  public val min: Double? = null,
   /**
    * New value to be set
    */

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/scalar_typealias/scalaraliasquery/ScalarWrapper.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/scalar_typealias/scalaraliasquery/ScalarWrapper.kt
@@ -14,7 +14,7 @@ public data class ScalarWrapper(
    */
   public val id: ID,
   /**
-   * Custom scalar
+   * Custom scalar of UUID
    */
-  public val custom: UUID
+  public val custom: UUID?
 )

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/custom_scalar_input/CustomScalarInputQuery.graphql
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/custom_scalar_input/CustomScalarInputQuery.graphql
@@ -1,0 +1,3 @@
+query CustomScalarInputQuery($requiredLocale: Locale!, $optionalLocale: Locale, $scalarWrapper: ScalarWrapperInput) {
+  inputCustomScalarQuery(requiredLocale: $requiredLocale, optionalLocale: $optionalLocale, scalarWrapper: $scalarWrapper)
+}

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/custom_scalar_input/CustomScalarInputQuery.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/custom_scalar_input/CustomScalarInputQuery.kt
@@ -1,0 +1,53 @@
+package com.expediagroup.graphql.generated
+
+import com.expediagroup.graphql.client.Generated
+import com.expediagroup.graphql.client.jackson.types.OptionalInput
+import com.expediagroup.graphql.client.jackson.types.OptionalInput.Undefined
+import com.expediagroup.graphql.client.types.GraphQLClientRequest
+import com.expediagroup.graphql.generated.inputs.ScalarWrapperInput
+import com.expediagroup.graphql.generated.scalars.AnyToULocaleConverter
+import com.expediagroup.graphql.generated.scalars.ULocaleToAnyConverter
+import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
+import com.fasterxml.jackson.databind.`annotation`.JsonSerialize
+import com.ibm.icu.util.ULocale
+import kotlin.Boolean
+import kotlin.String
+import kotlin.reflect.KClass
+
+public const val CUSTOM_SCALAR_INPUT_QUERY: String =
+    "query CustomScalarInputQuery(${'$'}requiredLocale: Locale!, ${'$'}optionalLocale: Locale, ${'$'}scalarWrapper: ScalarWrapperInput) {\n  inputCustomScalarQuery(requiredLocale: ${'$'}requiredLocale, optionalLocale: ${'$'}optionalLocale, scalarWrapper: ${'$'}scalarWrapper)\n}"
+
+@Generated
+public class CustomScalarInputQuery(
+  public override val variables: CustomScalarInputQuery.Variables
+) : GraphQLClientRequest<CustomScalarInputQuery.Result> {
+  public override val query: String = CUSTOM_SCALAR_INPUT_QUERY
+
+  public override val operationName: String = "CustomScalarInputQuery"
+
+  public override fun responseType(): KClass<CustomScalarInputQuery.Result> =
+      CustomScalarInputQuery.Result::class
+
+  @Generated
+  public data class Variables(
+    @JsonSerialize(converter = ULocaleToAnyConverter::class)
+    @JsonDeserialize(converter = AnyToULocaleConverter::class)
+    public val requiredLocale: ULocale,
+    /**
+     * NOTE: This field was not wrapped in optional as currently custom scalars do not work with
+     * optional wrappers.
+     */
+    @JsonSerialize(converter = ULocaleToAnyConverter::class)
+    @JsonDeserialize(converter = AnyToULocaleConverter::class)
+    public val optionalLocale: ULocale? = null,
+    public val scalarWrapper: OptionalInput<ScalarWrapperInput> = OptionalInput.Undefined
+  )
+
+  @Generated
+  public data class Result(
+    /**
+     * Query that accepts a custom scalar input
+     */
+    public val inputCustomScalarQuery: Boolean
+  )
+}

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/custom_scalar_input/GraphQLTypeAliases.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/custom_scalar_input/GraphQLTypeAliases.kt
@@ -1,0 +1,5 @@
+package com.expediagroup.graphql.generated
+
+import kotlin.String
+
+public typealias ID = String

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/custom_scalar_input/inputs/ScalarWrapperInput.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/custom_scalar_input/inputs/ScalarWrapperInput.kt
@@ -1,0 +1,74 @@
+package com.expediagroup.graphql.generated.inputs
+
+import com.expediagroup.graphql.client.Generated
+import com.expediagroup.graphql.client.jackson.types.OptionalInput
+import com.expediagroup.graphql.client.jackson.types.OptionalInput.Undefined
+import com.expediagroup.graphql.generated.ID
+import com.expediagroup.graphql.generated.scalars.AnyToULocaleConverter
+import com.expediagroup.graphql.generated.scalars.AnyToUUIDConverter
+import com.expediagroup.graphql.generated.scalars.ULocaleToAnyConverter
+import com.expediagroup.graphql.generated.scalars.UUIDToAnyConverter
+import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
+import com.fasterxml.jackson.databind.`annotation`.JsonSerialize
+import com.ibm.icu.util.ULocale
+import java.util.UUID
+import kotlin.Boolean
+import kotlin.Double
+import kotlin.Int
+import kotlin.String
+import kotlin.collections.List
+
+/**
+ * Wrapper that holds all supported scalar types
+ */
+@Generated
+public data class ScalarWrapperInput(
+  /**
+   * A signed 32-bit nullable integer value
+   */
+  public val count: OptionalInput<Int> = OptionalInput.Undefined,
+  /**
+   * Custom scalar of UUID
+   * NOTE: This field was not wrapped in optional as currently custom scalars do not work with
+   * optional wrappers.
+   */
+  @JsonSerialize(converter = UUIDToAnyConverter::class)
+  @JsonDeserialize(converter = AnyToUUIDConverter::class)
+  public val custom: UUID? = null,
+  /**
+   * List of custom scalar UUIDs
+   * NOTE: This field was not wrapped in optional as currently custom scalars do not work with
+   * optional wrappers.
+   */
+  @JsonSerialize(contentConverter = UUIDToAnyConverter::class)
+  @JsonDeserialize(contentConverter = AnyToUUIDConverter::class)
+  public val customList: List<UUID>? = null,
+  /**
+   * ID represents unique identifier that is not intended to be human readable
+   */
+  public val id: ID,
+  /**
+   * UTF-8 character sequence
+   */
+  public val name: String,
+  /**
+   * A nullable signed double-precision floating-point value
+   */
+  public val rating: OptionalInput<Double> = OptionalInput.Undefined,
+  /**
+   * Either true or false
+   */
+  public val valid: Boolean,
+  /**
+   * Custom scalar of Locale
+   */
+  @JsonSerialize(converter = ULocaleToAnyConverter::class)
+  @JsonDeserialize(converter = AnyToULocaleConverter::class)
+  public val locale: ULocale,
+  /**
+   * List of custom scalar Locales
+   */
+  @JsonSerialize(contentConverter = ULocaleToAnyConverter::class)
+  @JsonDeserialize(contentConverter = AnyToULocaleConverter::class)
+  public val listLocale: List<ULocale>
+)

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/custom_scalar_input/scalars/AnyToULocaleConverter.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/custom_scalar_input/scalars/AnyToULocaleConverter.kt
@@ -1,0 +1,14 @@
+package com.expediagroup.graphql.generated.scalars
+
+import com.expediagroup.graphql.client.Generated
+import com.expediagroup.graphql.plugin.client.generator.ULocaleScalarConverter
+import com.fasterxml.jackson.databind.util.StdConverter
+import com.ibm.icu.util.ULocale
+import kotlin.Any
+
+@Generated
+public class AnyToULocaleConverter : StdConverter<Any, ULocale>() {
+  private val converter: ULocaleScalarConverter = ULocaleScalarConverter()
+
+  public override fun convert(`value`: Any): ULocale = converter.toScalar(value)
+}

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/custom_scalar_input/scalars/AnyToUUIDConverter.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/custom_scalar_input/scalars/AnyToUUIDConverter.kt
@@ -1,0 +1,14 @@
+package com.expediagroup.graphql.generated.scalars
+
+import com.expediagroup.graphql.client.Generated
+import com.expediagroup.graphql.plugin.client.generator.UUIDScalarConverter
+import com.fasterxml.jackson.databind.util.StdConverter
+import java.util.UUID
+import kotlin.Any
+
+@Generated
+public class AnyToUUIDConverter : StdConverter<Any, UUID>() {
+  private val converter: UUIDScalarConverter = UUIDScalarConverter()
+
+  public override fun convert(`value`: Any): UUID = converter.toScalar(value)
+}

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/custom_scalar_input/scalars/ULocaleToAnyConverter.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/custom_scalar_input/scalars/ULocaleToAnyConverter.kt
@@ -1,0 +1,14 @@
+package com.expediagroup.graphql.generated.scalars
+
+import com.expediagroup.graphql.client.Generated
+import com.expediagroup.graphql.plugin.client.generator.ULocaleScalarConverter
+import com.fasterxml.jackson.databind.util.StdConverter
+import com.ibm.icu.util.ULocale
+import kotlin.Any
+
+@Generated
+public class ULocaleToAnyConverter : StdConverter<ULocale, Any>() {
+  private val converter: ULocaleScalarConverter = ULocaleScalarConverter()
+
+  public override fun convert(`value`: ULocale): Any = converter.toJson(value)
+}

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/custom_scalar_input/scalars/UUIDToAnyConverter.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/custom_scalar_input/scalars/UUIDToAnyConverter.kt
@@ -1,0 +1,14 @@
+package com.expediagroup.graphql.generated.scalars
+
+import com.expediagroup.graphql.client.Generated
+import com.expediagroup.graphql.plugin.client.generator.UUIDScalarConverter
+import com.fasterxml.jackson.databind.util.StdConverter
+import java.util.UUID
+import kotlin.Any
+
+@Generated
+public class UUIDToAnyConverter : StdConverter<UUID, Any>() {
+  private val converter: UUIDScalarConverter = UUIDScalarConverter()
+
+  public override fun convert(`value`: UUID): Any = converter.toJson(value)
+}

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/custom_scalars/CustomScalarQuery.graphql
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/custom_scalars/CustomScalarQuery.graphql
@@ -2,5 +2,7 @@ query CustomScalarQuery {
   scalarQuery {
     custom
     customList
+    locale
+    listLocale
   }
 }

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/custom_scalars/CustomScalarQuery.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/custom_scalars/CustomScalarQuery.kt
@@ -7,7 +7,7 @@ import kotlin.String
 import kotlin.reflect.KClass
 
 public const val CUSTOM_SCALAR_QUERY: String =
-    "query CustomScalarQuery {\n  scalarQuery {\n    custom\n    customList\n  }\n}"
+    "query CustomScalarQuery {\n  scalarQuery {\n    custom\n    customList\n    locale\n    listLocale\n  }\n}"
 
 @Generated
 public class CustomScalarQuery : GraphQLClientRequest<CustomScalarQuery.Result> {

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/custom_scalars/customscalarquery/ScalarWrapper.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/custom_scalars/customscalarquery/ScalarWrapper.kt
@@ -1,10 +1,13 @@
 package com.expediagroup.graphql.generated.customscalarquery
 
 import com.expediagroup.graphql.client.Generated
+import com.expediagroup.graphql.generated.scalars.AnyToULocaleConverter
 import com.expediagroup.graphql.generated.scalars.AnyToUUIDConverter
+import com.expediagroup.graphql.generated.scalars.ULocaleToAnyConverter
 import com.expediagroup.graphql.generated.scalars.UUIDToAnyConverter
 import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonSerialize
+import com.ibm.icu.util.ULocale
 import java.util.UUID
 import kotlin.collections.List
 
@@ -14,15 +17,27 @@ import kotlin.collections.List
 @Generated
 public data class ScalarWrapper(
   /**
-   * Custom scalar
+   * Custom scalar of UUID
    */
   @JsonSerialize(converter = UUIDToAnyConverter::class)
   @JsonDeserialize(converter = AnyToUUIDConverter::class)
-  public val custom: UUID,
+  public val custom: UUID?,
   /**
-   * List of custom scalars
+   * List of custom scalar UUIDs
    */
   @JsonSerialize(contentConverter = UUIDToAnyConverter::class)
   @JsonDeserialize(contentConverter = AnyToUUIDConverter::class)
-  public val customList: List<UUID>
+  public val customList: List<UUID>?,
+  /**
+   * Custom scalar of Locale
+   */
+  @JsonSerialize(converter = ULocaleToAnyConverter::class)
+  @JsonDeserialize(converter = AnyToULocaleConverter::class)
+  public val locale: ULocale,
+  /**
+   * List of custom scalar Locales
+   */
+  @JsonSerialize(contentConverter = ULocaleToAnyConverter::class)
+  @JsonDeserialize(contentConverter = AnyToULocaleConverter::class)
+  public val listLocale: List<ULocale>
 )

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/custom_scalars/scalars/AnyToULocaleConverter.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/custom_scalars/scalars/AnyToULocaleConverter.kt
@@ -1,0 +1,14 @@
+package com.expediagroup.graphql.generated.scalars
+
+import com.expediagroup.graphql.client.Generated
+import com.expediagroup.graphql.plugin.client.generator.ULocaleScalarConverter
+import com.fasterxml.jackson.databind.util.StdConverter
+import com.ibm.icu.util.ULocale
+import kotlin.Any
+
+@Generated
+public class AnyToULocaleConverter : StdConverter<Any, ULocale>() {
+  private val converter: ULocaleScalarConverter = ULocaleScalarConverter()
+
+  public override fun convert(`value`: Any): ULocale = converter.toScalar(value)
+}

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/custom_scalars/scalars/ULocaleToAnyConverter.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/custom_scalars/scalars/ULocaleToAnyConverter.kt
@@ -1,0 +1,14 @@
+package com.expediagroup.graphql.generated.scalars
+
+import com.expediagroup.graphql.client.Generated
+import com.expediagroup.graphql.plugin.client.generator.ULocaleScalarConverter
+import com.fasterxml.jackson.databind.util.StdConverter
+import com.ibm.icu.util.ULocale
+import kotlin.Any
+
+@Generated
+public class ULocaleToAnyConverter : StdConverter<ULocale, Any>() {
+  private val converter: ULocaleScalarConverter = ULocaleScalarConverter()
+
+  public override fun convert(`value`: ULocale): Any = converter.toJson(value)
+}

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/interface/interfacewithinlinefragmentsquery/BasicInterface.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/interface/interfacewithinlinefragmentsquery/BasicInterface.kt
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.`annotation`.JsonSubTypes
 import com.fasterxml.jackson.`annotation`.JsonTypeInfo
 import com.fasterxml.jackson.`annotation`.JsonTypeInfo.As.PROPERTY
 import com.fasterxml.jackson.`annotation`.JsonTypeInfo.Id.NAME
-import kotlin.Float
+import kotlin.Double
 import kotlin.Int
 import kotlin.String
 
@@ -69,5 +69,5 @@ public data class SecondInterfaceImplementation(
   /**
    * Custom field float value
    */
-  public val floatValue: Float
+  public val floatValue: Double
 ) : BasicInterface

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/variables/inputs/SimpleArgumentInput.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/variables/inputs/SimpleArgumentInput.kt
@@ -3,7 +3,7 @@ package com.expediagroup.graphql.generated.inputs
 import com.expediagroup.graphql.client.Generated
 import com.expediagroup.graphql.client.jackson.types.OptionalInput
 import com.expediagroup.graphql.client.jackson.types.OptionalInput.Undefined
-import kotlin.Float
+import kotlin.Double
 import kotlin.String
 
 /**
@@ -14,11 +14,11 @@ public data class SimpleArgumentInput(
   /**
    * Maximum value for test criteria
    */
-  public val max: OptionalInput<Float> = OptionalInput.Undefined,
+  public val max: OptionalInput<Double> = OptionalInput.Undefined,
   /**
    * Minimum value for test criteria
    */
-  public val min: OptionalInput<Float> = OptionalInput.Undefined,
+  public val min: OptionalInput<Double> = OptionalInput.Undefined,
   /**
    * New value to be set
    */

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/custom_scalar_input/CustomScalarInputQuery.graphql
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/custom_scalar_input/CustomScalarInputQuery.graphql
@@ -1,0 +1,3 @@
+query CustomScalarInputQuery($requiredLocale: Locale!, $optionalLocale: Locale, $scalarWrapper: ScalarWrapperInput) {
+  inputCustomScalarQuery(requiredLocale: $requiredLocale, optionalLocale: $optionalLocale, scalarWrapper: $scalarWrapper)
+}

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/custom_scalar_input/CustomScalarInputQuery.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/custom_scalar_input/CustomScalarInputQuery.kt
@@ -1,0 +1,49 @@
+package com.expediagroup.graphql.generated
+
+import com.expediagroup.graphql.client.Generated
+import com.expediagroup.graphql.client.types.GraphQLClientRequest
+import com.expediagroup.graphql.generated.inputs.ScalarWrapperInput
+import com.expediagroup.graphql.generated.scalars.ULocaleSerializer
+import com.ibm.icu.util.ULocale
+import kotlin.Boolean
+import kotlin.String
+import kotlin.reflect.KClass
+import kotlinx.serialization.Required
+import kotlinx.serialization.Serializable
+
+public const val CUSTOM_SCALAR_INPUT_QUERY: String =
+    "query CustomScalarInputQuery(${'$'}requiredLocale: Locale!, ${'$'}optionalLocale: Locale, ${'$'}scalarWrapper: ScalarWrapperInput) {\n  inputCustomScalarQuery(requiredLocale: ${'$'}requiredLocale, optionalLocale: ${'$'}optionalLocale, scalarWrapper: ${'$'}scalarWrapper)\n}"
+
+@Generated
+@Serializable
+public class CustomScalarInputQuery(
+  public override val variables: CustomScalarInputQuery.Variables
+) : GraphQLClientRequest<CustomScalarInputQuery.Result> {
+  @Required
+  public override val query: String = CUSTOM_SCALAR_INPUT_QUERY
+
+  @Required
+  public override val operationName: String = "CustomScalarInputQuery"
+
+  public override fun responseType(): KClass<CustomScalarInputQuery.Result> =
+      CustomScalarInputQuery.Result::class
+
+  @Generated
+  @Serializable
+  public data class Variables(
+    @Serializable(with = ULocaleSerializer::class)
+    public val requiredLocale: ULocale,
+    @Serializable(with = ULocaleSerializer::class)
+    public val optionalLocale: ULocale? = null,
+    public val scalarWrapper: ScalarWrapperInput? = null
+  )
+
+  @Generated
+  @Serializable
+  public data class Result(
+    /**
+     * Query that accepts a custom scalar input
+     */
+    public val inputCustomScalarQuery: Boolean
+  )
+}

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/custom_scalar_input/GraphQLTypeAliases.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/custom_scalar_input/GraphQLTypeAliases.kt
@@ -1,0 +1,5 @@
+package com.expediagroup.graphql.generated
+
+import kotlin.String
+
+public typealias ID = String

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/custom_scalar_input/inputs/ScalarWrapperInput.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/custom_scalar_input/inputs/ScalarWrapperInput.kt
@@ -1,0 +1,60 @@
+package com.expediagroup.graphql.generated.inputs
+
+import com.expediagroup.graphql.client.Generated
+import com.expediagroup.graphql.generated.ID
+import com.expediagroup.graphql.generated.scalars.ULocaleSerializer
+import com.expediagroup.graphql.generated.scalars.UUIDSerializer
+import com.ibm.icu.util.ULocale
+import java.util.UUID
+import kotlin.Boolean
+import kotlin.Double
+import kotlin.Int
+import kotlin.String
+import kotlin.collections.List
+import kotlinx.serialization.Serializable
+
+/**
+ * Wrapper that holds all supported scalar types
+ */
+@Generated
+@Serializable
+public data class ScalarWrapperInput(
+  /**
+   * A signed 32-bit nullable integer value
+   */
+  public val count: Int? = null,
+  /**
+   * Custom scalar of UUID
+   */
+  @Serializable(with = UUIDSerializer::class)
+  public val custom: UUID? = null,
+  /**
+   * List of custom scalar UUIDs
+   */
+  public val customList: List<@Serializable(with = UUIDSerializer::class) UUID>? = null,
+  /**
+   * ID represents unique identifier that is not intended to be human readable
+   */
+  public val id: ID,
+  /**
+   * UTF-8 character sequence
+   */
+  public val name: String,
+  /**
+   * A nullable signed double-precision floating-point value
+   */
+  public val rating: Double? = null,
+  /**
+   * Either true or false
+   */
+  public val valid: Boolean,
+  /**
+   * Custom scalar of Locale
+   */
+  @Serializable(with = ULocaleSerializer::class)
+  public val locale: ULocale,
+  /**
+   * List of custom scalar Locales
+   */
+  public val listLocale: List<@Serializable(with = ULocaleSerializer::class) ULocale>
+)

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/custom_scalar_input/scalars/ULocaleSerializer.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/custom_scalar_input/scalars/ULocaleSerializer.kt
@@ -1,0 +1,33 @@
+package com.expediagroup.graphql.generated.scalars
+
+import com.expediagroup.graphql.client.Generated
+import com.expediagroup.graphql.plugin.client.generator.ULocaleScalarConverter
+import com.ibm.icu.util.ULocale
+import kotlin.Unit
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind.STRING
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.jsonPrimitive
+
+@Generated
+public object ULocaleSerializer : KSerializer<ULocale> {
+  private val converter: ULocaleScalarConverter = ULocaleScalarConverter()
+
+  public override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("ULocale", STRING)
+
+  public override fun serialize(encoder: Encoder, `value`: ULocale): Unit {
+    val encoded = converter.toJson(value)
+    encoder.encodeString(encoded.toString())
+  }
+
+  public override fun deserialize(decoder: Decoder): ULocale {
+    val jsonDecoder = decoder as JsonDecoder
+    val element = jsonDecoder.decodeJsonElement()
+    val rawContent = element.jsonPrimitive.content
+    return converter.toScalar(rawContent)
+  }
+}

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/custom_scalar_input/scalars/UUIDSerializer.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/custom_scalar_input/scalars/UUIDSerializer.kt
@@ -1,0 +1,33 @@
+package com.expediagroup.graphql.generated.scalars
+
+import com.expediagroup.graphql.client.Generated
+import com.expediagroup.graphql.plugin.client.generator.UUIDScalarConverter
+import java.util.UUID
+import kotlin.Unit
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind.STRING
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.jsonPrimitive
+
+@Generated
+public object UUIDSerializer : KSerializer<UUID> {
+  private val converter: UUIDScalarConverter = UUIDScalarConverter()
+
+  public override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("UUID", STRING)
+
+  public override fun serialize(encoder: Encoder, `value`: UUID): Unit {
+    val encoded = converter.toJson(value)
+    encoder.encodeString(encoded.toString())
+  }
+
+  public override fun deserialize(decoder: Decoder): UUID {
+    val jsonDecoder = decoder as JsonDecoder
+    val element = jsonDecoder.decodeJsonElement()
+    val rawContent = element.jsonPrimitive.content
+    return converter.toScalar(rawContent)
+  }
+}

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/custom_scalars/CustomScalarQuery.graphql
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/custom_scalars/CustomScalarQuery.graphql
@@ -7,8 +7,9 @@ query CustomScalarQuery {
   }
 }
 fragment scalarSelections on ScalarWrapper {
-  count
+  id
   custom
   customList
-  id
+  locale
+  listLocale
 }

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/custom_scalars/CustomScalarQuery.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/custom_scalars/CustomScalarQuery.kt
@@ -9,7 +9,7 @@ import kotlinx.serialization.Required
 import kotlinx.serialization.Serializable
 
 public const val CUSTOM_SCALAR_QUERY: String =
-    "query CustomScalarQuery {\n  first: scalarQuery {\n    ... scalarSelections\n  }\n  second: scalarQuery {\n    ... scalarSelections\n  }\n}\nfragment scalarSelections on ScalarWrapper {\n  count\n  custom\n  customList\n  id\n}"
+    "query CustomScalarQuery {\n  first: scalarQuery {\n    ... scalarSelections\n  }\n  second: scalarQuery {\n    ... scalarSelections\n  }\n}\nfragment scalarSelections on ScalarWrapper {\n  id\n  custom\n  customList\n  locale\n  listLocale\n}"
 
 @Generated
 @Serializable

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/custom_scalars/customscalarquery/ScalarWrapper.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/custom_scalars/customscalarquery/ScalarWrapper.kt
@@ -2,9 +2,10 @@ package com.expediagroup.graphql.generated.customscalarquery
 
 import com.expediagroup.graphql.client.Generated
 import com.expediagroup.graphql.generated.ID
+import com.expediagroup.graphql.generated.scalars.ULocaleSerializer
 import com.expediagroup.graphql.generated.scalars.UUIDSerializer
+import com.ibm.icu.util.ULocale
 import java.util.UUID
-import kotlin.Int
 import kotlin.collections.List
 import kotlinx.serialization.Serializable
 
@@ -15,20 +16,25 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class ScalarWrapper(
   /**
-   * A signed 32-bit nullable integer value
-   */
-  public val count: Int?,
-  /**
-   * Custom scalar
-   */
-  @Serializable(with = UUIDSerializer::class)
-  public val custom: UUID,
-  /**
-   * List of custom scalars
-   */
-  public val customList: List<@Serializable(with = UUIDSerializer::class) UUID>,
-  /**
    * ID represents unique identifier that is not intended to be human readable
    */
-  public val id: ID
+  public val id: ID,
+  /**
+   * Custom scalar of UUID
+   */
+  @Serializable(with = UUIDSerializer::class)
+  public val custom: UUID?,
+  /**
+   * List of custom scalar UUIDs
+   */
+  public val customList: List<@Serializable(with = UUIDSerializer::class) UUID>?,
+  /**
+   * Custom scalar of Locale
+   */
+  @Serializable(with = ULocaleSerializer::class)
+  public val locale: ULocale,
+  /**
+   * List of custom scalar Locales
+   */
+  public val listLocale: List<@Serializable(with = ULocaleSerializer::class) ULocale>
 )

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/custom_scalars/scalars/ULocaleSerializer.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/custom_scalars/scalars/ULocaleSerializer.kt
@@ -1,0 +1,33 @@
+package com.expediagroup.graphql.generated.scalars
+
+import com.expediagroup.graphql.client.Generated
+import com.expediagroup.graphql.plugin.client.generator.ULocaleScalarConverter
+import com.ibm.icu.util.ULocale
+import kotlin.Unit
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind.STRING
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.jsonPrimitive
+
+@Generated
+public object ULocaleSerializer : KSerializer<ULocale> {
+  private val converter: ULocaleScalarConverter = ULocaleScalarConverter()
+
+  public override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("ULocale", STRING)
+
+  public override fun serialize(encoder: Encoder, `value`: ULocale): Unit {
+    val encoded = converter.toJson(value)
+    encoder.encodeString(encoded.toString())
+  }
+
+  public override fun deserialize(decoder: Decoder): ULocale {
+    val jsonDecoder = decoder as JsonDecoder
+    val element = jsonDecoder.decodeJsonElement()
+    val rawContent = element.jsonPrimitive.content
+    return converter.toScalar(rawContent)
+  }
+}

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/interface/interfacewithinlinefragmentsquery/BasicInterface.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/interface/interfacewithinlinefragmentsquery/BasicInterface.kt
@@ -1,7 +1,7 @@
 package com.expediagroup.graphql.generated.interfacewithinlinefragmentsquery
 
 import com.expediagroup.graphql.client.Generated
-import kotlin.Float
+import kotlin.Double
 import kotlin.Int
 import kotlin.String
 import kotlinx.serialization.SerialName
@@ -63,5 +63,5 @@ public data class SecondInterfaceImplementation(
   /**
    * Custom field float value
    */
-  public val floatValue: Float
+  public val floatValue: Double
 ) : BasicInterface()

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/multiple_queries/firstquery/BasicInterface.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/multiple_queries/firstquery/BasicInterface.kt
@@ -1,7 +1,7 @@
 package com.expediagroup.graphql.generated.firstquery
 
 import com.expediagroup.graphql.client.Generated
-import kotlin.Float
+import kotlin.Double
 import kotlin.Int
 import kotlin.String
 import kotlinx.serialization.SerialName
@@ -63,5 +63,5 @@ public data class SecondInterfaceImplementation(
   /**
    * Custom field float value
    */
-  public val floatValue: Float
+  public val floatValue: Double
 ) : BasicInterface()

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/multiple_queries/firstquery/ScalarWrapper.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/multiple_queries/firstquery/ScalarWrapper.kt
@@ -18,10 +18,10 @@ public data class ScalarWrapper(
    */
   public val count: Int?,
   /**
-   * Custom scalar
+   * Custom scalar of UUID
    */
   @Serializable(with = UUIDSerializer::class)
-  public val custom: UUID,
+  public val custom: UUID?,
   /**
    * ID represents unique identifier that is not intended to be human readable
    */

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/multiple_queries/inputs/ComplexArgumentInput.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/multiple_queries/inputs/ComplexArgumentInput.kt
@@ -1,7 +1,7 @@
 package com.expediagroup.graphql.generated.inputs
 
 import com.expediagroup.graphql.client.Generated
-import kotlin.Float
+import kotlin.Double
 import kotlinx.serialization.Serializable
 
 /**
@@ -13,11 +13,11 @@ public data class ComplexArgumentInput(
   /**
    * Maximum value for test criteria
    */
-  public val max: Float? = null,
+  public val max: Double? = null,
   /**
    * Minimum value for test criteria
    */
-  public val min: Float? = null,
+  public val min: Double? = null,
   /**
    * Next criteria
    */

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/multiple_queries/secondquery/BasicInterface.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/multiple_queries/secondquery/BasicInterface.kt
@@ -1,7 +1,7 @@
 package com.expediagroup.graphql.generated.secondquery
 
 import com.expediagroup.graphql.client.Generated
-import kotlin.Float
+import kotlin.Double
 import kotlin.Int
 import kotlin.String
 import kotlinx.serialization.SerialName
@@ -63,5 +63,5 @@ public data class SecondInterfaceImplementation(
   /**
    * Custom field float value
    */
-  public val floatValue: Float
+  public val floatValue: Double
 ) : BasicInterface()

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/multiple_queries/secondquery/ScalarWrapper.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/multiple_queries/secondquery/ScalarWrapper.kt
@@ -18,10 +18,10 @@ public data class ScalarWrapper(
    */
   public val count: Int?,
   /**
-   * Custom scalar
+   * Custom scalar of UUID
    */
   @Serializable(with = UUIDSerializer::class)
-  public val custom: UUID,
+  public val custom: UUID?,
   /**
    * ID represents unique identifier that is not intended to be human readable
    */

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/variables/inputs/SimpleArgumentInput.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/variables/inputs/SimpleArgumentInput.kt
@@ -1,7 +1,7 @@
 package com.expediagroup.graphql.generated.inputs
 
 import com.expediagroup.graphql.client.Generated
-import kotlin.Float
+import kotlin.Double
 import kotlin.String
 import kotlinx.serialization.Serializable
 
@@ -14,11 +14,11 @@ public data class SimpleArgumentInput(
   /**
    * Maximum value for test criteria
    */
-  public val max: Float? = null,
+  public val max: Double? = null,
   /**
    * Minimum value for test criteria
    */
-  public val min: Float? = null,
+  public val min: Double? = null,
   /**
    * New value to be set
    */

--- a/plugins/client/graphql-kotlin-client-generator/src/test/kotlin/com/expediagroup/graphql/plugin/client/generator/GenerateInvalidClientIT.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/kotlin/com/expediagroup/graphql/plugin/client/generator/GenerateInvalidClientIT.kt
@@ -33,7 +33,15 @@ class GenerateInvalidClientIT {
         val (queries, _) = locateTestFiles(testDirectory)
         val expectedException = File(testDirectory, "exception.txt").readText().trim()
 
-        val generator = GraphQLClientGenerator(TEST_SCHEMA_PATH, defaultConfig)
+        val config = defaultConfig.copy(
+            serializer = GraphQLSerializer.JACKSON,
+            customScalarMap = mapOf(
+                "UUID" to GraphQLScalar("UUID", "java.util.UUID", "com.expediagroup.graphql.plugin.client.generator.UUIDScalarConverter"),
+                "Locale" to GraphQLScalar("Locale", "com.ibm.icu.util.ULocale", "com.expediagroup.graphql.plugin.client.generator.ULocaleScalarConverter")
+            ),
+            useOptionalInputWrapper = true
+        )
+        val generator = GraphQLClientGenerator(TEST_SCHEMA_PATH, config)
         val exception = assertFails {
             generator.generate(queries)
         }

--- a/plugins/client/graphql-kotlin-client-generator/src/test/kotlin/com/expediagroup/graphql/plugin/client/generator/GenerateJacksonClientIT.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/kotlin/com/expediagroup/graphql/plugin/client/generator/GenerateJacksonClientIT.kt
@@ -27,8 +27,11 @@ class GenerateJacksonClientIT {
     @MethodSource("jacksonTests")
     fun `verify generation of client code using jackson`(testDirectory: File) {
         val config = defaultConfig.copy(
+            customScalarMap = mapOf(
+                "UUID" to GraphQLScalar("UUID", "java.util.UUID", "com.expediagroup.graphql.plugin.client.generator.UUIDScalarConverter"),
+                "Locale" to GraphQLScalar("Locale", "com.ibm.icu.util.ULocale", "com.expediagroup.graphql.plugin.client.generator.ULocaleScalarConverter")
+            ),
             serializer = GraphQLSerializer.JACKSON,
-            customScalarMap = mapOf("UUID" to GraphQLScalar("UUID", "java.util.UUID", "com.expediagroup.graphql.plugin.client.generator.UUIDScalarConverter")),
             useOptionalInputWrapper = true
         )
         verifyClientGeneration(config, testDirectory)

--- a/plugins/client/graphql-kotlin-client-generator/src/test/kotlin/com/expediagroup/graphql/plugin/client/generator/GenerateKotlinxClientIT.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/kotlin/com/expediagroup/graphql/plugin/client/generator/GenerateKotlinxClientIT.kt
@@ -28,7 +28,10 @@ class GenerateKotlinxClientIT {
     fun `verify generation of client code using kotlinx serialization`(testDirectory: File) {
         val config = defaultConfig.copy(
             allowDeprecated = true,
-            customScalarMap = mapOf("UUID" to GraphQLScalar("UUID", "java.util.UUID", "com.expediagroup.graphql.plugin.client.generator.UUIDScalarConverter")),
+            customScalarMap = mapOf(
+                "UUID" to GraphQLScalar("UUID", "java.util.UUID", "com.expediagroup.graphql.plugin.client.generator.UUIDScalarConverter"),
+                "Locale" to GraphQLScalar("Locale", "com.ibm.icu.util.ULocale", "com.expediagroup.graphql.plugin.client.generator.ULocaleScalarConverter")
+            ),
             serializer = GraphQLSerializer.KOTLINX
         )
         verifyClientGeneration(config, testDirectory)

--- a/plugins/client/graphql-kotlin-client-generator/src/test/kotlin/com/expediagroup/graphql/plugin/client/generator/GraphQLTestUtils.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/kotlin/com/expediagroup/graphql/plugin/client/generator/GraphQLTestUtils.kt
@@ -17,6 +17,7 @@
 package com.expediagroup.graphql.plugin.client.generator
 
 import com.expediagroup.graphql.client.converter.ScalarConverter
+import com.ibm.icu.util.ULocale
 import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.SourceFile
 import org.junit.jupiter.params.provider.Arguments
@@ -82,4 +83,9 @@ internal fun verifyClientGeneration(config: GraphQLClientGeneratorConfig, testDi
 class UUIDScalarConverter : ScalarConverter<UUID> {
     override fun toScalar(rawValue: Any): UUID = UUID.fromString(rawValue.toString())
     override fun toJson(value: UUID): String = value.toString()
+}
+
+class ULocaleScalarConverter : ScalarConverter<ULocale> {
+    override fun toScalar(rawValue: Any): ULocale = ULocale(rawValue.toString())
+    override fun toJson(value: ULocale): Any = value.toString()
 }

--- a/plugins/client/graphql-kotlin-client-generator/src/test/resources/testSchema.graphql
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/resources/testSchema.graphql
@@ -96,6 +96,8 @@ type Query {
   otherEnumQuery: OtherEnum!
   "Query that accepts some input arguments"
   inputObjectQuery(criteria: SimpleArgumentInput!): Boolean!
+  "Query that accepts a custom scalar input"
+  inputCustomScalarQuery(requiredLocale: Locale!, optionalLocale: Locale, scalarWrapper: ScalarWrapperInput): Boolean!
   "Query returning an interface"
   interfaceQuery: BasicInterface!
   "Query returning list of simple objects"
@@ -115,10 +117,10 @@ type Query {
 type ScalarWrapper {
   "A signed 32-bit nullable integer value"
   count: Int
-  "Custom scalar"
-  custom: UUID!
-  "List of custom scalars"
-  customList: [UUID!]!
+  "Custom scalar of UUID"
+  custom: UUID
+  "List of custom scalar UUIDs"
+  customList: [UUID!]
   "ID represents unique identifier that is not intended to be human readable"
   id: ID!
   "UTF-8 character sequence"
@@ -185,4 +187,25 @@ input ComplexArgumentInput {
   min: Float
   "Next criteria"
   next: ComplexArgumentInput
+}
+"Wrapper that holds all supported scalar types"
+input ScalarWrapperInput {
+    "A signed 32-bit nullable integer value"
+    count: Int
+    "Custom scalar of UUID"
+    custom: UUID
+    "List of custom scalar UUIDs"
+    customList: [UUID!]
+    "ID represents unique identifier that is not intended to be human readable"
+    id: ID!
+    "UTF-8 character sequence"
+    name: String!
+    "A nullable signed double-precision floating-point value"
+    rating: Float
+    "Either true or false"
+    valid: Boolean!
+    "Custom scalar of Locale"
+    locale: Locale!
+    "List of custom scalar Locales"
+    listLocale: [Locale!]!
 }

--- a/plugins/graphql-kotlin-gradle-plugin/src/integration/client-generator/custom_scalars/build.gradle.kts
+++ b/plugins/graphql-kotlin-gradle-plugin/src/integration/client-generator/custom_scalars/build.gradle.kts
@@ -1,0 +1,79 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import com.expediagroup.graphql.plugin.gradle.config.GraphQLScalar
+import com.expediagroup.graphql.plugin.gradle.tasks.GraphQLGenerateSDLTask
+import com.expediagroup.graphql.plugin.gradle.tasks.GraphQLGenerateTestClientTask
+
+buildscript {
+    repositories {
+        mavenLocal {
+            content {
+                includeGroup("com.expediagroup")
+            }
+        }
+    }
+
+    val graphQLKotlinVersion = System.getenv("GRAPHQL_KOTLIN_VERSION") ?: "5.0.0-SNAPSHOT"
+    dependencies {
+        classpath("com.expediagroup:graphql-kotlin-gradle-plugin:$graphQLKotlinVersion")
+    }
+}
+
+plugins {
+    id("org.springframework.boot") version "2.5.3"
+    kotlin("jvm") version "1.5.20"
+    kotlin("plugin.spring") version "1.5.20"
+}
+
+apply(plugin = "com.expediagroup.graphql")
+
+group = "com.expediagroup"
+version = "0.0.1-SNAPSHOT"
+
+repositories {
+    mavenCentral()
+    mavenLocal {
+        content {
+            includeGroup("com.expediagroup")
+        }
+    }
+}
+
+val graphQLKotlinVersion = System.getenv("GRAPHQL_KOTLIN_VERSION") ?: "5.0.0-SNAPSHOT"
+val icuVersion = System.getenv("ICU_VERSION") ?: "69.1"
+val junitVersion = System.getenv("JUNIT_VERSION") ?: "5.7.2"
+val kotlinVersion = System.getenv("KOTLIN_VERSION") ?: "1.5.20"
+val springBootVersion = System.getenv("SPRINGBOOT_VERSION") ?: "2.5.3"
+dependencies {
+    implementation("com.expediagroup:graphql-kotlin-hooks-provider:$graphQLKotlinVersion")
+    implementation("com.expediagroup:graphql-kotlin-spring-client:$graphQLKotlinVersion")
+    implementation("com.expediagroup:graphql-kotlin-spring-server:$graphQLKotlinVersion")
+    implementation("com.ibm.icu:icu4j:$icuVersion")
+    testImplementation(kotlin("test-junit5", kotlinVersion))
+    testImplementation("org.junit.jupiter:junit-jupiter-api:$junitVersion")
+    testImplementation("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
+    testImplementation("org.springframework.boot:spring-boot-starter-test:$springBootVersion")
+}
+
+tasks.withType<KotlinCompile> {
+    kotlinOptions {
+        freeCompilerArgs = listOf("-Xjsr305=strict")
+        jvmTarget = "11"
+    }
+}
+
+tasks.withType<Test> {
+    useJUnitPlatform()
+}
+
+val graphqlGenerateSDL by tasks.getting(GraphQLGenerateSDLTask::class) {
+    packages.set(listOf("com.expediagroup.scalars"))
+}
+val graphqlGenerateTestClient by tasks.getting(GraphQLGenerateTestClientTask::class) {
+    packageName.set("com.expediagroup.scalars.generated")
+    schemaFile.set(graphqlGenerateSDL.schemaFile)
+    useOptionalInputWrapper.set(true)
+
+    // custom scalars
+    customScalars.add(GraphQLScalar("UUID", "java.util.UUID", "com.expediagroup.scalars.converters.UUIDScalarConverter"))
+    customScalars.add(GraphQLScalar("Locale", "com.ibm.icu.util.ULocale", "com.expediagroup.scalars.converters.ULocaleScalarConverter"))
+}

--- a/plugins/graphql-kotlin-gradle-plugin/src/integration/client-generator/custom_scalars/settings.gradle.kts
+++ b/plugins/graphql-kotlin-gradle-plugin/src/integration/client-generator/custom_scalars/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "custom-scalars-test"

--- a/plugins/graphql-kotlin-gradle-plugin/src/integration/client-generator/custom_scalars/src/main/kotlin/com/expediagroup/scalars/Application.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/integration/client-generator/custom_scalars/src/main/kotlin/com/expediagroup/scalars/Application.kt
@@ -1,0 +1,17 @@
+package com.expediagroup.scalars
+
+import com.expediagroup.graphql.generator.hooks.SchemaGeneratorHooks
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+import org.springframework.context.annotation.Bean
+
+@SpringBootApplication
+class Application {
+
+    @Bean
+    fun customHooks(): SchemaGeneratorHooks = CustomScalarHooks
+}
+
+fun main(args: Array<String>) {
+    runApplication<Application>(*args)
+}

--- a/plugins/graphql-kotlin-gradle-plugin/src/integration/client-generator/custom_scalars/src/main/kotlin/com/expediagroup/scalars/CustomScalarHooks.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/integration/client-generator/custom_scalars/src/main/kotlin/com/expediagroup/scalars/CustomScalarHooks.kt
@@ -1,0 +1,22 @@
+package com.expediagroup.scalars
+
+import com.expediagroup.graphql.generator.hooks.SchemaGeneratorHooks
+import com.expediagroup.graphql.plugin.schema.hooks.SchemaGeneratorHooksProvider
+import com.expediagroup.scalars.types.graphqlLocaleType
+import com.expediagroup.scalars.types.graphqlUUIDType
+import com.ibm.icu.util.ULocale
+import graphql.schema.GraphQLType
+import java.util.UUID
+import kotlin.reflect.KType
+
+object CustomScalarHooks : SchemaGeneratorHooks {
+    override fun willGenerateGraphQLType(type: KType): GraphQLType? = when (type.classifier) {
+        ULocale::class -> graphqlLocaleType
+        UUID::class -> graphqlUUIDType
+        else -> null
+    }
+}
+
+class CustomScalarHooksProvider : SchemaGeneratorHooksProvider {
+    override fun hooks(): SchemaGeneratorHooks = CustomScalarHooks
+}

--- a/plugins/graphql-kotlin-gradle-plugin/src/integration/client-generator/custom_scalars/src/main/kotlin/com/expediagroup/scalars/ScalarQuery.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/integration/client-generator/custom_scalars/src/main/kotlin/com/expediagroup/scalars/ScalarQuery.kt
@@ -1,0 +1,32 @@
+package com.expediagroup.scalars
+
+import com.expediagroup.graphql.generator.scalars.ID
+import com.expediagroup.graphql.server.operations.Query
+import com.ibm.icu.util.ULocale
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import java.util.UUID
+import kotlin.random.Random
+
+@Component
+class ScalarQuery : Query {
+
+    private val logger: Logger = LoggerFactory.getLogger(ScalarQuery::class.java)
+    private val random: Random = Random(1337)
+
+    fun scalarQuery(required: ULocale, optional: ULocale? = null, wrapper: ScalarWrapper? = null): ScalarWrapper {
+        logger.info("received: required $required, optional $optional, wrapper $wrapper")
+        return wrapper ?: ScalarWrapper(
+            count = random.nextInt(),
+            id = ID(random.nextInt().toString()),
+            name = "test",
+            locale = ULocale.US,
+            localeList = listOf(ULocale.UK, ULocale.FRANCE),
+            rating = random.nextDouble(),
+            uuid = UUID.randomUUID(),
+            uuidList = listOf(UUID.randomUUID()),
+            valid = random.nextBoolean()
+        )
+    }
+}

--- a/plugins/graphql-kotlin-gradle-plugin/src/integration/client-generator/custom_scalars/src/main/kotlin/com/expediagroup/scalars/ScalarWrapper.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/integration/client-generator/custom_scalars/src/main/kotlin/com/expediagroup/scalars/ScalarWrapper.kt
@@ -1,0 +1,27 @@
+package com.expediagroup.scalars
+
+import com.expediagroup.graphql.generator.scalars.ID
+import com.ibm.icu.util.ULocale
+import java.util.UUID
+
+/** Wrapper that holds all supported scalar types */
+data class ScalarWrapper(
+    /** A signed 32-bit nullable integer value */
+    val count: Int? = null,
+    /** ID represents unique identifier that is not intended to be human readable */
+    val id: ID,
+    /** UTF-8 character sequence */
+    val name: String,
+    /** Custom scalar of Locale */
+    val locale: ULocale,
+    /** List of custom scalar Locales */
+    val localeList: List<ULocale>,
+    /** A nullable signed double-precision floating-point value */
+    val rating: Double? = null,
+    /** Custom scalar of UUID */
+    val uuid: UUID? = null,
+    /** List of custom scalar UUIDs */
+    val uuidList: List<UUID>? = null,
+    /** Either true or false */
+    val valid: Boolean = true
+)

--- a/plugins/graphql-kotlin-gradle-plugin/src/integration/client-generator/custom_scalars/src/main/kotlin/com/expediagroup/scalars/types/graphqlLocaleType.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/integration/client-generator/custom_scalars/src/main/kotlin/com/expediagroup/scalars/types/graphqlLocaleType.kt
@@ -1,0 +1,27 @@
+package com.expediagroup.scalars.types
+
+import com.ibm.icu.util.ULocale
+import graphql.language.StringValue
+import graphql.schema.Coercing
+import graphql.schema.CoercingParseLiteralException
+import graphql.schema.CoercingParseValueException
+import graphql.schema.CoercingSerializeException
+import graphql.schema.GraphQLScalarType
+import java.util.UUID
+
+// We coerce between <String, String> due to a secondary deserialization from Jackson
+// see: https://github.com/ExpediaGroup/graphql-kotlin/issues/1220
+val graphqlLocaleType: GraphQLScalarType = GraphQLScalarType.newScalar()
+    .name("Locale")
+    .description("A type representing a Locale such as en_US or fr_FR")
+    .coercing(object : Coercing<String, String> {
+        override fun parseValue(input: Any): String = input.toString()
+
+        override fun parseLiteral(input: Any): String {
+            val locale = (input as? StringValue)?.value
+            return locale ?: throw CoercingParseLiteralException("Expected valid Locale literal but was $locale")
+        }
+
+        override fun serialize(dataFetcherResult: Any): String = dataFetcherResult.toString()
+    })
+    .build()

--- a/plugins/graphql-kotlin-gradle-plugin/src/integration/client-generator/custom_scalars/src/main/kotlin/com/expediagroup/scalars/types/graphqlUUIDType.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/integration/client-generator/custom_scalars/src/main/kotlin/com/expediagroup/scalars/types/graphqlUUIDType.kt
@@ -1,0 +1,36 @@
+package com.expediagroup.scalars.types
+
+import graphql.language.StringValue
+import graphql.schema.Coercing
+import graphql.schema.CoercingParseLiteralException
+import graphql.schema.CoercingParseValueException
+import graphql.schema.CoercingSerializeException
+import graphql.schema.GraphQLScalarType
+import java.util.UUID
+
+val graphqlUUIDType: GraphQLScalarType = GraphQLScalarType.newScalar()
+    .name("UUID")
+    .description("A type representing a formatted java.util.UUID")
+    .coercing(object : Coercing<UUID, String> {
+        override fun parseValue(input: Any): UUID = runCatching {
+            UUID.fromString(serialize(input))
+        }.getOrElse {
+            throw CoercingParseValueException("Expected valid UUID but was $input")
+        }
+
+        override fun parseLiteral(input: Any): UUID {
+            val uuidString = (input as? StringValue)?.value
+            return runCatching {
+                UUID.fromString(uuidString)
+            }.getOrElse {
+                throw CoercingParseLiteralException("Expected valid UUID literal but was $uuidString")
+            }
+        }
+
+        override fun serialize(dataFetcherResult: Any): String = runCatching {
+            dataFetcherResult.toString()
+        }.getOrElse {
+            throw CoercingSerializeException("Data fetcher result $dataFetcherResult cannot be serialized to a String")
+        }
+    })
+    .build()

--- a/plugins/graphql-kotlin-gradle-plugin/src/integration/client-generator/custom_scalars/src/main/resources/META-INF/services/com.expediagroup.graphql.plugin.schema.hooks.SchemaGeneratorHooksProvider
+++ b/plugins/graphql-kotlin-gradle-plugin/src/integration/client-generator/custom_scalars/src/main/resources/META-INF/services/com.expediagroup.graphql.plugin.schema.hooks.SchemaGeneratorHooksProvider
@@ -1,0 +1,1 @@
+com.expediagroup.scalars.CustomScalarHooksProvider

--- a/plugins/graphql-kotlin-gradle-plugin/src/integration/client-generator/custom_scalars/src/main/resources/application.yml
+++ b/plugins/graphql-kotlin-gradle-plugin/src/integration/client-generator/custom_scalars/src/main/resources/application.yml
@@ -1,0 +1,3 @@
+graphql:
+  packages:
+    - "com.expediagroup.scalars"

--- a/plugins/graphql-kotlin-gradle-plugin/src/integration/client-generator/custom_scalars/src/test/kotlin/com/expediagroup/scalars/CustomScalarApplicationTests.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/integration/client-generator/custom_scalars/src/test/kotlin/com/expediagroup/scalars/CustomScalarApplicationTests.kt
@@ -1,0 +1,55 @@
+package com.expediagroup.scalars
+
+import com.expediagroup.graphql.client.jackson.types.OptionalInput
+import com.expediagroup.graphql.client.spring.GraphQLWebClient
+import com.expediagroup.scalars.generated.CustomScalarQuery
+import com.expediagroup.scalars.generated.inputs.ScalarWrapperInput
+import com.ibm.icu.util.ULocale
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.web.server.LocalServerPort
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class CustomScalarApplicationTests(@LocalServerPort private val port: Int) {
+
+    @Test
+    fun `verify custom scalars are correctly serialized and deserialized`() = runBlocking {
+        val client = GraphQLWebClient(url = "http://localhost:$port/graphql")
+
+        val wrapperInput = ScalarWrapperInput(
+            id = "123456789abcdef",
+            locale = ULocale.US,
+            localeList = listOf(ULocale.FRANCE, ULocale.UK),
+            name = "junit_test",
+            rating = OptionalInput.Defined(1.2345),
+            uuid = UUID.randomUUID(),
+            uuidList = listOf(UUID.randomUUID()),
+            valid = true
+        )
+
+        val query = CustomScalarQuery(variables = CustomScalarQuery.Variables(
+            required = ULocale.US,
+            optional = null,
+            wrapper = OptionalInput.Defined(wrapperInput)
+        ))
+
+        val response = client.execute(query)
+        val wrapperResponse = response.data?.scalarQuery
+        assertNotNull(wrapperResponse)
+
+        assertNull(wrapperResponse.count)
+        assertEquals(wrapperInput.id, wrapperResponse.id)
+        assertEquals(wrapperInput.localeList, wrapperResponse.localeList)
+        assertEquals(wrapperInput.name, wrapperResponse.name)
+        assertEquals((wrapperInput.rating as? OptionalInput.Defined<Double>)?.value, wrapperResponse.rating)
+        assertEquals(wrapperInput.uuid, wrapperResponse.uuid)
+        assertEquals(wrapperInput.uuidList, wrapperResponse.uuidList)
+        assertEquals(wrapperInput.valid, wrapperResponse.valid)
+    }
+
+}

--- a/plugins/graphql-kotlin-gradle-plugin/src/integration/client-generator/custom_scalars/src/test/kotlin/com/expediagroup/scalars/converters/ULocaleScalarConverter.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/integration/client-generator/custom_scalars/src/test/kotlin/com/expediagroup/scalars/converters/ULocaleScalarConverter.kt
@@ -1,0 +1,9 @@
+package com.expediagroup.scalars.converters
+
+import com.expediagroup.graphql.client.converter.ScalarConverter
+import com.ibm.icu.util.ULocale
+
+class ULocaleScalarConverter : ScalarConverter<ULocale> {
+    override fun toScalar(rawValue: Any): ULocale = ULocale(rawValue.toString())
+    override fun toJson(value: ULocale): Any = value.toString()
+}

--- a/plugins/graphql-kotlin-gradle-plugin/src/integration/client-generator/custom_scalars/src/test/kotlin/com/expediagroup/scalars/converters/UUIDScalarConverter.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/integration/client-generator/custom_scalars/src/test/kotlin/com/expediagroup/scalars/converters/UUIDScalarConverter.kt
@@ -1,0 +1,9 @@
+package com.expediagroup.scalars.converters
+
+import com.expediagroup.graphql.client.converter.ScalarConverter
+import java.util.UUID
+
+class UUIDScalarConverter : ScalarConverter<UUID> {
+    override fun toScalar(rawValue: Any): UUID = UUID.fromString(rawValue.toString())
+    override fun toJson(value: UUID): String = value.toString()
+}

--- a/plugins/graphql-kotlin-gradle-plugin/src/integration/client-generator/custom_scalars/src/test/resources/CustomScalarsQuery.graphql
+++ b/plugins/graphql-kotlin-gradle-plugin/src/integration/client-generator/custom_scalars/src/test/resources/CustomScalarsQuery.graphql
@@ -1,0 +1,17 @@
+query CustomScalarQuery(
+    $required: Locale!
+    $optional: Locale
+    $wrapper: ScalarWrapperInput
+) {
+    scalarQuery(required: $required, optional: $optional, wrapper: $wrapper) {
+        count
+        id
+        locale
+        localeList
+        name
+        rating
+        uuid
+        uuidList
+        valid
+    }
+}

--- a/plugins/graphql-kotlin-gradle-plugin/src/integration/client-generator/jacoco/src/test/kotlin/com/expediagroup/jacoco/FooTest.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/integration/client-generator/jacoco/src/test/kotlin/com/expediagroup/jacoco/FooTest.kt
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test
 class FooTest {
 
     @Test
-    fun `simple test for 0`() = runBlocking {
+    fun `simple test for excluding generated code from coverage`() = runBlocking {
         val mockkClient = mockk<GraphQLWebClient> {
             coEvery { execute(any<GraphQLClientRequest<String>>(), any()) } returns JacksonGraphQLResponse(data = "Bar")
         }

--- a/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGenerateClientIT.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGenerateClientIT.kt
@@ -16,7 +16,6 @@
 
 package com.expediagroup.graphql.plugin.gradle
 
-import com.expediagroup.graphql.plugin.gradle.tasks.GENERATE_CLIENT_TASK_NAME
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
 import org.junit.jupiter.api.io.TempDir
@@ -52,7 +51,7 @@ class GraphQLGenerateClientIT {
             .forwardOutput()
             .build()
 
-        assertEquals(TaskOutcome.SUCCESS, buildResult.task(":$GENERATE_CLIENT_TASK_NAME")?.outcome)
+        assertEquals(TaskOutcome.SUCCESS, buildResult.task(":build")?.outcome)
     }
 
     companion object {

--- a/website/docs/client/client-customization.mdx
+++ b/website/docs/client/client-customization.mdx
@@ -127,6 +127,10 @@ deprecated fields. This ensures that your clients have to explicitly opt-in into
 
 ## Custom GraphQL Scalars
 
+:::note
+Optional input wrappers are currently not supported for custom scalars.
+:::
+
 By default, custom GraphQL scalars are serialized and [type-aliased](https://kotlinlang.org/docs/reference/type-aliases.html)
 to a String. GraphQL Kotlin plugins also support custom serialization based on provided configuration.
 

--- a/website/docs/client/client-features.mdx
+++ b/website/docs/client/client-features.mdx
@@ -208,6 +208,10 @@ val results: List<GraphQLResponse<*>> = client.execute(listOf(firstQuery, second
 
 ## Optional Input Support
 
+:::note
+Optional input wrappers are currently not supported for custom scalars.
+:::
+
 In the GraphQL world, input types can be optional which means that the client can specify a value, specify a `null` value
 OR don't specify any value. This is in contrast with the JVM world where objects can either have some specific value or
 don't have any value (i.e. are `null`). By default, GraphQL Kotlin Client treats `null` Kotlin values as unspecified, which


### PR DESCRIPTION
### :pencil: Description

Update client generation logic to correctly annotate custom scalars when they are used as input fields. Due to the extra wrapper layer, optional input functionality is not supported with custom scalars at this point.

This PR also fixes client generation logic to map GraphQL Floats to Kotlin Double (instead of a Float).

### :link: Related Issues

* * partially resolves #1263