### PR TITLE
examples/ktor-server: expose GraphQL Schema at /sdl

### DIFF
--- a/examples/server/ktor-server/README.md
+++ b/examples/server/ktor-server/README.md
@@ -22,7 +22,8 @@ cd /path/to/graphql-kotlin/examples
 
 Once the app has started you can:
 - send GraphQL requests by opening the Playground endpoint at http://localhost:8080/playground
-- check out the GraphQL Schema by opening http://localhost:8080/sdl
+- send GraphQL requests directly to the endpoint at http://localhost:8080/graphql
+- explore and interact with the example schema by opening the Playground IDE endpoint at http://localhost:8080/playground
 
 #### Example query
 

--- a/examples/server/ktor-server/README.md
+++ b/examples/server/ktor-server/README.md
@@ -20,7 +20,9 @@ cd /path/to/graphql-kotlin/examples
 ./gradlew ktor-server:run
 ```
 
-Once the app has started you can explore the example schema by opening Playground endpoint at http://localhost:8080/playground
+Once the app has started you can:
+- send GraphQL requests by opening the Playground endpoint at http://localhost:8080/playground
+- check out the GraphQL Schema by opening http://localhost:8080/sdl
 
 #### Example query
 

--- a/examples/server/ktor-server/src/main/kotlin/com/expediagroup/graphql/examples/server/ktor/GraphQLModule.kt
+++ b/examples/server/ktor-server/src/main/kotlin/com/expediagroup/graphql/examples/server/ktor/GraphQLModule.kt
@@ -16,7 +16,7 @@
 
 package com.expediagroup.graphql.examples.server.ktor
 
-import com.expediagroup.graphql.generator.extensions.*
+import com.expediagroup.graphql.generator.extensions.print
 import io.ktor.application.Application
 import io.ktor.application.call
 import io.ktor.application.install

--- a/examples/server/ktor-server/src/main/kotlin/com/expediagroup/graphql/examples/server/ktor/GraphQLModule.kt
+++ b/examples/server/ktor-server/src/main/kotlin/com/expediagroup/graphql/examples/server/ktor/GraphQLModule.kt
@@ -16,6 +16,7 @@
 
 package com.expediagroup.graphql.examples.server.ktor
 
+import com.expediagroup.graphql.generator.extensions.*
 import io.ktor.application.Application
 import io.ktor.application.call
 import io.ktor.application.install
@@ -32,6 +33,10 @@ fun Application.graphQLModule() {
     routing {
         post("graphql") {
             KtorServer().handle(this.call)
+        }
+
+        get("sdl") {
+            call.respondText(graphQLSchema.print())
         }
 
         get("playground") {

--- a/examples/server/ktor-server/src/main/kotlin/com/expediagroup/graphql/examples/server/ktor/ktorGraphQLSchema.kt
+++ b/examples/server/ktor-server/src/main/kotlin/com/expediagroup/graphql/examples/server/ktor/ktorGraphQLSchema.kt
@@ -39,6 +39,6 @@ private val queries = listOf(
     TopLevelObject(UniversityQueryService())
 )
 private val mutations = listOf(TopLevelObject(LoginMutationService()))
-private val graphQLSchema = toSchema(config, queries, mutations)
+val graphQLSchema = toSchema(config, queries, mutations)
 
 fun getGraphQLObject(): GraphQL = GraphQL.newGraphQL(graphQLSchema).build()


### PR DESCRIPTION
### :pencil: Description

Not having the GraphQL schema complete with directives caused me troubles (see linked PR)

In spring-server, the `/sdl` endpoint expose the GraphQL schema

If this commit is merged, it will be exposed as well in the ktor-server example


### :link: Related Issues

https://github.com/ExpediaGroup/graphql-kotlin/pull/1350