### PR TITLE
[generator] support input field deprecation

### DIFF
--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateArgument.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateArgument.kt
@@ -50,7 +50,7 @@ internal fun generateArgument(generator: SchemaGenerator, parameter: KParameter)
     val typeInfo = GraphQLKTypeMetadata(inputType = true, fieldName = parameter.getName(), fieldAnnotations = parameter.annotations)
     val graphQLType = generateGraphQLType(generator = generator, type = unwrappedType, typeInfo)
 
-    // Deprecation of arguments is currently unsupported: https://github.com/facebook/graphql/issues/197
+    // Deprecation of arguments is currently unsupported: https://youtrack.jetbrains.com/issue/KT-25643
     val builder = GraphQLArgument.newArgument()
         .name(parameter.getName())
         .description(parameter.getGraphQLDescription())

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/types/GenerateInputPropertyTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/types/GenerateInputPropertyTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Expedia, Inc
+ * Copyright 2022 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,21 +21,21 @@ import com.expediagroup.graphql.generator.annotations.GraphQLName
 import com.expediagroup.graphql.generator.test.utils.SimpleDirective
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 internal class GenerateInputPropertyTest : TypeTestHelper() {
 
     private data class InputPropertyTestClass(
         @GraphQLDescription("Custom description")
         val description: String,
-
         @GraphQLName("newName")
         val changeMe: String,
-
         @SimpleDirective
         val directiveWithNoPrefix: String,
-
         @property:SimpleDirective
-        val directiveWithPrefix: String
+        val directiveWithPrefix: String,
+        @Deprecated("This field is deprecated")
+        val deprecatedDescription: String? = null
     )
 
     @Test
@@ -59,5 +59,12 @@ internal class GenerateInputPropertyTest : TypeTestHelper() {
         val resultWithPrefix = generateInputProperty(generator, InputPropertyTestClass::directiveWithPrefix, InputPropertyTestClass::class)
         assertEquals(1, resultWithPrefix.directives.size)
         assertEquals("simpleDirective", resultWithPrefix.directives.first().name)
+    }
+
+    @Test
+    fun `Input properties can be deprecated`() {
+        val deprecatedResult = generateInputProperty(generator, InputPropertyTestClass::deprecatedDescription, InputPropertyTestClass::class)
+        assertTrue(deprecatedResult.isDeprecated)
+        assertEquals("This field is deprecated", deprecatedResult.deprecationReason)
     }
 }

--- a/website/docs/schema-generator/customizing-schemas/deprecating-schema.md
+++ b/website/docs/schema-generator/customizing-schemas/deprecating-schema.md
@@ -26,6 +26,6 @@ type Query {
 ```
 
 While you can deprecate any fields/functions/classes in your Kotlin code, GraphQL only supports deprecation directive on
-the fields (which correspond to Kotlin fields and functions) and enum values.
+the fields (which correspond to Kotlin properties and functions), input fields and enum values.
 
-Deprecation of input types is not yet supported [in the GraphQL spec](https://github.com/graphql/graphql-spec/pull/525).
+Deprecation of arguments is currently not supported [in Kotlin](https://youtrack.jetbrains.com/issue/KT-25643).


### PR DESCRIPTION
### :pencil: Description

With recent GraphQL spec changes, deprecation should be supported on fields, input fields (new), arguments (new) and enum values. This change adds the support for deprecating input fields.

Argument deprecation is not supported as Kotlin `@Deprecated` is not applicable to parameters.

### :link: Related Issues

 See https://youtrack.jetbrains.com/issue/KT-25643