### PR TITLE
Add deprecation warning at runtime when using GraphQLContext injection

### DIFF
--- a/generator/graphql-kotlin-schema-generator/build.gradle.kts
+++ b/generator/graphql-kotlin-schema-generator/build.gradle.kts
@@ -6,12 +6,14 @@ val jacksonVersion: String by project
 val kotlinCoroutinesVersion: String by project
 val rxjavaVersion: String by project
 val junitVersion: String by project
+val slf4jVersion: String by project
 
 dependencies {
     api("com.graphql-java:graphql-java:$graphQLJavaVersion")
     api("org.jetbrains.kotlinx:kotlinx-coroutines-reactive:$kotlinCoroutinesVersion")
     api("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion")
     implementation("io.github.classgraph:classgraph:$classGraphVersion")
+    implementation("org.slf4j:slf4j-api:$slf4jVersion")
     testImplementation("io.reactivex.rxjava3:rxjava:$rxjavaVersion")
     testImplementation("org.junit.jupiter:junit-jupiter-params:$junitVersion")
 }

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/execution/FunctionDataFetcher.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/execution/FunctionDataFetcher.kt
@@ -32,6 +32,7 @@ import graphql.schema.DataFetchingEnvironment
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.future.future
+import org.slf4j.LoggerFactory
 import java.lang.reflect.InvocationTargetException
 import java.util.concurrent.CompletableFuture
 import kotlin.coroutines.CoroutineContext
@@ -58,6 +59,7 @@ open class FunctionDataFetcher(
     private val objectMapper: ObjectMapper = jacksonObjectMapper(),
     private val defaultCoroutineContext: CoroutineContext = EmptyCoroutineContext
 ) : DataFetcher<Any?> {
+    private val logger = LoggerFactory.getLogger(FunctionDataFetcher::class.java)
 
     /**
      * Invoke a suspend function or blocking function, passing in the [target] if not null or default to using the source from the environment.
@@ -106,7 +108,10 @@ open class FunctionDataFetcher(
      */
     protected open fun mapParameterToValue(param: KParameter, environment: DataFetchingEnvironment): Pair<KParameter, Any?>? =
         when {
-            param.isGraphQLContext() -> param to environment.getContext()
+            param.isGraphQLContext() -> {
+                logger.warn("GraphQLContext interface injection is deprecated. Please use DataFetchingEnvironment to retrieve ${param.getName()}.")
+                param to environment.getContext()
+            }
             param.isDataFetchingEnvironment() -> param to environment
             else -> {
                 val name = param.getName()

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/execution/FunctionDataFetcher.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/execution/FunctionDataFetcher.kt
@@ -32,7 +32,6 @@ import graphql.schema.DataFetchingEnvironment
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.future.future
-import org.slf4j.LoggerFactory
 import java.lang.reflect.InvocationTargetException
 import java.util.concurrent.CompletableFuture
 import kotlin.coroutines.CoroutineContext
@@ -59,7 +58,6 @@ open class FunctionDataFetcher(
     private val objectMapper: ObjectMapper = jacksonObjectMapper(),
     private val defaultCoroutineContext: CoroutineContext = EmptyCoroutineContext
 ) : DataFetcher<Any?> {
-    private val logger = LoggerFactory.getLogger(FunctionDataFetcher::class.java)
 
     /**
      * Invoke a suspend function or blocking function, passing in the [target] if not null or default to using the source from the environment.
@@ -108,10 +106,7 @@ open class FunctionDataFetcher(
      */
     protected open fun mapParameterToValue(param: KParameter, environment: DataFetchingEnvironment): Pair<KParameter, Any?>? =
         when {
-            param.isGraphQLContext() -> {
-                logger.warn("GraphQLContext interface injection is deprecated. Please use DataFetchingEnvironment to retrieve ${param.getName()}.")
-                param to environment.getContext()
-            }
+            param.isGraphQLContext() -> param to environment.getContext()
             param.isDataFetchingEnvironment() -> param to environment
             else -> {
                 val name = param.getName()

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/extensions/kFunctionExtensions.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/extensions/kFunctionExtensions.kt
@@ -24,12 +24,12 @@ import kotlin.reflect.full.valueParameters
 
 private val logger: Logger = LoggerFactory.getLogger("schemaGenerator")
 
-internal fun KFunction<*>.getValidArguments(): List<KParameter> {
+internal fun KFunction<*>.getValidArguments(parentName: String? = null): List<KParameter> {
     return this.valueParameters.mapNotNull {
         when {
             it.isGraphQLIgnored() || it.isDataFetchingEnvironment() -> null
             it.isGraphQLContext() -> {
-                logger.warn("GraphQLContext interface injection is deprecated. Please use DataFetchingEnvironment to retrieve ${it.getName()}.")
+                logger.warn("GraphQLContext interface injection is deprecated. Please use DataFetchingEnvironment to retrieve context. Parent: $parentName, function: ${getFunctionName()}, context: ${it.getName()}")
                 null
             }
             else -> it

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateFunction.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateFunction.kt
@@ -45,7 +45,7 @@ internal fun generateFunction(generator: SchemaGenerator, fn: KFunction<*>, pare
         builder.withDirective(it)
     }
 
-    fn.getValidArguments().forEach {
+    fn.getValidArguments(parentName).forEach {
         builder.argument(generateArgument(generator, it))
     }
 


### PR DESCRIPTION
### :pencil: Description

This PR updates `FunctionDataFetcher` so that it logs a warning when injecting a `GraphQLContext`.  This functionality is [deprecated](https://github.com/ExpediaGroup/graphql-kotlin/blob/master/website/docs/schema-generator/execution/contextual-data.md#interface-injection-deprecated).  Unlike the `GraphQLContext` interface itself, which is annotated `@deprecated, there is no compile or runtime time warning when using `GraphQLContext` interface injection in a query or mutation.

### :link: Related Issues
https://github.com/ExpediaGroup/graphql-kotlin/discussions/1305