### PR TITLE
feat: support directives with the union annotation

### DIFF
--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/SchemaGenerator.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/SchemaGenerator.kt
@@ -17,6 +17,7 @@
 package com.expediagroup.graphql.generator
 
 import com.expediagroup.graphql.generator.exceptions.InvalidPackagesException
+import com.expediagroup.graphql.generator.internal.extensions.getKClass
 import com.expediagroup.graphql.generator.internal.state.AdditionalType
 import com.expediagroup.graphql.generator.internal.state.ClassScanner
 import com.expediagroup.graphql.generator.internal.state.TypesCache
@@ -121,7 +122,7 @@ open class SchemaGenerator(internal val config: SchemaGeneratorConfig) : Closeab
             this.additionalTypes.clear()
             graphqlTypes.addAll(
                 currentlyProcessedTypes.map {
-                    GraphQLTypeUtil.unwrapNonNull(generateGraphQLType(this, it.kType, GraphQLKTypeMetadata(inputType = it.inputType)))
+                    GraphQLTypeUtil.unwrapNonNull(generateGraphQLType(this, it.kType, GraphQLKTypeMetadata(inputType = it.inputType, fieldAnnotations = it.kType.getKClass().annotations)))
                 }
             )
         }

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/annotations/GraphQLUnion.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/annotations/GraphQLUnion.kt
@@ -18,7 +18,7 @@ package com.expediagroup.graphql.generator.annotations
 
 import kotlin.reflect.KClass
 
