### PR TITLE
feat: DataLoader Sync Execution Exhaustion Instrumentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Visit our [documentation site](https://expediagroup.github.io/graphql-kotlin) fo
 
 * [clients](/clients) - Lightweight GraphQL Kotlin HTTP clients based on Ktor HTTP client and Spring WebClient
 * [examples](/examples) - Example apps that use graphql-kotlin libraries to test and demonstrate usages
+* [executions](/executions) - Custom instrumentations for a GraphQL operation
 * [generator](/generator) - Code-First schema generator and extensions to build Apollo Federation schemas
 * [plugins](/plugins) - Gradle and Maven plugins
 * [servers](/servers) - Common and library specific modules for running a GraphQL server

--- a/executions/graphql-kotlin-dataloader-instrumentation/src/main/kotlin/com/expediagroup/graphql/dataloader/instrumentation/syncexhaustion/DataLoaderSyncExecutionExhaustedInstrumentation.kt
+++ b/executions/graphql-kotlin-dataloader-instrumentation/src/main/kotlin/com/expediagroup/graphql/dataloader/instrumentation/syncexhaustion/DataLoaderSyncExecutionExhaustedInstrumentation.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.dataloader.instrumentation.syncexhaustion
+
+import com.expediagroup.graphql.dataloader.KotlinDataLoaderRegistry
+import com.expediagroup.graphql.dataloader.instrumentation.syncexhaustion.execution.AbstractSyncExecutionExhaustedInstrumentation
+import com.expediagroup.graphql.dataloader.instrumentation.syncexhaustion.execution.OnSyncExecutionExhaustedCallback
+import com.expediagroup.graphql.dataloader.instrumentation.syncexhaustion.execution.SyncExecutionExhaustedInstrumentationParameters
+import graphql.ExecutionInput
+import graphql.GraphQLContext
+import graphql.execution.instrumentation.Instrumentation
+import graphql.schema.DataFetcher
+import org.dataloader.DataLoader
+import java.util.concurrent.CompletableFuture
+
+/**
+ * Custom GraphQL [Instrumentation] that will dispatch all [DataLoader]s inside a [KotlinDataLoaderRegistry]
+ * when the synchronous execution of all [ExecutionInput] sharing a [GraphQLContext] was exhausted.
+ *
+ * A Synchronous Execution is considered Exhausted when all [DataFetcher]s of all paths were executed up until
+ * an scalar leaf or a [DataFetcher] that returns a [CompletableFuture]
+ */
+class DataLoaderSyncExecutionExhaustedInstrumentation : AbstractSyncExecutionExhaustedInstrumentation() {
+    override fun getOnSyncExecutionExhaustedCallback(
+        parameters: SyncExecutionExhaustedInstrumentationParameters
+    ): OnSyncExecutionExhaustedCallback = {
+        parameters
+            .executionContext
+            .graphQLContext.get<KotlinDataLoaderRegistry>(KotlinDataLoaderRegistry::class)
+            ?.dispatchAll()
+    }
+}

--- a/executions/graphql-kotlin-dataloader-instrumentation/src/main/kotlin/com/expediagroup/graphql/dataloader/instrumentation/syncexhaustion/execution/AbstractSyncExecutionExhaustedInstrumentation.kt
+++ b/executions/graphql-kotlin-dataloader-instrumentation/src/main/kotlin/com/expediagroup/graphql/dataloader/instrumentation/syncexhaustion/execution/AbstractSyncExecutionExhaustedInstrumentation.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2022 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.dataloader.instrumentation.syncexhaustion.execution
+
+import com.expediagroup.graphql.dataloader.instrumentation.NoOpExecutionStrategyInstrumentationContext
+import com.expediagroup.graphql.dataloader.instrumentation.syncexhaustion.state.SyncExecutionExhaustedState
+import graphql.ExecutionInput
+import graphql.ExecutionResult
+import graphql.GraphQLContext
+import graphql.execution.instrumentation.ExecutionStrategyInstrumentationContext
+import graphql.execution.instrumentation.Instrumentation
+import graphql.execution.instrumentation.InstrumentationContext
+import graphql.execution.instrumentation.SimpleInstrumentation
+import graphql.execution.instrumentation.SimpleInstrumentationContext
+import graphql.execution.instrumentation.parameters.InstrumentationExecuteOperationParameters
+import graphql.execution.instrumentation.parameters.InstrumentationExecutionStrategyParameters
+import graphql.execution.instrumentation.parameters.InstrumentationFieldFetchParameters
+
+/**
+ * typealias that represents the signature of a callback that will be executed when sync execution is exhausted
+ */
+internal typealias OnSyncExecutionExhaustedCallback = (List<ExecutionInput>) -> Unit
+
+/**
+ * Custom GraphQL [Instrumentation] that calculate the synchronous execution exhaustion
+ * of all GraphQL operations sharing the same [GraphQLContext]
+ */
+abstract class AbstractSyncExecutionExhaustedInstrumentation : SimpleInstrumentation() {
+    /**
+     * This is invoked each time instrumentation attempts to calculate exhaustion state, this can be called from either
+     * `beginFieldField.dispatch` or `beginFieldFetch.complete`.
+     *
+     * @param parameters contains information of which [ExecutionInput] caused the calculation
+     * @return [OnSyncExecutionExhaustedCallback] to invoke when the synchronous execution of all operations was exhausted
+     */
+    abstract fun getOnSyncExecutionExhaustedCallback(
+        parameters: SyncExecutionExhaustedInstrumentationParameters
+    ): OnSyncExecutionExhaustedCallback
+
+    override fun beginExecuteOperation(
+        parameters: InstrumentationExecuteOperationParameters
+    ): InstrumentationContext<ExecutionResult> =
+        parameters.executionContext
+            .graphQLContext.get<SyncExecutionExhaustedState>(SyncExecutionExhaustedState::class)
+            ?.beginExecuteOperation(parameters)
+            ?: SimpleInstrumentationContext.noOp()
+
+    override fun beginExecutionStrategy(
+        parameters: InstrumentationExecutionStrategyParameters
+    ): ExecutionStrategyInstrumentationContext =
+        parameters.executionContext
+            .graphQLContext.get<SyncExecutionExhaustedState>(SyncExecutionExhaustedState::class)
+            ?.beginExecutionStrategy(parameters)
+            ?: NoOpExecutionStrategyInstrumentationContext
+
+    override fun beginFieldFetch(
+        parameters: InstrumentationFieldFetchParameters
+    ): InstrumentationContext<Any> =
+        parameters.executionContext
+            .graphQLContext.get<SyncExecutionExhaustedState>(SyncExecutionExhaustedState::class)
+            ?.beginFieldFetch(
+                parameters,
+                this.getOnSyncExecutionExhaustedCallback(
+                    SyncExecutionExhaustedInstrumentationParameters(parameters.executionContext)
+                )
+            )
+            ?: SimpleInstrumentationContext.noOp()
+}

--- a/executions/graphql-kotlin-dataloader-instrumentation/src/main/kotlin/com/expediagroup/graphql/dataloader/instrumentation/syncexhaustion/execution/SyncExecutionExhaustedInstrumentationParameters.kt
+++ b/executions/graphql-kotlin-dataloader-instrumentation/src/main/kotlin/com/expediagroup/graphql/dataloader/instrumentation/syncexhaustion/execution/SyncExecutionExhaustedInstrumentationParameters.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2022 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.dataloader.instrumentation.syncexhaustion.execution
+
+import com.expediagroup.graphql.dataloader.instrumentation.syncexhaustion.DataLoaderSyncExecutionExhaustedInstrumentation
+import graphql.execution.ExecutionContext
+
+/**
+ * Hold information that will be provided to an instance of [DataLoaderSyncExecutionExhaustedInstrumentation]
+ */
+data class SyncExecutionExhaustedInstrumentationParameters(
+    val executionContext: ExecutionContext
+)

--- a/executions/graphql-kotlin-dataloader-instrumentation/src/main/kotlin/com/expediagroup/graphql/dataloader/instrumentation/syncexhaustion/state/ExecutionBatchState.kt
+++ b/executions/graphql-kotlin-dataloader-instrumentation/src/main/kotlin/com/expediagroup/graphql/dataloader/instrumentation/syncexhaustion/state/ExecutionBatchState.kt
@@ -1,0 +1,245 @@
+/*
+ * Copyright 2022 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.dataloader.instrumentation.syncexhaustion.state
+
+import graphql.ExecutionInput
+import graphql.execution.ResultPath
+import graphql.language.Field
+import graphql.schema.DataFetcher
+import graphql.schema.GraphQLType
+import graphql.schema.GraphQLTypeUtil.isList
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Hold and calculate the state of a given [ExecutionInput] by holding and tracking information of all Execution Strategies that
+ * were executed to resolve the [ExecutionInput].
+ *
+ * Example:
+ *
+ * given this [ExecutionInput]
+ *
+ * ```
+ * query getAstronaut {
+ *   astronaut(id: 1) {
+ *      id
+ *      name
+ *   }
+ * }
+ * ```
+ *
+ * When the [ExecutionBatchState] will be considered exhausted will have this state:
+ *
+ * ```
+ * {
+ *   "/": {
+ *     "dispatchedFetches": 1,
+ *       "fieldsState": {
+ *         "astronaut": {
+ *           "fetchState": "DISPATCHED",
+ *           "fetchType": "ASYNC",
+ *           "result": null,
+ *           "executionStrategyPaths": []
+ *         }
+ *      }
+ *   }
+ * }
+ * ```
+ *
+ * once astronaut [DataFetcher] completes his value starting a new ExecutionStrategy for `astronaut` field for
+ * the resolution of `id`, and `name`, once these fields are dispatched and completed
+ * and exhaustion will be calculated again and the state of [ExecutionBatchState] will be the following:
+ *
+ * ```
+ * {
+ *   "/": {
+ *     "dispatchedFetches": 1,
+ *       "fieldsState": {
+ *         "astronaut": {
+ *           "fetchState": "COMPLETED",
+ *           "fetchType": "ASYNC",
+ *           "result": { ... },
+ *           "executionStrategyPaths": ["/astronaut"]
+ *         }
+ *      }
+ *   },
+ *   "/astronaut": {
+ *     "dispatchedFetches": 2,
+ *     "fieldsState": {
+ *       "id": {
+ *         "fetchState": "COMPLETED",
+ *         "fetchType": "SYNC",
+ *         "executionStrategyPaths": []
+ *       },
+ *       "name": {
+ *         "fetchState": "COMPLETED",
+ *         "fetchType": "SYNC",
+ *         "executionStrategyPaths": []
+ *       }
+ *     }
+ *   }
+ * }
+ * ```
+ */
+class ExecutionBatchState {
+
+    private val executionStrategiesState: ConcurrentHashMap<String, ExecutionStrategyState> = ConcurrentHashMap()
+
+    /**
+     * This method will add an [ExecutionStrategyState] into [executionStrategiesState] which state will be changed when a field
+     * dispatches or completes
+     *
+     * @param field a nullable [Field] that represents the field that just started an executionStrategy, the ONLY use case where this
+     * param could be null is when the root executionStrategy starts.
+     * @param fieldExecutionStrategyPath the [ResultPath] of the field that just started an executionStrategy, example: `"/astronaut"`, `"/"`.
+     * @param fieldSelections the list of [Field]s that the executionStrategy will attempt to resolve.
+     * @param parentFieldGraphQLType the [GraphQLType] of the parent [field] that will start an execution strategy.
+     */
+    fun addExecutionStrategyState(
+        field: Field?,
+        fieldExecutionStrategyPath: ResultPath,
+        fieldSelections: List<Field>,
+        parentFieldGraphQLType: GraphQLType?
+    ) {
+        val fieldExecutionStrategyPathString = fieldExecutionStrategyPath.toString()
+
+        executionStrategiesState.computeIfAbsent(fieldExecutionStrategyPathString) {
+            ExecutionStrategyState(fieldSelections)
+        }
+
+        val parentFieldExecutionStrategyPathString = when {
+            isList(parentFieldGraphQLType) -> fieldExecutionStrategyPath.parent?.parent?.toString()
+            else -> fieldExecutionStrategyPath.parent?.toString()
+        }
+
+        parentFieldExecutionStrategyPathString?.let {
+            executionStrategiesState
+                .computeIfPresent(parentFieldExecutionStrategyPathString) { _, parentExecutionStrategyState ->
+                    parentExecutionStrategyState.fieldsState[field?.resultKey]?.addExecutionStrategyPath(
+                        fieldExecutionStrategyPathString
+                    )
+                    parentExecutionStrategyState
+                }
+        }
+    }
+
+    /**
+     * Apply a transition on the [field] to dispatched state.
+     *
+     * @param field the [Field] that will transition to dispatched state.
+     * @param fieldExecutionStrategyPath the [ResultPath] associated to the ExecutionStrategy that dispatched the [field].
+     * @param fieldGraphQLType the [GraphQLType] of the [field].
+     * @param result the [DataFetcher] [CompletableFuture] result.
+     */
+    fun fieldToDispatchedState(
+        field: Field,
+        fieldExecutionStrategyPath: ResultPath,
+        fieldGraphQLType: GraphQLType,
+        result: CompletableFuture<Any?>
+    ) {
+        val fieldExecutionStrategyPathString = fieldExecutionStrategyPath.toString()
+        executionStrategiesState[fieldExecutionStrategyPathString]?.let { executionStrategyState ->
+            executionStrategyState.fieldsState[field.resultKey]?.toDispatchedState(fieldGraphQLType, result)
+            setPathToNotExhaustedState(fieldExecutionStrategyPath)
+        }
+    }
+
+    /**
+     * Apply a transition on the [field] to completed state.
+     *
+     * @param field the [Field] that will transition to completed state.
+     * @param fieldExecutionStrategyPath the [ResultPath] associated to the ExecutionStrategy that completed the [field].
+     * @param result the nullable [Any] result of the [DataFetcher] when its completed
+     */
+    fun fieldToCompletedState(
+        field: Field,
+        fieldExecutionStrategyPath: ResultPath,
+        result: Any?
+    ) {
+        val fieldExecutionStrategyPathString = fieldExecutionStrategyPath.toString()
+        executionStrategiesState[fieldExecutionStrategyPathString]?.let { executionStrategyState ->
+            executionStrategyState.fieldsState[field.resultKey]?.toCompletedState(result)
+            setPathToNotExhaustedState(fieldExecutionStrategyPath)
+        }
+    }
+
+    /**
+     * Recursively calculate the sync state of this [ExecutionBatchState],
+     * by traversing all [executionStrategiesState].
+     *
+     * @param executionStrategyPath the string representation of the executionStrategy which state will be calculated,
+     * defaults to [ROOT_EXECUTION_STRATEGY_PATH] to start fom the root [ExecutionStrategyState].
+     */
+    fun isSyncExecutionExhausted(
+        executionStrategyPath: String = ROOT_EXECUTION_STRATEGY_PATH
+    ): Boolean {
+        val executionStrategyState = this.executionStrategiesState[executionStrategyPath] ?: return false
+
+        if (!executionStrategyState.allFieldsVisited()) {
+            return false
+        }
+        if (executionStrategyState.isSyncStateExhausted()) {
+            return true
+        }
+
+        return executionStrategyState.fieldsState.all { (_, state) ->
+            when {
+                state.isCompletedListOfComplexObjects() -> {
+                    state.executionStrategyPaths.all { executionStrategyPath ->
+                        isSyncExecutionExhausted(executionStrategyPath)
+                    }
+                }
+                state.isCompletedComplexObject() -> {
+                    isSyncExecutionExhausted(state.executionStrategyPaths.first())
+                }
+                state.isCompletedLeafOrNull() || state.isAsyncDispatchedNotLeaf() -> {
+                    true
+                }
+                else -> false
+            }
+        }.also { isExhausted ->
+            /**
+             * in order to avoid some computations we can store the [ExecutionStrategySyncState] that we
+             * just calculated.
+             */
+            when {
+                isExhausted -> executionStrategyState.transitionTo(ExecutionStrategySyncState.EXHAUSTED)
+                else -> executionStrategyState.transitionTo(ExecutionStrategySyncState.NOT_EXHAUSTED)
+            }
+        }
+    }
+
+    /**
+     * Reset the [ExecutionStrategySyncState] of each [ExecutionStrategyState] from [origin] path to root.
+     *
+     * @param origin [ResultPath] from where the [ExecutionStrategySyncState] will be reset
+     * up to the root [ExecutionStrategyState]
+     */
+    private fun setPathToNotExhaustedState(
+        origin: ResultPath
+    ) {
+        var currentPath: ResultPath? = origin
+        while (currentPath != null) {
+            executionStrategiesState[currentPath.toString()]?.transitionTo(ExecutionStrategySyncState.NOT_EXHAUSTED)
+            currentPath = currentPath.parent
+        }
+    }
+
+    companion object {
+        private const val ROOT_EXECUTION_STRATEGY_PATH: String = ""
+    }
+}

--- a/executions/graphql-kotlin-dataloader-instrumentation/src/main/kotlin/com/expediagroup/graphql/dataloader/instrumentation/syncexhaustion/state/ExecutionStrategyState.kt
+++ b/executions/graphql-kotlin-dataloader-instrumentation/src/main/kotlin/com/expediagroup/graphql/dataloader/instrumentation/syncexhaustion/state/ExecutionStrategyState.kt
@@ -1,0 +1,221 @@
+/*
+ * Copyright 2022 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.dataloader.instrumentation.syncexhaustion.state
+
+import graphql.ExecutionInput
+import graphql.execution.ExecutionStrategy
+import graphql.language.Field
+import graphql.schema.DataFetcher
+import graphql.schema.GraphQLList
+import graphql.schema.GraphQLType
+import graphql.schema.GraphQLTypeUtil
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Hold and calculate the [fieldsState] of an [ExecutionStrategy]
+ * associated with an [ExecutionInput] complex field.
+ *
+ * Example:
+ *
+ * Given this [ExecutionInput]:
+ *
+ * ```
+ * query getAstronaut {
+ *   astronaut(id: 1) {
+ *      id
+ *      name
+ *   }
+ * }
+ * ```
+ *
+ * the [ExecutionStrategyState] of the root [ExecutionStrategy] would be this:
+ *
+ * ```
+ * {
+ *   "/": {
+ *     "dispatchedFetches": 1,
+ *       "fieldsState": {
+ *         "astronaut": {
+ *           "fetchState": "DISPATCHED",
+ *           "fetchType": "ASYNC",
+ *           "result": null,
+ *           "executionStrategyPaths": []
+ *         }
+ *      }
+ *   }
+ * }
+ * ```
+ */
+class ExecutionStrategyState(
+    selections: List<Field>
+) {
+    private var dispatchedFields: AtomicReference<Int> = AtomicReference(0)
+    private var syncState: AtomicReference<ExecutionStrategySyncState> = AtomicReference(ExecutionStrategySyncState.NOT_EXHAUSTED)
+    val fieldsState: ConcurrentHashMap<String, FieldState> = ConcurrentHashMap(
+        selections.associateBy(Field::getResultKey) { FieldState() }
+    )
+
+    /**
+     * Transition this [ExecutionStrategyState] to a new state
+     * @param newState the new [ExecutionStrategySyncState] that the executionStrategyState will transition
+     */
+    fun transitionTo(newState: ExecutionStrategySyncState): Unit = syncState.set(newState)
+
+    /**
+     * Check if the [syncState] was previously calculated as [ExecutionStrategySyncState.EXHAUSTED].
+     *
+     * @return Boolean result of checking if [syncState] is exhausted.
+     */
+    fun isSyncStateExhausted(): Boolean = syncState.get() == ExecutionStrategySyncState.EXHAUSTED
+
+    /**
+     * Check if all the [Field]s associated with this [ExecutionStrategyState] were visited.
+     * A field is considered `"visited"` if at least was transitioned to [FieldFetchState.DISPATCHED] state
+     *
+     * @return Boolean result of checking if all fields were visited.
+     */
+    fun allFieldsVisited(): Boolean = dispatchedFields.get() == fieldsState.size
+
+    /**
+     * Hold, calculate and transition the state of a [Field] associated with a [ExecutionStrategyState].
+     */
+    inner class FieldState {
+        private var fetchState: FieldFetchState = FieldFetchState.NOT_DISPATCHED
+        private var fetchType: FieldFetchType = FieldFetchType.UNKNOWN
+        private var graphQLType: GraphQLType? = null
+        private var result: Any? = null
+        val executionStrategyPaths: MutableList<String> = mutableListOf()
+
+        /**
+         * Transition the [FieldState] to [FieldFetchState.DISPATCHED] state
+         * at this state we know the [GraphQLType] of the [Field] and have access to the result [CompletableFuture]
+         * of the [Field] [DataFetcher] in order to calculate the [Field] [FieldFetchType].
+         *
+         * @param graphQLType [GraphQLType] of the [Field] which [DataFetcher] was dispatched.
+         * @param result [CompletableFuture] result of the [DataFetcher.get] call.
+         * @return this [FieldState].
+         */
+        fun toDispatchedState(
+            graphQLType: GraphQLType,
+            result: CompletableFuture<Any?>
+        ): FieldState = this.also {
+            this.fetchState = FieldFetchState.DISPATCHED
+            this.graphQLType = graphQLType
+            this.fetchType = when {
+                result.isDone -> FieldFetchType.SYNC
+                else -> FieldFetchType.ASYNC
+            }
+
+            this@ExecutionStrategyState.dispatchedFields.updateAndGet { current -> current + 1 }
+        }
+
+        /**
+         * Transition the [FieldState] to [FieldFetchState.COMPLETED]state
+         * at this state we know the result of the [CompletableFuture] [DataFetcher] call and potentially spin
+         * new [ExecutionStrategy]ies depending on the [GraphQLType] type and [result] nullability
+         *
+         * @param result nullable Object after the [DataFetcher] [CompletableFuture] associated with the [Field]
+         * completed.
+         *
+         * @return this [FieldState].
+         */
+        fun toCompletedState(
+            result: Any?
+        ): FieldState = this.also {
+            this.fetchState = FieldFetchState.COMPLETED
+            this.result = result
+        }
+
+        /**
+         * Add the executionStrategy of a field that came out of the [result] object
+         *
+         * @param executionStrategyPath the execution strategy string representation of the field
+         * associated with the [result] of this state.
+         *
+         * Example:
+         *
+         * ```
+         * query allAstronauts {
+         *   astronauts {
+         *     id
+         *     name
+         *   }
+         * }
+         * ```
+         *
+         * `astronauts` [DataFetcher] will complete with a list of 3 object, the state will transition
+         * to completed and an ExecutionStrategy for each object will begin, this method will receive
+         * `"/astronauts[0]"` and it will add it to the state [executionStrategyPaths]
+         * ```
+         * {
+         *   "fetchState": "COMPLETED",
+         *   "fetchType": "ASYNC",
+         *   "GraphQLType": "GraphQLList",
+         *   "result": [{ "id": 1, ... }, { "id": 2, .... }, { "id": 3, .... }]
+         *   "executionStrategyPaths": ["/astronauts[0]"]
+         * }
+         * ```
+         */
+        fun addExecutionStrategyPath(
+            executionStrategyPath: String
+        ) {
+            executionStrategyPaths.add(executionStrategyPath)
+        }
+
+        /**
+         * field [fetchState] is completed with a non null [result] and
+         * [graphQLType] is not a leaf [GraphQLList] and
+         * all non null complex objects inside the [result] list started their own executionStrategy
+         *
+         * @return Boolean indicating if above sentence result
+         */
+        fun isCompletedListOfComplexObjects(): Boolean =
+            fetchState == FieldFetchState.COMPLETED && result != null &&
+                GraphQLTypeUtil.isList(graphQLType) && !GraphQLTypeUtil.isLeaf(graphQLType) &&
+                (result as? List<*>)?.filterNotNull()?.size == executionStrategyPaths.size
+
+        /**
+         * field [fetchState] is completed with a non null [result] and
+         * [graphQLType] is not a leaf complex type which executionStrategy was started.
+         *
+         * @return Boolean indicating if above sentence result
+         */
+        fun isCompletedComplexObject(): Boolean =
+            fetchState == FieldFetchState.COMPLETED && result != null &&
+                !GraphQLTypeUtil.isList(graphQLType) && !GraphQLTypeUtil.isLeaf(graphQLType) &&
+                executionStrategyPaths.isNotEmpty()
+
+        /**
+         * field [fetchState] is completed and [graphQLType] is a Leaf or null.
+         *
+         * @return Boolean indicating if above sentence result
+         */
+        fun isCompletedLeafOrNull(): Boolean =
+            fetchState == FieldFetchState.COMPLETED &&
+                (GraphQLTypeUtil.isLeaf(graphQLType) || result == null)
+
+        /**
+         * field [fetchType] is Async and [fetchState] is dispatched and
+         * is not a leaf
+         */
+        fun isAsyncDispatchedNotLeaf(): Boolean =
+            fetchType == FieldFetchType.ASYNC && fetchState == FieldFetchState.DISPATCHED &&
+                !GraphQLTypeUtil.isLeaf(graphQLType)
+    }
+}

--- a/executions/graphql-kotlin-dataloader-instrumentation/src/main/kotlin/com/expediagroup/graphql/dataloader/instrumentation/syncexhaustion/state/ExecutionStrategySyncState.kt
+++ b/executions/graphql-kotlin-dataloader-instrumentation/src/main/kotlin/com/expediagroup/graphql/dataloader/instrumentation/syncexhaustion/state/ExecutionStrategySyncState.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.dataloader.instrumentation.syncexhaustion.state
+
+import graphql.execution.ExecutionStrategy
+import graphql.schema.DataFetcher
+
+/**
+ * Possible states of an [ExecutionStrategy]
+ */
+enum class ExecutionStrategySyncState { NOT_EXHAUSTED, EXHAUSTED }
+
+/**
+ * Possible states of a field [DataFetcher]
+ */
+enum class FieldFetchState { NOT_DISPATCHED, DISPATCHED, COMPLETED }
+
+/**
+ * Possible execution types of a field [DataFetcher]
+ */
+enum class FieldFetchType { UNKNOWN, ASYNC, SYNC }

--- a/executions/graphql-kotlin-dataloader-instrumentation/src/main/kotlin/com/expediagroup/graphql/dataloader/instrumentation/syncexhaustion/state/SyncExecutionExhaustedState.kt
+++ b/executions/graphql-kotlin-dataloader-instrumentation/src/main/kotlin/com/expediagroup/graphql/dataloader/instrumentation/syncexhaustion/state/SyncExecutionExhaustedState.kt
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2022 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.dataloader.instrumentation.syncexhaustion.state
+
+import com.expediagroup.graphql.dataloader.KotlinDataLoaderRegistry
+import com.expediagroup.graphql.dataloader.instrumentation.NoOpExecutionStrategyInstrumentationContext
+import com.expediagroup.graphql.dataloader.instrumentation.syncexhaustion.execution.OnSyncExecutionExhaustedCallback
+import graphql.ExecutionInput
+import graphql.ExecutionResult
+import graphql.GraphQLContext
+import graphql.execution.MergedField
+import graphql.execution.instrumentation.ExecutionStrategyInstrumentationContext
+import graphql.execution.instrumentation.InstrumentationContext
+import graphql.execution.instrumentation.SimpleInstrumentationContext
+import graphql.execution.instrumentation.parameters.InstrumentationExecuteOperationParameters
+import graphql.execution.instrumentation.parameters.InstrumentationExecutionStrategyParameters
+import graphql.execution.instrumentation.parameters.InstrumentationFieldFetchParameters
+import graphql.schema.DataFetcher
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Orchestrate the [ExecutionBatchState] of all [ExecutionInput] sharing the same [GraphQLContext],
+ * when a certain state is reached will invoke [OnSyncExecutionExhaustedCallback]
+ */
+class SyncExecutionExhaustedState(
+    private val totalExecutions: Int,
+    private val dataLoaderRegistry: KotlinDataLoaderRegistry
+) {
+    val executions = ConcurrentHashMap<ExecutionInput, ExecutionBatchState>()
+
+    /**
+     * Create the [ExecutionBatchState] When a specific [ExecutionInput] starts his execution
+     *
+     * @param parameters contains information of which [ExecutionInput] will start his execution
+     * @return a non null [InstrumentationContext] object
+     */
+    fun beginExecuteOperation(
+        parameters: InstrumentationExecuteOperationParameters
+    ): InstrumentationContext<ExecutionResult> {
+        executions[parameters.executionContext.executionInput] = ExecutionBatchState()
+        return SimpleInstrumentationContext.noOp()
+    }
+
+    /**
+     * Add [ExecutionStrategyState] into operation [ExecutionBatchState] for the field that
+     * just started an ExecutionStrategy
+     *
+     * @param parameters contains information of which [ExecutionInput] started an executionStrategy
+     * @return a noop [ExecutionStrategyInstrumentationContext]
+     */
+    fun beginExecutionStrategy(
+        parameters: InstrumentationExecutionStrategyParameters
+    ): ExecutionStrategyInstrumentationContext {
+        val executionInput = parameters.executionContext.executionInput
+
+        executions.computeIfPresent(executionInput) { _, executionState ->
+            val executionStrategyParameters = parameters.executionStrategyParameters
+
+            val field = executionStrategyParameters.field?.singleField
+            val path = executionStrategyParameters.path
+            val selectionFields = executionStrategyParameters.fields.subFieldsList.map(MergedField::getSingleField)
+            val parentGraphQLType = executionStrategyParameters.executionStepInfo.parent?.unwrappedNonNullType
+
+            executionState.addExecutionStrategyState(field, path, selectionFields, parentGraphQLType)
+            executionState
+        }
+        return NoOpExecutionStrategyInstrumentationContext
+    }
+
+    /**
+     * This is called just before a field [DataFetcher] is invoked
+     *
+     * @param parameters contains information of which field will starting the fetching
+     * @param onSyncExecutionExhausted invoke when the sync execution fo all operations is exhausted
+     * @return a [InstrumentationContext] object that will be called back when the [DataFetcher]
+     * dispatches and completes
+     */
+    fun beginFieldFetch(
+        parameters: InstrumentationFieldFetchParameters,
+        onSyncExecutionExhausted: OnSyncExecutionExhaustedCallback
+    ): InstrumentationContext<Any> {
+        val executionInput = parameters.executionContext.executionInput
+        val executionStepInfo = parameters.executionStepInfo
+        val field = parameters.executionStepInfo.field.singleField
+        val fieldExecutionStrategyPath = parameters.environment.executionStepInfo.path.parent
+        val fieldGraphQLType = executionStepInfo.unwrappedNonNullType
+
+        return object : InstrumentationContext<Any> {
+            override fun onDispatched(result: CompletableFuture<Any?>) {
+                executions.computeIfPresent(executionInput) { _, executionState ->
+                    executionState.fieldToDispatchedState(field, fieldExecutionStrategyPath, fieldGraphQLType, result)
+                    executionState
+                }
+
+                val allSyncExecutionsExhausted = allSyncExecutionsExhausted()
+                if (allSyncExecutionsExhausted) {
+                    onSyncExecutionExhausted(executions.keys().toList())
+                }
+            }
+            override fun onCompleted(result: Any?, t: Throwable?) {
+                executions.computeIfPresent(executionInput) { _, executionState ->
+                    executionState.fieldToCompletedState(field, fieldExecutionStrategyPath, result)
+                    executionState
+                }
+
+                val allSyncExecutionsExhausted = allSyncExecutionsExhausted()
+                if (allSyncExecutionsExhausted) {
+                    onSyncExecutionExhausted(executions.keys().toList())
+                }
+            }
+        }
+    }
+
+    /**
+     * Provide the information about when all [ExecutionInput] sharing a [GraphQLContext] exhausted their execution
+     * A Synchronous Execution is considered Exhausted when all [DataFetcher]s of all paths were executed up until
+     * an scalar leaf or a [DataFetcher] that returns a [CompletableFuture]
+     */
+    private fun allSyncExecutionsExhausted(): Boolean = synchronized(executions) {
+        when {
+            executions.size < totalExecutions || !dataLoaderRegistry.isDispatchedAndCompleted() -> false
+            else -> executions.values.all(ExecutionBatchState::isSyncExecutionExhausted)
+        }
+    }
+}

--- a/executions/graphql-kotlin-dataloader-instrumentation/src/test/kotlin/com/expediagroup/graphql/dataloader/instrumentation/fixture/TestGraphQL.kt
+++ b/executions/graphql-kotlin-dataloader-instrumentation/src/test/kotlin/com/expediagroup/graphql/dataloader/instrumentation/fixture/TestGraphQL.kt
@@ -16,29 +16,49 @@
 
 package com.expediagroup.graphql.dataloader.instrumentation.fixture
 
+import com.expediagroup.graphql.dataloader.KotlinDataLoaderRegistry
+import com.expediagroup.graphql.dataloader.KotlinDataLoaderRegistryFactory
+import com.expediagroup.graphql.dataloader.instrumentation.fixture.datafetcher.AstronautDataLoader
 import com.expediagroup.graphql.dataloader.instrumentation.fixture.domain.Astronaut
 import com.expediagroup.graphql.dataloader.instrumentation.fixture.datafetcher.AstronautService
 import com.expediagroup.graphql.dataloader.instrumentation.fixture.datafetcher.AstronautServiceRequest
+import com.expediagroup.graphql.dataloader.instrumentation.fixture.datafetcher.MissionDataLoader
 import com.expediagroup.graphql.dataloader.instrumentation.fixture.datafetcher.MissionService
 import com.expediagroup.graphql.dataloader.instrumentation.fixture.datafetcher.MissionServiceRequest
+import com.expediagroup.graphql.dataloader.instrumentation.fixture.datafetcher.MissionsByAstronautDataLoader
 import com.expediagroup.graphql.dataloader.instrumentation.fixture.domain.Nasa
+import com.expediagroup.graphql.dataloader.instrumentation.level.state.ExecutionLevelDispatchedState
+import com.expediagroup.graphql.dataloader.instrumentation.syncexhaustion.state.SyncExecutionExhaustedState
+import graphql.ExecutionInput
+import graphql.ExecutionResult
 import graphql.GraphQL
 import graphql.schema.DataFetcher
 import graphql.schema.idl.RuntimeWiring
 import graphql.schema.idl.SchemaGenerator
 import graphql.schema.idl.SchemaParser
 import graphql.schema.idl.TypeRuntimeWiring
+import io.mockk.spyk
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.future.await
+import kotlinx.coroutines.runBlocking
+
+enum class DataLoaderInstrumentationStrategy { LEVEL_DISPATCHED, SYNC_EXHAUSTION }
 
 object TestGraphQL {
     private val schema = """
         type Query {
             astronaut(id: ID!): Astronaut
             mission(id: ID!): Mission
+            astronauts(ids: [ID!]): [Astronaut]!
+            missions(ids: [ID!]): [Mission]!
             nasa: Nasa!
         }
         type Nasa {
             astronaut(id: ID!): Astronaut
             mission(id: ID!): Mission
+            astronauts(ids: [ID!]): [Astronaut]!
+            missions(ids: [ID!]): [Mission]!
             address: Address!
             phoneNumber: String!
         }
@@ -67,6 +87,14 @@ object TestGraphQL {
             environment
         )
     }
+    private val astronautsDataFetcher = DataFetcher { environment ->
+        astronautService.getAstronauts(
+            environment.getArgument<List<String>>("ids")
+                ?.map { id -> AstronautServiceRequest(id.toInt()) }
+                ?: emptyList(),
+            environment
+        )
+    }
 
     private val missionService = MissionService()
     private val missionDataFetcher = DataFetcher { environment ->
@@ -77,31 +105,42 @@ object TestGraphQL {
             environment
         )
     }
+    private val missionsDataFetcher = DataFetcher { environment ->
+        missionService.getMissions(
+            environment.getArgument<List<String>>("ids")
+                ?.map { id -> MissionServiceRequest(id.toInt()) }
+                ?: emptyList(),
+            environment
+        )
+    }
+    private val missionsByAstronautDataFetcher = DataFetcher { environment ->
+        val astronaut = environment.getSource<Astronaut>()
+        missionService
+            .getMissionsByAstronaut(
+                MissionServiceRequest(0, astronaut.id),
+                environment
+            )
+    }
 
     private val runtimeWiring = RuntimeWiring.newRuntimeWiring().apply {
         type(
             TypeRuntimeWiring.newTypeWiring("Query")
                 .dataFetcher("astronaut", astronautDataFetcher)
                 .dataFetcher("mission", missionDataFetcher)
-                .dataFetcher("nasa") {
-                    Nasa()
-                }
+                .dataFetcher("astronauts", astronautsDataFetcher)
+                .dataFetcher("missions", missionsDataFetcher)
+                .dataFetcher("nasa") { Nasa() }
         )
         type(
             TypeRuntimeWiring.newTypeWiring("Astronaut")
-                .dataFetcher("missions") { environment ->
-                    val astronaut = environment.getSource<Astronaut>()
-                    missionService
-                        .getMissionsByAstronaut(
-                            MissionServiceRequest(0, astronaut.id),
-                            environment
-                        )
-                }
+                .dataFetcher("missions", missionsByAstronautDataFetcher)
         )
         type(
             TypeRuntimeWiring.newTypeWiring("Nasa")
                 .dataFetcher("astronaut", astronautDataFetcher)
                 .dataFetcher("mission", missionDataFetcher)
+                .dataFetcher("astronauts", astronautsDataFetcher)
+                .dataFetcher("missions", missionsDataFetcher)
         )
     }.build()
 
@@ -111,4 +150,43 @@ object TestGraphQL {
             runtimeWiring
         )
     )
+
+    fun execute(
+        graphQL: GraphQL,
+        queries: List<String>,
+        dataLoaderInstrumentationStrategy: DataLoaderInstrumentationStrategy
+    ): Pair<List<ExecutionResult>, KotlinDataLoaderRegistry> {
+        val kotlinDataLoaderRegistry = spyk(
+            KotlinDataLoaderRegistryFactory(
+                AstronautDataLoader(), MissionDataLoader(), MissionsByAstronautDataLoader()
+            ).generate()
+        )
+
+        val graphQLContext = mapOf(
+            KotlinDataLoaderRegistry::class to kotlinDataLoaderRegistry,
+            when (dataLoaderInstrumentationStrategy) {
+                DataLoaderInstrumentationStrategy.SYNC_EXHAUSTION ->
+                    SyncExecutionExhaustedState::class to SyncExecutionExhaustedState(
+                        queries.size,
+                        kotlinDataLoaderRegistry
+                    )
+                DataLoaderInstrumentationStrategy.LEVEL_DISPATCHED ->
+                    ExecutionLevelDispatchedState::class to ExecutionLevelDispatchedState(
+                        queries.size
+                    )
+            }
+        )
+
+        val results = runBlocking {
+            queries.map { query ->
+                async {
+                    graphQL.executeAsync(
+                        ExecutionInput.newExecutionInput(query).graphQLContext(graphQLContext).build()
+                    ).await()
+                }
+            }.awaitAll()
+        }
+
+        return Pair(results, kotlinDataLoaderRegistry)
+    }
 }

--- a/executions/graphql-kotlin-dataloader-instrumentation/src/test/kotlin/com/expediagroup/graphql/dataloader/instrumentation/fixture/extensions/ListExtensions.kt
+++ b/executions/graphql-kotlin-dataloader-instrumentation/src/test/kotlin/com/expediagroup/graphql/dataloader/instrumentation/fixture/extensions/ListExtensions.kt
@@ -1,0 +1,10 @@
+package com.expediagroup.graphql.dataloader.instrumentation.fixture.extensions
+
+import java.util.Optional
+
+fun <T : Any> List<Optional<T>>.toListOfNullables(): List<T?> = map { optional ->
+    when {
+        optional.isPresent -> optional.get()
+        else -> null
+    }
+}

--- a/executions/graphql-kotlin-dataloader-instrumentation/src/test/kotlin/com/expediagroup/graphql/dataloader/instrumentation/fixture/extensions/ListExtensions.kt
+++ b/executions/graphql-kotlin-dataloader-instrumentation/src/test/kotlin/com/expediagroup/graphql/dataloader/instrumentation/fixture/extensions/ListExtensions.kt
@@ -2,7 +2,7 @@ package com.expediagroup.graphql.dataloader.instrumentation.fixture.extensions
 
 import java.util.Optional
 
-fun <T : Any> List<Optional<T>>.toListOfNullables(): List<T?> = map { optional ->
+internal fun <T : Any> List<Optional<T>>.toListOfNullables(): List<T?> = map { optional ->
     when {
         optional.isPresent -> optional.get()
         else -> null

--- a/executions/graphql-kotlin-dataloader-instrumentation/src/test/kotlin/com/expediagroup/graphql/dataloader/instrumentation/fixture/repository/AstronautRepository.kt
+++ b/executions/graphql-kotlin-dataloader-instrumentation/src/test/kotlin/com/expediagroup/graphql/dataloader/instrumentation/fixture/repository/AstronautRepository.kt
@@ -21,7 +21,7 @@ import reactor.core.publisher.Flux
 import reactor.kotlin.core.publisher.toFlux
 import reactor.kotlin.core.publisher.toMono
 import java.time.Duration
-import java.util.*
+import java.util.Optional
 
 object AstronautRepository {
     private val astronauts = listOf(

--- a/executions/graphql-kotlin-dataloader-instrumentation/src/test/kotlin/com/expediagroup/graphql/dataloader/instrumentation/level/DataLoaderLevelDispatchedInstrumentationTest.kt
+++ b/executions/graphql-kotlin-dataloader-instrumentation/src/test/kotlin/com/expediagroup/graphql/dataloader/instrumentation/level/DataLoaderLevelDispatchedInstrumentationTest.kt
@@ -16,20 +16,9 @@
 
 package com.expediagroup.graphql.dataloader.instrumentation.level
 
-import com.expediagroup.graphql.dataloader.KotlinDataLoaderRegistry
-import com.expediagroup.graphql.dataloader.KotlinDataLoaderRegistryFactory
+import com.expediagroup.graphql.dataloader.instrumentation.fixture.DataLoaderInstrumentationStrategy
 import com.expediagroup.graphql.dataloader.instrumentation.fixture.TestGraphQL
-import com.expediagroup.graphql.dataloader.instrumentation.fixture.datafetcher.AstronautDataLoader
-import com.expediagroup.graphql.dataloader.instrumentation.fixture.datafetcher.MissionDataLoader
-import com.expediagroup.graphql.dataloader.instrumentation.fixture.datafetcher.MissionsByAstronautDataLoader
-import com.expediagroup.graphql.dataloader.instrumentation.level.state.ExecutionLevelDispatchedState
-import graphql.ExecutionInput
-import io.mockk.spyk
 import io.mockk.verify
-import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
-import kotlinx.coroutines.future.await
-import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
@@ -49,26 +38,11 @@ class DataLoaderLevelDispatchedInstrumentationTest {
             "{ mission(id: 4) { designation } }"
         )
 
-        val kotlinDataLoaderRegistry = spyk(
-            KotlinDataLoaderRegistryFactory(
-                AstronautDataLoader(), MissionDataLoader()
-            ).generate()
+        val (results, kotlinDataLoaderRegistry) = TestGraphQL.execute(
+            graphQL,
+            queries,
+            DataLoaderInstrumentationStrategy.LEVEL_DISPATCHED
         )
-
-        val graphQLContext = mapOf(
-            KotlinDataLoaderRegistry::class to kotlinDataLoaderRegistry,
-            ExecutionLevelDispatchedState::class to ExecutionLevelDispatchedState(queries.size)
-        )
-
-        val results = runBlocking {
-            queries.map { query ->
-                async {
-                    graphQL.executeAsync(
-                        ExecutionInput.newExecutionInput(query).graphQLContext(graphQLContext).build()
-                    ).await()
-                }
-            }.awaitAll()
-        }
 
         assertEquals(4, results.size)
 
@@ -95,26 +69,11 @@ class DataLoaderLevelDispatchedInstrumentationTest {
             "{ nasa { mission(id: 4) { id designation } } }"
         )
 
-        val kotlinDataLoaderRegistry = spyk(
-            KotlinDataLoaderRegistryFactory(
-                AstronautDataLoader(), MissionDataLoader()
-            ).generate()
+        val (results, kotlinDataLoaderRegistry) = TestGraphQL.execute(
+            graphQL,
+            queries,
+            DataLoaderInstrumentationStrategy.LEVEL_DISPATCHED
         )
-
-        val graphQLContext = mapOf(
-            KotlinDataLoaderRegistry::class to kotlinDataLoaderRegistry,
-            ExecutionLevelDispatchedState::class to ExecutionLevelDispatchedState(queries.size)
-        )
-
-        val results = runBlocking {
-            queries.map { query ->
-                async {
-                    graphQL.executeAsync(
-                        ExecutionInput.newExecutionInput(query).graphQLContext(graphQLContext).build()
-                    ).await()
-                }
-            }.awaitAll()
-        }
 
         assertEquals(4, results.size)
 
@@ -145,26 +104,11 @@ class DataLoaderLevelDispatchedInstrumentationTest {
             "{ mission(id: 4) { designation } }"
         )
 
-        val kotlinDataLoaderRegistry = spyk(
-            KotlinDataLoaderRegistryFactory(
-                AstronautDataLoader(), MissionDataLoader(), MissionsByAstronautDataLoader()
-            ).generate()
+        val (results, kotlinDataLoaderRegistry) = TestGraphQL.execute(
+            graphQL,
+            queries,
+            DataLoaderInstrumentationStrategy.LEVEL_DISPATCHED
         )
-
-        val graphQLContext = mapOf(
-            KotlinDataLoaderRegistry::class to kotlinDataLoaderRegistry,
-            ExecutionLevelDispatchedState::class to ExecutionLevelDispatchedState(queries.size)
-        )
-
-        val results = runBlocking {
-            queries.map { query ->
-                async {
-                    graphQL.executeAsync(
-                        ExecutionInput.newExecutionInput(query).graphQLContext(graphQLContext).build()
-                    ).await()
-                }
-            }.awaitAll()
-        }
 
         assertEquals(4, results.size)
 

--- a/executions/graphql-kotlin-dataloader-instrumentation/src/test/kotlin/com/expediagroup/graphql/dataloader/instrumentation/syncexhaustion/DataLoaderSyncExecutionExhaustedInstrumentationTest.kt
+++ b/executions/graphql-kotlin-dataloader-instrumentation/src/test/kotlin/com/expediagroup/graphql/dataloader/instrumentation/syncexhaustion/DataLoaderSyncExecutionExhaustedInstrumentationTest.kt
@@ -295,7 +295,6 @@ class DataLoaderSyncExecutionExhaustedInstrumentationTest {
 
         val missionsByAstronautStatistics = kotlinDataLoaderRegistry.dataLoadersMap["MissionsByAstronautDataLoader"]?.statistics
         assertEquals(1, missionsByAstronautStatistics?.batchInvokeCount)
-        assertEquals(32, missionsByAstronautStatistics?.batchLoadCount)
 
         verify(exactly = 2) {
             kotlinDataLoaderRegistry.dispatchAll()

--- a/executions/graphql-kotlin-dataloader-instrumentation/src/test/kotlin/com/expediagroup/graphql/dataloader/instrumentation/syncexhaustion/DataLoaderSyncExecutionExhaustedInstrumentationTest.kt
+++ b/executions/graphql-kotlin-dataloader-instrumentation/src/test/kotlin/com/expediagroup/graphql/dataloader/instrumentation/syncexhaustion/DataLoaderSyncExecutionExhaustedInstrumentationTest.kt
@@ -1,0 +1,304 @@
+/*
+ * Copyright 2022 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.dataloader.instrumentation.syncexhaustion
+
+import com.expediagroup.graphql.dataloader.instrumentation.fixture.DataLoaderInstrumentationStrategy
+import com.expediagroup.graphql.dataloader.instrumentation.fixture.TestGraphQL
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class DataLoaderSyncExecutionExhaustedInstrumentationTest {
+    private val graphQL = TestGraphQL.builder
+        .instrumentation(DataLoaderSyncExecutionExhaustedInstrumentation())
+        // graphql java adds DataLoaderDispatcherInstrumentation by default
+        .doNotAddDefaultInstrumentations()
+        .build()
+
+    @Test
+    fun `Instrumentation should batch transactions on async top level fields`() {
+        val queries = listOf(
+            "{ astronaut(id: 1) { name } }",
+            "{ astronaut(id: 2) { id name } }",
+            "{ mission(id: 3) { id designation } }",
+            "{ mission(id: 4) { designation } }"
+        )
+
+        val (results, kotlinDataLoaderRegistry) = TestGraphQL.execute(
+            graphQL,
+            queries,
+            DataLoaderInstrumentationStrategy.SYNC_EXHAUSTION
+        )
+
+        assertEquals(4, results.size)
+
+        val astronautStatistics = kotlinDataLoaderRegistry.dataLoadersMap["AstronautDataLoader"]?.statistics
+        val missionStatistics = kotlinDataLoaderRegistry.dataLoadersMap["MissionDataLoader"]?.statistics
+
+        assertEquals(1, astronautStatistics?.batchInvokeCount)
+        assertEquals(2, astronautStatistics?.batchLoadCount)
+
+        assertEquals(1, missionStatistics?.batchInvokeCount)
+        assertEquals(2, missionStatistics?.batchLoadCount)
+
+        verify(exactly = 2) {
+            kotlinDataLoaderRegistry.dispatchAll()
+        }
+    }
+
+    @Test
+    fun `Instrumentation should batch transactions on sync top level fields`() {
+        val queries = listOf(
+            "{ nasa { astronaut(id: 1) { name } } }",
+            "{ nasa { astronaut(id: 2) { id name } } }",
+            "{ nasa { mission(id: 3) { designation } } }",
+            "{ nasa { mission(id: 4) { id designation } } }"
+        )
+
+        val (results, kotlinDataLoaderRegistry) = TestGraphQL.execute(
+            graphQL,
+            queries,
+            DataLoaderInstrumentationStrategy.SYNC_EXHAUSTION
+        )
+
+        assertEquals(4, results.size)
+
+        val astronautStatistics = kotlinDataLoaderRegistry.dataLoadersMap["AstronautDataLoader"]?.statistics
+        val missionStatistics = kotlinDataLoaderRegistry.dataLoadersMap["MissionDataLoader"]?.statistics
+
+        assertEquals(1, astronautStatistics?.batchInvokeCount)
+        assertEquals(2, astronautStatistics?.batchLoadCount)
+
+        assertEquals(1, missionStatistics?.batchInvokeCount)
+        assertEquals(2, missionStatistics?.batchLoadCount)
+
+        verify(exactly = 2) {
+            kotlinDataLoaderRegistry.dispatchAll()
+        }
+    }
+
+    @Test
+    fun `Instrumentation should batch transactions on different levels`() {
+        val queries = listOf(
+            // L2 astronaut - L3 missions
+            "{ nasa { astronaut(id: 1) { id name missions { designation } } } }",
+            // L1 astronaut - L2 missions
+            "{ astronaut(id: 2) { id name missions { designation } } }",
+            // L2 mission
+            "{ nasa { mission(id: 3) { designation } } }",
+            // L1 mission
+            "{ mission(id: 4) { designation } }"
+        )
+
+        val (results, kotlinDataLoaderRegistry) = TestGraphQL.execute(
+            graphQL,
+            queries,
+            DataLoaderInstrumentationStrategy.SYNC_EXHAUSTION
+        )
+
+        assertEquals(4, results.size)
+
+        val astronautStatistics = kotlinDataLoaderRegistry.dataLoadersMap["AstronautDataLoader"]?.statistics
+        val missionStatistics = kotlinDataLoaderRegistry.dataLoadersMap["MissionDataLoader"]?.statistics
+        val missionsByAstronautStatistics = kotlinDataLoaderRegistry.dataLoadersMap["MissionsByAstronautDataLoader"]?.statistics
+
+        assertEquals(1, astronautStatistics?.batchInvokeCount)
+        // Level 1 and 2
+        assertEquals(2, astronautStatistics?.batchLoadCount)
+
+        assertEquals(1, missionStatistics?.batchInvokeCount)
+        // Level 1 and 2
+        assertEquals(2, missionStatistics?.batchLoadCount)
+
+        assertEquals(1, missionsByAstronautStatistics?.batchInvokeCount)
+        // Level 2 and 3
+        assertEquals(2, missionsByAstronautStatistics?.batchLoadCount)
+
+        verify(exactly = 3) {
+            kotlinDataLoaderRegistry.dispatchAll()
+        }
+    }
+
+    @Test
+    fun `Instrumentation should batch transactions after exhausting a single ExecutionInput`() {
+        val queries = listOf(
+            """
+                fragment AstronautFragment on Astronaut { name missions { designation } }
+                query ComplexQuery {
+                    astronaut1: astronaut(id: 1) { ...AstronautFragment }
+                    nasa {
+                        astronaut(id: 2) {...AstronautFragment }
+                    }
+                    astronaut3: astronaut(id: 3) { ...AstronautFragment }
+                }
+            """.trimIndent()
+        )
+
+        val (results, kotlinDataLoaderRegistry) = TestGraphQL.execute(
+            graphQL,
+            queries,
+            DataLoaderInstrumentationStrategy.SYNC_EXHAUSTION
+        )
+
+        assertEquals(1, results.size)
+
+        val astronautStatistics = kotlinDataLoaderRegistry.dataLoadersMap["AstronautDataLoader"]?.statistics
+        val missionsByAstronautStatistics = kotlinDataLoaderRegistry.dataLoadersMap["MissionsByAstronautDataLoader"]?.statistics
+
+        assertEquals(1, astronautStatistics?.batchInvokeCount)
+        assertEquals(3, astronautStatistics?.batchLoadCount)
+
+        assertEquals(1, missionsByAstronautStatistics?.batchInvokeCount)
+        assertEquals(3, missionsByAstronautStatistics?.batchLoadCount)
+
+        verify(exactly = 3) {
+            kotlinDataLoaderRegistry.dispatchAll()
+        }
+    }
+
+    @Test
+    fun `Instrumentation should batch transactions after exhausting multiple ExecutionInput`() {
+        val queries = listOf(
+            """
+                fragment AstronautFragment on Astronaut { name missions { designation } }
+                fragment MissionFragment on Mission { designation }
+                query ComplexQuery {
+                    mission1: mission(id: 1) { ...MissionFragment }
+                    astronaut1: astronaut(id: 1) { ...AstronautFragment }
+                    nasa {
+                        astronaut(id: 2) {...AstronautFragment }
+                    }
+                    astronaut3: astronaut(id: 3) { ...AstronautFragment }
+                }
+            """.trimIndent(),
+            """
+                fragment AstronautFragment on Astronaut { name missions { designation } }
+                fragment MissionFragment on Mission { designation }
+                query ComplexQuery2 {
+                    astronaut1: astronaut(id: 1) { ...AstronautFragment }
+                    mission1: mission(id: 1) { ...MissionFragment }
+                    nasa {
+                        mission(id: 2) {...MissionFragment }
+                    }
+                    mission3: mission(id: 3) { ...MissionFragment }
+                }
+            """.trimIndent()
+        )
+
+        val (results, kotlinDataLoaderRegistry) = TestGraphQL.execute(
+            graphQL,
+            queries,
+            DataLoaderInstrumentationStrategy.SYNC_EXHAUSTION
+        )
+
+        assertEquals(2, results.size)
+
+        val astronautStatistics = kotlinDataLoaderRegistry.dataLoadersMap["AstronautDataLoader"]?.statistics
+        val missionStatistics = kotlinDataLoaderRegistry.dataLoadersMap["MissionDataLoader"]?.statistics
+        val missionsByAstronautStatistics = kotlinDataLoaderRegistry.dataLoadersMap["MissionsByAstronautDataLoader"]?.statistics
+
+        assertEquals(1, astronautStatistics?.batchInvokeCount)
+        assertEquals(3, astronautStatistics?.batchLoadCount)
+
+        assertEquals(1, missionStatistics?.batchInvokeCount)
+        assertEquals(3, missionStatistics?.batchLoadCount)
+
+        assertEquals(1, missionsByAstronautStatistics?.batchInvokeCount)
+        assertEquals(3, missionsByAstronautStatistics?.batchLoadCount)
+
+        verify(exactly = 3) {
+            kotlinDataLoaderRegistry.dispatchAll()
+        }
+    }
+
+    @Test
+    fun `Instrumentation should batch transactions for list of lists`() {
+        val queries = listOf(
+            """
+                fragment AstronautFragment on Astronaut { name missions { designation } }
+                fragment MissionFragment on Mission { designation }
+                query ComplexQuery {
+                    astronauts1And2: astronauts(ids: [1, 2]) { ...AstronautFragment }
+                    missions1And2: missions(ids: [1, 2]) { ...MissionFragment }
+                    nasa {
+                        phoneNumber
+                        address { street zipCode }
+                        astronauts3AndNull: astronauts(ids: [3, 404]) { ...AstronautFragment }
+                        missions3AndNull: missions(ids: [3, 404]) { ...MissionFragment }
+                    }
+                }
+            """.trimIndent()
+        )
+
+        val (results, kotlinDataLoaderRegistry) = TestGraphQL.execute(
+            graphQL,
+            queries,
+            DataLoaderInstrumentationStrategy.SYNC_EXHAUSTION
+        )
+
+        assertEquals(1, results.size)
+
+        val astronautStatistics = kotlinDataLoaderRegistry.dataLoadersMap["AstronautDataLoader"]?.statistics
+        val missionStatistics = kotlinDataLoaderRegistry.dataLoadersMap["MissionDataLoader"]?.statistics
+        val missionsByAstronautStatistics = kotlinDataLoaderRegistry.dataLoadersMap["MissionsByAstronautDataLoader"]?.statistics
+
+        assertEquals(1, astronautStatistics?.batchInvokeCount)
+        assertEquals(4, astronautStatistics?.batchLoadCount)
+
+        assertEquals(1, missionStatistics?.batchInvokeCount)
+        assertEquals(4, missionStatistics?.batchLoadCount)
+
+        assertEquals(1, missionsByAstronautStatistics?.batchInvokeCount)
+        assertEquals(3, missionsByAstronautStatistics?.batchLoadCount)
+
+        verify(exactly = 3) {
+            kotlinDataLoaderRegistry.dispatchAll()
+        }
+    }
+
+    @Test
+    fun `Instrumentation should batch transactions for list of lists without arguments`() {
+        val queries = listOf(
+            """
+                fragment AstronautFragment on Astronaut { name missions { designation } }
+                fragment MissionFragment on Mission { designation }
+                {
+                    astronauts { ...AstronautFragment }
+                    nasa {
+                        missions { ...MissionFragment }
+                    }
+                }
+            """.trimIndent()
+        )
+
+        val (results, kotlinDataLoaderRegistry) = TestGraphQL.execute(
+            graphQL,
+            queries,
+            DataLoaderInstrumentationStrategy.SYNC_EXHAUSTION
+        )
+
+        assertEquals(1, results.size)
+
+        val missionsByAstronautStatistics = kotlinDataLoaderRegistry.dataLoadersMap["MissionsByAstronautDataLoader"]?.statistics
+        assertEquals(1, missionsByAstronautStatistics?.batchInvokeCount)
+        assertEquals(32, missionsByAstronautStatistics?.batchLoadCount)
+
+        verify(exactly = 2) {
+            kotlinDataLoaderRegistry.dispatchAll()
+        }
+    }
+}

--- a/executions/graphql-kotlin-dataloader-instrumentation/src/test/kotlin/com/expediagroup/graphql/dataloader/instrumentation/syncexhaustion/DataLoaderSyncExecutionExhaustedInstrumentationTest.kt
+++ b/executions/graphql-kotlin-dataloader-instrumentation/src/test/kotlin/com/expediagroup/graphql/dataloader/instrumentation/syncexhaustion/DataLoaderSyncExecutionExhaustedInstrumentationTest.kt
@@ -293,11 +293,12 @@ class DataLoaderSyncExecutionExhaustedInstrumentationTest {
 
         assertEquals(1, results.size)
 
+        val astronautStatistics = kotlinDataLoaderRegistry.dataLoadersMap["AstronautDataLoader"]?.statistics
+        val missionStatistics = kotlinDataLoaderRegistry.dataLoadersMap["MissionDataLoader"]?.statistics
         val missionsByAstronautStatistics = kotlinDataLoaderRegistry.dataLoadersMap["MissionsByAstronautDataLoader"]?.statistics
-        assertEquals(1, missionsByAstronautStatistics?.batchInvokeCount)
 
-        verify(exactly = 2) {
-            kotlinDataLoaderRegistry.dispatchAll()
-        }
+        assertEquals(0, astronautStatistics?.batchInvokeCount)
+        assertEquals(0, missionStatistics?.batchInvokeCount)
+        assertEquals(1, missionsByAstronautStatistics?.batchInvokeCount)
     }
 }


### PR DESCRIPTION
### :pencil: Description
Adding a Custom Instrumentation that will dispatch a [DataLoaderRegistry](https://github.com/graphql-java/java-dataloader/blob/master/src/main/java/org/dataloader/DataLoaderRegistry.java), when the synchronous execution of all operations sharing the same `GraphQLContext` was **exhausted**

by **exhausted** it means that all the AST paths were visited until finding a leaf scalar or a non-trivial dataFetcher that returns a `CompletableFuture`

This Instrumentation keeps track on the state of each [ExecutionStrategy](https://www.javadoc.io/doc/com.graphql-java/graphql-java/18.0/graphql/execution/ExecutionStrategy.html) associated with an operation using the following data structure

<img width="1448" alt="image" src="https://user-images.githubusercontent.com/6611331/161652559-1ea854ff-fdbd-483f-8f8e-5bc1aa6a1696.png">

![image](https://user-images.githubusercontent.com/6611331/161652575-21481b6c-8d35-4274-ac06-07cff76237b1.png)


### :link: Related Issues
This PR is related to [this discussion opened in graphql-java](https://github.com/graphql-java/graphql-java/discussions/2715)

