### PR TITLE
[federation] fix non-federated schema SDL

### DIFF
--- a/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/directives/FieldSet.kt
+++ b/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/directives/FieldSet.kt
@@ -18,6 +18,7 @@ package com.expediagroup.graphql.generator.federation.directives
 
 import com.expediagroup.graphql.generator.federation.types.FIELD_SET_SCALAR_TYPE
 import graphql.schema.GraphQLArgument
+import graphql.schema.GraphQLNonNull
 
 /**
  * Annotation representing _FieldSet scalar type that is used to represent a set of fields.
@@ -37,5 +38,5 @@ internal const val FIELD_SET_ARGUMENT_NAME = "fields"
 
 internal val FIELD_SET_ARGUMENT = GraphQLArgument.newArgument()
     .name(FIELD_SET_ARGUMENT_NAME)
-    .type(FIELD_SET_SCALAR_TYPE)
+    .type(GraphQLNonNull(FIELD_SET_SCALAR_TYPE))
     .build()

--- a/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/FederatedSchemaGeneratorTest.kt
+++ b/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/FederatedSchemaGeneratorTest.kt
@@ -179,13 +179,13 @@ class FederatedSchemaGeneratorTest {
             directive @external on FIELD_DEFINITION
 
             "Specifies required input field set from the base type for a resolver"
-            directive @requires(fields: _FieldSet) on FIELD_DEFINITION
+            directive @requires(fields: _FieldSet!) on FIELD_DEFINITION
 
             "Specifies the base type field set that will be selectable by the gateway"
-            directive @provides(fields: _FieldSet) on FIELD_DEFINITION
+            directive @provides(fields: _FieldSet!) on FIELD_DEFINITION
 
             "Space separated list of primary keys needed to access federated object"
-            directive @key(fields: _FieldSet) on OBJECT | INTERFACE
+            directive @key(fields: _FieldSet!) on OBJECT | INTERFACE
 
             "Marks target object as extending part of the federated schema"
             directive @extends on OBJECT | INTERFACE

--- a/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePluginIT.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePluginIT.kt
@@ -548,13 +548,13 @@ class GraphQLGradlePluginIT : GraphQLGradlePluginAbstractIT() {
             directive @external on FIELD_DEFINITION
 
             "Specifies required input field set from the base type for a resolver"
-            directive @requires(fields: _FieldSet) on FIELD_DEFINITION
+            directive @requires(fields: _FieldSet!) on FIELD_DEFINITION
 
             "Specifies the base type field set that will be selectable by the gateway"
-            directive @provides(fields: _FieldSet) on FIELD_DEFINITION
+            directive @provides(fields: _FieldSet!) on FIELD_DEFINITION
 
             "Space separated list of primary keys needed to access federated object"
-            directive @key(fields: _FieldSet) on OBJECT | INTERFACE
+            directive @key(fields: _FieldSet!) on OBJECT | INTERFACE
 
             "Marks target object as extending part of the federated schema"
             directive @extends on OBJECT | INTERFACE

--- a/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/GraphQLGenerateSDLTaskIT.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/GraphQLGenerateSDLTaskIT.kt
@@ -97,13 +97,13 @@ internal val FEDERATED_SCHEMA =
     directive @external on FIELD_DEFINITION
 
     "Specifies required input field set from the base type for a resolver"
-    directive @requires(fields: _FieldSet) on FIELD_DEFINITION
+    directive @requires(fields: _FieldSet!) on FIELD_DEFINITION
 
     "Specifies the base type field set that will be selectable by the gateway"
-    directive @provides(fields: _FieldSet) on FIELD_DEFINITION
+    directive @provides(fields: _FieldSet!) on FIELD_DEFINITION
 
     "Space separated list of primary keys needed to access federated object"
-    directive @key(fields: _FieldSet) on OBJECT | INTERFACE
+    directive @key(fields: _FieldSet!) on OBJECT | INTERFACE
 
     "Marks target object as extending part of the federated schema"
     directive @extends on OBJECT | INTERFACE

--- a/plugins/graphql-kotlin-maven-plugin/src/integration/generate-sdl-federated/src/test/kotlin/com/expediagroup/graphql/plugin/maven/GenerateSDLMojoTest.kt
+++ b/plugins/graphql-kotlin-maven-plugin/src/integration/generate-sdl-federated/src/test/kotlin/com/expediagroup/graphql/plugin/maven/GenerateSDLMojoTest.kt
@@ -68,13 +68,13 @@ class GenerateSDLMojoTest {
             directive @external on FIELD_DEFINITION
 
             "Specifies required input field set from the base type for a resolver"
-            directive @requires(fields: _FieldSet) on FIELD_DEFINITION
+            directive @requires(fields: _FieldSet!) on FIELD_DEFINITION
 
             "Specifies the base type field set that will be selectable by the gateway"
-            directive @provides(fields: _FieldSet) on FIELD_DEFINITION
+            directive @provides(fields: _FieldSet!) on FIELD_DEFINITION
 
             "Space separated list of primary keys needed to access federated object"
-            directive @key(fields: _FieldSet) on OBJECT | INTERFACE
+            directive @key(fields: _FieldSet!) on OBJECT | INTERFACE
 
             "Marks target object as extending part of the federated schema"
             directive @extends on OBJECT | INTERFACE

--- a/plugins/graphql-kotlin-maven-plugin/src/integration/generate-sdl-hooks/src/test/kotlin/com/expediagroup/graphql/plugin/maven/GenerateSDLMojoTest.kt
+++ b/plugins/graphql-kotlin-maven-plugin/src/integration/generate-sdl-hooks/src/test/kotlin/com/expediagroup/graphql/plugin/maven/GenerateSDLMojoTest.kt
@@ -68,13 +68,13 @@ class GenerateSDLMojoTest {
             directive @external on FIELD_DEFINITION
 
             "Specifies required input field set from the base type for a resolver"
-            directive @requires(fields: _FieldSet) on FIELD_DEFINITION
+            directive @requires(fields: _FieldSet!) on FIELD_DEFINITION
 
             "Specifies the base type field set that will be selectable by the gateway"
-            directive @provides(fields: _FieldSet) on FIELD_DEFINITION
+            directive @provides(fields: _FieldSet!) on FIELD_DEFINITION
 
             "Space separated list of primary keys needed to access federated object"
-            directive @key(fields: _FieldSet) on OBJECT | INTERFACE
+            directive @key(fields: _FieldSet!) on OBJECT | INTERFACE
 
             "Marks target object as extending part of the federated schema"
             directive @extends on OBJECT | INTERFACE

--- a/plugins/schema/graphql-kotlin-sdl-generator/src/integrationTest/kotlin/com/expediagroup/graphql/plugin/schema/GenerateCustomSDLTest.kt
+++ b/plugins/schema/graphql-kotlin-sdl-generator/src/integrationTest/kotlin/com/expediagroup/graphql/plugin/schema/GenerateCustomSDLTest.kt
@@ -57,13 +57,13 @@ class GenerateCustomSDLTest {
                 directive @external on FIELD_DEFINITION
 
                 "Specifies required input field set from the base type for a resolver"
-                directive @requires(fields: _FieldSet) on FIELD_DEFINITION
+                directive @requires(fields: _FieldSet!) on FIELD_DEFINITION
 
                 "Specifies the base type field set that will be selectable by the gateway"
-                directive @provides(fields: _FieldSet) on FIELD_DEFINITION
+                directive @provides(fields: _FieldSet!) on FIELD_DEFINITION
 
                 "Space separated list of primary keys needed to access federated object"
-                directive @key(fields: _FieldSet) on OBJECT | INTERFACE
+                directive @key(fields: _FieldSet!) on OBJECT | INTERFACE
 
                 "Marks target object as extending part of the federated schema"
                 directive @extends on OBJECT | INTERFACE


### PR DESCRIPTION
### :pencil: Description

When generating federated base schema (i.e. without extended types), we were manually adding invalid required federated types (e.g. directive definitions). Generated federated schema was correct when directives were generated from the annotations. Manually added federated directives were incorrectly specifying their arguments as nullable `_FieldSet`.

SDL is printed as a debug information at a startup and can also be generated using one of our plugins. Depenendng how you use this federated SDL, this may or may not be a problem - Apollo federation 1.0 does not allow re-definition of the types across schemas so federated system types have to be scrubbed from published schema SDL and at runtime relies on `_service` query that returns modified SDL (again without federated directives).

### :link: Related Issues

Resolves: https://github.com/ExpediaGroup/graphql-kotlin/issues/1310