### PR TITLE
[build] set target Java 8 in Gradle metadata

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -93,9 +93,10 @@ subprojects {
             // NOTE: in order to run gradle and maven plugin integration tests we need to have our build artifacts available in local repo
             finalizedBy("publishToMavenLocal")
         }
-        test {
-            useJUnitPlatform()
-            finalizedBy(jacocoTestReport)
+        java {
+            // even though we don't have any Java code, since we are building using Java LTS version,
+            // this is required for Gradle to set the correct JVM versions in the module metadata
+            targetCompatibility = JavaVersion.VERSION_1_8
         }
 
         // published artifacts
@@ -166,6 +167,11 @@ subprojects {
             val signingPassword: String? = System.getenv("GPG_PASSPHRASE")
             useInMemoryPgpKeys(signingKey, signingPassword)
             sign(publishing.publications)
+        }
+
+        test {
+            useJUnitPlatform()
+            finalizedBy(jacocoTestReport)
         }
     }
 


### PR DESCRIPTION
### :pencil: Description

With the switch to build and release using Java 11 we did not verify whether projects would still work with Java 8. While we were targeting Java 8 with Kotlin compiler, Gradle was still populating module metadata with the target JVM version that was used for the build.

### :link: Related Issues

Resolves: https://github.com/ExpediaGroup/graphql-kotlin/issues/1269