### PR TITLE
[generator] support repeatable directives

### DIFF
--- a/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/FederatedSchemaGeneratorHooks.kt
+++ b/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/FederatedSchemaGeneratorHooks.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Expedia, Inc
+ * Copyright 2022 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -147,7 +147,7 @@ open class FederatedSchemaGeneratorHooks(private val resolvers: List<FederatedTy
         return originalSchema.allTypesAsList
             .asSequence()
             .filterIsInstance<GraphQLObjectType>()
-            .filter { type -> type.getDirective(KEY_DIRECTIVE_NAME) != null }
+            .filter { type -> type.hasDirective(KEY_DIRECTIVE_NAME) }
             .map { it.name }
             .toSet()
     }

--- a/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/directives/KeyDirective.kt
+++ b/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/directives/KeyDirective.kt
@@ -21,7 +21,7 @@ import graphql.introspection.Introspection.DirectiveLocation
 
 /**
  * ```graphql
- * directive @key(fields: _FieldSet!) on OBJECT | INTERFACE
+ * directive @key(fields: _FieldSet!) repeatable on OBJECT | INTERFACE
  * ```
  *
  * The @key directive is used to indicate a combination of fields that can be used to uniquely identify and fetch an object or interface. Key directive should be specified on the root base type as

--- a/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/directives/KeyDirective.kt
+++ b/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/directives/KeyDirective.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Expedia, Inc
+ * Copyright 2022 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,9 +28,6 @@ import graphql.introspection.Introspection.DirectiveLocation
  * well as all the corresponding federated (i.e. extended) types. Key fields specified in the directive field set should correspond to a valid field on the underlying GraphQL interface/object.
  * Federated extended types should also instrument all the referenced key fields with @external directive.
  *
- * NOTE: The Federation spec specifies that multiple @key directives can be applied on the field. The GraphQL spec has been recently changed to allow this behavior,
- *   but we are currently blocked and are tracking progress in [this issue](https://github.com/ExpediaGroup/graphql-kotlin/issues/590).
- *
  * Example:
  * Given
  *
@@ -55,6 +52,7 @@ import graphql.introspection.Introspection.DirectiveLocation
  * @see ExtendsDirective
  * @see ExternalDirective
  */
