### PR TITLE
[docs] fix breaking page on Expedia logo click

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -50,7 +50,8 @@ module.exports = {
     navbar: {
       title: "GraphQL Kotlin",
       logo: {
-        src: "img/EG_Icon_White_on_Blue.png"
+        src: "img/EG_Icon_White_on_Blue.png",
+        href: "/docs"
       },
       items: [
         {


### PR DESCRIPTION
### :pencil: Description
Fixing docs by providing /docs ref for the Expedia logo

### :link: Related Issues
https://github.com/ExpediaGroup/graphql-kotlin/issues/1400