### PR TITLE
Try and fail to implement a directive @constraint

### DIFF
--- a/examples/server/ktor-server/src/main/kotlin/com/expediagroup/graphql/examples/server/ktor/Directives.kt
+++ b/examples/server/ktor-server/src/main/kotlin/com/expediagroup/graphql/examples/server/ktor/Directives.kt
@@ -1,0 +1,60 @@
+package com.expediagroup.graphql.examples.server.ktor
+
+import com.expediagroup.graphql.generator.annotations.*
+import com.expediagroup.graphql.generator.annotations.GraphQLDirective
+import com.expediagroup.graphql.generator.directives.*
+import graphql.introspection.*
+import graphql.schema.*
+
+/**
+ * This GraphQL directive allows to add constraints to the GraphQL Schema
+ *
+ * See https://opensource.expediagroup.com/graphql-kotlin/docs/schema-generator/customizing-schemas/directives/
+ * See https://www.apollographql.com/blog/backend/validation/graphql-validation-using-directives/
+ */
+@GraphQLDirective(
+    name = "constraint",
+    description = "This GraphQL directive allows to add constraints to the GraphQL Schema - https://www.apollographql.com/blog/backend/validation/graphql-validation-using-directives/",
+    locations = [
+        Introspection.DirectiveLocation.FIELD_DEFINITION,
+        Introspection.DirectiveLocation.INPUT_OBJECT,
+        Introspection.DirectiveLocation.INPUT_FIELD_DEFINITION
+    ]
+
+)
+annotation class ConstraintDirective(
+    val format: String = "",
+    val minLength: Int = 1,
+    val maxLength: Int = Int.MAX_VALUE,
+    val pattern: String = ""
+)
+
+
+class ConstraintDirectiveWiring: KotlinSchemaDirectiveWiring {
+
+    override fun onField(environment: KotlinFieldDirectiveEnvironment): GraphQLFieldDefinition {
+        val field: GraphQLFieldDefinition = environment.element
+        val originalDataFetcher: DataFetcher<*> = environment.getDataFetcher()
+        val newDataFetcher = DataFetcherFactories.wrapDataFetcher(originalDataFetcher) { _, value ->
+            println("todo: handle the @constraint() directive")
+            value.toString()
+        }
+        environment.setDataFetcher(newDataFetcher)
+        return field
+    }
+}
+
+data class DirectiveInput(
+    @ConstraintDirective(format = "email")
+    val email: String,
+    @ConstraintDirective(minLength = 8, maxLength = 16)
+    val deviceId: String
+)
+
+data class DirectivePayload(
+    @ConstraintDirective(format = "email")
+    val email: String,
+    @ConstraintDirective(minLength = 8, maxLength = 16)
+    val deviceId: String
+)
+

--- a/examples/server/ktor-server/src/main/kotlin/com/expediagroup/graphql/examples/server/ktor/ktorGraphQLSchema.kt
+++ b/examples/server/ktor-server/src/main/kotlin/com/expediagroup/graphql/examples/server/ktor/ktorGraphQLSchema.kt
@@ -23,6 +23,8 @@ import com.expediagroup.graphql.examples.server.ktor.schema.LoginMutationService
 import com.expediagroup.graphql.examples.server.ktor.schema.UniversityQueryService
 import com.expediagroup.graphql.generator.SchemaGeneratorConfig
 import com.expediagroup.graphql.generator.TopLevelObject
+import com.expediagroup.graphql.generator.directives.*
+import com.expediagroup.graphql.generator.hooks.*
 import com.expediagroup.graphql.generator.toSchema
 import graphql.GraphQL
 
@@ -31,7 +33,19 @@ import graphql.GraphQL
  * needed to handle incoming requests. In a more enterprise solution you may want to load more things from
  * configuration files instead of hardcoding them.
  */
-private val config = SchemaGeneratorConfig(supportedPackages = listOf("com.expediagroup.graphql.examples.server.ktor"))
+
+val customWiringFactory = KotlinDirectiveWiringFactory(
+    manualWiring = mapOf("constraint" to ConstraintDirectiveWiring())
+)
+
+private val config = SchemaGeneratorConfig(
+    supportedPackages = listOf("com.expediagroup.graphql.examples.server.ktor"),
+    hooks = object : SchemaGeneratorHooks {
+        override val wiringFactory: KotlinDirectiveWiringFactory
+            get() = customWiringFactory
+    }
+)
+
 private val queries = listOf(
     TopLevelObject(HelloQueryService()),
     TopLevelObject(BookQueryService()),

--- a/examples/server/ktor-server/src/main/kotlin/com/expediagroup/graphql/examples/server/ktor/schema/LoginMutationService.kt
+++ b/examples/server/ktor-server/src/main/kotlin/com/expediagroup/graphql/examples/server/ktor/schema/LoginMutationService.kt
@@ -16,13 +16,18 @@
 
 package com.expediagroup.graphql.examples.server.ktor.schema
 
+import com.expediagroup.graphql.examples.server.ktor.*
 import com.expediagroup.graphql.examples.server.ktor.schema.models.User
 import com.expediagroup.graphql.server.operations.Mutation
 
 data class AuthPayload(val token: String? = null, val user: User? = null)
 
 class LoginMutationService : Mutation {
-    suspend fun login(email: String, password: String, aliasUUID: String?): AuthPayload {
+    suspend fun login(
+        @ConstraintDirective(format = "email") email: String,
+        password: String,
+        aliasUUID: String?
+    ): AuthPayload {
         val token = "fake-token"
         val user = User(
             email = "fake@site.com",
@@ -32,4 +37,8 @@ class LoginMutationService : Mutation {
         )
         return AuthPayload(token, user)
     }
+
+    suspend fun directive(input: DirectiveInput): DirectivePayload =
+        DirectivePayload("hello@gmail.com", "123456")
 }
+


### PR DESCRIPTION
### :pencil: Description

Helo, I tried and failed to implement a GraphQL directive as explained here 
-> https://opensource.expediagroup.com/graphql-kotlin/docs/schema-generator/customizing-schemas/directives#custom-directives

Dariusz Kuc asked  me on Slack to provide a sample that shows the issue and here it is.

Reproducing steps:

- run the `:ktor-server:run`  Gradle task
- fetch the GraphQL schema


### Expected:

```
"This GraphQL directive allows to add constraints to the GraphQL Schema - https://www.apollographql.com/blog/backend/validation/graphql-validation-using-directives/"
directive @constraint(format: String!, maxLength: Int!, minLength: Int!, pattern: String!) on VARIABLE_DEFINITION | FIELD_DEFINITION | INPUT_OBJECT

input DirectiveInput {
    deviceId: String! @constraint(minLength: 8, maxLength: 16)
    email: String! @constraint(format: "email")
}


type DirectivePayload {
    deviceId: String! @constraint(minLength: 8, maxLength: 16)
    email: String! @constraint(format: "email")
}
```

### Got:


```
"This GraphQL directive allows to add constraints to the GraphQL Schema - https://www.apollographql.com/blog/backend/validation/graphql-validation-using-directives/"
directive @constraint(format: String!, maxLength: Int!, minLength: Int!, pattern: String!) on VARIABLE_DEFINITION | FIELD_DEFINITION | INPUT_OBJECT

input DirectiveInput {
    deviceId: String!
    email: String!
}


type DirectivePayload {
    deviceId: String!
    email: String!
}
```

### :link: Related Issues
