### PR TITLE
[generator] apply hooks after filtering properties and functions

### DIFF
--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/extensions/kClassExtensions.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/extensions/kClassExtensions.kt
@@ -39,18 +39,18 @@ private const val INPUT_SUFFIX = "Input"
 
 internal fun KClass<*>.getValidProperties(hooks: SchemaGeneratorHooks): List<KProperty<*>> =
     this.memberProperties
-        .filter { prop -> hooks.isValidProperty(this, prop) }
         .filter { prop -> propertyFilters.all { it.invoke(prop, this) } }
+        .filter { prop -> hooks.isValidProperty(this, prop) }
 
 internal fun KClass<*>.getValidFunctions(hooks: SchemaGeneratorHooks): List<KFunction<*>> =
     this.memberFunctions
-        .filter { func -> hooks.isValidFunction(this, func) }
         .filter { func -> functionFilters.all { it.invoke(func) } }
+        .filter { func -> hooks.isValidFunction(this, func) }
 
 internal fun KClass<*>.getValidSuperclasses(hooks: SchemaGeneratorHooks): List<KClass<*>> =
     this.superclasses
-        .filter { hooks.isValidSuperclass(it) }
         .filter { kClass -> superclassFilters.all { it.invoke(kClass) } }
+        .filter { hooks.isValidSuperclass(it) }
         .plus(this.superclasses.flatMap { it.getValidSuperclasses(hooks) })
         .distinct()
 

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/filters/superclassFilters.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/filters/superclassFilters.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Expedia, Inc
+ * Copyright 2022 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,4 +29,4 @@ private val isInterface: SuperclassFilter = { it.isInterface() }
 private val isNotUnion: SuperclassFilter = { it.isUnion().not() }
 private val isNotIgnored: SuperclassFilter = { it.isGraphQLIgnored().not() }
 
-internal val superclassFilters: List<SuperclassFilter> = listOf(isPublic, isInterface, isNotUnion, isNotIgnored)
+internal val superclassFilters: List<SuperclassFilter> = listOf(isPublic, isNotIgnored, isInterface, isNotUnion)

--- a/website/docs/getting-started.mdx
+++ b/website/docs/getting-started.mdx
@@ -79,4 +79,4 @@ You can find more posts and recorded conference talks on GraphQL and `graphql-ko
 ## Additional resources
 
 -   [GraphQL](https://graphql.org/)
--   [graphql-java](https://www.graphql-java.com/documentation/)
+-   [graphql-java](https://www.graphql-java.com/)

--- a/website/docs/schema-generator/writing-schemas/fields.md
+++ b/website/docs/schema-generator/writing-schemas/fields.md
@@ -1,0 +1,24 @@
+---
+id: fields
+title: Types and Fields
+---
+`graphql-kotlin-schema-generator` uses [reflection](https://kotlinlang.org/docs/reflection.html) to automatically map
+Kotlin classes and enums to the corresponding GraphQL types.
+
+By default, all public properties and functions with a [valid GraphQL name](https://spec.graphql.org/draft/#sec-Names)
+and a supported return type will be mapped to a corresponding GraphQL field. Kotlin return types have to be either one of the
+[supported scalars](./scalars.md) or a custom Kotlin type defined within supported packages. Nullability information is
+automatically inferred from the underlying Kotlin return type.
+
+Additional built-in validations
+* function types aka lambdas property types are currently not supported by the schema generator
+* automatically generated data class methods (`componentN`, `copy`, `equals`, `hashCode`, `toString`) are filtered out
+
+Default behavior can be customized. Fields can be [renamed](../customizing-schemas/renaming-fields.md) or [excluded](../customizing-schemas/excluding-fields.md).
+Support for additional types or validations can be added by providing an instance of custom [SchemaGeneratorHook](../customizing-schemas/generator-config.md#schemageneratorhooks).
+
+## Type Inheritance
+
+`graphql-kotlin-schema-generator` provides support for both GraphQL [unions](./unions.md) and [interfaces](./interfaces.md).
+Superclasses and interfaces can be excluded from the schema by marking them with `@GraphQLIgnore` annotation or by providing
+custom filtering logic in a custom [SchemaGeneratorHook](../customizing-schemas/generator-config.md#schemageneratorhooks).

--- a/website/docs/schema-generator/writing-schemas/interfaces.md
+++ b/website/docs/schema-generator/writing-schemas/interfaces.md
@@ -2,10 +2,10 @@
 id: interfaces
 title: Interfaces
 ---
-Any Kotlin interfaces will be mapped to a GraphQL interface. Due to the GraphQL distinction between interface and a [union type](./unions.md), Kotlin interfaces need to specify at least
-one common field (property or a function).
-
-Abstract and sealed classes will also be converted to a GraphQL interface.
+Kotlin interfaces, abstract and sealed classes will be mapped to a GraphQL interface. Due to the GraphQL distinction between interface
+and a [union type](./unions.md), Kotlin interfaces need to specify at least one common field (property or a function). Superclasses and
+interfaces can be excluded from the schema by marking them with `@GraphQLIgnore` annotation or by providing custom filtering logic in a
+custom schema generator hook.
 
 :::note
 [The GraphQL spec](http://spec.graphql.org/June2018/#sec-Interfaces) does not allow interfaces to be used as input.
@@ -91,5 +91,39 @@ class Square(sideLength: Double) : Shape(sideLength * sideLength)
 sealed class Pet(val name: String) {
     class Dog(name: String, val goodBoysReceived: Int) : Pet(name)
     class Cat(name: String, val livesRemaining: Int) : Pet(name)
+}
+```
+
+## Nested Interfaces
+
+Interfaces can implement other interfaces.
+
+```kotlin
+interface Foo {
+    val foo: String
+}
+
+interface Bar : Foo {
+    val bar: String
+}
+
+class Baz(override val foo: String, override val bar: String) : Bar
+```
+
+Code above generates following schema
+
+```graphql
+interface Foo {
+  foo: String!
+}
+
+interface Bar implements Foo {
+  bar: String!
+  foo: String!
+}
+
+type Baz implements Bar & Foo {
+  bar: String!
+  foo: String!
 }
 ```

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -12,6 +12,7 @@ module.exports = {
         type: 'category',
         label: 'Writing schemas with Kotlin',
         items: [
+          'schema-generator/writing-schemas/fields',
           'schema-generator/writing-schemas/nullability',
           'schema-generator/writing-schemas/arguments',
           'schema-generator/writing-schemas/scalars',


### PR DESCRIPTION
### :pencil: Description

`graphql-kotlin-schema-generator` automatically applies some basic filtering logic to exclude invalid properties/functions. Filters ensure that processed properties/functions are public, have valid name, are not ignored, etc.

Users can also provide some additional filtering logic to exclude properties/functions but they are currently applied before basic filters. This PR updates the filtering logic to apply basic filtering first and then apply custom validations.

### :link: Related Issues

Resolves: https://github.com/ExpediaGroup/graphql-kotlin/issues/1368