### PR TITLE
Support graphql-java `GraphQLContext` injection

### DIFF
--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/execution/GraphQLContext.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/execution/GraphQLContext.kt
@@ -20,4 +20,5 @@ package com.expediagroup.graphql.generator.execution
  * Marker interface to indicate that the implementing class should be considered
  * as the GraphQL context. This means the implementing class will not appear in the schema.
  */
+@Deprecated(message = "Please migrate to graphql-java GraphQLContext", replaceWith = ReplaceWith("graphql.GraphQLContext"))
 interface GraphQLContext

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/extensions/kParameterExtensions.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/extensions/kParameterExtensions.kt
@@ -24,7 +24,7 @@ import kotlin.reflect.full.isSubclassOf
 
 internal fun KParameter.isInterface() = this.type.getKClass().isInterface()
 
-internal fun KParameter.isGraphQLContext() = this.type.getKClass().isSubclassOf(GraphQLContext::class)
+internal fun KParameter.isGraphQLContext() = this.type.getKClass().isSubclassOf(GraphQLContext::class) || this.type.classifier == graphql.GraphQLContext::class
 
 internal fun KParameter.isDataFetchingEnvironment() = this.type.classifier == DataFetchingEnvironment::class
 

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/execution/FunctionDataFetcherTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/execution/FunctionDataFetcherTest.kt
@@ -50,6 +50,8 @@ class FunctionDataFetcherTest {
 
         fun contextClass(myContext: MyContext) = myContext.value
 
+        fun graphQlJavaContext(context: graphql.GraphQLContext): String = context.get("hello")
+
         fun dataFetchingEnvironment(environment: DataFetchingEnvironment): String = environment.field.name
 
         suspend fun suspendPrint(string: String): String = coroutineScope {
@@ -122,6 +124,17 @@ class FunctionDataFetcherTest {
             every { containsArgument(any()) } returns false
         }
         assertEquals(expected = "foo", actual = dataFetcher.get(mockEnvironmet))
+    }
+
+    @Test
+    fun `valid target with graphql-java context class`() {
+        val dataFetcher = FunctionDataFetcher(target = MyClass(), fn = MyClass::graphQlJavaContext)
+        val mockEnvironment: DataFetchingEnvironment = mockk {
+            every { getContext<graphql.GraphQLContext>() } returns graphql.GraphQLContext.newContext().of("hello", "world").build()
+            every { arguments } returns emptyMap()
+            every { containsArgument(any()) } returns false
+        }
+        assertEquals(expected = "world", actual = dataFetcher.get(mockEnvironment))
     }
 
     @Test

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/types/GenerateFunctionTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/types/GenerateFunctionTest.kt
@@ -79,6 +79,8 @@ class GenerateFunctionTest : TypeTestHelper() {
 
         fun context(context: MyContext, string: String) = "${context.value} and $string"
 
+        fun graphQlJavaContext(context: graphql.GraphQLContext, string: String): String = "${context.get<String>("hello")} and $string"
+
         fun ignoredParameter(color: String, @GraphQLIgnore ignoreMe: String) = "$color and $ignoreMe"
 
         fun publisher(num: Int): Publisher<Int> = Flowable.just(num)
@@ -158,6 +160,17 @@ class GenerateFunctionTest : TypeTestHelper() {
     @Test
     fun `test context on argument`() {
         val kFunction = Happy::context
+        val result = generateFunction(generator, kFunction, "Query", target = null, abstract = false)
+
+        assertTrue(result.directives.isEmpty())
+        assertEquals(expected = 1, actual = result.arguments.size)
+        val arg = result.arguments.firstOrNull()
+        assertEquals(expected = "string", actual = arg?.name)
+    }
+
+    @Test
+    fun `test graphql-java context on argument`() {
+        val kFunction = Happy::graphQlJavaContext
         val result = generateFunction(generator, kFunction, "Query", target = null, abstract = false)
 
         assertTrue(result.directives.isEmpty())

--- a/website/docs/schema-generator/execution/contextual-data.md
+++ b/website/docs/schema-generator/execution/contextual-data.md
@@ -14,7 +14,7 @@ what it should contain. `graphql-kotlin-server` provides a simple mechanism to
 build a context per operation with the [GraphQLContextFactory](../../server/graphql-context-factory.md).
 If a custom factory is defined, it will then be used to populate GraphQL context based on the incoming request and make it available during execution.
 
-## GraphQLContext Interface
+## GraphQLContext Interface (deprecated)
 
 The easiest way to specify a context class is to use the `GraphQLContext` marker interface. This interface does not require any implementations,
 it is just used to inform the schema generator that this is the class that should be used as the context for every request.
@@ -43,6 +43,31 @@ type Query {
 ```
 
 Note that the argument that implements `GraphQLContext` is not reflected in the GraphQL schema.
+
+## graphql-java GraphQLContext
+
+Starting with graphql-java 17.0 passing an arbitrary context object is deprecated. Instead,
+a new [GraphQLContext](https://javadoc.io/doc/com.graphql-java/graphql-java/17.0/graphql/GraphQLContext.html) definition
+was introduced as a mutable key value map as the preferred context mechanism.
+
+It can be accessed as an argument in functions just like custom context objects:
+
+```kotlin
+class ContextualQuery : Query {
+    fun contextualQuery(
+        context: graphql.GraphQLContext,
+        value: Int
+    ): String = "The custom value was ${context.get<String>("hello")} and the value was $value"
+}
+```
+
+The above query would produce the following GraphQL schema:
+
+```graphql
+type Query {
+  contextualQuery(value: Int!): String!
+}
+```
 
 ## Handling Context Errors
 


### PR DESCRIPTION
### :pencil: Description

With graphql-java 17.x injecting a custom context object was deprecated.
The new preferred context method is to use a mutable key-value map defined by graphql-java.

As the marker interface in graphql-kotlin can not be applied to `GraphQLContext` in graphql-java, downstream projects can not migrate to the new context object.

This change makes it possible to use graphql-java `GraphQLContext` objects like custom objects. The marker interface in graphql-kotlin is deprecated but not removed to offer a migration path, as I didn't know what the stance of graphql-kotlin on this change.

This is a pretty naive approach and I only just started reading the code base, so it may be an inadequate solution.

See also:
- https://github.com/graphql-java/graphql-java/pull/2368