### PR TITLE
EntityResolver interface

### DIFF
--- a/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/execution/GlobalScopeEntityResolver.kt
+++ b/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/execution/GlobalScopeEntityResolver.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.generator.federation.execution
+
+import graphql.execution.DataFetcherResult
+import graphql.schema.DataFetchingEnvironment
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.future.future
+import java.util.concurrent.CompletableFuture
+
+/**
+ * [EntityResolver] that uses the `GlobalScope` coroutine for resolving the Entities
+ */
+open class GlobalScopeEntityResolver(resolvers: List<FederatedTypeResolver<*>>) : EntityResolver<CompletableFuture<DataFetcherResult<List<Any?>>>> {
+
+    override val resolverMap: Map<String, FederatedTypeResolver<*>> = resolvers.associateBy { it.typeName }
+
+    override fun get(env: DataFetchingEnvironment): CompletableFuture<DataFetcherResult<List<Any?>>> {
+        return GlobalScope.future {
+            resolve(env)
+        }
+    }
+}

--- a/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/execution/GlobalScopeEntityQueryResolverTest.kt
+++ b/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/execution/GlobalScopeEntityQueryResolverTest.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.generator.federation.execution
+
+import com.expediagroup.graphql.generator.federation.data.UserResolver
+import graphql.schema.DataFetchingEnvironment
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import kotlin.test.assertNotNull
+
+class GlobalScopeEntityQueryResolverTest {
+
+    @Test
+    fun `verify it returns a CompletableFuture`() {
+        val resolver = GlobalScopeEntityResolver(listOf(UserResolver()))
+        val representations = listOf(mapOf<String, Any>("__typename" to "User", "userId" to 123, "name" to "testName"))
+        val env = mockk<DataFetchingEnvironment> {
+            every { getArgument<Any>(any()) } returns representations
+        }
+
+        val result = resolver.get(env).get()
+        assertNotNull(result)
+    }
+
+}

--- a/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/execution/GlobalScopeEntityQueryResolverTest.kt
+++ b/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/execution/GlobalScopeEntityQueryResolverTest.kt
@@ -36,5 +36,4 @@ class GlobalScopeEntityQueryResolverTest {
         val result = resolver.get(env).get()
         assertNotNull(result)
     }
-
 }


### PR DESCRIPTION
### :pencil: Description
The `EntityResolver` class uses `GlobalScope.future` to dispatch the load for the entity resolving. It is easy to accidentally create resource or memory leaks when GlobalScope is used.

This PR abstracts out the actual entity resolving logic as an interface. The logic has moved to a `resolve` method, that can be called from any class that implements this interface.

The EntityResolver can be injected into the `FederatedSchemaGeneratorHooks` class, in case this needs to have a different way of being called. There is a default implementation (`GlobalScopeEntityResolver`), which keeps the current behavior in tact. A convenience `constructor` is added to maintain the current initialization with an array of `FederatedTypeResolver` and is using that `GlobalScopeEntityResolver` to maintain backwards compatibility