### PR TITLE
Value type improvements

### DIFF
--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/execution/convertArgumentValue.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/execution/convertArgumentValue.kt
@@ -104,5 +104,7 @@ private fun mapToEnumValue(paramType: KType, enumValue: String): Enum<*> =
 
 private fun <T : Any> mapToInlineValueClass(value: Any?, targetClass: KClass<T>): T {
     val targetConstructor = targetClass.primaryConstructor ?: throw PrimaryConstructorNotFound(targetClass)
-    return targetConstructor.call(value)
+    // if the user has registered a coercer for the value class, it may already be an instance of the target type
+    @Suppress("UNCHECKED_CAST")
+    return if (targetClass.isInstance(value)) value as T else targetConstructor.call(value)
 }

--- a/website/docs/schema-generator/writing-schemas/scalars.md
+++ b/website/docs/schema-generator/writing-schemas/scalars.md
@@ -130,7 +130,9 @@ It is often beneficial to create a wrapper around the underlying primitive type 
 to optimize such use cases - Kotlin compiler will attempt to use underlying type directly whenever possible and only keep the wrapper classes
 whenever it is necessary.
 
-In order to use inline value classes in your schema, you need to register it using hooks and also provide value unboxer that will be used by
+#### Representing Unwrapped Value Classes in the Schema as the Underlying Type
+
+In order to represent unwrapped inline value classes in your schema as the underlying type, you need to register it using hooks and also provide value unboxer that will be used by
 `graphql-java` when dealing with its wrapper object.
 
 ```kotlin
@@ -151,10 +153,9 @@ class MySchemaGeneratorHooks : SchemaGeneratorHooks {
 }
 
 class MyValueUnboxer : IDValueUnboxer() {
-    override fun unbox(`object`: Any?): Any? = if (`object` is MyValueClass) {
-        `object`.value
-    } else {
-        super.unbox(`object`)
+    override fun unbox(value: Any?): Any? = when (value) {
+        is MyValueClass -> `object`.value
+        else -> super.unbox(`object`)
     }
 }
 
@@ -171,7 +172,7 @@ val graphQL = GraphQL.newGraphQL(graphQLSchema)
     .build()
 ```
 
-This will generate the schema that exposes value classes as corresponding primitive types in the schema
+This will generate a schema that exposes value classes as the corresponding wrapped type:
 
 ```graphql
 type Query {
@@ -180,8 +181,7 @@ type Query {
 ```
 
 :::note
-GraphQL ID scalar type is represented using inline value class. When registering additional inline value classes you should extend the
-`IDValueUnboxer` to ensure IDs will be correctly processed.
+GraphQL ID scalar type is represented using inline value class. When registering additional inline value classes you should extend the `IDValueUnboxer` to ensure IDs will be correctly processed. Alternatively, extend `DefaultValueUnboxer` and handle the `ID` value class as above.
 
 If you are using `graphql-kotlin-spring-server` you should create an instance of your bean as
 
@@ -190,6 +190,67 @@ If you are using `graphql-kotlin-spring-server` you should create an instance of
 fun idValueUnboxer(): IDValueUnboxer = MyValueUnboxer()
 ```
 :::
+
+#### Representing Unwrapped Value Classes in the Schema as a Custom Scalar Type
+
+In many cases, it may be useful to represent value classes in the schema as a custom scalar type, as the additional type information is often useful for clients. In this form, the value class is unwrapped, but uses a custom scalar type to preserve the extra type information.
+
+To do this, define a coercer for the value class that transforms it to and from the underlying type, and register it with the custom schema hooks:
+
+```kotlin
+val graphqlMyValueClassType: GraphQLScalarType = GraphQLScalarType.newScalar()
+  .name("MyValueClass")
+  .description(
+    """
+    |Represents my value class as a String value.
+    |""".trimMargin()
+  )
+  .coercing(MyValueClassCoercing)
+  .build()
+
+object MyValueClassCoercing : Coercing<MyValueClass, String> {
+  override fun parseValue(input: Any): MyValueClass = ...
+  override fun parseLiteral(input: Any): MyValueClass = ...
+  override fun serialize(dataFetcherResult: Any): String = ...
+}
+
+class CustomSchemaGeneratorHooks : SchemaGeneratorHooks {
+  override fun willGenerateGraphQLType(type: KType): GraphQLType? = when (type.classifier as? KClass<*>) {
+    MyValueClass::class -> graphqlMyValueClassType
+    else -> null
+  }
+}
+```
+
+This will generate the schema that exposes value classes as a scalar type:
+
+```graphql
+scalar MyValueClass
+
+type Query {
+  inlineValueClassQuery(value: MyValueClass): MyValueClass!
+}
+```
+
+#### Representing Value Classes in the Schema as Objects
+
+To do this, simply use the value class directly without defining any coercers or unboxers as in the previous sections.
+
+This will generate the schema that exposes value classes as a wrapped type, similar to a regular class:
+
+```graphql
+input MyValueClassInput {
+    value: String!
+}
+
+type MyValueClass {
+    value: String!
+}
+
+type Query {
+  inlineValueClassQuery(value: MyValueClassInput): MyValueClass!
+}
+```
 
 ## Common Issues
 

--- a/website/docs/schema-generator/writing-schemas/scalars.md
+++ b/website/docs/schema-generator/writing-schemas/scalars.md
@@ -130,6 +130,10 @@ It is often beneficial to create a wrapper around the underlying primitive type 
 to optimize such use cases - Kotlin compiler will attempt to use underlying type directly whenever possible and only keep the wrapper classes
 whenever it is necessary.
 
+:::note
+Nullable value class types may result in a runtime `IllegalArgumentException` due to https://youtrack.jetbrains.com/issue/KT-31141. This should be resolved in Kotlin 1.7.0+.
+:::
+
 #### Representing Unwrapped Value Classes in the Schema as the Underlying Type
 
 In order to represent unwrapped inline value classes in your schema as the underlying type, you need to register it using hooks and also provide value unboxer that will be used by


### PR DESCRIPTION
### :pencil: Description

Value types can be represented in various ways:

1) Unwrapped, as the underlying type

2) Unwrapped, as a custom scalar type representing the value type

3) Wrapped, like a regular class

There are valid use cases for all 3, though in my opinion options number 2 and 3 are generally the best, as they maintain the extra type information provided by the value class in the schema.

Currently, the docs only discuss option 1, and option 2 is actually not possible.

This PR makes a minor change to the code to support option 2, and documents all 3 value class representations.

NOTE: While the code change works for me, I would like to add tests, but frankly I'm not sure of the best way to do so. Some guidance would be appreciated.

### :link: Related Issues

https://github.com/ExpediaGroup/graphql-kotlin/issues/1370
https://github.com/ExpediaGroup/graphql-kotlin/pull/1395
