### PR TITLE
feat(server): add TransactionBatcher to graphQLContext

### DIFF
--- a/servers/graphql-kotlin-server/build.gradle.kts
+++ b/servers/graphql-kotlin-server/build.gradle.kts
@@ -12,6 +12,7 @@ plugins {
 val jacksonVersion: String by project
 dependencies {
     api(project(path = ":graphql-kotlin-schema-generator"))
+    api(project(path = ":graphql-kotlin-transaction-batcher-instrumentation"))
     api("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:$kotlinCoroutinesVersion")
 }

--- a/servers/graphql-kotlin-server/src/main/kotlin/com/expediagroup/graphql/server/execution/GraphQLRequestHandler.kt
+++ b/servers/graphql-kotlin-server/src/main/kotlin/com/expediagroup/graphql/server/execution/GraphQLRequestHandler.kt
@@ -30,13 +30,16 @@ open class GraphQLRequestHandler(
     private val graphQL: GraphQL,
     private val dataLoaderRegistryFactory: DataLoaderRegistryFactory? = null
 ) {
-
     /**
      * Execute a GraphQL request in a non-blocking fashion.
      * This should only be used for queries and mutations.
      * Subscriptions require more specific server logic and will need to be handled separately.
      */
-    open suspend fun executeRequest(request: GraphQLRequest, context: GraphQLContext? = null, graphQLContext: Map<*, Any> = emptyMap<Any, Any>()): GraphQLResponse<*> {
+    open suspend fun executeRequest(
+        request: GraphQLRequest,
+        context: GraphQLContext? = null,
+        graphQLContext: Map<*, Any> = emptyMap<Any, Any>()
+    ): GraphQLResponse<*> {
         // We should generate a new registry for every request
         val dataLoaderRegistry = dataLoaderRegistryFactory?.generate()
         val executionInput = request.toExecutionInput(context, dataLoaderRegistry, graphQLContext)

--- a/servers/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/server/spring/GraphQLConfigurationProperties.kt
+++ b/servers/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/server/spring/GraphQLConfigurationProperties.kt
@@ -33,7 +33,8 @@ data class GraphQLConfigurationProperties(
     val subscriptions: SubscriptionConfigurationProperties = SubscriptionConfigurationProperties(),
     val playground: PlaygroundConfigurationProperties = PlaygroundConfigurationProperties(),
     val sdl: SDLConfigurationProperties = SDLConfigurationProperties(),
-    val introspection: IntrospectionConfigurationProperties = IntrospectionConfigurationProperties()
+    val introspection: IntrospectionConfigurationProperties = IntrospectionConfigurationProperties(),
+    val batching: BatchingConfigurationProperties = BatchingConfigurationProperties()
 ) {
     /**
      * Apollo Federation configuration properties.
@@ -102,5 +103,13 @@ data class GraphQLConfigurationProperties(
     data class IntrospectionConfigurationProperties(
         /** Boolean flag indicating whether introspection queries are enabled. */
         val enabled: Boolean = true
+    )
+
+    /**
+     * Batching configuration properties.
+     */
+    data class BatchingConfigurationProperties(
+        /** Boolean flag indicating whether batching is enabled. */
+        val enabled: Boolean = false
     )
 }


### PR DESCRIPTION
### :pencil: Description
Adding `TransactionBatcher` and `ExecutionLevelInstrumentationState` instances to the GraphQLContext that will be used as a context for all `ExecutionInput`  aka `GraphQLOperation` in a Request (single or batched).

This way client only responsibility will be opt it or opt out from the optional `TransactionBatcherLevelInstrumentation`

### :link: Related Issues
