### PR TITLE
feat: add GraphQLContext extension functions

### DIFF
--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/extensions/GraphQLContextExtensions.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/extensions/GraphQLContextExtensions.kt
@@ -18,6 +18,22 @@ package com.expediagroup.graphql.generator.extensions
 
 import graphql.GraphQLContext
 
+/**
+ * Returns a value in the context by KClass key
+ * @return a value or null
+ */
 inline fun <reified T> GraphQLContext.get(): T? = get(T::class)
+
+/**
+ * Returns a value in the context by KClass key
+ * @param defaultValue the default value to use if there is no KClass key entry
+ * @return a value or default value
+ */
 inline fun <reified T> GraphQLContext.getOrDefault(defaultValue: T): T = getOrDefault(T::class, defaultValue)
+
+/**
+ * Returns a value in the context by KClass key
+ * @param defaultValue function to invoke if there is no KClass key entry
+ * @return a value or result of [defaultValue] function
+ */
 inline fun <reified T> GraphQLContext.getOrElse(defaultValue: () -> T): T = get(T::class) ?: defaultValue.invoke()

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/extensions/GraphQLContextExtensions.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/extensions/GraphQLContextExtensions.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2022 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.generator.extensions
+
+import graphql.GraphQLContext
+
+inline fun <reified T> GraphQLContext.get(): T? = get(T::class)
+inline fun <reified T> GraphQLContext.getOrDefault(defaultValue: T): T = getOrDefault(T::class, defaultValue)
+inline fun <reified T> GraphQLContext.getOrElse(defaultValue: () -> T): T = get(T::class) ?: defaultValue.invoke()

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/extensions/GraphQLSchemaExtensions.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/extensions/GraphQLSchemaExtensions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Expedia, Inc
+ * Copyright 2022 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/extensions/GraphqlTypeExtensions.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/extensions/GraphqlTypeExtensions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Expedia, Inc
+ * Copyright 2022 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
### :pencil: Description
In the `GraphQLContext` map we often use `KClass` as a key

```kotlin
environment.graphQlContext.getOrDefault(CoroutineScope::class, CoroutineScope(EmptyCoroutineContext))
```

adding some inline reified extension functions to reduce the verbosity to allow

```kotlin
// explicitly provide type
val scope = environment.graphQlContext.get<CoroutineScope>() // return nullable 
// type can also be inferred
val scope: CoroutineScope = environment.graphQlContext.get()

// provide default value, type inferred from default value
environment.graphQlContext.getOrDefault(CoroutineScope(EmptyCoroutineContext))

// provide lambda to compute default value, type inferred from default value
environment.graphQlContext.getOrElse { CoroutineScope(EmptyCoroutineContext) } 
```

### :link: Related Issues
Resolves https://github.com/ExpediaGroup/graphql-kotlin/issues/1365