### PR TITLE
[client] support optional scalar input

### DIFF
--- a/plugins/client/graphql-kotlin-client-generator/build.gradle.kts
+++ b/plugins/client/graphql-kotlin-client-generator/build.gradle.kts
@@ -24,10 +24,11 @@ dependencies {
     }
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion")
     testImplementation(project(path = ":graphql-kotlin-client-jackson"))
+    testImplementation(project(path = ":graphql-kotlin-client-serialization"))
     testImplementation("com.github.tomakehurst:wiremock-jre8:$wireMockVersion")
     testImplementation("com.github.tschuchortdev:kotlin-compile-testing:$compileTestingVersion")
-    testImplementation("org.junit.jupiter:junit-jupiter-params:$junitVersion")
     testImplementation("com.ibm.icu:icu4j:$icuVersion")
+    testImplementation("org.junit.jupiter:junit-jupiter-params:$junitVersion")
 }
 
 tasks {

--- a/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/GraphQLClientGenerator.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/GraphQLClientGenerator.kt
@@ -19,7 +19,9 @@ package com.expediagroup.graphql.plugin.client.generator
 import com.expediagroup.graphql.client.Generated
 import com.expediagroup.graphql.plugin.client.generator.exceptions.MultipleOperationsInFileException
 import com.expediagroup.graphql.plugin.client.generator.exceptions.SchemaUnavailableException
+import com.expediagroup.graphql.plugin.client.generator.types.OPTIONAL_SCALAR_INPUT_JACKSON_SERIALIZER_NAME
 import com.expediagroup.graphql.plugin.client.generator.types.generateGraphQLObjectTypeSpec
+import com.expediagroup.graphql.plugin.client.generator.types.generateJacksonOptionalInputScalarSerializer
 import com.expediagroup.graphql.plugin.client.generator.types.generateVariableTypeSpec
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FileSpec
@@ -37,11 +39,9 @@ import graphql.schema.idl.SchemaParser
 import graphql.schema.idl.TypeDefinitionRegistry
 import kotlinx.serialization.Required
 import kotlinx.serialization.Serializable
-import org.slf4j.LoggerFactory
 import java.io.File
 
 private const val CORE_TYPES_PACKAGE = "com.expediagroup.graphql.client.types"
-internal val LOGGER = LoggerFactory.getLogger(GraphQLClientGenerator::class.java)
 
 /**
  * GraphQL client code generator that uses [KotlinPoet](https://github.com/square/kotlinpoet) to generate Kotlin classes based on the specified GraphQL queries.
@@ -212,6 +212,14 @@ class GraphQLClientGenerator(
                     }
                 }
             typeAliases.putAll(context.typeAliases)
+
+            if (context.requireJacksonOptionalScalarSerializer) {
+                val optionalJacksonSerializer = generateJacksonOptionalInputScalarSerializer(config)
+                fileSpecs.add(FileSpec.builder(packageName = "${config.packageName}.scalars", fileName = OPTIONAL_SCALAR_INPUT_JACKSON_SERIALIZER_NAME)
+                    .addType(optionalJacksonSerializer)
+                    .build()
+                )
+            }
         }
         return fileSpecs
     }

--- a/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/GraphQLClientGenerator.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/GraphQLClientGenerator.kt
@@ -215,9 +215,10 @@ class GraphQLClientGenerator(
 
             if (context.requireJacksonOptionalScalarSerializer) {
                 val optionalJacksonSerializer = generateJacksonOptionalInputScalarSerializer(config)
-                fileSpecs.add(FileSpec.builder(packageName = "${config.packageName}.scalars", fileName = OPTIONAL_SCALAR_INPUT_JACKSON_SERIALIZER_NAME)
-                    .addType(optionalJacksonSerializer)
-                    .build()
+                fileSpecs.add(
+                    FileSpec.builder(packageName = "${config.packageName}.scalars", fileName = OPTIONAL_SCALAR_INPUT_JACKSON_SERIALIZER_NAME)
+                        .addType(optionalJacksonSerializer)
+                        .build()
                 )
             }
         }

--- a/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/GraphQLClientGeneratorContext.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/GraphQLClientGeneratorContext.kt
@@ -54,6 +54,7 @@ data class GraphQLClientGeneratorContext(
 
     private val customScalarClassNames: Set<ClassName> = customScalarMap.values.map { it.className }.toSet()
     internal fun isCustomScalar(typeName: TypeName): Boolean = customScalarClassNames.contains(typeName)
+    var requireJacksonOptionalScalarSerializer = false
 }
 
 sealed class ScalarConverterInfo {

--- a/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/types/generateGraphQLCustomScalarTypeAlias.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/types/generateGraphQLCustomScalarTypeAlias.kt
@@ -22,8 +22,6 @@ import graphql.language.ScalarTypeDefinition
 
 /**
  * Generate String type alias to custom GraphQL scalars (including ID) since they are serialized as Strings by default.
- *
- * @see generateGraphQLCustomScalarTypeSpec for handling of custom type safe scalars
  */
 internal fun generateGraphQLCustomScalarTypeAlias(context: GraphQLClientGeneratorContext, scalarTypeDefinition: ScalarTypeDefinition): TypeAliasSpec {
     val typeAliasSpec = TypeAliasSpec.builder(scalarTypeDefinition.name, String::class)

--- a/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/types/generateGraphQLInputObjectTypeSpec.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/types/generateGraphQLInputObjectTypeSpec.kt
@@ -19,7 +19,6 @@ package com.expediagroup.graphql.plugin.client.generator.types
 import com.expediagroup.graphql.client.Generated
 import com.expediagroup.graphql.plugin.client.generator.GraphQLClientGeneratorContext
 import com.expediagroup.graphql.plugin.client.generator.GraphQLSerializer
-import com.expediagroup.graphql.plugin.client.generator.LOGGER
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FunSpec
@@ -31,6 +30,7 @@ import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.TypeSpec
 import graphql.language.InputObjectTypeDefinition
+import graphql.language.Type
 import kotlinx.serialization.Serializable
 
 /**
@@ -51,45 +51,14 @@ internal fun generateGraphQLInputObjectTypeSpec(context: GraphQLClientGeneratorC
 
     val constructorBuilder = FunSpec.constructorBuilder()
     inputObjectDefinition.inputValueDefinitions.forEach { fieldDefinition ->
-        val kotlinFieldTypeName = generateTypeName(context, fieldDefinition.type)
-
-        val (rawType, isList) = unwrapRawType(kotlinFieldTypeName)
-        val isCustomScalar = context.isCustomScalar(rawType)
-        val shouldWrapInOptional = shouldWrapInOptional(kotlinFieldTypeName, context)
-
-        val inputFieldType = if (!isCustomScalar && shouldWrapInOptional) {
-            kotlinFieldTypeName.wrapOptionalInputType(context)
-        } else {
-            kotlinFieldTypeName
-        }
-
-        val inputPropertySpec = PropertySpec.builder(fieldDefinition.name, inputFieldType)
-            .initializer(fieldDefinition.name)
-            .also { builder ->
-                fieldDefinition.description?.content?.let { kdoc ->
-                    builder.addKdoc("%L", kdoc)
-                }
-
-                if (isCustomScalar) {
-                    builder.addAnnotations(generateCustomScalarPropertyAnnotations(context, rawType, isList))
-
-                    if (shouldWrapInOptional) {
-                        LOGGER.warn(
-                            "Operation ${context.operationName} specifies optional custom scalar as input - ${fieldDefinition.name} in Variables. " +
-                                "Currently custom scalars do not work with optional wrappers."
-                        )
-                        builder.addKdoc("\nNOTE: This field was not wrapped in optional as currently custom scalars do not work with optional wrappers.")
-                    }
-                }
-            }
-            .build()
+        val (inputPropertySpec, defaultValue) = createInputPropertySpec(context, fieldDefinition.name, fieldDefinition.type, fieldDefinition.description?.content)
         inputObjectTypeSpecBuilder.addProperty(inputPropertySpec)
 
         constructorBuilder.addParameter(
             ParameterSpec.builder(inputPropertySpec.name, inputPropertySpec.type)
                 .also { builder ->
-                    if (kotlinFieldTypeName.isNullable) {
-                        builder.defaultValue(nullableDefaultValueCodeBlock(context, isCustomScalar))
+                    if (defaultValue != null) {
+                        builder.defaultValue(defaultValue)
                     }
                 }
                 .build()
@@ -111,7 +80,58 @@ internal fun TypeName.wrapOptionalInputType(context: GraphQLClientGeneratorConte
             .parameterizedBy(this.copy(nullable = false))
     }
 
-internal fun nullableDefaultValueCodeBlock(context: GraphQLClientGeneratorContext, isCustomScalar: Boolean): CodeBlock = if (context.useOptionalInputWrapper && !isCustomScalar) {
+internal fun createInputPropertySpec(context: GraphQLClientGeneratorContext, graphqlFieldName: String, graphqlFieldType: Type<*>, graphqlFieldDescription: String? = null): Pair<PropertySpec, CodeBlock?> {
+    val kotlinFieldTypeName = generateTypeName(context, graphqlFieldType)
+
+    val (rawType, isList) = unwrapRawType(kotlinFieldTypeName)
+    val isCustomScalar = context.isCustomScalar(rawType)
+    val shouldWrapInOptional = shouldWrapInOptional(kotlinFieldTypeName, context)
+
+    val scalarAnnotations = if (isCustomScalar) {
+        generateCustomScalarPropertyAnnotations(context, rawType, isList, shouldWrapInOptional)
+    } else {
+        emptyList()
+    }
+
+    val inputFieldType = if (shouldWrapInOptional) {
+        if (context.serializer == GraphQLSerializer.KOTLINX) {
+            kotlinFieldTypeName.copy(annotations = scalarAnnotations).wrapOptionalInputType(context)
+        } else {
+            kotlinFieldTypeName.wrapOptionalInputType(context)
+        }
+    } else {
+        kotlinFieldTypeName
+    }
+
+    val inputProperty = PropertySpec.builder(graphqlFieldName, inputFieldType)
+        .initializer(graphqlFieldName)
+        .also { builder ->
+            if (graphqlFieldDescription != null) {
+                builder.addKdoc("%L", graphqlFieldDescription)
+            }
+
+            if (isCustomScalar) {
+                if (shouldWrapInOptional) {
+                    // annotations were already set for KOTLINX optional scalar
+                    if (context.serializer == GraphQLSerializer.JACKSON) {
+                        context.requireJacksonOptionalScalarSerializer = true
+                        builder.addAnnotations(scalarAnnotations)
+                    }
+                } else {
+                    builder.addAnnotations(scalarAnnotations)
+                }
+            }
+        }
+        .build()
+    val defaultValue = if (kotlinFieldTypeName.isNullable) {
+        nullableDefaultValueCodeBlock(context)
+    } else {
+        null
+    }
+    return inputProperty to defaultValue
+}
+
+internal fun nullableDefaultValueCodeBlock(context: GraphQLClientGeneratorContext): CodeBlock = if (context.useOptionalInputWrapper) {
     if (context.serializer == GraphQLSerializer.JACKSON) {
         CodeBlock.of("%M", MemberName("com.expediagroup.graphql.client.jackson.types", "OptionalInput.Undefined"))
     } else {

--- a/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/types/generateGraphQLInputObjectTypeSpec.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/types/generateGraphQLInputObjectTypeSpec.kt
@@ -80,7 +80,12 @@ internal fun TypeName.wrapOptionalInputType(context: GraphQLClientGeneratorConte
             .parameterizedBy(this.copy(nullable = false))
     }
 
-internal fun createInputPropertySpec(context: GraphQLClientGeneratorContext, graphqlFieldName: String, graphqlFieldType: Type<*>, graphqlFieldDescription: String? = null): Pair<PropertySpec, CodeBlock?> {
+internal fun createInputPropertySpec(
+    context: GraphQLClientGeneratorContext,
+    graphqlFieldName: String,
+    graphqlFieldType: Type<*>,
+    graphqlFieldDescription: String? = null
+): Pair<PropertySpec, CodeBlock?> {
     val kotlinFieldTypeName = generateTypeName(context, graphqlFieldType)
 
     val (rawType, isList) = unwrapRawType(kotlinFieldTypeName)

--- a/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/types/generateJacksonOptionalInputScalarSerializer.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/types/generateJacksonOptionalInputScalarSerializer.kt
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 package com.expediagroup.graphql.plugin.client.generator.types
 
 import com.expediagroup.graphql.client.converter.ScalarConverter
@@ -73,21 +72,22 @@ fun generateJacksonOptionalInputScalarSerializer(config: GraphQLClientGeneratorC
         }
         .addFunction(
             FunSpec.builder("isEmpty")
-            .addModifiers(KModifier.OVERRIDE)
-            .addParameter("provider", SerializerProvider::class.java)
-            .addParameter("value", jacksonOptionalInput)
-            .returns(BOOLEAN)
-            .addStatement("return value == %M", jacksonUndefinedInput)
-            .build()
+                .addModifiers(KModifier.OVERRIDE)
+                .addParameter("provider", SerializerProvider::class.java)
+                .addParameter("value", jacksonOptionalInput)
+                .returns(BOOLEAN)
+                .addStatement("return value == %M", jacksonUndefinedInput)
+                .build()
         )
         .addFunction(
             FunSpec.builder("serialize")
-            .addModifiers(KModifier.OVERRIDE)
-            .addParameter("value", jacksonOptionalInput)
-            .addParameter("gen", JsonGenerator::class.java)
-            .addParameter("serializers", SerializerProvider::class.java)
-            .addCode(
-                CodeBlock.of("""when (value) {
+                .addModifiers(KModifier.OVERRIDE)
+                .addParameter("value", jacksonOptionalInput)
+                .addParameter("gen", JsonGenerator::class.java)
+                .addParameter("serializers", SerializerProvider::class.java)
+                .addCode(
+                    CodeBlock.of(
+                        """when (value) {
                         |  is %M -> return
                         |  is %M -> {
                         |    val rawValue = value.value
@@ -104,26 +104,31 @@ fun generateJacksonOptionalInputScalarSerializer(config: GraphQLClientGeneratorC
                         |    }
                         |  }
                         |}
-                        """.trimMargin(), jacksonUndefinedInput, jacksonDefinedInput)
-            )
-            .build()
+                        """.trimMargin(),
+                        jacksonUndefinedInput, jacksonDefinedInput
+                    )
+                )
+                .build()
         )
         .addFunction(
             FunSpec.builder("serializeValue")
-            .addModifiers(KModifier.PRIVATE)
-            .addParameter("value", ANY)
-            .addParameter("gen", JsonGenerator::class.java)
-            .addParameter("serializers", SerializerProvider::class.java)
-            .addCode(
-                CodeBlock.of("""val clazz = value::class.java
+                .addModifiers(KModifier.PRIVATE)
+                .addParameter("value", ANY)
+                .addParameter("gen", JsonGenerator::class.java)
+                .addParameter("serializers", SerializerProvider::class.java)
+                .addCode(
+                    CodeBlock.of(
+                        """val clazz = value::class.java
                         |val converter = converters[clazz] as? ScalarConverter<Any>
                         |if (converter != null) {
                         |  serializers.defaultSerializeValue(converter.toJson(value), gen)
                         |} else {
                         |  serializers.findValueSerializer(clazz).serialize(value, gen, serializers)
                         |}
-                    """.trimMargin()))
-            .build()
+                    """.trimMargin()
+                    )
+                )
+                .build()
         )
         .build()
 }

--- a/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/types/generateJacksonOptionalInputScalarSerializer.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/types/generateJacksonOptionalInputScalarSerializer.kt
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2021 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.expediagroup.graphql.plugin.client.generator.types
+
+import com.expediagroup.graphql.client.converter.ScalarConverter
+import com.expediagroup.graphql.plugin.client.generator.GraphQLClientGeneratorConfig
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.databind.JsonSerializer
+import com.fasterxml.jackson.databind.SerializerProvider
+import com.squareup.kotlinpoet.ANY
+import com.squareup.kotlinpoet.BOOLEAN
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.CodeBlock
+import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.KModifier
+import com.squareup.kotlinpoet.MemberName
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import com.squareup.kotlinpoet.PropertySpec
+import com.squareup.kotlinpoet.STAR
+import com.squareup.kotlinpoet.TypeSpec
+import com.squareup.kotlinpoet.asClassName
+
+internal const val OPTIONAL_SCALAR_INPUT_JACKSON_SERIALIZER_NAME = "OptionalScalarInputSerializer"
+
+/**
+ * Generates custom OptionalInput serializer that works for custom scalars.
+ */
+fun generateJacksonOptionalInputScalarSerializer(config: GraphQLClientGeneratorConfig): TypeSpec {
+    val jacksonOptionalInput = ClassName("com.expediagroup.graphql.client.jackson.types", "OptionalInput").parameterizedBy(STAR)
+    val jacksonDefinedInput = MemberName("com.expediagroup.graphql.client.jackson.types", "OptionalInput.Defined")
+    val jacksonUndefinedInput = MemberName("com.expediagroup.graphql.client.jackson.types", "OptionalInput.Undefined")
+
+    return TypeSpec.classBuilder(OPTIONAL_SCALAR_INPUT_JACKSON_SERIALIZER_NAME)
+        .superclass(JsonSerializer::class.asClassName().parameterizedBy(jacksonOptionalInput))
+        .also { builder ->
+            val convertersInitBlock = CodeBlock.builder()
+                .add(CodeBlock.of("%M(", MemberName("kotlin.collections", "mapOf")))
+                .also { initBuilder ->
+                    config.customScalarMap.values.withIndex().forEach { (index, customScalarInfo) ->
+                        if (index > 0) {
+                            initBuilder.add(", ")
+                        }
+                        initBuilder.add(CodeBlock.of("%T::class.java to %T()", customScalarInfo.className, customScalarInfo.converterClassName))
+                    }
+                }
+                .add(")")
+                .build()
+            val converterMapProperty = PropertySpec.builder(
+                "converters",
+                Map::class.asClassName().parameterizedBy(
+                    Class::class.asClassName().parameterizedBy(STAR),
+                    ScalarConverter::class.asClassName().parameterizedBy(STAR)
+                ),
+                KModifier.PRIVATE
+            ).initializer(convertersInitBlock)
+                .build()
+            builder.addProperty(converterMapProperty)
+        }
+        .addFunction(
+            FunSpec.builder("isEmpty")
+            .addModifiers(KModifier.OVERRIDE)
+            .addParameter("provider", SerializerProvider::class.java)
+            .addParameter("value", jacksonOptionalInput)
+            .returns(BOOLEAN)
+            .addStatement("return value == %M", jacksonUndefinedInput)
+            .build()
+        )
+        .addFunction(
+            FunSpec.builder("serialize")
+            .addModifiers(KModifier.OVERRIDE)
+            .addParameter("value", jacksonOptionalInput)
+            .addParameter("gen", JsonGenerator::class.java)
+            .addParameter("serializers", SerializerProvider::class.java)
+            .addCode(
+                CodeBlock.of("""when (value) {
+                        |  is %M -> return
+                        |  is %M -> {
+                        |    val rawValue = value.value
+                        |    when (rawValue) {
+                        |      null -> serializers.defaultNullValueSerializer.serialize(rawValue, gen, serializers)
+                        |      is List<*> -> {
+                        |        gen.writeStartArray()
+                        |        rawValue.filterNotNull().forEach { entry ->
+                        |          serializeValue(entry, gen, serializers)
+                        |        }
+                        |        gen.writeEndArray()
+                        |      }
+                        |      else -> serializeValue(rawValue, gen, serializers)
+                        |    }
+                        |  }
+                        |}
+                        """.trimMargin(), jacksonUndefinedInput, jacksonDefinedInput)
+            )
+            .build()
+        )
+        .addFunction(
+            FunSpec.builder("serializeValue")
+            .addModifiers(KModifier.PRIVATE)
+            .addParameter("value", ANY)
+            .addParameter("gen", JsonGenerator::class.java)
+            .addParameter("serializers", SerializerProvider::class.java)
+            .addCode(
+                CodeBlock.of("""val clazz = value::class.java
+                        |val converter = converters[clazz] as? ScalarConverter<Any>
+                        |if (converter != null) {
+                        |  serializers.defaultSerializeValue(converter.toJson(value), gen)
+                        |} else {
+                        |  serializers.findValueSerializer(clazz).serialize(value, gen, serializers)
+                        |}
+                    """.trimMargin()))
+            .build()
+        )
+        .build()
+}

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/custom_scalar_input/CustomScalarInputQuery.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/custom_scalar_input/CustomScalarInputQuery.kt
@@ -6,6 +6,7 @@ import com.expediagroup.graphql.client.jackson.types.OptionalInput.Undefined
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
 import com.expediagroup.graphql.generated.inputs.ScalarWrapperInput
 import com.expediagroup.graphql.generated.scalars.AnyToULocaleConverter
+import com.expediagroup.graphql.generated.scalars.OptionalScalarInputSerializer
 import com.expediagroup.graphql.generated.scalars.ULocaleToAnyConverter
 import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonSerialize
@@ -33,13 +34,8 @@ public class CustomScalarInputQuery(
     @JsonSerialize(converter = ULocaleToAnyConverter::class)
     @JsonDeserialize(converter = AnyToULocaleConverter::class)
     public val requiredLocale: ULocale,
-    /**
-     * NOTE: This field was not wrapped in optional as currently custom scalars do not work with
-     * optional wrappers.
-     */
-    @JsonSerialize(converter = ULocaleToAnyConverter::class)
-    @JsonDeserialize(converter = AnyToULocaleConverter::class)
-    public val optionalLocale: ULocale? = null,
+    @JsonSerialize(using = OptionalScalarInputSerializer::class)
+    public val optionalLocale: OptionalInput<ULocale> = OptionalInput.Undefined,
     public val scalarWrapper: OptionalInput<ScalarWrapperInput> = OptionalInput.Undefined
   )
 

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/custom_scalar_input/inputs/ScalarWrapperInput.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/custom_scalar_input/inputs/ScalarWrapperInput.kt
@@ -5,9 +5,8 @@ import com.expediagroup.graphql.client.jackson.types.OptionalInput
 import com.expediagroup.graphql.client.jackson.types.OptionalInput.Undefined
 import com.expediagroup.graphql.generated.ID
 import com.expediagroup.graphql.generated.scalars.AnyToULocaleConverter
-import com.expediagroup.graphql.generated.scalars.AnyToUUIDConverter
+import com.expediagroup.graphql.generated.scalars.OptionalScalarInputSerializer
 import com.expediagroup.graphql.generated.scalars.ULocaleToAnyConverter
-import com.expediagroup.graphql.generated.scalars.UUIDToAnyConverter
 import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonSerialize
 import com.ibm.icu.util.ULocale
@@ -29,20 +28,14 @@ public data class ScalarWrapperInput(
   public val count: OptionalInput<Int> = OptionalInput.Undefined,
   /**
    * Custom scalar of UUID
-   * NOTE: This field was not wrapped in optional as currently custom scalars do not work with
-   * optional wrappers.
    */
-  @JsonSerialize(converter = UUIDToAnyConverter::class)
-  @JsonDeserialize(converter = AnyToUUIDConverter::class)
-  public val custom: UUID? = null,
+  @JsonSerialize(using = OptionalScalarInputSerializer::class)
+  public val custom: OptionalInput<UUID> = OptionalInput.Undefined,
   /**
    * List of custom scalar UUIDs
-   * NOTE: This field was not wrapped in optional as currently custom scalars do not work with
-   * optional wrappers.
    */
-  @JsonSerialize(contentConverter = UUIDToAnyConverter::class)
-  @JsonDeserialize(contentConverter = AnyToUUIDConverter::class)
-  public val customList: List<UUID>? = null,
+  @JsonSerialize(using = OptionalScalarInputSerializer::class)
+  public val customList: OptionalInput<List<UUID>> = OptionalInput.Undefined,
   /**
    * ID represents unique identifier that is not intended to be human readable
    */

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/custom_scalar_input/scalars/OptionalScalarInputSerializer.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/custom_scalar_input/scalars/OptionalScalarInputSerializer.kt
@@ -1,0 +1,65 @@
+package com.expediagroup.graphql.generated.scalars
+
+import com.expediagroup.graphql.client.converter.ScalarConverter
+import com.expediagroup.graphql.client.jackson.types.OptionalInput
+import com.expediagroup.graphql.client.jackson.types.OptionalInput.Defined
+import com.expediagroup.graphql.client.jackson.types.OptionalInput.Undefined
+import com.expediagroup.graphql.plugin.client.generator.ULocaleScalarConverter
+import com.expediagroup.graphql.plugin.client.generator.UUIDScalarConverter
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.databind.JsonSerializer
+import com.fasterxml.jackson.databind.SerializerProvider
+import com.ibm.icu.util.ULocale
+import java.lang.Class
+import java.util.UUID
+import kotlin.Any
+import kotlin.Boolean
+import kotlin.Unit
+import kotlin.collections.Map
+import kotlin.collections.mapOf
+
+public class OptionalScalarInputSerializer : JsonSerializer<OptionalInput<*>>() {
+  private val converters: Map<Class<*>, ScalarConverter<*>> = mapOf(UUID::class.java to
+      UUIDScalarConverter(), ULocale::class.java to ULocaleScalarConverter())
+
+  public override fun isEmpty(provider: SerializerProvider, `value`: OptionalInput<*>): Boolean =
+      value == OptionalInput.Undefined
+
+  public override fun serialize(
+    `value`: OptionalInput<*>,
+    gen: JsonGenerator,
+    serializers: SerializerProvider
+  ): Unit {
+    when (value) {
+      is OptionalInput.Undefined -> return
+      is OptionalInput.Defined -> {
+        val rawValue = value.value
+        when (rawValue) {
+          null -> serializers.defaultNullValueSerializer.serialize(rawValue, gen, serializers)
+          is List<*> -> {
+            gen.writeStartArray()
+            rawValue.filterNotNull().forEach { entry ->
+              serializeValue(entry, gen, serializers)
+            }
+            gen.writeEndArray()
+          }
+          else -> serializeValue(rawValue, gen, serializers)
+        }
+      }
+    }
+  }
+
+  private fun serializeValue(
+    `value`: Any,
+    gen: JsonGenerator,
+    serializers: SerializerProvider
+  ): Unit {
+    val clazz = value::class.java
+    val converter = converters[clazz] as? ScalarConverter<Any>
+    if (converter != null) {
+      serializers.defaultSerializeValue(converter.toJson(value), gen)
+    } else {
+      serializers.findValueSerializer(clazz).serialize(value, gen, serializers)
+    }
+  }
+}

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/custom_scalar_input/CustomScalarInputQuery.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/custom_scalar_input/CustomScalarInputQuery.kt
@@ -1,6 +1,8 @@
 package com.expediagroup.graphql.generated
 
 import com.expediagroup.graphql.client.Generated
+import com.expediagroup.graphql.client.serialization.types.OptionalInput
+import com.expediagroup.graphql.client.serialization.types.OptionalInput.Undefined
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
 import com.expediagroup.graphql.generated.inputs.ScalarWrapperInput
 import com.expediagroup.graphql.generated.scalars.ULocaleSerializer
@@ -33,9 +35,9 @@ public class CustomScalarInputQuery(
   public data class Variables(
     @Serializable(with = ULocaleSerializer::class)
     public val requiredLocale: ULocale,
-    @Serializable(with = ULocaleSerializer::class)
-    public val optionalLocale: ULocale? = null,
-    public val scalarWrapper: ScalarWrapperInput? = null
+    public val optionalLocale: OptionalInput<@Serializable(with = ULocaleSerializer::class) ULocale>
+        = OptionalInput.Undefined,
+    public val scalarWrapper: OptionalInput<ScalarWrapperInput> = OptionalInput.Undefined
   )
 
   @Generated

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/custom_scalar_input/inputs/ScalarWrapperInput.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/custom_scalar_input/inputs/ScalarWrapperInput.kt
@@ -1,6 +1,8 @@
 package com.expediagroup.graphql.generated.inputs
 
 import com.expediagroup.graphql.client.Generated
+import com.expediagroup.graphql.client.serialization.types.OptionalInput
+import com.expediagroup.graphql.client.serialization.types.OptionalInput.Undefined
 import com.expediagroup.graphql.generated.ID
 import com.expediagroup.graphql.generated.scalars.ULocaleSerializer
 import com.expediagroup.graphql.generated.scalars.UUIDSerializer
@@ -22,16 +24,17 @@ public data class ScalarWrapperInput(
   /**
    * A signed 32-bit nullable integer value
    */
-  public val count: Int? = null,
+  public val count: OptionalInput<Int> = OptionalInput.Undefined,
   /**
    * Custom scalar of UUID
    */
-  @Serializable(with = UUIDSerializer::class)
-  public val custom: UUID? = null,
+  public val custom: OptionalInput<@Serializable(with = UUIDSerializer::class) UUID> =
+      OptionalInput.Undefined,
   /**
    * List of custom scalar UUIDs
    */
-  public val customList: List<@Serializable(with = UUIDSerializer::class) UUID>? = null,
+  public val customList: OptionalInput<List<@Serializable(with = UUIDSerializer::class) UUID>> =
+      OptionalInput.Undefined,
   /**
    * ID represents unique identifier that is not intended to be human readable
    */
@@ -43,7 +46,7 @@ public data class ScalarWrapperInput(
   /**
    * A nullable signed double-precision floating-point value
    */
-  public val rating: Double? = null,
+  public val rating: OptionalInput<Double> = OptionalInput.Undefined,
   /**
    * Either true or false
    */

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/multiple_queries/FirstQuery.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/multiple_queries/FirstQuery.kt
@@ -1,6 +1,8 @@
 package com.expediagroup.graphql.generated
 
 import com.expediagroup.graphql.client.Generated
+import com.expediagroup.graphql.client.serialization.types.OptionalInput
+import com.expediagroup.graphql.client.serialization.types.OptionalInput.Undefined
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
 import com.expediagroup.graphql.generated.enums.CustomEnum
 import com.expediagroup.graphql.generated.firstquery.BasicInterface
@@ -32,7 +34,7 @@ public class FirstQuery(
   @Generated
   @Serializable
   public data class Variables(
-    public val input: ComplexArgumentInput? = null
+    public val input: OptionalInput<ComplexArgumentInput> = OptionalInput.Undefined
   )
 
   @Generated

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/multiple_queries/SecondQuery.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/multiple_queries/SecondQuery.kt
@@ -1,6 +1,8 @@
 package com.expediagroup.graphql.generated
 
 import com.expediagroup.graphql.client.Generated
+import com.expediagroup.graphql.client.serialization.types.OptionalInput
+import com.expediagroup.graphql.client.serialization.types.OptionalInput.Undefined
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
 import com.expediagroup.graphql.generated.enums.CustomEnum
 import com.expediagroup.graphql.generated.inputs.ComplexArgumentInput
@@ -32,7 +34,7 @@ public class SecondQuery(
   @Generated
   @Serializable
   public data class Variables(
-    public val input: ComplexArgumentInput? = null
+    public val input: OptionalInput<ComplexArgumentInput> = OptionalInput.Undefined
   )
 
   @Generated

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/multiple_queries/inputs/ComplexArgumentInput.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/multiple_queries/inputs/ComplexArgumentInput.kt
@@ -1,6 +1,8 @@
 package com.expediagroup.graphql.generated.inputs
 
 import com.expediagroup.graphql.client.Generated
+import com.expediagroup.graphql.client.serialization.types.OptionalInput
+import com.expediagroup.graphql.client.serialization.types.OptionalInput.Undefined
 import kotlin.Double
 import kotlinx.serialization.Serializable
 
@@ -13,13 +15,13 @@ public data class ComplexArgumentInput(
   /**
    * Maximum value for test criteria
    */
-  public val max: Double? = null,
+  public val max: OptionalInput<Double> = OptionalInput.Undefined,
   /**
    * Minimum value for test criteria
    */
-  public val min: Double? = null,
+  public val min: OptionalInput<Double> = OptionalInput.Undefined,
   /**
    * Next criteria
    */
-  public val next: ComplexArgumentInput? = null
+  public val next: OptionalInput<ComplexArgumentInput> = OptionalInput.Undefined
 )

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/variables/KotlinXInputQuery.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/variables/KotlinXInputQuery.kt
@@ -1,6 +1,8 @@
 package com.expediagroup.graphql.generated
 
 import com.expediagroup.graphql.client.Generated
+import com.expediagroup.graphql.client.serialization.types.OptionalInput
+import com.expediagroup.graphql.client.serialization.types.OptionalInput.Undefined
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
 import com.expediagroup.graphql.generated.inputs.SimpleArgumentInput
 import kotlin.Boolean
@@ -29,7 +31,7 @@ public class KotlinXInputQuery(
   @Generated
   @Serializable
   public data class Variables(
-    public val input: SimpleArgumentInput? = null
+    public val input: OptionalInput<SimpleArgumentInput> = OptionalInput.Undefined
   )
 
   @Generated

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/variables/inputs/SimpleArgumentInput.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/variables/inputs/SimpleArgumentInput.kt
@@ -1,6 +1,8 @@
 package com.expediagroup.graphql.generated.inputs
 
 import com.expediagroup.graphql.client.Generated
+import com.expediagroup.graphql.client.serialization.types.OptionalInput
+import com.expediagroup.graphql.client.serialization.types.OptionalInput.Undefined
 import kotlin.Double
 import kotlin.String
 import kotlinx.serialization.Serializable
@@ -14,13 +16,13 @@ public data class SimpleArgumentInput(
   /**
    * Maximum value for test criteria
    */
-  public val max: Double? = null,
+  public val max: OptionalInput<Double> = OptionalInput.Undefined,
   /**
    * Minimum value for test criteria
    */
-  public val min: Double? = null,
+  public val min: OptionalInput<Double> = OptionalInput.Undefined,
   /**
    * New value to be set
    */
-  public val newName: String? = null
+  public val newName: OptionalInput<String> = OptionalInput.Undefined
 )

--- a/plugins/client/graphql-kotlin-client-generator/src/test/kotlin/com/expediagroup/graphql/plugin/client/generator/GenerateKotlinxClientIT.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/kotlin/com/expediagroup/graphql/plugin/client/generator/GenerateKotlinxClientIT.kt
@@ -32,7 +32,8 @@ class GenerateKotlinxClientIT {
                 "UUID" to GraphQLScalar("UUID", "java.util.UUID", "com.expediagroup.graphql.plugin.client.generator.UUIDScalarConverter"),
                 "Locale" to GraphQLScalar("Locale", "com.ibm.icu.util.ULocale", "com.expediagroup.graphql.plugin.client.generator.ULocaleScalarConverter")
             ),
-            serializer = GraphQLSerializer.KOTLINX
+            serializer = GraphQLSerializer.KOTLINX,
+            useOptionalInputWrapper = true
         )
         verifyClientGeneration(config, testDirectory)
     }

--- a/plugins/client/graphql-kotlin-client-generator/src/test/kotlin/com/expediagroup/graphql/plugin/client/generator/GraphQLTestUtils.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/kotlin/com/expediagroup/graphql/plugin/client/generator/GraphQLTestUtils.kt
@@ -69,6 +69,7 @@ internal fun verifyClientGeneration(config: GraphQLClientGeneratorConfig, testDi
         val fileName = spec.packageName + "." + spec.name + ".kt"
         SourceFile.kotlin(fileName, spec.toString())
     }
+
     val compilationResult = KotlinCompilation().apply {
         jvmTarget = "1.8"
         sources = generatedSources

--- a/plugins/graphql-kotlin-gradle-plugin/src/integration/client-generator/custom_scalars/src/main/kotlin/com/expediagroup/scalars/ScalarWrapper.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/integration/client-generator/custom_scalars/src/main/kotlin/com/expediagroup/scalars/ScalarWrapper.kt
@@ -12,6 +12,8 @@ data class ScalarWrapper(
     val id: ID,
     /** UTF-8 character sequence */
     val name: String,
+    /** Optional String with default value */
+    val optional: String? = "undefined value",
     /** Custom scalar of Locale */
     val locale: ULocale,
     /** List of custom scalar Locales */

--- a/plugins/graphql-kotlin-gradle-plugin/src/integration/client-generator/custom_scalars/src/test/kotlin/com/expediagroup/scalars/CustomScalarApplicationTests.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/integration/client-generator/custom_scalars/src/test/kotlin/com/expediagroup/scalars/CustomScalarApplicationTests.kt
@@ -27,14 +27,14 @@ class CustomScalarApplicationTests(@LocalServerPort private val port: Int) {
             localeList = listOf(ULocale.FRANCE, ULocale.UK),
             name = "junit_test",
             rating = OptionalInput.Defined(1.2345),
-            uuid = UUID.randomUUID(),
-            uuidList = listOf(UUID.randomUUID()),
+            uuid = OptionalInput.Defined(UUID.randomUUID()),
+            uuidList = OptionalInput.Defined(listOf(UUID.randomUUID())),
             valid = true
         )
 
         val query = CustomScalarQuery(variables = CustomScalarQuery.Variables(
             required = ULocale.US,
-            optional = null,
+            optional = OptionalInput.Undefined,
             wrapper = OptionalInput.Defined(wrapperInput)
         ))
 
@@ -46,9 +46,11 @@ class CustomScalarApplicationTests(@LocalServerPort private val port: Int) {
         assertEquals(wrapperInput.id, wrapperResponse.id)
         assertEquals(wrapperInput.localeList, wrapperResponse.localeList)
         assertEquals(wrapperInput.name, wrapperResponse.name)
+        // default value from server
+        assertEquals("undefined value", wrapperResponse.optional)
         assertEquals((wrapperInput.rating as? OptionalInput.Defined<Double>)?.value, wrapperResponse.rating)
-        assertEquals(wrapperInput.uuid, wrapperResponse.uuid)
-        assertEquals(wrapperInput.uuidList, wrapperResponse.uuidList)
+        assertEquals((wrapperInput.uuid as? OptionalInput.Defined<UUID>)?.value, wrapperResponse.uuid)
+        assertEquals((wrapperInput.uuidList as? OptionalInput.Defined<List<UUID>>)?.value, wrapperResponse.uuidList)
         assertEquals(wrapperInput.valid, wrapperResponse.valid)
     }
 

--- a/plugins/graphql-kotlin-gradle-plugin/src/integration/client-generator/custom_scalars/src/test/resources/CustomScalarsQuery.graphql
+++ b/plugins/graphql-kotlin-gradle-plugin/src/integration/client-generator/custom_scalars/src/test/resources/CustomScalarsQuery.graphql
@@ -9,6 +9,7 @@ query CustomScalarQuery(
         locale
         localeList
         name
+        optional
         rating
         uuid
         uuidList

--- a/website/docs/client/client-customization.mdx
+++ b/website/docs/client/client-customization.mdx
@@ -127,10 +127,6 @@ deprecated fields. This ensures that your clients have to explicitly opt-in into
 
 ## Custom GraphQL Scalars
 
-:::note
-Optional input wrappers are currently not supported for custom scalars.
-:::
-
 By default, custom GraphQL scalars are serialized and [type-aliased](https://kotlinlang.org/docs/reference/type-aliases.html)
 to a String. GraphQL Kotlin plugins also support custom serialization based on provided configuration.
 

--- a/website/docs/client/client-features.mdx
+++ b/website/docs/client/client-features.mdx
@@ -208,10 +208,6 @@ val results: List<GraphQLResponse<*>> = client.execute(listOf(firstQuery, second
 
 ## Optional Input Support
 
-:::note
-Optional input wrappers are currently not supported for custom scalars.
-:::
-
 In the GraphQL world, input types can be optional which means that the client can specify a value, specify a `null` value
 OR don't specify any value. This is in contrast with the JVM world where objects can either have some specific value or
 don't have any value (i.e. are `null`). By default, GraphQL Kotlin Client treats `null` Kotlin values as unspecified, which


### PR DESCRIPTION
### :pencil: Description

Update client generation logic to support serializing optional scalar input.

### :link: Related Issues

Resolves: https://github.com/ExpediaGroup/graphql-kotlin/issues/1263

