### PR TITLE
Remove deprecated XX:MaxPermSize JVM argument from gradle properties, causing failures with Java 17

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ systemProp.org.gradle.internal.publish.checksums.insecure=true
 
 # Increase the memory to run on GH Actions
 # See: https://github.com/gradle/gradle/issues/8139
-org.gradle.jvmargs=-Xmx2g -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError
+org.gradle.jvmargs=-Xmx2g -XX:+HeapDumpOnOutOfMemoryError
 
 # dependencies
 kotlinJvmVersion = 1.8


### PR DESCRIPTION
### :pencil: Description
The MaxPermSize JVM argument was deprecated in JDK 8, per [this document](https://docs.oracle.com/javase/8/docs/technotes/tools/windows/java.html):
```
-XX:MaxPermSize=size
Sets the maximum permanent generation space size (in bytes). This option was deprecated in JDK 8, and superseded by the -XX:MaxMetaspaceSize option.
```

Thus, since JDK 8, this argument hasn't actually done anything, but has been relatively harmless all the same.

However, Java 17 actually outright removes this parameter. Running the repo's `gradlew` with Java 17 thus results in the following error:
```
% ./gradlew check
Starting a Gradle Daemon, 1 busy and 1 stopped Daemons could not be reused, use --status for details

FAILURE: Build failed with an exception.

* What went wrong:
Unable to start the daemon process.
This problem might be caused by incorrect configuration of the daemon.
<...snip...>
-----------------------
Unrecognized VM option 'MaxPermSize=512m'
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
```

Because this argument hasn't been doing anything (it has no effect in JDK 8 onwards), to avoid changing behavior I am proposing to remove it outright, rather than consider using `MaxMetaspaceSize` (which would be a change in behavior).

With this change, I can successfully run `./gradlew check` in my environment.

### :link: Related Issues
I didn't think it worth to create an issue for this, but happy to if helpful.