+@Repeatable
 @GraphQLDirective(
     name = KEY_DIRECTIVE_NAME,
     description = KEY_DIRECTIVE_DESCRIPTION,
@@ -70,4 +68,5 @@ internal val KEY_DIRECTIVE_TYPE: graphql.schema.GraphQLDirective = graphql.schem
     .description(KEY_DIRECTIVE_DESCRIPTION)
     .validLocations(DirectiveLocation.OBJECT, DirectiveLocation.INTERFACE)
     .argument(FIELD_SET_ARGUMENT)
+    .repeatable(true)
     .build()

--- a/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/extensions/GraphQLDirectiveContainerExtensions.kt
+++ b/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/extensions/GraphQLDirectiveContainerExtensions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Expedia, Inc
+ * Copyright 2022 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,6 @@ import com.expediagroup.graphql.generator.federation.directives.EXTENDS_DIRECTIV
 import com.expediagroup.graphql.generator.federation.directives.KEY_DIRECTIVE_NAME
 import graphql.schema.GraphQLDirectiveContainer
 
-internal fun GraphQLDirectiveContainer.isFederatedType() = this.getDirective(KEY_DIRECTIVE_NAME) != null || isExtendedType()
+internal fun GraphQLDirectiveContainer.isFederatedType() = this.getDirectives(KEY_DIRECTIVE_NAME).isNotEmpty() || isExtendedType()
 
 internal fun GraphQLDirectiveContainer.isExtendedType() = this.getDirective(EXTENDS_DIRECTIVE_NAME) != null

--- a/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/extensions/graphQLSchemaExtensions.kt
+++ b/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/extensions/graphQLSchemaExtensions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Expedia, Inc
+ * Copyright 2022 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ internal fun GraphQLSchema.addDirectivesIfNotPresent(directives: List<GraphQLDir
     val newBuilder = GraphQLSchema.newSchema(this)
 
     directives.forEach {
-        if (this.getDirective(it.name) == null) {
+        if (!this.allDirectivesByName.containsKey(it.name)) {
             newBuilder.additionalDirective(it)
         }
     }

--- a/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/validation/validateProvidesDirective.kt
+++ b/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/validation/validateProvidesDirective.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Expedia, Inc
+ * Copyright 2022 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ internal fun validateProvidesDirective(federatedType: String, field: GraphQLFiel
             validateDirective(
                 "$federatedType.${field.name}",
                 PROVIDES_DIRECTIVE_NAME,
-                field.directivesByName,
+                field.allDirectivesByName,
                 returnTypeFields,
                 true
             )

--- a/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/validation/validateRequiresDirective.kt
+++ b/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/validation/validateRequiresDirective.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Expedia, Inc
+ * Copyright 2022 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import graphql.schema.GraphQLFieldDefinition
 internal fun validateRequiresDirective(validatedType: String, validatedField: GraphQLFieldDefinition, fieldMap: Map<String, GraphQLFieldDefinition>, extendedType: Boolean): List<String> {
     val errors = mutableListOf<String>()
     if (extendedType) {
-        errors.addAll(validateDirective("$validatedType.${validatedField.name}", REQUIRES_DIRECTIVE_NAME, validatedField.directivesByName, fieldMap, extendedType))
+        errors.addAll(validateDirective("$validatedType.${validatedField.name}", REQUIRES_DIRECTIVE_NAME, validatedField.allDirectivesByName, fieldMap, extendedType))
     } else {
         errors.add("base $validatedType type has fields marked with @requires directive, validatedField=${validatedField.name}")
     }

--- a/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/data/integration/key/failure/_01/FederatedMissingKey.kt
+++ b/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/data/integration/key/failure/_01/FederatedMissingKey.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Expedia, Inc
+ * Copyright 2022 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,19 +14,17 @@
  * limitations under the License.
  */
 
-package com.expediagroup.graphql.generator.federation.data.integration.key.failure._5
+package com.expediagroup.graphql.generator.federation.data.integration.key.failure._01
 
 import com.expediagroup.graphql.generator.federation.directives.ExtendsDirective
-import com.expediagroup.graphql.generator.federation.directives.FieldSet
-import com.expediagroup.graphql.generator.federation.directives.KeyDirective
+import com.expediagroup.graphql.generator.federation.directives.ExternalDirective
 
 /*
-# example invalid usage of @key directive - extended type references local field
-type ExternalKeyReferencingLocalField @extends @key(fields : "id") {
+# example of invalid federated type - missing @key directive
+type FederatedMissingKey @extends {
   description: String!
-  id: String!
+  id: String! @external
 }
  */
-@KeyDirective(fields = FieldSet("id"))
 @ExtendsDirective
-data class ExternalKeyReferencingLocalField(val id: String, val description: String)
+data class FederatedMissingKey(@ExternalDirective val id: String, val description: String)

--- a/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/data/integration/key/failure/_02/KeyMissingFieldSelection.kt
+++ b/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/data/integration/key/failure/_02/KeyMissingFieldSelection.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Expedia, Inc
+ * Copyright 2022 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,22 +14,22 @@
  * limitations under the License.
  */
 
-package com.expediagroup.graphql.generator.federation.data.integration.key.failure._9
+package com.expediagroup.graphql.generator.federation.data.integration.key.failure._02
 
 import com.expediagroup.graphql.generator.federation.directives.FieldSet
 import com.expediagroup.graphql.generator.federation.directives.KeyDirective
 import io.mockk.mockk
 
 /*
-# example invalid usage of @key directive - field set references complex key on scalar
-type NestedKeyReferencingScalar @key(fields : "id { uuid }") {
+# example invalid usage of @key directive - does not specify any fields
+type KeyMissingFieldSelection @key(fields : "") {
   description: String!
   id: String!
 }
  */
-@KeyDirective(fields = FieldSet("id { uuid }"))
-data class NestedKeyReferencingScalar(val id: String, val description: String)
+@KeyDirective(FieldSet(""))
+data class KeyMissingFieldSelection(val id: String, val description: String)
 
-class NestedKeyReferencingScalarQuery {
-    fun keyQuery(): NestedKeyReferencingScalar = mockk()
+class KeyMissingFieldSelectionQuery {
+    fun keyQuery(): KeyMissingFieldSelection = mockk()
 }

--- a/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/data/integration/key/failure/_03/InvalidKey.kt
+++ b/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/data/integration/key/failure/_03/InvalidKey.kt
@@ -14,22 +14,22 @@
  * limitations under the License.
  */
 
-package com.expediagroup.graphql.generator.federation.data.integration.key.failure._6
+package com.expediagroup.graphql.generator.federation.data.integration.key.failure._03
 
 import com.expediagroup.graphql.generator.federation.directives.FieldSet
 import com.expediagroup.graphql.generator.federation.directives.KeyDirective
 import io.mockk.mockk
 
 /*
-# example usage of invalid @key directive - field set references a list
-type KeyReferencingList @key(fields : "id") {
+# example invalid usage of @key directive - references non-existent field
+type InvalidKey @key(fields : "id") {
   description: String!
-  id: [String!]!
+  productId: String!
 }
  */
 @KeyDirective(fields = FieldSet("id"))
-data class KeyReferencingList(val id: List<String>, val description: String)
+data class InvalidKey(val productId: String, val description: String)
 
-class KeyReferencingListQuery {
-    fun keyQuery(): KeyReferencingList = mockk()
+class InvalidKeyQuery {
+    fun keyQuery(): InvalidKey = mockk()
 }

--- a/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/data/integration/key/failure/_04/BaseKeyReferencingExternalFields.kt
+++ b/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/data/integration/key/failure/_04/BaseKeyReferencingExternalFields.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Expedia, Inc
+ * Copyright 2022 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,17 +14,23 @@
  * limitations under the License.
  */
 
-package com.expediagroup.graphql.generator.federation.data.integration.key.failure._1
+package com.expediagroup.graphql.generator.federation.data.integration.key.failure._04
 
-import com.expediagroup.graphql.generator.federation.directives.ExtendsDirective
 import com.expediagroup.graphql.generator.federation.directives.ExternalDirective
+import com.expediagroup.graphql.generator.federation.directives.FieldSet
+import com.expediagroup.graphql.generator.federation.directives.KeyDirective
+import io.mockk.mockk
 
 /*
-# example of invalid federated type - missing @key directive
-type FederatedMissingKey @extends {
+# example usage of invalid type - external type specified in local object
+type BaseKeyReferencingExternalFields @key(fields : "id") {
   description: String!
   id: String! @external
 }
  */
-@ExtendsDirective
-data class FederatedMissingKey(@ExternalDirective val id: String, val description: String)
+@KeyDirective(fields = FieldSet("id"))
+data class BaseKeyReferencingExternalFields(@ExternalDirective val id: String, val description: String)
+
+class BaseKeyReferencingExternalFieldsQuery {
+    fun keyQuery(): BaseKeyReferencingExternalFields = mockk()
+}

--- a/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/data/integration/key/failure/_05/ExternalKeyReferencingLocalField.kt
+++ b/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/data/integration/key/failure/_05/ExternalKeyReferencingLocalField.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.generator.federation.data.integration.key.failure._05
+
+import com.expediagroup.graphql.generator.federation.directives.ExtendsDirective
+import com.expediagroup.graphql.generator.federation.directives.FieldSet
+import com.expediagroup.graphql.generator.federation.directives.KeyDirective
+
+/*
+# example invalid usage of @key directive - extended type references local field
+type ExternalKeyReferencingLocalField @extends @key(fields : "id") {
+  description: String!
+  id: String!
+}
+ */
+@KeyDirective(fields = FieldSet("id"))
+@ExtendsDirective
+data class ExternalKeyReferencingLocalField(val id: String, val description: String)

--- a/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/data/integration/key/failure/_06/KeyReferencingList.kt
+++ b/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/data/integration/key/failure/_06/KeyReferencingList.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Expedia, Inc
+ * Copyright 2022 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,22 +14,22 @@
  * limitations under the License.
  */
 
-package com.expediagroup.graphql.generator.federation.data.integration.key.failure._2
+package com.expediagroup.graphql.generator.federation.data.integration.key.failure._06
 
 import com.expediagroup.graphql.generator.federation.directives.FieldSet
 import com.expediagroup.graphql.generator.federation.directives.KeyDirective
 import io.mockk.mockk
 
 /*
-# example invalid usage of @key directive - does not specify any fields
-type KeyMissingFieldSelection @key(fields : "") {
+# example usage of invalid @key directive - field set references a list
+type KeyReferencingList @key(fields : "id") {
   description: String!
-  id: String!
+  id: [String!]!
 }
  */
-@KeyDirective(FieldSet(""))
-data class KeyMissingFieldSelection(val id: String, val description: String)
+@KeyDirective(fields = FieldSet("id"))
+data class KeyReferencingList(val id: List<String>, val description: String)
 
-class KeyMissingFieldSelectionQuery {
-    fun keyQuery(): KeyMissingFieldSelection = mockk()
+class KeyReferencingListQuery {
+    fun keyQuery(): KeyReferencingList = mockk()
 }

--- a/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/data/integration/key/failure/_07/KeyReferencingInterface.kt
+++ b/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/data/integration/key/failure/_07/KeyReferencingInterface.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Expedia, Inc
+ * Copyright 2022 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.expediagroup.graphql.generator.federation.data.integration.key.failure._7
+package com.expediagroup.graphql.generator.federation.data.integration.key.failure._07
 
 import com.expediagroup.graphql.generator.federation.directives.FieldSet
 import com.expediagroup.graphql.generator.federation.directives.KeyDirective

--- a/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/data/integration/key/failure/_08/KeyReferencingUnion.kt
+++ b/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/data/integration/key/failure/_08/KeyReferencingUnion.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Expedia, Inc
+ * Copyright 2022 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.expediagroup.graphql.generator.federation.data.integration.key.failure._8
+package com.expediagroup.graphql.generator.federation.data.integration.key.failure._08
 
 import com.expediagroup.graphql.generator.federation.directives.FieldSet
 import com.expediagroup.graphql.generator.federation.directives.KeyDirective

--- a/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/data/integration/key/failure/_09/NestedKeyReferencingScalar.kt
+++ b/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/data/integration/key/failure/_09/NestedKeyReferencingScalar.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Expedia, Inc
+ * Copyright 2022 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,23 +14,22 @@
  * limitations under the License.
  */
 
-package com.expediagroup.graphql.generator.federation.data.integration.key.failure._4
+package com.expediagroup.graphql.generator.federation.data.integration.key.failure._09
 
-import com.expediagroup.graphql.generator.federation.directives.ExternalDirective
 import com.expediagroup.graphql.generator.federation.directives.FieldSet
 import com.expediagroup.graphql.generator.federation.directives.KeyDirective
 import io.mockk.mockk
 
 /*
-# example usage of invalid type - external type specified in local object
-type BaseKeyReferencingExternalFields @key(fields : "id") {
+# example invalid usage of @key directive - field set references complex key on scalar
+type NestedKeyReferencingScalar @key(fields : "id { uuid }") {
   description: String!
-  id: String! @external
+  id: String!
 }
  */
-@KeyDirective(fields = FieldSet("id"))
-data class BaseKeyReferencingExternalFields(@ExternalDirective val id: String, val description: String)
+@KeyDirective(fields = FieldSet("id { uuid }"))
+data class NestedKeyReferencingScalar(val id: String, val description: String)
 
-class BaseKeyReferencingExternalFieldsQuery {
-    fun keyQuery(): BaseKeyReferencingExternalFields = mockk()
+class NestedKeyReferencingScalarQuery {
+    fun keyQuery(): NestedKeyReferencingScalar = mockk()
 }

--- a/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/data/integration/key/failure/_10/MultipleKeysOneInvalid.kt
+++ b/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/data/integration/key/failure/_10/MultipleKeysOneInvalid.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2022 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.generator.federation.data.integration.key.failure._10
+
+import com.expediagroup.graphql.generator.federation.directives.FieldSet
+import com.expediagroup.graphql.generator.federation.directives.KeyDirective
+import io.mockk.mockk
+
+/*
+# example invalid usage of @key directive - field set references non-existent field
+type MultipleKeysOneInvalid @key(fields : "id") @key(fields : "upc") {
+  description: String!
+  id: String!
+}
+ */
+@KeyDirective(fields = FieldSet("id"))
+@KeyDirective(fields = FieldSet("upc"))
+data class MultipleKeysOneInvalid(val id: String, val description: String)
+
+class MultipleKeysOneInvalidQuery {
+    fun multipleKeysOneInvalid(): MultipleKeysOneInvalid = mockk()
+}

--- a/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/data/integration/key/success/_7/MultipleKeys.kt
+++ b/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/data/integration/key/success/_7/MultipleKeys.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Expedia, Inc
+ * Copyright 2022 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,22 +14,24 @@
  * limitations under the License.
  */
 
-package com.expediagroup.graphql.generator.federation.data.integration.key.failure._3
+package com.expediagroup.graphql.generator.federation.data.integration.key.success._7
 
 import com.expediagroup.graphql.generator.federation.directives.FieldSet
 import com.expediagroup.graphql.generator.federation.directives.KeyDirective
 import io.mockk.mockk
 
 /*
-# example invalid usage of @key directive - references non-existent field
-type InvalidKey @key(fields : "id") {
+# example usage of a valid @key directive referencing single field on a local type
+type MultipleKeys @key(fields : "id") @key(fields : "upc") {
   description: String!
-  productId: String!
+  id: String!
+  upc: String!
 }
  */
 @KeyDirective(fields = FieldSet("id"))
-data class InvalidKey(val productId: String, val description: String)
+@KeyDirective(fields = FieldSet("upc"))
+data class MultipleKeys(val id: String, val upc: String, val description: String)
 
-class InvalidKeyQuery {
-    fun keyQuery(): InvalidKey = mockk()
+class MultipleKeyQuery {
+    fun multipleKeys(): MultipleKeys = mockk()
 }

--- a/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/data/queries/federated/Product.kt
+++ b/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/data/queries/federated/Product.kt
@@ -28,22 +28,26 @@ import com.expediagroup.graphql.generator.federation.directives.RequiresDirectiv
 import kotlin.properties.Delegates
 
 /*
-interface Product @extends @key(fields : "id") {
+interface Product @extends @key(fields : "id") @key(fields : "upc") {
   id: String! @external
+  upc: String! @external
   reviews: [Review!]!
 }
  */
 @KeyDirective(fields = FieldSet("id"))
+@KeyDirective(fields = FieldSet("upc"))
 @ExtendsDirective
 interface Product {
     @ExternalDirective val id: String
+    @ExternalDirective val upc: String
     fun reviews(): List<Review>
 }
 
 /*
-type Book implements Product @extends @key(fields : "id") {
+type Book implements Product @extends @key(fields : "id") @key(fields : "upc") {
   author: User! @provides(fields : "name")
   id: String! @external
+  upc: String! @external
   reviews: [Review!]!
   shippingCost: String! @requires(fields : "weight")
   weight: Float! @external
@@ -51,9 +55,13 @@ type Book implements Product @extends @key(fields : "id") {
  */
 @ExtendsDirective
 @KeyDirective(FieldSet("id"))
+@KeyDirective(FieldSet("upc"))
 class Book(
-    @ExternalDirective override val id: String
+    @ExternalDirective override val id: String,
+    @ExternalDirective override val upc: String
 ) : Product {
+
+    constructor(id: String) : this(id, id)
 
     // optionally provided as it is not part of the @key field set
     // will only be specified if federated query attempts to resolve shippingCost

--- a/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/execution/ServiceQueryResolverTest.kt
+++ b/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/execution/ServiceQueryResolverTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Expedia, Inc
+ * Copyright 2022 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,16 +39,18 @@ import kotlin.test.assertNotNull
 // SDL is returned without _entity and _service queries
 const val FEDERATED_SERVICE_SDL =
 """
-interface Product @extends @key(fields : "id") {
+interface Product @extends @key(fields : "id") @key(fields : "upc") {
   id: String! @external
   reviews: [Review!]!
+  upc: String! @external
 }
 
-type Book implements Product @extends @key(fields : "id") {
+type Book implements Product @extends @key(fields : "id") @key(fields : "upc") {
   author: User! @provides(fields : "name")
   id: String! @external
   reviews: [Review!]!
   shippingCost: String! @requires(fields : "weight")
+  upc: String! @external
   weight: Float! @external
 }
 

--- a/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/validation/ValidateDirectiveKtTest.kt
+++ b/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/validation/ValidateDirectiveKtTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Expedia, Inc
+ * Copyright 2022 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ internal class ValidateDirectiveKtTest {
         val validationErrors = validateDirective(
             validatedType = "",
             targetDirective = "",
-            directives = emptyMap(),
+            directiveMap = emptyMap(),
             fieldMap = emptyMap(),
             extendedType = false
         )
@@ -54,7 +54,7 @@ internal class ValidateDirectiveKtTest {
         val validationErrors = validateDirective(
             validatedType = "",
             targetDirective = "foo",
-            directives = mapOf("foo" to directive),
+            directiveMap = mapOf("foo" to listOf(directive)),
             fieldMap = emptyMap(),
             extendedType = false
         )
@@ -77,7 +77,7 @@ internal class ValidateDirectiveKtTest {
         val validationErrors = validateDirective(
             validatedType = "",
             targetDirective = "foo",
-            directives = mapOf("foo" to directive),
+            directiveMap = mapOf("foo" to listOf(directive)),
             fieldMap = emptyMap(),
             extendedType = false
         )
@@ -100,7 +100,7 @@ internal class ValidateDirectiveKtTest {
         val validationErrors = validateDirective(
             validatedType = "",
             targetDirective = "foo",
-            directives = mapOf("foo" to directive),
+            directiveMap = mapOf("foo" to listOf(directive)),
             fieldMap = emptyMap(),
             extendedType = false
         )
@@ -125,7 +125,7 @@ internal class ValidateDirectiveKtTest {
         val validationErrors = validateDirective(
             validatedType = "",
             targetDirective = "foo",
-            directives = mapOf("foo" to directive),
+            directiveMap = mapOf("foo" to listOf(directive)),
             fieldMap = emptyMap(),
             extendedType = false
         )
@@ -150,7 +150,7 @@ internal class ValidateDirectiveKtTest {
         val validationErrors = validateDirective(
             validatedType = "",
             targetDirective = "foo",
-            directives = mapOf("foo" to directive),
+            directiveMap = mapOf("foo" to listOf(directive)),
             fieldMap = emptyMap(),
             extendedType = false
         )
@@ -175,7 +175,7 @@ internal class ValidateDirectiveKtTest {
         val validationErrors = validateDirective(
             validatedType = "",
             targetDirective = "foo",
-            directives = mapOf("foo" to directive),
+            directiveMap = mapOf("foo" to listOf(directive)),
             fieldMap = emptyMap(),
             extendedType = false
         )
@@ -207,7 +207,7 @@ internal class ValidateDirectiveKtTest {
         val validationErrors = validateDirective(
             validatedType = "MyType",
             targetDirective = "foo",
-            directives = mapOf("foo" to directive),
+            directiveMap = mapOf("foo" to listOf(directive)),
             fieldMap = mapOf("bar" to graphqlField),
             extendedType = false
         )
@@ -245,7 +245,7 @@ internal class ValidateDirectiveKtTest {
         val validationErrors = validateDirective(
             validatedType = "MyType",
             targetDirective = "foo",
-            directives = mapOf("foo" to directive),
+            directiveMap = mapOf("foo" to listOf(directive)),
             fieldMap = mapOf("bar" to graphqlField1, "baz" to graphqlField2),
             extendedType = false
         )

--- a/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/validation/integration/FederatedKeyDirectiveIT.kt
+++ b/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/validation/integration/FederatedKeyDirectiveIT.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Expedia, Inc
+ * Copyright 2022 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,16 +17,18 @@
 package com.expediagroup.graphql.generator.federation.validation.integration
 
 import com.expediagroup.graphql.generator.TopLevelObject
-import com.expediagroup.graphql.generator.federation.data.integration.key.failure._2.KeyMissingFieldSelectionQuery
-import com.expediagroup.graphql.generator.federation.data.integration.key.failure._3.InvalidKeyQuery
-import com.expediagroup.graphql.generator.federation.data.integration.key.failure._4.BaseKeyReferencingExternalFieldsQuery
-import com.expediagroup.graphql.generator.federation.data.integration.key.failure._6.KeyReferencingListQuery
-import com.expediagroup.graphql.generator.federation.data.integration.key.failure._7.KeyReferencingInterfaceQuery
-import com.expediagroup.graphql.generator.federation.data.integration.key.failure._8.KeyReferencingUnionQuery
-import com.expediagroup.graphql.generator.federation.data.integration.key.failure._9.NestedKeyReferencingScalarQuery
+import com.expediagroup.graphql.generator.federation.data.integration.key.failure._02.KeyMissingFieldSelectionQuery
+import com.expediagroup.graphql.generator.federation.data.integration.key.failure._03.InvalidKeyQuery
+import com.expediagroup.graphql.generator.federation.data.integration.key.failure._04.BaseKeyReferencingExternalFieldsQuery
+import com.expediagroup.graphql.generator.federation.data.integration.key.failure._06.KeyReferencingListQuery
+import com.expediagroup.graphql.generator.federation.data.integration.key.failure._07.KeyReferencingInterfaceQuery
+import com.expediagroup.graphql.generator.federation.data.integration.key.failure._08.KeyReferencingUnionQuery
+import com.expediagroup.graphql.generator.federation.data.integration.key.failure._09.NestedKeyReferencingScalarQuery
+import com.expediagroup.graphql.generator.federation.data.integration.key.failure._10.MultipleKeysOneInvalidQuery
 import com.expediagroup.graphql.generator.federation.data.integration.key.success._1.SimpleKeyQuery
 import com.expediagroup.graphql.generator.federation.data.integration.key.success._3.KeyWithMultipleFieldsQuery
 import com.expediagroup.graphql.generator.federation.data.integration.key.success._5.KeyWithNestedFieldsQuery
+import com.expediagroup.graphql.generator.federation.data.integration.key.success._7.MultipleKeyQuery
 import com.expediagroup.graphql.generator.federation.exception.InvalidFederatedSchema
 import com.expediagroup.graphql.generator.federation.toFederatedSchema
 import graphql.schema.GraphQLSchema
@@ -35,6 +37,7 @@ import org.junit.jupiter.api.assertDoesNotThrow
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 class FederatedKeyDirectiveIT {
 
@@ -98,13 +101,13 @@ class FederatedKeyDirectiveIT {
     private fun validateTypeWasCreatedWithKeyDirective(schema: GraphQLSchema, typeName: String) {
         val validatedType = schema.getObjectType(typeName)
         assertNotNull(validatedType)
-        assertNotNull(validatedType.getDirective("key"))
+        assertTrue(validatedType.hasDirective("key"))
     }
 
     @Test
     fun `@extended type should specify @key directive`() {
         val exception = assertFailsWith<InvalidFederatedSchema> {
-            toFederatedSchema(config = federatedTestConfig("com.expediagroup.graphql.generator.federation.data.integration.key.failure._1"))
+            toFederatedSchema(config = federatedTestConfig("com.expediagroup.graphql.generator.federation.data.integration.key.failure._01"))
         }
         val expected = "Invalid federated schema:\n - @key directive is missing on federated FederatedMissingKey type"
         assertEquals(expected, exception.message)
@@ -114,7 +117,7 @@ class FederatedKeyDirectiveIT {
     fun `@key directive field set cannot be empty`() {
         val exception = assertFailsWith<InvalidFederatedSchema> {
             toFederatedSchema(
-                config = federatedTestConfig("com.expediagroup.graphql.generator.federation.data.integration.key.failure._2"),
+                config = federatedTestConfig("com.expediagroup.graphql.generator.federation.data.integration.key.failure._02"),
                 queries = listOf(TopLevelObject(KeyMissingFieldSelectionQuery()))
             )
         }
@@ -126,7 +129,7 @@ class FederatedKeyDirectiveIT {
     fun `@key directive needs to reference valid field`() {
         val exception = assertFailsWith<InvalidFederatedSchema> {
             toFederatedSchema(
-                config = federatedTestConfig("com.expediagroup.graphql.generator.federation.data.integration.key.failure._3"),
+                config = federatedTestConfig("com.expediagroup.graphql.generator.federation.data.integration.key.failure._03"),
                 queries = listOf(TopLevelObject(InvalidKeyQuery()))
             )
         }
@@ -138,7 +141,7 @@ class FederatedKeyDirectiveIT {
     fun `@key directive on local type cannot reference external fields`() {
         val exception = assertFailsWith<InvalidFederatedSchema> {
             toFederatedSchema(
-                config = federatedTestConfig("com.expediagroup.graphql.generator.federation.data.integration.key.failure._4"),
+                config = federatedTestConfig("com.expediagroup.graphql.generator.federation.data.integration.key.failure._04"),
                 queries = listOf(TopLevelObject(BaseKeyReferencingExternalFieldsQuery()))
             )
         }
@@ -151,7 +154,7 @@ class FederatedKeyDirectiveIT {
     @Test
     fun `@extended type @key directive cannot reference local fields`() {
         val exception = assertFailsWith<InvalidFederatedSchema> {
-            toFederatedSchema(config = federatedTestConfig("com.expediagroup.graphql.generator.federation.data.integration.key.failure._5"))
+            toFederatedSchema(config = federatedTestConfig("com.expediagroup.graphql.generator.federation.data.integration.key.failure._05"))
         }
         val expected = "Invalid federated schema:\n" +
             " - @key(fields = id) directive on ExternalKeyReferencingLocalField specifies invalid field set - extended type incorrectly references local field=id"
@@ -162,7 +165,7 @@ class FederatedKeyDirectiveIT {
     fun `@key directive field set cannot reference list field`() {
         val exception = assertFailsWith<InvalidFederatedSchema> {
             toFederatedSchema(
-                config = federatedTestConfig("com.expediagroup.graphql.generator.federation.data.integration.key.failure._6"),
+                config = federatedTestConfig("com.expediagroup.graphql.generator.federation.data.integration.key.failure._06"),
                 queries = listOf(TopLevelObject(KeyReferencingListQuery()))
             )
         }
@@ -175,7 +178,7 @@ class FederatedKeyDirectiveIT {
     fun `@key directive field set cannot reference interface field`() {
         val exception = assertFailsWith<InvalidFederatedSchema> {
             toFederatedSchema(
-                config = federatedTestConfig("com.expediagroup.graphql.generator.federation.data.integration.key.failure._7"),
+                config = federatedTestConfig("com.expediagroup.graphql.generator.federation.data.integration.key.failure._07"),
                 queries = listOf(TopLevelObject(KeyReferencingInterfaceQuery()))
             )
         }
@@ -188,7 +191,7 @@ class FederatedKeyDirectiveIT {
     fun `@key directive field set cannot reference union field`() {
         val exception = assertFailsWith<InvalidFederatedSchema> {
             toFederatedSchema(
-                config = federatedTestConfig("com.expediagroup.graphql.generator.federation.data.integration.key.failure._8"),
+                config = federatedTestConfig("com.expediagroup.graphql.generator.federation.data.integration.key.failure._08"),
                 queries = listOf(TopLevelObject(KeyReferencingUnionQuery()))
             )
         }
@@ -201,13 +204,41 @@ class FederatedKeyDirectiveIT {
     fun `@key directive field set cannot reference scalar complex key`() {
         val exception = assertFailsWith<InvalidFederatedSchema> {
             toFederatedSchema(
-                config = federatedTestConfig("com.expediagroup.graphql.generator.federation.data.integration.key.failure._9"),
+                config = federatedTestConfig("com.expediagroup.graphql.generator.federation.data.integration.key.failure._09"),
                 queries = listOf(TopLevelObject(NestedKeyReferencingScalarQuery()))
             )
         }
         val expected = "Invalid federated schema:\n" +
             " - @key(fields = id { uuid }) directive on NestedKeyReferencingScalar specifies invalid field set - field set defines nested selection set on unsupported type\n" +
             " - @key(fields = id { uuid }) directive on NestedKeyReferencingScalar specifies invalid field set - field set specifies field that does not exist, field=uuid"
+        assertEquals(expected, exception.message)
+    }
+
+    @Test
+    fun `verifies multiple @key directive on a local type`() {
+        assertDoesNotThrow {
+            val schema = toFederatedSchema(
+                config = federatedTestConfig("com.expediagroup.graphql.generator.federation.data.integration.key.success._7"),
+                queries = listOf(TopLevelObject(MultipleKeyQuery()))
+            )
+            val validatedType = schema.getObjectType("MultipleKeys")
+            assertNotNull(validatedType)
+            val keyDirectives = validatedType.getDirectives("key")
+            assertTrue(keyDirectives.isNotEmpty())
+            assertEquals(2, keyDirectives.size)
+        }
+    }
+
+    @Test
+    fun `verifies validation runs on multiple @key directives`() {
+        val exception = assertFailsWith<InvalidFederatedSchema> {
+            toFederatedSchema(
+                config = federatedTestConfig("com.expediagroup.graphql.generator.federation.data.integration.key.failure._10"),
+                queries = listOf(TopLevelObject(MultipleKeysOneInvalidQuery()))
+            )
+        }
+        val expected = "Invalid federated schema:\n" +
+            " - @key(fields = upc) directive on MultipleKeysOneInvalid specifies invalid field set - field set specifies field that does not exist, field=upc"
         assertEquals(expected, exception.message)
     }
 }

--- a/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/validation/integration/FederatedProvidesDirectiveIT.kt
+++ b/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/validation/integration/FederatedProvidesDirectiveIT.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Expedia, Inc
+ * Copyright 2022 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.assertDoesNotThrow
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 class FederatedProvidesDirectiveIT {
 
@@ -62,7 +63,7 @@ class FederatedProvidesDirectiveIT {
     private fun validateTypeWasCreatedWithProvidesDirective(schema: GraphQLSchema, typeName: String) {
         val validatedType = schema.getObjectType(typeName)
         assertNotNull(validatedType)
-        assertNotNull(validatedType.getDirective("key"))
+        assertTrue(validatedType.hasDirective("key"))
         val providedField = validatedType.getFieldDefinition("provided")
         assertNotNull(providedField)
         assertNotNull(providedField.getDirective("provides"))

--- a/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/validation/integration/FederatedRequiresDirectiveIT.kt
+++ b/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/validation/integration/FederatedRequiresDirectiveIT.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Expedia, Inc
+ * Copyright 2022 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.assertDoesNotThrow
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 class FederatedRequiresDirectiveIT {
 
@@ -33,7 +34,7 @@ class FederatedRequiresDirectiveIT {
         assertDoesNotThrow {
             val schema = toFederatedSchema(config = federatedTestConfig("com.expediagroup.graphql.generator.federation.data.integration.requires.success._1"))
             val validatedType = schema.getObjectType("SimpleRequires")
-            assertNotNull(validatedType.getDirective("key"))
+            assertTrue(validatedType.hasDirective("key"))
             val weightField = validatedType.getFieldDefinition("weight")
             assertNotNull(weightField)
             assertNotNull(weightField.getDirective("external"))
@@ -90,7 +91,7 @@ class FederatedRequiresDirectiveIT {
         assertDoesNotThrow {
             val schema = toFederatedSchema(config = federatedTestConfig("com.expediagroup.graphql.generator.federation.data.integration.requires.success._2"))
             val validatedType = schema.getObjectType("User")
-            assertNotNull(validatedType.getDirective("key"))
+            assertTrue(validatedType.hasDirective("key"))
             val externalField = validatedType.getFieldDefinition("email")
             assertNotNull(externalField)
             assertNotNull(externalField.getDirective("external"))
@@ -105,7 +106,7 @@ class FederatedRequiresDirectiveIT {
         assertDoesNotThrow {
             val schema = toFederatedSchema(config = federatedTestConfig("com.expediagroup.graphql.generator.federation.data.integration.requires.success._3"))
             val validatedType = schema.getObjectType("User")
-            assertNotNull(validatedType.getDirective("key"))
+            assertTrue(validatedType.hasDirective("key"))
             val externalField = validatedType.getFieldDefinition("email")
             assertNotNull(externalField)
             assertNotNull(externalField.getDirective("external"))
@@ -120,7 +121,7 @@ class FederatedRequiresDirectiveIT {
         assertDoesNotThrow {
             val schema = toFederatedSchema(config = federatedTestConfig("com.expediagroup.graphql.generator.federation.data.integration.requires.success._4"))
             val validatedType = schema.getObjectType("User")
-            assertNotNull(validatedType.getDirective("key"))
+            assertTrue(validatedType.hasDirective("key"))
             val externalField = validatedType.getFieldDefinition("email")
             assertNotNull(externalField)
             assertNotNull(externalField.getDirective("external"))

--- a/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePluginIT.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePluginIT.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Expedia, Inc
+ * Copyright 2022 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -554,7 +554,7 @@ class GraphQLGradlePluginIT : GraphQLGradlePluginAbstractIT() {
             directive @provides(fields: _FieldSet!) on FIELD_DEFINITION
 
             "Space separated list of primary keys needed to access federated object"
-            directive @key(fields: _FieldSet!) on OBJECT | INTERFACE
+            directive @key(fields: _FieldSet!) repeatable on OBJECT | INTERFACE
 
             "Marks target object as extending part of the federated schema"
             directive @extends on OBJECT | INTERFACE

--- a/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/GraphQLGenerateSDLTaskIT.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/GraphQLGenerateSDLTaskIT.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Expedia, Inc
+ * Copyright 2022 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -103,7 +103,7 @@ internal val FEDERATED_SCHEMA =
     directive @provides(fields: _FieldSet!) on FIELD_DEFINITION
 
     "Space separated list of primary keys needed to access federated object"
-    directive @key(fields: _FieldSet!) on OBJECT | INTERFACE
+    directive @key(fields: _FieldSet!) repeatable on OBJECT | INTERFACE
 
     "Marks target object as extending part of the federated schema"
     directive @extends on OBJECT | INTERFACE

--- a/plugins/graphql-kotlin-maven-plugin/src/integration/generate-sdl-federated/src/test/kotlin/com/expediagroup/graphql/plugin/maven/GenerateSDLMojoTest.kt
+++ b/plugins/graphql-kotlin-maven-plugin/src/integration/generate-sdl-federated/src/test/kotlin/com/expediagroup/graphql/plugin/maven/GenerateSDLMojoTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Expedia, Inc
+ * Copyright 2022 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,7 +74,7 @@ class GenerateSDLMojoTest {
             directive @provides(fields: _FieldSet!) on FIELD_DEFINITION
 
             "Space separated list of primary keys needed to access federated object"
-            directive @key(fields: _FieldSet!) on OBJECT | INTERFACE
+            directive @key(fields: _FieldSet!) repeatable on OBJECT | INTERFACE
 
             "Marks target object as extending part of the federated schema"
             directive @extends on OBJECT | INTERFACE

--- a/plugins/graphql-kotlin-maven-plugin/src/integration/generate-sdl-hooks/src/test/kotlin/com/expediagroup/graphql/plugin/maven/GenerateSDLMojoTest.kt
+++ b/plugins/graphql-kotlin-maven-plugin/src/integration/generate-sdl-hooks/src/test/kotlin/com/expediagroup/graphql/plugin/maven/GenerateSDLMojoTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Expedia, Inc
+ * Copyright 2022 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,7 +74,7 @@ class GenerateSDLMojoTest {
             directive @provides(fields: _FieldSet!) on FIELD_DEFINITION
 
             "Space separated list of primary keys needed to access federated object"
-            directive @key(fields: _FieldSet!) on OBJECT | INTERFACE
+            directive @key(fields: _FieldSet!) repeatable on OBJECT | INTERFACE
 
             "Marks target object as extending part of the federated schema"
             directive @extends on OBJECT | INTERFACE

--- a/plugins/schema/graphql-kotlin-sdl-generator/src/integrationTest/kotlin/com/expediagroup/graphql/plugin/schema/GenerateCustomSDLTest.kt
+++ b/plugins/schema/graphql-kotlin-sdl-generator/src/integrationTest/kotlin/com/expediagroup/graphql/plugin/schema/GenerateCustomSDLTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Expedia, Inc
+ * Copyright 2022 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,7 +63,7 @@ class GenerateCustomSDLTest {
                 directive @provides(fields: _FieldSet!) on FIELD_DEFINITION
 
                 "Space separated list of primary keys needed to access federated object"
-                directive @key(fields: _FieldSet!) on OBJECT | INTERFACE
+                directive @key(fields: _FieldSet!) repeatable on OBJECT | INTERFACE
 
                 "Marks target object as extending part of the federated schema"
                 directive @extends on OBJECT | INTERFACE

--- a/website/docs/schema-generator/customizing-schemas/directives.md
+++ b/website/docs/schema-generator/customizing-schemas/directives.md
@@ -142,6 +142,24 @@ This is a different behavior than `graphql-java` which will first attempt to use
 For more details please refer to the example usage of directives in our [example
 app](https://github.com/ExpediaGroup/graphql-kotlin/tree/master/examples/server/spring-server).
 
+### Repeatable Directives
+
+GraphQL supports repeatable directives (e.g. Apollo federation allows developers to specify multiple `@key` directives).
+By default, Kotlin does not allow applying same annotation multiple times. In order to make your directives repeatable,
+you need to annotate it with `kotlin.annotation.Repeatable` annotation.
+
+```kotlin
+@Repeatable
+@GraphQLDirective(locations = [DirectiveLocation.OBJECT, DirectiveLocation.INTERFACE])
+annotation class MyRepeatableDirective(val value: String)
+```
+
+Generates the above directive as
+
+```graphql
+directive @myRepeatableDirective(value: String!) repeatable on OBJECT | INTERFACE
+```
+
 ## Directive Chaining
 
 Directives are applied in the order annotations are declared on the given object. Given

--- a/website/docs/schema-generator/federation/federated-directives.md
+++ b/website/docs/schema-generator/federation/federated-directives.md
@@ -68,7 +68,7 @@ type Product @key(fields : "id") @extends {
 ## `@key` directive
 
 ```graphql
-directive @key(fields: _FieldSet!) on OBJECT | INTERFACE
+directive @key(fields: _FieldSet!) repeatable on OBJECT | INTERFACE
 ```
 
 The `@key` directive is used to indicate a combination of fields that can be used to uniquely identify and fetch an

--- a/website/docs/schema-generator/federation/federated-directives.md
+++ b/website/docs/schema-generator/federation/federated-directives.md
@@ -73,29 +73,28 @@ directive @key(fields: _FieldSet!) on OBJECT | INTERFACE
 
 The `@key` directive is used to indicate a combination of fields that can be used to uniquely identify and fetch an
 object or interface. The specified field set can represent single field (e.g. `"id"`), multiple fields (e.g. `"id name"`) or
-nested selection sets (e.g. `"id user { name }"`).
+nested selection sets (e.g. `"id user { name }"`). Multiple keys can be specified on a target type.
 
 Key directives should be specified on the root base type as well as all the corresponding federated (i.e. extended)
 types. Key fields specified in the directive field set should correspond to a valid field on the underlying GraphQL
 interface/object. Federated extended types should also instrument all the referenced key fields with `@external`
 directive.
 
-&gt; NOTE: The Federation spec specifies that multiple @key directives can be applied on the field. The GraphQL spec has been recently changed to allow this behavior,
-&gt; but we are currently blocked and are tracking progress in [this issue](https://github.com/ExpediaGroup/graphql-kotlin/issues/590).
-
 Example
 
 ```kotlin
 @KeyDirective(FieldSet("id"))
-class Product(val id: String, val name: String)
+@KeyDirective(FieldSet("upc"))
+class Product(val id: String, val upc: String, val name: String)
 ```
 
 will generate
 
 ```graphql
-type Product @key(fields: "id") {
+type Product @key(fields: "id") @key(fields: "upc") {
   id: String!
   name: String!
+  upc: String!
 }
 ```
 


### PR DESCRIPTION
### :pencil: Description

Kotlin 1.6 provides support for repeatable annotations with `RUNTIME` retention. This allows to finally support repeatable directives.

In order to make your directives repeatable, you need to annotate it with `kotlin.annotation.Repeatable` annotation.

```kotlin
@Repeatable
@GraphQLDirective
annotation class MyRepeatableDirective(val value: String)
```

Generates the above directive as

```graphql
directive @myRepeatableDirective(value: String!) repeatable on OBJECT | INTERFACE
```

### :link: Related Issues

* resolves https://github.com/ExpediaGroup/graphql-kotlin/issues/590
* depends on https://github.com/ExpediaGroup/graphql-kotlin/pull/1358