### PR TITLE
Improve errors for unions

### DIFF
--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/exceptions/InvalidUnionException.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/exceptions/InvalidUnionException.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2021 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.generator.exceptions
+
+class InvalidUnionException(type: String) : GraphQLKotlinException("The type $type was specified as a union but had no implementations. A Union type must define one or more member types.")

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateUnion.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateUnion.kt
@@ -18,6 +18,7 @@ package com.expediagroup.graphql.generator.internal.types
 
 import com.expediagroup.graphql.generator.SchemaGenerator
 import com.expediagroup.graphql.generator.annotations.GraphQLUnion
+import com.expediagroup.graphql.generator.exceptions.InvalidUnionException
 import com.expediagroup.graphql.generator.extensions.unwrapType
 import com.expediagroup.graphql.generator.internal.extensions.getGraphQLDescription
 import com.expediagroup.graphql.generator.internal.extensions.getSimpleName
@@ -49,7 +50,7 @@ private fun generateUnionFromAnnotation(generator: SchemaGenerator, unionAnnotat
 
     val possibleTypes = unionAnnotation.possibleTypes.toList()
 
-    return createUnion(generator, builder, possibleTypes)
+    return createUnion(unionName, generator, builder, possibleTypes)
 }
 
 private fun generateUnionFromKClass(generator: SchemaGenerator, kClass: KClass<*>): GraphQLUnionType {
@@ -66,10 +67,14 @@ private fun generateUnionFromKClass(generator: SchemaGenerator, kClass: KClass<*
 
     val types = generator.classScanner.getSubTypesOf(kClass)
 
-    return createUnion(generator, builder, types)
+    return createUnion(name, generator, builder, types)
 }
 
-private fun createUnion(generator: SchemaGenerator, builder: GraphQLUnionType.Builder, types: List<KClass<*>>): GraphQLUnionType {
+private fun createUnion(typeName: String, generator: SchemaGenerator, builder: GraphQLUnionType.Builder, types: List<KClass<*>>): GraphQLUnionType {
+    if (types.isEmpty()) {
+        throw InvalidUnionException(typeName)
+    }
+
     types.map { generateGraphQLType(generator, it.createType()) }
         .forEach {
             when (val unwrappedType = it.unwrapType()) {

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/types/GenerateUnionTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/types/GenerateUnionTest.kt
@@ -20,6 +20,7 @@ import com.expediagroup.graphql.generator.annotations.GraphQLDescription
 import com.expediagroup.graphql.generator.annotations.GraphQLName
 import com.expediagroup.graphql.generator.annotations.GraphQLUnion
 import com.expediagroup.graphql.generator.exceptions.InvalidGraphQLNameException
+import com.expediagroup.graphql.generator.exceptions.InvalidUnionException
 import com.expediagroup.graphql.generator.test.utils.SimpleDirective
 import graphql.schema.GraphQLObjectType
 import graphql.schema.GraphQLUnionType
@@ -84,7 +85,7 @@ class GenerateUnionTest : TypeTestHelper() {
 
     @Test
     fun `unused unions throw exception`() {
-        assertFailsWith(graphql.AssertException::class) {
+        assertFailsWith(InvalidUnionException::class) {
             generateUnion(generator, UnusedUnion::class)
         }
     }
@@ -133,7 +134,7 @@ class GenerateUnionTest : TypeTestHelper() {
     @Test
     fun `custom union annotation throws if possible types is empty`() {
         val annotation = AnnotationUnion::emptyUnion.annotations.first() as GraphQLUnion
-        assertFailsWith(graphql.AssertException::class) {
+        assertFailsWith(InvalidUnionException::class) {
             generateUnion(generator, Any::class, annotation)
         }
     }


### PR DESCRIPTION
### :pencil: Description
Improve the error messaging around invalid unions. We are still throwing an exception but now with just better messaging, specifically for the SDL plugin. 

This is the current error message

```
* What went wrong:
Execution failed for task ':graphqlGenerateSDL'.
> There was a failure while executing work items
   > A failure occurred while executing com.expediagroup.graphql.plugin.gradle.actions.GenerateSDLAction
      > A Union type must define one or more member types.
```
