### PR TITLE
[docs] documentation on inline value classes

### DIFF
--- a/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/server/spring/Application.kt
+++ b/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/server/spring/Application.kt
@@ -22,7 +22,9 @@ import com.expediagroup.graphql.examples.server.spring.execution.CustomDataFetch
 import com.expediagroup.graphql.examples.server.spring.execution.MySubscriptionHooks
 import com.expediagroup.graphql.examples.server.spring.execution.SpringDataFetcherFactory
 import com.expediagroup.graphql.examples.server.spring.hooks.CustomSchemaGeneratorHooks
+import com.expediagroup.graphql.examples.server.spring.model.MyValueClass
 import com.expediagroup.graphql.generator.directives.KotlinDirectiveWiringFactory
+import com.expediagroup.graphql.generator.scalars.IDValueUnboxer
 import com.expediagroup.graphql.server.spring.subscriptions.ApolloSubscriptionHooks
 import graphql.execution.DataFetcherExceptionHandler
 import org.springframework.boot.autoconfigure.SpringBootApplication
@@ -50,6 +52,15 @@ class Application {
 
     @Bean
     fun apolloSubscriptionHooks(): ApolloSubscriptionHooks = MySubscriptionHooks()
+
+    @Bean
+    fun idValueUnboxer(): IDValueUnboxer = object : IDValueUnboxer() {
+        override fun unbox(`object`: Any?): Any? = if (`object` is MyValueClass) {
+            `object`.value
+        } else {
+            super.unbox(`object`)
+        }
+    }
 }
 
 fun main(args: Array<String>) {

--- a/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/server/spring/hooks/CustomSchemaGeneratorHooks.kt
+++ b/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/server/spring/hooks/CustomSchemaGeneratorHooks.kt
@@ -16,8 +16,10 @@
 
 package com.expediagroup.graphql.examples.server.spring.hooks
 
+import com.expediagroup.graphql.examples.server.spring.model.MyValueClass
 import com.expediagroup.graphql.generator.directives.KotlinDirectiveWiringFactory
 import com.expediagroup.graphql.generator.hooks.SchemaGeneratorHooks
+import graphql.Scalars
 import graphql.language.StringValue
 import graphql.schema.Coercing
 import graphql.schema.CoercingParseLiteralException
@@ -43,6 +45,7 @@ class CustomSchemaGeneratorHooks(override val wiringFactory: KotlinDirectiveWiri
      * Register additional GraphQL scalar types.
      */
     override fun willGenerateGraphQLType(type: KType): GraphQLType? = when (type.classifier) {
+        MyValueClass::class -> Scalars.GraphQLString
         UUID::class -> graphqlUUIDType
         ClosedRange::class -> {
             when (type.arguments[0].type?.classifier as? KClass<*>) {

--- a/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/server/spring/model/CustomScalarInput.kt
+++ b/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/server/spring/model/CustomScalarInput.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2022 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.examples.server.spring.model
+
+import com.expediagroup.graphql.examples.server.spring.hooks.Period
+
+data class CustomScalarInput(
+    val foo: String,
+    val range: Period,
+)

--- a/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/server/spring/model/MyValueClass.kt
+++ b/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/server/spring/model/MyValueClass.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2022 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.examples.server.spring.model
+
+@JvmInline
+value class MyValueClass(
+    val value: String
+)

--- a/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/server/spring/query/ScalarQuery.kt
+++ b/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/server/spring/query/ScalarQuery.kt
@@ -16,7 +16,8 @@
 
 package com.expediagroup.graphql.examples.server.spring.query
 
-import com.expediagroup.graphql.examples.server.spring.hooks.Period
+import com.expediagroup.graphql.examples.server.spring.model.CustomScalarInput
+import com.expediagroup.graphql.examples.server.spring.model.MyValueClass
 import com.expediagroup.graphql.examples.server.spring.model.Person
 import com.expediagroup.graphql.generator.annotations.GraphQLDescription
 import com.expediagroup.graphql.generator.scalars.ID
@@ -46,8 +47,5 @@ class ScalarQuery : Query {
 
     fun customScalarInput(input: CustomScalarInput): String = "foo is ${input.foo} and range is ${input.range}"
 
-    data class CustomScalarInput(
-        val foo: String,
-        val range: Period,
-    )
+    fun inlineValueClass(value: MyValueClass? = null): MyValueClass = value ?: MyValueClass("default")
 }


### PR DESCRIPTION
### :pencil: Description

It is often beneficial to create a wrapper around the underlying primitive type to better represent its meaning. Inline value classes can be used to optimize such use cases - Kotlin compiler will attempt to use underlying type directly whenever possible and only keep the wrapper classes whenever it is necessary.

In order to use inline value classes in your schema, you need to register it using hooks and also provide value unboxer that will be used by `graphql-java` when dealing with its wrapper object.

```kotlin
@JvmInline
value class MyValueClass(
    val value: String
)

class MyQuery : Query {
    fun inlineValueClassQuery(value: MyValueClass? = null): MyValueClass = value ?: MyValueClass("default")
}

class MySchemaGeneratorHooks : SchemaGeneratorHooks {
    override fun willGenerateGraphQLType(type: KType): GraphQLType? = when (type.classifier) {
        MyValueClass::class -> Scalars.GraphQLString
        else -> null
    }
}

class MyValueUnboxer : IDValueUnboxer() {
    override fun unbox(`object`: Any?): Any? = if (`object` is MyValueClass) {
        `object`.value
    } else {
        super.unbox(`object`)
    }
}

val config = SchemaGeneratorConfig(
    supportedPackages = listOf("com.example"),
    hooks = MySchemaGeneratorHooks()
)
val schema = toSchema(
    config = config,
    queries = listOf(TopLevelObject(MyQuery()))
)
val graphQL = GraphQL.newGraphQL(graphQLSchema)
    .valueUnboxer(IDValueUnboxer())
    .build()
```

This will generate the schema that exposes value classes as corresponding primitive types in the schema

```graphql
type Query {
  inlineValueClassQuery(value: String): String!
}
```

### :link: Related Issues

Resolves https://github.com/ExpediaGroup/graphql-kotlin/issues/1370