### PR TITLE
[generator] support toplevel Include and Skip directives

### DIFF
--- a/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/types/generatePropertySpecs.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/types/generatePropertySpecs.kt
@@ -30,6 +30,8 @@ import com.squareup.kotlinpoet.ParameterizedTypeName
 import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeName
 import graphql.Directives.DeprecatedDirective
+import graphql.Directives.IncludeDirective
+import graphql.Directives.SkipDirective
 import graphql.language.Field
 import graphql.language.FieldDefinition
 import graphql.language.NonNullType
@@ -59,7 +61,10 @@ internal fun generatePropertySpecs(
             throw MissingArgumentException(context.operationName, objectName, selectedField.name, missingRequiredArguments)
         }
 
-        val kotlinFieldType = generateTypeName(context, fieldDefinition.type, selectedField.selectionSet)
+        val optional = selectedField.directives.any {
+            it.name == SkipDirective.name || it.name == IncludeDirective.name
+        }
+        val kotlinFieldType = generateTypeName(context, fieldDefinition.type, selectedField.selectionSet, optional = optional)
         val fieldName = selectedField.alias ?: fieldDefinition.name
 
         val propertySpecBuilder = PropertySpec.builder(fieldName, kotlinFieldType)

--- a/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/types/generateTypeName.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/types/generateTypeName.kt
@@ -51,8 +51,13 @@ import kotlinx.serialization.Serializable
 /**
  * Generate [TypeName] reference to a Kotlin class representation of an underlying GraphQL type.
  */
-internal fun generateTypeName(context: GraphQLClientGeneratorContext, graphQLType: Type<*>, selectionSet: SelectionSet? = null): TypeName {
-    val nullable = graphQLType !is NonNullType
+internal fun generateTypeName(
+    context: GraphQLClientGeneratorContext,
+    graphQLType: Type<*>,
+    selectionSet: SelectionSet? = null,
+    optional: Boolean = false
+): TypeName {
+    val nullable = optional || graphQLType !is NonNullType
 
     return when (graphQLType) {
         is NonNullType -> generateTypeName(context, graphQLType.type, selectionSet)

--- a/plugins/graphql-kotlin-gradle-plugin/src/test/resources/mocks/JUnitQuery.graphql
+++ b/plugins/graphql-kotlin-gradle-plugin/src/test/resources/mocks/JUnitQuery.graphql
@@ -22,6 +22,13 @@ query JUnitQuery($simpleCriteria: SimpleArgumentInput!) {
       value
     }
   }
+  includeComplexObjectQuery: complexObjectQuery @include(if: true) {
+    id
+  }
+  skipComplexObjectQuery: complexObjectQuery @skip(if: false) {
+    id
+  }
+
   interfaceQuery {
     __typename
     id

--- a/plugins/graphql-kotlin-gradle-plugin/src/test/resources/templates/JUnit.mustache
+++ b/plugins/graphql-kotlin-gradle-plugin/src/test/resources/templates/JUnit.mustache
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import java.io.File
 import java.nio.file.Paths
+import kotlin.reflect.full.declaredMemberProperties
 
 class GraphQLMavenPluginTest {
 
@@ -24,6 +25,16 @@ class GraphQLMavenPluginTest {
         val buildDirectory = System.getProperty("buildDirectory")
         val path = Paths.get(buildDirectory, "generated", "sources", "graphql", "com", "example", "generated", "JUnitQuery.kt")
         assertTrue(path.toFile().exists(), "graphql client was generated")
+    }
+
+    @Test
+    fun `verify topLevelDirective fields are nullable`() {
+        assertTrue(
+            JUnitQuery.Result::class.declaredMemberProperties.first { it.name == "includeComplexObjectQuery" }.returnType.isMarkedNullable
+        )
+        assertTrue(
+            JUnitQuery.Result::class.declaredMemberProperties.first { it.name == "skipComplexObjectQuery" }.returnType.isMarkedNullable
+        )
     }
 
     @Test


### PR DESCRIPTION
Generate nullable Result properties when Include or Skip directives provided in query

### :pencil: Description
Checking if query file contains toplevel`skip` or `include` directive and generating nullable properties in `Result` data class if directive provided

### :link: Related Issues
https://github.com/ExpediaGroup/graphql-kotlin/issues/1282

I am open to suggestions if some additional tests / documentation / examples are needed