### PR TITLE
[client] support @include and @skip directives

### DIFF
--- a/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/types/generateGraphQLObjectTypeSpec.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/types/generateGraphQLObjectTypeSpec.kt
@@ -68,7 +68,9 @@ internal fun generateGraphQLObjectTypeSpec(
 
         val constructorParameter = ParameterSpec.builder(propertySpec.name, propertySpec.type)
         val className = propertySpec.type as? ClassName
-        if (className != null && context.enumClassToTypeSpecs.keys.contains(className)) {
+        if (propertySpec.type.isNullable) {
+            constructorParameter.defaultValue("null")
+        } else if (className != null && context.enumClassToTypeSpecs.keys.contains(className)) {
             constructorParameter.defaultValue("%T.%N", className, className.member(UNKNOWN_VALUE))
         }
         constructorBuilder.addParameter(constructorParameter.build())

--- a/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/types/generatePropertySpecs.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/types/generatePropertySpecs.kt
@@ -30,6 +30,8 @@ import com.squareup.kotlinpoet.ParameterizedTypeName
 import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeName
 import graphql.Directives.DeprecatedDirective
+import graphql.Directives.IncludeDirective
+import graphql.Directives.SkipDirective
 import graphql.language.Field
 import graphql.language.FieldDefinition
 import graphql.language.NonNullType
@@ -59,7 +61,10 @@ internal fun generatePropertySpecs(
             throw MissingArgumentException(context.operationName, objectName, selectedField.name, missingRequiredArguments)
         }
 
-        val kotlinFieldType = generateTypeName(context, fieldDefinition.type, selectedField.selectionSet)
+        val optional = selectedField.directives.any {
+            it.name == SkipDirective.name || it.name == IncludeDirective.name
+        }
+        val kotlinFieldType = generateTypeName(context, fieldDefinition.type, selectedField.selectionSet, optional = optional)
         val fieldName = selectedField.alias ?: fieldDefinition.name
 
         val propertySpecBuilder = PropertySpec.builder(fieldName, kotlinFieldType)

--- a/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/types/generateTypeName.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/types/generateTypeName.kt
@@ -51,8 +51,13 @@ import kotlinx.serialization.Serializable
 /**
  * Generate [TypeName] reference to a Kotlin class representation of an underlying GraphQL type.
  */
-internal fun generateTypeName(context: GraphQLClientGeneratorContext, graphQLType: Type<*>, selectionSet: SelectionSet? = null): TypeName {
-    val nullable = graphQLType !is NonNullType
+internal fun generateTypeName(
+    context: GraphQLClientGeneratorContext,
+    graphQLType: Type<*>,
+    selectionSet: SelectionSet? = null,
+    optional: Boolean = false
+): TypeName {
+    val nullable = optional || graphQLType !is NonNullType
 
     return when (graphQLType) {
         is NonNullType -> generateTypeName(context, graphQLType.type, selectionSet)

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/include_skip_directives/IncludeSkipDirectivesQuery.graphql
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/include_skip_directives/IncludeSkipDirectivesQuery.graphql
@@ -1,0 +1,6 @@
+query IncludeSkipDirectivesQuery($includeCondition: Boolean!, $skipCondition: Boolean!) {
+  enumQuery @include(if: $includeCondition)
+  scalarQuery @skip(if: $skipCondition) {
+    count
+  }
+}

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/include_skip_directives/IncludeSkipDirectivesQuery.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/include_skip_directives/IncludeSkipDirectivesQuery.kt
@@ -1,0 +1,42 @@
+package com.expediagroup.graphql.generated
+
+import com.expediagroup.graphql.client.Generated
+import com.expediagroup.graphql.client.types.GraphQLClientRequest
+import com.expediagroup.graphql.generated.enums.CustomEnum
+import com.expediagroup.graphql.generated.includeskipdirectivesquery.ScalarWrapper
+import kotlin.Boolean
+import kotlin.String
+import kotlin.reflect.KClass
+
+public const val INCLUDE_SKIP_DIRECTIVES_QUERY: String =
+    "query IncludeSkipDirectivesQuery(${'$'}includeCondition: Boolean!, ${'$'}skipCondition: Boolean!) {\n  enumQuery @include(if: ${'$'}includeCondition)\n  scalarQuery @skip(if: ${'$'}skipCondition) {\n    count\n  }\n}"
+
+@Generated
+public class IncludeSkipDirectivesQuery(
+  public override val variables: IncludeSkipDirectivesQuery.Variables
+) : GraphQLClientRequest<IncludeSkipDirectivesQuery.Result> {
+  public override val query: String = INCLUDE_SKIP_DIRECTIVES_QUERY
+
+  public override val operationName: String = "IncludeSkipDirectivesQuery"
+
+  public override fun responseType(): KClass<IncludeSkipDirectivesQuery.Result> =
+      IncludeSkipDirectivesQuery.Result::class
+
+  @Generated
+  public data class Variables(
+    public val includeCondition: Boolean,
+    public val skipCondition: Boolean
+  )
+
+  @Generated
+  public data class Result(
+    /**
+     * Query that returns enum value
+     */
+    public val enumQuery: CustomEnum?,
+    /**
+     * Query that returns wrapper object with all supported scalar types
+     */
+    public val scalarQuery: ScalarWrapper?
+  )
+}

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/include_skip_directives/IncludeSkipDirectivesQuery.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/include_skip_directives/IncludeSkipDirectivesQuery.kt
@@ -33,10 +33,10 @@ public class IncludeSkipDirectivesQuery(
     /**
      * Query that returns enum value
      */
-    public val enumQuery: CustomEnum?,
+    public val enumQuery: CustomEnum? = null,
     /**
      * Query that returns wrapper object with all supported scalar types
      */
-    public val scalarQuery: ScalarWrapper?
+    public val scalarQuery: ScalarWrapper? = null
   )
 }

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/include_skip_directives/enums/CustomEnum.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/include_skip_directives/enums/CustomEnum.kt
@@ -1,0 +1,36 @@
+package com.expediagroup.graphql.generated.enums
+
+import com.expediagroup.graphql.client.Generated
+import com.fasterxml.jackson.`annotation`.JsonEnumDefaultValue
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import kotlin.Deprecated
+
+/**
+ * Custom enum description
+ */
+@Generated
+public enum class CustomEnum {
+  /**
+   * First enum value
+   */
+  ONE,
+  /**
+   * Third enum value
+   */
+  @Deprecated(message = "only goes up to two")
+  THREE,
+  /**
+   * Second enum value
+   */
+  TWO,
+  /**
+   * Lowercase enum value
+   */
+  @JsonProperty("four")
+  FOUR,
+  /**
+   * This is a default enum value that will be used when attempting to deserialize unknown value.
+   */
+  @JsonEnumDefaultValue
+  __UNKNOWN_VALUE,
+}

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/include_skip_directives/includeskipdirectivesquery/ScalarWrapper.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/include_skip_directives/includeskipdirectivesquery/ScalarWrapper.kt
@@ -1,0 +1,15 @@
+package com.expediagroup.graphql.generated.includeskipdirectivesquery
+
+import com.expediagroup.graphql.client.Generated
+import kotlin.Int
+
+/**
+ * Wrapper that holds all supported scalar types
+ */
+@Generated
+public data class ScalarWrapper(
+  /**
+   * A signed 32-bit nullable integer value
+   */
+  public val count: Int?
+)

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/include_skip_directives/includeskipdirectivesquery/ScalarWrapper.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/include_skip_directives/includeskipdirectivesquery/ScalarWrapper.kt
@@ -11,5 +11,5 @@ public data class ScalarWrapper(
   /**
    * A signed 32-bit nullable integer value
    */
-  public val count: Int?
+  public val count: Int? = null
 )

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/input_lists/InputListQuery.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/input_lists/InputListQuery.kt
@@ -31,6 +31,6 @@ public class InputListQuery(
     /**
      * Query accepting list input
      */
-    public val listInputQuery: String?
+    public val listInputQuery: String? = null
   )
 }

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/scalar_typealias/scalaraliasquery/ScalarWrapper.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/scalar_typealias/scalaraliasquery/ScalarWrapper.kt
@@ -16,5 +16,5 @@ public data class ScalarWrapper(
   /**
    * Custom scalar of UUID
    */
-  public val custom: UUID?
+  public val custom: UUID? = null
 )

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/custom_scalars/customscalarquery/ScalarWrapper.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/custom_scalars/customscalarquery/ScalarWrapper.kt
@@ -21,13 +21,13 @@ public data class ScalarWrapper(
    */
   @JsonSerialize(converter = UUIDToAnyConverter::class)
   @JsonDeserialize(converter = AnyToUUIDConverter::class)
-  public val custom: UUID?,
+  public val custom: UUID? = null,
   /**
    * List of custom scalar UUIDs
    */
   @JsonSerialize(contentConverter = UUIDToAnyConverter::class)
   @JsonDeserialize(contentConverter = AnyToUUIDConverter::class)
-  public val customList: List<UUID>?,
+  public val customList: List<UUID>? = null,
   /**
    * Custom scalar of Locale
    */

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/object/complexobjectquery/ComplexObject.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/object/complexobjectquery/ComplexObject.kt
@@ -23,7 +23,7 @@ public data class ComplexObject(
    * Optional value
    * Second line of the description
    */
-  public val optional: String?,
+  public val optional: String? = null,
   /**
    * Some additional details
    */

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/multiple_queries/firstquery/ComplexObject.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/multiple_queries/firstquery/ComplexObject.kt
@@ -25,7 +25,7 @@ public data class ComplexObject(
    * Optional value
    * Second line of the description
    */
-  public val optional: String?,
+  public val optional: String? = null,
   /**
    * Some additional details
    */

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/multiple_queries/firstquery/ScalarWrapper.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/multiple_queries/firstquery/ScalarWrapper.kt
@@ -16,12 +16,12 @@ public data class ScalarWrapper(
   /**
    * A signed 32-bit nullable integer value
    */
-  public val count: Int?,
+  public val count: Int? = null,
   /**
    * Custom scalar of UUID
    */
   @Serializable(with = UUIDSerializer::class)
-  public val custom: UUID?,
+  public val custom: UUID? = null,
   /**
    * ID represents unique identifier that is not intended to be human readable
    */

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/multiple_queries/secondquery/ScalarWrapper.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/multiple_queries/secondquery/ScalarWrapper.kt
@@ -16,12 +16,12 @@ public data class ScalarWrapper(
   /**
    * A signed 32-bit nullable integer value
    */
-  public val count: Int?,
+  public val count: Int? = null,
   /**
    * Custom scalar of UUID
    */
   @Serializable(with = UUIDSerializer::class)
-  public val custom: UUID?,
+  public val custom: UUID? = null,
   /**
    * ID represents unique identifier that is not intended to be human readable
    */

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/object/complexobjectquery/ComplexObject.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/kotlinx/object/complexobjectquery/ComplexObject.kt
@@ -25,7 +25,7 @@ public data class ComplexObject(
    * Optional value
    * Second line of the description
    */
-  public val optional: String?,
+  public val optional: String? = null,
   /**
    * Some additional details
    */

--- a/plugins/graphql-kotlin-gradle-plugin/src/integration/client-generator/skip_include/build.gradle.kts
+++ b/plugins/graphql-kotlin-gradle-plugin/src/integration/client-generator/skip_include/build.gradle.kts
@@ -1,0 +1,73 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import com.expediagroup.graphql.plugin.gradle.tasks.GraphQLGenerateSDLTask
+import com.expediagroup.graphql.plugin.gradle.tasks.GraphQLGenerateTestClientTask
+
+buildscript {
+    repositories {
+        mavenLocal {
+            content {
+                includeGroup("com.expediagroup")
+            }
+        }
+    }
+
+    val graphQLKotlinVersion = System.getenv("GRAPHQL_KOTLIN_VERSION") ?: "5.0.0-SNAPSHOT"
+    dependencies {
+        classpath("com.expediagroup:graphql-kotlin-gradle-plugin:$graphQLKotlinVersion")
+    }
+}
+
+plugins {
+    id("org.springframework.boot") version "2.5.5"
+    kotlin("jvm") version "1.5.31"
+    kotlin("plugin.spring") version "1.5.31"
+}
+
+apply(plugin = "com.expediagroup.graphql")
+
+group = "com.expediagroup"
+version = "0.0.1-SNAPSHOT"
+
+repositories {
+    mavenCentral()
+    mavenLocal {
+        content {
+            includeGroup("com.expediagroup")
+        }
+    }
+}
+
+val graphQLKotlinVersion = System.getenv("GRAPHQL_KOTLIN_VERSION") ?: "5.0.0-SNAPSHOT"
+val icuVersion = System.getenv("ICU_VERSION") ?: "69.1"
+val junitVersion = System.getenv("JUNIT_VERSION") ?: "5.7.2"
+val kotlinVersion = System.getenv("KOTLIN_VERSION") ?: "1.5.31"
+val springBootVersion = System.getenv("SPRINGBOOT_VERSION") ?: "2.5.5"
+dependencies {
+    implementation("com.expediagroup:graphql-kotlin-hooks-provider:$graphQLKotlinVersion")
+    implementation("com.expediagroup:graphql-kotlin-spring-client:$graphQLKotlinVersion")
+    implementation("com.expediagroup:graphql-kotlin-spring-server:$graphQLKotlinVersion")
+    implementation("com.ibm.icu:icu4j:$icuVersion")
+    testImplementation(kotlin("test-junit5", kotlinVersion))
+    testImplementation("org.junit.jupiter:junit-jupiter-api:$junitVersion")
+    testImplementation("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
+    testImplementation("org.springframework.boot:spring-boot-starter-test:$springBootVersion")
+}
+
+tasks.withType<KotlinCompile> {
+    kotlinOptions {
+        freeCompilerArgs = listOf("-Xjsr305=strict")
+        jvmTarget = "11"
+    }
+}
+
+tasks.withType<Test> {
+    useJUnitPlatform()
+}
+
+val graphqlGenerateSDL by tasks.getting(GraphQLGenerateSDLTask::class) {
+    packages.set(listOf("com.expediagroup.directives"))
+}
+val graphqlGenerateTestClient by tasks.getting(GraphQLGenerateTestClientTask::class) {
+    packageName.set("com.expediagroup.directives.generated")
+    schemaFile.set(graphqlGenerateSDL.schemaFile)
+}

--- a/plugins/graphql-kotlin-gradle-plugin/src/integration/client-generator/skip_include/settings.gradle.kts
+++ b/plugins/graphql-kotlin-gradle-plugin/src/integration/client-generator/skip_include/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "include-skip-test"

--- a/plugins/graphql-kotlin-gradle-plugin/src/integration/client-generator/skip_include/src/main/kotlin/com/expediagroup/directives/Application.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/integration/client-generator/skip_include/src/main/kotlin/com/expediagroup/directives/Application.kt
@@ -1,0 +1,11 @@
+package com.expediagroup.directives
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+
+@SpringBootApplication
+class Application
+
+fun main(args: Array<String>) {
+    runApplication<Application>(*args)
+}

--- a/plugins/graphql-kotlin-gradle-plugin/src/integration/client-generator/skip_include/src/main/kotlin/com/expediagroup/directives/SimpleQuery.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/integration/client-generator/skip_include/src/main/kotlin/com/expediagroup/directives/SimpleQuery.kt
@@ -1,0 +1,11 @@
+package com.expediagroup.directives
+
+import com.expediagroup.graphql.server.operations.Query
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+@Component
+class SimpleQuery : Query {
+
+    fun simpleQuery(): String = UUID.randomUUID().toString()
+}

--- a/plugins/graphql-kotlin-gradle-plugin/src/integration/client-generator/skip_include/src/main/resources/application.yml
+++ b/plugins/graphql-kotlin-gradle-plugin/src/integration/client-generator/skip_include/src/main/resources/application.yml
@@ -1,0 +1,3 @@
+graphql:
+  packages:
+    - "com.expediagroup.directives"

--- a/plugins/graphql-kotlin-gradle-plugin/src/integration/client-generator/skip_include/src/test/kotlin/com/expediagroup/directives/ApplicationTest.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/integration/client-generator/skip_include/src/test/kotlin/com/expediagroup/directives/ApplicationTest.kt
@@ -1,0 +1,52 @@
+package com.expediagroup.directives
+
+import com.expediagroup.graphql.client.spring.GraphQLWebClient
+import com.expediagroup.directives.generated.IncludeSkipQuery
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.web.server.LocalServerPort
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class ApplicationTest(@LocalServerPort private val port: Int) {
+
+    @Test
+    fun `verify include and skip directives are honored by client`() = runBlocking {
+        val client = GraphQLWebClient(url = "http://localhost:$port/graphql")
+
+        val skippedQuery = IncludeSkipQuery(variables = IncludeSkipQuery.Variables(
+            includeCondition = false,
+            skipCondition = true
+        ))
+
+        val response = client.execute(skippedQuery)
+        val simpleResponse = response.data?.simpleQuery
+        assertNotNull(simpleResponse)
+        assertNotNull(UUID.fromString(simpleResponse))
+
+        val included = response.data?.included
+        assertNull(included)
+        val skipped = response.data?.skipped
+        assertNull(skipped)
+
+        val includeQuery = IncludeSkipQuery(variables = IncludeSkipQuery.Variables(
+            includeCondition = true,
+            skipCondition = false
+        ))
+
+        val response = client.execute(includeQuery)
+        val simpleResponse = response.data?.simpleQuery
+        assertNotNull(simpleResponse)
+        assertNotNull(UUID.fromString(simpleResponse))
+
+        val included = response.data?.included
+        assertNotNull(included)
+        assertNotNull(UUID.fromString(included))
+        val skipped = response.data?.skipped
+        assertNotNull(skipped)
+        assertNotNull(UUID.fromString(skipped))
+    }
+
+}

--- a/plugins/graphql-kotlin-gradle-plugin/src/integration/client-generator/skip_include/src/test/kotlin/com/expediagroup/directives/ApplicationTest.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/integration/client-generator/skip_include/src/test/kotlin/com/expediagroup/directives/ApplicationTest.kt
@@ -1,11 +1,12 @@
 package com.expediagroup.directives
 
-import com.expediagroup.graphql.client.spring.GraphQLWebClient
 import com.expediagroup.directives.generated.IncludeSkipQuery
+import com.expediagroup.graphql.client.spring.GraphQLWebClient
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.web.server.LocalServerPort
+import java.util.UUID
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
@@ -13,7 +14,7 @@ import kotlin.test.assertNull
 class ApplicationTest(@LocalServerPort private val port: Int) {
 
     @Test
-    fun `verify include and skip directives are honored by client`() = runBlocking {
+    fun `verify include and skip directives are honored by client`(): Unit = runBlocking {
         val client = GraphQLWebClient(url = "http://localhost:$port/graphql")
 
         val skippedQuery = IncludeSkipQuery(variables = IncludeSkipQuery.Variables(
@@ -36,17 +37,16 @@ class ApplicationTest(@LocalServerPort private val port: Int) {
             skipCondition = false
         ))
 
-        val response = client.execute(includeQuery)
-        val simpleResponse = response.data?.simpleQuery
-        assertNotNull(simpleResponse)
-        assertNotNull(UUID.fromString(simpleResponse))
+        val nonNullResponse = client.execute(includeQuery)
+        val simpleResponseNonNull = nonNullResponse.data?.simpleQuery
+        assertNotNull(simpleResponseNonNull)
+        assertNotNull(UUID.fromString(simpleResponseNonNull))
 
-        val included = response.data?.included
-        assertNotNull(included)
-        assertNotNull(UUID.fromString(included))
-        val skipped = response.data?.skipped
-        assertNotNull(skipped)
-        assertNotNull(UUID.fromString(skipped))
+        val includedNonNull = nonNullResponse.data?.included
+        assertNotNull(includedNonNull)
+        assertNotNull(UUID.fromString(includedNonNull))
+        val skippedNonNull = nonNullResponse.data?.skipped
+        assertNotNull(skippedNonNull)
+        assertNotNull(UUID.fromString(skippedNonNull))
     }
-
 }

--- a/plugins/graphql-kotlin-gradle-plugin/src/integration/client-generator/skip_include/src/test/resources/IncludeSkipQuery.graphql
+++ b/plugins/graphql-kotlin-gradle-plugin/src/integration/client-generator/skip_include/src/test/resources/IncludeSkipQuery.graphql
@@ -1,0 +1,5 @@
+query IncludeSkipQuery($includeCondition: Boolean!, $skipCondition: Boolean!) {
+  simpleQuery
+  included: simpleQuery @include(if: $includeCondition)
+  skipped: simpleQuery @skip(if: $skipCondition)
+}

--- a/plugins/graphql-kotlin-gradle-plugin/src/test/resources/mocks/JUnitQuery.graphql
+++ b/plugins/graphql-kotlin-gradle-plugin/src/test/resources/mocks/JUnitQuery.graphql
@@ -22,6 +22,13 @@ query JUnitQuery($simpleCriteria: SimpleArgumentInput!) {
       value
     }
   }
+  includeComplexObjectQuery: complexObjectQuery @include(if: true) {
+    id
+  }
+  skipComplexObjectQuery: complexObjectQuery @skip(if: false) {
+    id
+  }
+
   interfaceQuery {
     __typename
     id

--- a/plugins/graphql-kotlin-gradle-plugin/src/test/resources/mocks/JUnitQuery.graphql
+++ b/plugins/graphql-kotlin-gradle-plugin/src/test/resources/mocks/JUnitQuery.graphql
@@ -22,13 +22,6 @@ query JUnitQuery($simpleCriteria: SimpleArgumentInput!) {
       value
     }
   }
-  includeComplexObjectQuery: complexObjectQuery @include(if: true) {
-    id
-  }
-  skipComplexObjectQuery: complexObjectQuery @skip(if: false) {
-    id
-  }
-
   interfaceQuery {
     __typename
     id

--- a/plugins/graphql-kotlin-gradle-plugin/src/test/resources/templates/JUnit.mustache
+++ b/plugins/graphql-kotlin-gradle-plugin/src/test/resources/templates/JUnit.mustache
@@ -16,7 +16,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import java.io.File
 import java.nio.file.Paths
-import kotlin.reflect.full.declaredMemberProperties
 
 class GraphQLMavenPluginTest {
 
@@ -25,16 +24,6 @@ class GraphQLMavenPluginTest {
         val buildDirectory = System.getProperty("buildDirectory")
         val path = Paths.get(buildDirectory, "generated", "sources", "graphql", "com", "example", "generated", "JUnitQuery.kt")
         assertTrue(path.toFile().exists(), "graphql client was generated")
-    }
-
-    @Test
-    fun `verify topLevelDirective fields are nullable`() {
-        assertTrue(
-            JUnitQuery.Result::class.declaredMemberProperties.first { it.name == "includeComplexObjectQuery" }.returnType.isMarkedNullable
-        )
-        assertTrue(
-            JUnitQuery.Result::class.declaredMemberProperties.first { it.name == "skipComplexObjectQuery" }.returnType.isMarkedNullable
-        )
     }
 
     @Test

--- a/plugins/graphql-kotlin-gradle-plugin/src/test/resources/templates/JUnit.mustache
+++ b/plugins/graphql-kotlin-gradle-plugin/src/test/resources/templates/JUnit.mustache
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import java.io.File
 import java.nio.file.Paths
+import kotlin.reflect.full.declaredMemberProperties
 
 class GraphQLMavenPluginTest {
 
@@ -24,6 +25,16 @@ class GraphQLMavenPluginTest {
         val buildDirectory = System.getProperty("buildDirectory")
         val path = Paths.get(buildDirectory, "generated", "sources", "graphql", "com", "example", "generated", "JUnitQuery.kt")
         assertTrue(path.toFile().exists(), "graphql client was generated")
+    }
+
+    @Test
+    fun `verify topLevelDirective fields are nullable`() {
+        assertTrue(
+            JUnitQuery.Result::class.declaredMemberProperties.first { it.name == "includeComplexObjectQuery" }.returnType.isMarkedNullable
+        )
+        assertTrue(
+            JUnitQuery.Result::class.declaredMemberProperties.first { it.name == "skipComplexObjectQuery" }.returnType.isMarkedNullable
+        )
     }
 
     @Test


### PR DESCRIPTION
### :pencil: Description
Update client generator logic to handle `@skip` and `@include` directives. If directives are specified they will override nullability of the underlying field to always be nullable. 

### :link: Related Issues
Supersedes: https://github.com/ExpediaGroup/graphql-kotlin/pull/1327
Resolves: https://github.com/ExpediaGroup/graphql-kotlin/issues/1282
