### PR TITLE
Class name in SchemaGeneratorHooksProvider example

### DIFF
--- a/examples/server/spring-server/src/main/resources/META-INF/services/com.expediagroup.graphql.plugin.schema.hooks.SchemaGeneratorHooksProvider
+++ b/examples/server/spring-server/src/main/resources/META-INF/services/com.expediagroup.graphql.plugin.schema.hooks.SchemaGeneratorHooksProvider
@@ -1,1 +1,1 @@
-com.expediagroup.graphql.examples.hooks.CustomHooksProvider
+com.expediagroup.graphql.examples.server.spring.hooks.CustomHooksProvider


### PR DESCRIPTION
The class name for the service provider is incorrect in example for SchemaGeneratorHooksProvider

### :pencil: Description


### :link: Related Issues
