### PR TITLE
[generator] support directive array/vararg parameters

### DIFF
--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/extensions/kClassExtensions.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/extensions/kClassExtensions.kt
@@ -80,7 +80,7 @@ internal fun KClass<*>.isValidAdditionalType(inputType: Boolean): Boolean = !(in
 
 internal fun KClass<*>.isEnum(): Boolean = this.isSubclassOf(Enum::class)
 
-internal fun KClass<*>.isListType(): Boolean = this.isSubclassOf(List::class)
+internal fun KClass<*>.isListType(isDirective: Boolean = false): Boolean = this.isSubclassOf(List::class) || (isDirective && this.java.isArray)
 
 @Throws(CouldNotGetNameOfKClassException::class)
 internal fun KClass<*>.getSimpleName(isInputClass: Boolean = false): String {

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/state/TypesCache.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/state/TypesCache.kt
@@ -77,8 +77,8 @@ internal class TypesCache(private val supportedPackages: List<String>) : Closeab
     }
 
     private fun generateCacheKey(type: KType, typeInfo: GraphQLKTypeMetadata): TypesCacheKey {
-        if (type.getKClass().isListType()) {
-            return TypesCacheKey(type, typeInfo.inputType)
+        if (type.getKClass().isListType(typeInfo.isDirective)) {
+            return TypesCacheKey(type, typeInfo.inputType, isDirective = typeInfo.isDirective)
         }
 
         val customTypeAnnotation = typeInfo.fieldAnnotations.getCustomTypeAnnotation()
@@ -125,7 +125,7 @@ internal class TypesCache(private val supportedPackages: List<String>) : Closeab
             val kClass = type.getKClass()
 
             when {
-                kClass.isListType() -> null
+                kClass.isListType(cacheKey.isDirective) -> null
                 kClass.isSubclassOf(Enum::class) -> kClass.getSimpleName()
                 isTypeNotSupported(type) -> throw TypeNotSupportedException(type, supportedPackages)
                 else -> type.getSimpleName(cacheKey.inputType)
@@ -136,7 +136,7 @@ internal class TypesCache(private val supportedPackages: List<String>) : Closeab
     private fun isTypeNotSupported(type: KType): Boolean = supportedPackages.none { type.qualifiedName.startsWith(it) }
 
     internal fun buildIfNotUnderConstruction(kClass: KClass<*>, typeInfo: GraphQLKTypeMetadata, build: (KClass<*>) -> GraphQLType): GraphQLType {
-        if (kClass.isListType()) {
+        if (kClass.isListType(typeInfo.isDirective)) {
             return build(kClass)
         }
 

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/state/TypesCacheKey.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/state/TypesCacheKey.kt
@@ -21,5 +21,6 @@ import kotlin.reflect.KType
 internal data class TypesCacheKey(
     val type: KType,
     val inputType: Boolean = false,
-    val name: String? = null
+    val name: String? = null,
+    val isDirective: Boolean = false
 )

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/GraphQLKTypeMetadata.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/GraphQLKTypeMetadata.kt
@@ -23,5 +23,6 @@ package com.expediagroup.graphql.generator.internal.types
 internal data class GraphQLKTypeMetadata(
     val inputType: Boolean = false,
     val fieldName: String? = null,
-    val fieldAnnotations: List<Annotation> = emptyList()
+    val fieldAnnotations: List<Annotation> = emptyList(),
+    val isDirective: Boolean = false
 )

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateDirective.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateDirective.kt
@@ -108,7 +108,7 @@ private fun getDirective(generator: SchemaGenerator, directiveInfo: DirectiveInf
 
 private fun generateDirectiveArgument(prop: KProperty<*>, generator: SchemaGenerator): GraphQLArgument {
     val propertyName = prop.name
-    val type = generateGraphQLType(generator, prop.returnType)
+    val type = generateGraphQLType(generator, prop.returnType, GraphQLKTypeMetadata(inputType = true, isDirective = true))
 
     // default directive argument values are unsupported
     // https://github.com/ExpediaGroup/graphql-kotlin/issues/53

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateGraphQLType.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateGraphQLType.kt
@@ -80,7 +80,7 @@ private fun getGraphQLType(
 
     return when {
         kClass.isEnum() -> @Suppress("UNCHECKED_CAST") (generateEnum(generator, kClass as KClass<Enum<*>>))
-        kClass.isListType() -> generateList(generator, type, typeInfo)
+        kClass.isListType(typeInfo.isDirective) -> generateList(generator, type, typeInfo)
         kClass.isUnion(typeInfo.fieldAnnotations) -> generateUnion(
             generator,
             kClass,

--- a/website/docs/schema-generator/customizing-schemas/directives.md
+++ b/website/docs/schema-generator/customizing-schemas/directives.md
@@ -1,3 +1,4 @@
+
 ---
 id: directives
 title: Directives
@@ -199,3 +200,12 @@ directive @directiveWithIgnoredArgs(
   string: String!
 ) on ...
 ```
+
+## Limitations
+
+GraphQL specification allows usage of any valid input objects as directive arguments. Since we rely on Kotlin annotation
+functionality to define our custom directives, we are limited in what can be used as annotation parameter - only primitives (or scalars),
+Strings, Enums, other annotations or an array of any of the above are supported.
+
+Support for input objects can be added by providing that object representation as an annotation class and then adding support
+for it through custom schema generator hooks.


### PR DESCRIPTION
### :pencil: Description

With the refactoring of our argument parsing logic (https://github.com/ExpediaGroup/graphql-kotlin/pull/1379) we dropped the support for the arrays. This had a side effect that directives could no longer be declared as accepting a list of arguments. Adding back support of arrays/varargs just for the directives.

### :link: Related Issues

Resolves: https://github.com/ExpediaGroup/graphql-kotlin/issues/1404