-@Target(AnnotationTarget.PROPERTY, AnnotationTarget.FUNCTION)
+@Target(AnnotationTarget.PROPERTY, AnnotationTarget.FUNCTION, AnnotationTarget.ANNOTATION_CLASS)
 annotation class GraphQLUnion(
     val name: String,
     val possibleTypes: Array<KClass<*>>,

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/extensions/annotationExtensions.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/extensions/annotationExtensions.kt
@@ -22,6 +22,7 @@ import com.expediagroup.graphql.generator.annotations.GraphQLName
 import com.expediagroup.graphql.generator.annotations.GraphQLType
 import com.expediagroup.graphql.generator.annotations.GraphQLUnion
 import kotlin.reflect.KAnnotatedElement
+import kotlin.reflect.KClass
 import kotlin.reflect.full.findAnnotation
 
 internal fun KAnnotatedElement.getGraphQLDescription(): String? = this.findAnnotation<GraphQLDescription>()?.value
@@ -32,7 +33,11 @@ internal fun KAnnotatedElement.getDeprecationReason(): String? = this.findAnnota
 
 internal fun KAnnotatedElement.isGraphQLIgnored(): Boolean = this.findAnnotation<GraphQLIgnore>() != null
 
-internal fun List<Annotation>.getUnionAnnotation(): GraphQLUnion? = this.filterIsInstance(GraphQLUnion::class.java).firstOrNull()
+internal fun List<Annotation>.getUnionAnnotation(): GraphQLUnion? = this.filterIsInstance(GraphQLUnion::class.java).firstOrNull() ?: this.map { it.getMetaUnionAnnotation() }.firstOrNull()
+
+internal fun List<Annotation>.getCustomUnionClassWithMetaUnionAnnotation(): KClass<*>? = this.firstOrNull { it.getMetaUnionAnnotation() != null }?.annotationClass
+
+private fun Annotation.getMetaUnionAnnotation(): GraphQLUnion? = this.annotationClass.annotations.filterIsInstance(GraphQLUnion::class.java).firstOrNull()
 
 internal fun List<Annotation>.getCustomTypeAnnotation(): GraphQLType? = this.filterIsInstance(GraphQLType::class.java).firstOrNull()
 

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/extensions/kClassExtensions.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/extensions/kClassExtensions.kt
@@ -64,7 +64,10 @@ internal fun KClass<*>.isUnion(fieldAnnotations: List<Annotation> = emptyList())
 
 private fun KClass<*>.isDeclaredUnion() = this.isInterface() && this.declaredMemberProperties.isEmpty() && this.declaredMemberFunctions.isEmpty()
 
-internal fun KClass<*>.isAnnotationUnion(fieldAnnotations: List<Annotation>): Boolean = this.isInstance(Any::class) && fieldAnnotations.getUnionAnnotation() != null
+internal fun KClass<*>.isAnnotationUnion(fieldAnnotations: List<Annotation>): Boolean = (this.isInstance(Any::class) || this.isSubclassOf(Annotation::class)) &&
+    fieldAnnotations.getUnionAnnotation() != null
+
+internal fun KClass<*>.isAnnotation(): Boolean = this.isSubclassOf(Annotation::class)
 
 /**
  * Do not add interfaces as additional types if it expects all the types

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/extensions/kClassExtensions.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/extensions/kClassExtensions.kt
@@ -64,7 +64,7 @@ internal fun KClass<*>.isUnion(fieldAnnotations: List<Annotation> = emptyList())
 
 private fun KClass<*>.isDeclaredUnion() = this.isInterface() && this.declaredMemberProperties.isEmpty() && this.declaredMemberFunctions.isEmpty()
 
-internal fun KClass<*>.isAnnotationUnion(fieldAnnotations: List<Annotation>): Boolean = (this.isInstance(Any::class) || this.isSubclassOf(Annotation::class)) &&
+internal fun KClass<*>.isAnnotationUnion(fieldAnnotations: List<Annotation>): Boolean = (this.isInstance(Any::class) || this.isAnnotation()) &&
     fieldAnnotations.getUnionAnnotation() != null
 
 internal fun KClass<*>.isAnnotation(): Boolean = this.isSubclassOf(Annotation::class)

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/state/TypesCache.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/state/TypesCache.kt
@@ -34,6 +34,7 @@ import graphql.schema.GraphQLTypeReference
 import java.io.Closeable
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
+import kotlin.reflect.full.createType
 import kotlin.reflect.full.isSubclassOf
 import kotlin.reflect.full.starProjectedType
 
@@ -88,7 +89,7 @@ internal class TypesCache(private val supportedPackages: List<String>) : Closeab
         val unionAnnotation = typeInfo.fieldAnnotations.getUnionAnnotation()
         if (unionAnnotation != null) {
             if (type.getKClass().isAnnotationUnion(typeInfo.fieldAnnotations)) {
-                return TypesCacheKey(type, typeInfo.inputType, getCustomUnionNameKey(unionAnnotation))
+                return TypesCacheKey(Any::class.createType(), typeInfo.inputType, getCustomUnionNameKey(unionAnnotation))
             } else {
                 throw InvalidCustomUnionException(type)
             }
@@ -148,7 +149,8 @@ internal class TypesCache(private val supportedPackages: List<String>) : Closeab
                 typesUnderConstruction.add(cacheKey)
                 val newType = build(kClass)
                 if (newType !is GraphQLTypeReference && newType is GraphQLNamedType) {
-                    put(cacheKey, KGraphQLType(kClass, newType))
+                    val cacheKClass = if (kClass.isAnnotationUnion(typeInfo.fieldAnnotations)) Any::class else kClass
+                    put(cacheKey, KGraphQLType(cacheKClass, newType))
                 }
                 typesUnderConstruction.remove(cacheKey)
                 newType

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateGraphQLType.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateGraphQLType.kt
@@ -19,8 +19,10 @@ package com.expediagroup.graphql.generator.internal.types
 import com.expediagroup.graphql.generator.SchemaGenerator
 import com.expediagroup.graphql.generator.extensions.unwrapType
 import com.expediagroup.graphql.generator.internal.extensions.getCustomTypeAnnotation
+import com.expediagroup.graphql.generator.internal.extensions.getCustomUnionClassWithMetaUnionAnnotation
 import com.expediagroup.graphql.generator.internal.extensions.getKClass
 import com.expediagroup.graphql.generator.internal.extensions.getUnionAnnotation
+import com.expediagroup.graphql.generator.internal.extensions.isAnnotation
 import com.expediagroup.graphql.generator.internal.extensions.isEnum
 import com.expediagroup.graphql.generator.internal.extensions.isInterface
 import com.expediagroup.graphql.generator.internal.extensions.isListType
@@ -79,7 +81,12 @@ private fun getGraphQLType(
     return when {
         kClass.isEnum() -> @Suppress("UNCHECKED_CAST") (generateEnum(generator, kClass as KClass<Enum<*>>))
         kClass.isListType() -> generateList(generator, type, typeInfo)
-        kClass.isUnion(typeInfo.fieldAnnotations) -> generateUnion(generator, kClass, typeInfo.fieldAnnotations.getUnionAnnotation())
+        kClass.isUnion(typeInfo.fieldAnnotations) -> generateUnion(
+            generator,
+            kClass,
+            typeInfo.fieldAnnotations.getUnionAnnotation(),
+            if (kClass.isAnnotation()) kClass else typeInfo.fieldAnnotations.getCustomUnionClassWithMetaUnionAnnotation()
+        )
         kClass.isInterface() -> generateInterface(generator, kClass)
         typeInfo.inputType -> generateInputObject(generator, kClass)
         else -> generateObject(generator, kClass)

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/extensions/AnnotationExtensionsTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/extensions/AnnotationExtensionsTest.kt
@@ -19,11 +19,13 @@ package com.expediagroup.graphql.generator.internal.extensions
 import com.expediagroup.graphql.generator.annotations.GraphQLDescription
 import com.expediagroup.graphql.generator.annotations.GraphQLIgnore
 import com.expediagroup.graphql.generator.annotations.GraphQLName
+import com.expediagroup.graphql.generator.annotations.GraphQLUnion
 import org.junit.jupiter.api.Test
 import kotlin.reflect.KClass
 import kotlin.reflect.full.declaredMemberProperties
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -38,10 +40,19 @@ class AnnotationExtensionsTest {
         @property:Deprecated("property deprecated")
         @property:GraphQLDescription("property description")
         @property:GraphQLName("newName")
-        val id: String
+        val id: String,
+
+        @GraphQLUnion(name = "CustomUnion", possibleTypes = [NoAnnotations::class])
+        val union: Any,
+
+        @property:MetaUnion
+        val metaUnion: Any
     )
 
     private data class NoAnnotations(val id: String)
+
+    @GraphQLUnion(name = "MetaUnion", possibleTypes = [NoAnnotations::class])
+    annotation class MetaUnion
 
     @Test
     fun `verify @GraphQLName on classes`() {
@@ -83,6 +94,22 @@ class AnnotationExtensionsTest {
         @Suppress("DEPRECATION")
         assertTrue(WithAnnotations::class.isGraphQLIgnored())
         assertFalse(NoAnnotations::class.isGraphQLIgnored())
+    }
+
+    @Test
+    fun `verify @GraphQLUnion`() {
+        @Suppress("DEPRECATION")
+        assertNotNull(WithAnnotations::class.findMemberProperty("union")?.annotations?.getUnionAnnotation())
+        @Suppress("DEPRECATION")
+        assertNull(WithAnnotations::class.findMemberProperty("union")?.annotations?.getCustomUnionClassWithMetaUnionAnnotation())
+        @Suppress("DEPRECATION")
+        assertNotNull(WithAnnotations::class.findMemberProperty("metaUnion")?.annotations?.getUnionAnnotation())
+        @Suppress("DEPRECATION")
+        assertNotNull(WithAnnotations::class.findMemberProperty("metaUnion")?.annotations?.getCustomUnionClassWithMetaUnionAnnotation())
+        @Suppress("DEPRECATION")
+        assertNull(WithAnnotations::class.findMemberProperty("id")?.annotations?.getUnionAnnotation())
+        @Suppress("DEPRECATION")
+        assertNull(WithAnnotations::class.findMemberProperty("id")?.annotations?.getCustomUnionClassWithMetaUnionAnnotation())
     }
 
     private fun KClass<*>.findMemberProperty(name: String) = this.declaredMemberProperties.find { it.name == name }

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/extensions/KClassExtensionsTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/extensions/KClassExtensionsTest.kt
@@ -157,7 +157,16 @@ open class KClassExtensionsTest {
 
         @GraphQLUnion(name = "InvalidUnion", possibleTypes = [One::class, Two::class])
         fun invalidCustomUnion(): Int = 1
+
+        @MetaUnion
+        fun customMetaUnion(): Any = One("1")
+
+        @MetaUnion
+        fun invalidCustomMetaUnion(): Int = 1
     }
+
+    @GraphQLUnion(name = "MetaUnion", possibleTypes = [One::class, Two::class])
+    annotation class MetaUnion
 
     private class FilterHooks : SchemaGeneratorHooks {
         override fun isValidProperty(kClass: KClass<*>, property: KProperty<*>) =
@@ -283,11 +292,23 @@ open class KClassExtensionsTest {
         assertTrue(TestUnion::class.isUnion())
         val customAnnotationUnion = TestQuery::customUnion
         assertTrue(customAnnotationUnion.returnType.getKClass().isUnion(customAnnotationUnion.annotations))
+        val metaAnnotationUnion = TestQuery::customMetaUnion
+        assertTrue(metaAnnotationUnion.returnType.getKClass().isUnion(metaAnnotationUnion.annotations))
+        val metaUnionAnnotationClass = MetaUnion::class
+        assertTrue(metaUnionAnnotationClass.isUnion(metaAnnotationUnion.annotations))
         assertFalse(InvalidPropertyUnionInterface::class.isUnion())
         assertFalse(InvalidFunctionUnionInterface::class.isUnion())
         assertFalse(Pet::class.isUnion())
         val invalidAnnotationUnion = TestQuery::invalidCustomUnion
         assertFalse(invalidAnnotationUnion.returnType.getKClass().isUnion(invalidAnnotationUnion.annotations))
+        val invalidMetaAnnotationUnion = TestQuery::invalidCustomMetaUnion
+        assertFalse(invalidMetaAnnotationUnion.returnType.getKClass().isUnion(invalidMetaAnnotationUnion.annotations))
+    }
+
+    @Test
+    fun `test isAnnotation extension`() {
+        assertTrue(MetaUnion::class.isAnnotation())
+        assertFalse(TestUnion::class.isAnnotation())
     }
 
     @Test

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/types/GenerateUnionTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/types/GenerateUnionTest.kt
@@ -21,6 +21,7 @@ import com.expediagroup.graphql.generator.annotations.GraphQLName
 import com.expediagroup.graphql.generator.annotations.GraphQLUnion
 import com.expediagroup.graphql.generator.exceptions.InvalidGraphQLNameException
 import com.expediagroup.graphql.generator.exceptions.InvalidUnionException
+import com.expediagroup.graphql.generator.internal.extensions.getUnionAnnotation
 import com.expediagroup.graphql.generator.test.utils.SimpleDirective
 import graphql.schema.GraphQLObjectType
 import graphql.schema.GraphQLUnionType
@@ -60,6 +61,10 @@ class GenerateUnionTest : TypeTestHelper() {
         fun getUnionB(): NestedUnionB = NestedClass()
     }
 
+    @SimpleDirective
+    @GraphQLUnion(name = "MetaUnion", possibleTypes = [StrawBerryCake::class], description = "meta union")
+    annotation class MetaUnion
+
     class AnnotationUnion {
         @GraphQLUnion(name = "Foo", possibleTypes = [StrawBerryCakeCustomName::class, StrawBerryCake::class], description = "A custom cake")
         fun cake(withName: Boolean): Any = if (withName) StrawBerryCakeCustomName() else StrawBerryCake()
@@ -69,6 +74,9 @@ class GenerateUnionTest : TypeTestHelper() {
 
         @GraphQLUnion(name = "Invalid\$Name", possibleTypes = [StrawBerryCake::class])
         fun invalidUnion(): Any = StrawBerryCake()
+
+        @MetaUnion
+        fun metaUnion(): Any = StrawBerryCake()
     }
 
     interface `Invalid$UnionName`
@@ -129,6 +137,20 @@ class GenerateUnionTest : TypeTestHelper() {
         assertEquals("StrawBerryCakeRenamed", result.types[0].name)
         assertEquals("StrawBerryCake", result.types[1].name)
         assertEquals("A custom cake", result.description)
+    }
+
+    @Test
+    fun `custom union with meta union annotation and directives can be used`() {
+        val annotation = AnnotationUnion::metaUnion.annotations.first() as MetaUnion
+        val result = generateUnion(generator, Any::class, annotation.annotationClass.annotations.getUnionAnnotation(), annotation.annotationClass)
+
+        assertEquals("MetaUnion", result.name)
+        assertEquals(1, result.types.size)
+        assertEquals("StrawBerryCake", result.types[0].name)
+        assertEquals("meta union", result.description)
+        assertNotNull(result.appliedDirectives)
+        assertEquals(1, result.appliedDirectives.size)
+        assertEquals("simpleDirective", result.appliedDirectives.first().name)
     }
 
     @Test

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/test/integration/CustomUnionAnnotationTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/test/integration/CustomUnionAnnotationTest.kt
@@ -16,15 +16,23 @@
 
 package com.expediagroup.graphql.generator.test.integration
 
+import com.expediagroup.graphql.generator.SchemaGenerator
+import com.expediagroup.graphql.generator.SchemaGeneratorConfig
 import com.expediagroup.graphql.generator.TopLevelObject
+import com.expediagroup.graphql.generator.annotations.GraphQLDirective
 import com.expediagroup.graphql.generator.annotations.GraphQLUnion
 import com.expediagroup.graphql.generator.extensions.deepName
+import com.expediagroup.graphql.generator.extensions.unwrapType
 import com.expediagroup.graphql.generator.testSchemaConfig
 import com.expediagroup.graphql.generator.toSchema
+import graphql.schema.GraphQLObjectType
+import graphql.schema.GraphQLUnionType
 import org.junit.jupiter.api.Test
+import kotlin.reflect.KClass
 import kotlin.test.assertEquals
 import kotlin.test.assertFails
 import kotlin.test.assertNotNull
+import kotlin.test.assertSame
 
 class CustomUnionAnnotationTest {
 
@@ -39,10 +47,22 @@ class CustomUnionAnnotationTest {
         assertNotNull(schema.getType("Even"))
         assertNotNull(schema.getType("Odd"))
         assertNotNull(schema.getType("Number"))
+        assertNotNull(schema.getType("Prime"))
         assertEquals("Even!", schema.queryType.getFieldDefinition("even").type.deepName)
         assertEquals("Odd!", schema.queryType.getFieldDefinition("odd").type.deepName)
         assertEquals("Number!", schema.queryType.getFieldDefinition("number").type.deepName)
+        assertEquals("Number", schema.queryType.getFieldDefinition("nullableNumber").type.deepName)
         assertEquals("[Number!]!", schema.queryType.getFieldDefinition("listNumbers").type.deepName)
+        assertEquals("[Number]", schema.queryType.getFieldDefinition("nullableListNumbers").type.deepName)
+        assertEquals("Prime!", schema.queryType.getFieldDefinition("prime").type.deepName)
+        assertEquals("Prime", schema.queryType.getFieldDefinition("nullablePrime").type.deepName)
+        assertEquals("[Prime!]!", schema.queryType.getFieldDefinition("listPrimes").type.deepName)
+        assertEquals("[Prime]", schema.queryType.getFieldDefinition("nullableListPrimes").type.deepName)
+
+        val unionWithDirective = schema.getType("Prime") as GraphQLUnionType
+        assertNotNull(unionWithDirective.appliedDirectives)
+        assertEquals(1, unionWithDirective.appliedDirectives.size)
+        assertEquals("TestDirective", unionWithDirective.appliedDirectives[0].name)
     }
 
     @Test
@@ -55,8 +75,26 @@ class CustomUnionAnnotationTest {
     @Test
     fun `verify exception is thrown when custom union return type is not Any`() {
         assertFails {
-            toSchema(testSchemaConfig, listOf(TopLevelObject(InvalidReturnType())))
+            toSchema(testSchemaConfig, listOf(TopLevelObject(InvalidReturnTypeNumber())))
         }
+        assertFails {
+            toSchema(testSchemaConfig, listOf(TopLevelObject(InvalidReturnTypePrime())))
+        }
+    }
+
+    @Test
+    fun `verify Meta Union Annotation when adding as additional type`() {
+        val generator = CustomSchemaGenerator(testSchemaConfig)
+        generator.addTypes(MyAnnotation::class)
+        val types = generator.generateCustomAdditionalTypes()
+
+        assertEquals(2, types.size)
+        val metaUnion = types.find { it.deepName == "Prime" } as GraphQLUnionType
+        assertNotNull(metaUnion)
+        assertNotNull(metaUnion.appliedDirectives)
+        assertEquals(1, metaUnion.appliedDirectives.size)
+        assertEquals("TestDirective", metaUnion.appliedDirectives[0].name)
+        assertSame(metaUnion, (types.find { it.deepName != "Prime" } as GraphQLObjectType).getField("union").type.unwrapType())
     }
 
     class One(val value: String)
@@ -75,7 +113,25 @@ class CustomUnionAnnotationTest {
         fun number(): Any = One("1")
 
         @GraphQLUnion(name = "Number", possibleTypes = [One::class, Two::class, Three::class, Four::class])
+        fun nullableNumber(isNull: Boolean): Any? = if (isNull) null else One("1")
+
+        @GraphQLUnion(name = "Number", possibleTypes = [One::class, Two::class, Three::class, Four::class])
         fun listNumbers(): List<Any> = listOf(One("1"), Two("2"))
+
+        @GraphQLUnion(name = "Number", possibleTypes = [One::class, Two::class, Three::class, Four::class])
+        fun nullableListNumbers(): List<Any?>? = null
+
+        @PrimeUnion
+        fun prime(first: Boolean): Any = if (first) Two("2") else Three("3")
+
+        @PrimeUnion
+        fun nullablePrime(isNull: Boolean): Any? = if (isNull) null else Two("2")
+
+        @PrimeUnion
+        fun listPrimes(): List<Any> = listOf(Two("2"), Three("3"))
+
+        @PrimeUnion
+        fun nullableListPrimes(): List<Any?>? = null
     }
 
     /**
@@ -94,10 +150,41 @@ class CustomUnionAnnotationTest {
      * While it is valid to compile, library users should return Any for the custom
      * union annotation
      */
-    class InvalidReturnType {
+    class InvalidReturnTypeNumber {
         @GraphQLUnion(name = "Number", possibleTypes = [One::class, Two::class])
         fun number1(): One = One("one")
 
         fun number2(): One = One("two")
+    }
+
+    /**
+     * While it is valid to compile, library users should return Any for the annotation
+     * with the meta union annotation
+     */
+    class InvalidReturnTypePrime {
+        @PrimeUnion
+        fun prime(): Two = Two("two")
+    }
+
+    @GraphQLDirective(name = "TestDirective")
+    annotation class TestDirective
+
+    annotation class MyAnnotation
+
+    @TestDirective
+    @MyAnnotation
+    @GraphQLUnion(name = "Prime", possibleTypes = [Two::class, Three::class])
+    annotation class PrimeUnion
+
+    @MyAnnotation
+    data class MyType(
+        @PrimeUnion
+        val union: Any
+    )
+
+    class CustomSchemaGenerator(config: SchemaGeneratorConfig) : SchemaGenerator(config) {
+        internal fun addTypes(annotation: KClass<*>) = addAdditionalTypesWithAnnotation(annotation)
+
+        internal fun generateCustomAdditionalTypes() = generateAdditionalTypes()
     }
 }

--- a/website/docs/schema-generator/writing-schemas/unions.md
+++ b/website/docs/schema-generator/writing-schemas/unions.md
@@ -103,11 +103,37 @@ class Query {
 }
 ```
 
+If directives are needed, this can also be used as a meta-annotation
+
+### Example Usage
+```kotlin
+// Defined in some other library
+class SharedModel(val foo: String)
+
+// Our code
+class ServiceModel(val bar: String)
+
+
+@SomeDirective
+@GraphQLUnion(
+    name = "CustomUnion",
+    possibleTypes = [SharedModel::class, ServiceModel::class],
+    description = "Return one or the other model"
+)
+annotation class CustomUnion
+
+class Query {
+    @CustomUnion
+    fun getModel(): Any = ServiceModel("abc")
+}
+```
+
 The annotation requires the `name` of the new union to create and the `possibleTypes` that this union can return.
 However since we can not enforce the type checks anymore, you must use `Any` as the return type.
 
 ### Limitations
-Since this union is defined with an added annotation it is not currently possible to add directives directly to this union definition.
+Even when using it as a meta-annotation, it is not always possible to add directives to the union definition
+if the directive annotation cannot apply to an annotation class.
 You will have to modify the type with [schema generator hooks](../customizing-schemas/generator-config.md).
 
 [@GraphQLType](../customizing-schemas/custom-type-reference.md) annotation can be used as a workaround to this issue.


### PR DESCRIPTION
### :pencil: Description
the `@GraphQLUnion` annotation does not support directives. This is to add support by allowing it to be a meta-annotation where you can create an annotation for your union that you then annotate with `@GraphQLUnion` and directives
```
// Defined in some other library
class SharedModel(val foo: String)

// Our code
class ServiceModel(val bar: String)

@SomeDirective
@GraphQLUnion(
    name = "CustomUnion",
    possibleTypes = [SharedModel::class, ServiceModel::class],
    description = "Return one or the other model"
)
annotation class CustomUnion

class Query {

    @CustomUnion
    fun getModel(): Any = ServiceModel("abc")
}
```
### :link: Related Issues
