### PR TITLE
feat(generator): avoid adding `input`-suffix for input-only classes

### DIFF
--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/types/GenerateInputObjectTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/types/GenerateInputObjectTest.kt
@@ -50,6 +50,11 @@ class GenerateInputObjectTest : TypeTestHelper() {
         val myField: String = "car"
     }
 
+    @GraphQLValidObjectLocations(locations = [GraphQLValidObjectLocations.Locations.INPUT_OBJECT, GraphQLValidObjectLocations.Locations.OBJECT])
+    class InputAndObjectLocation {
+        val myField: String = "car"
+    }
+
     @GraphQLValidObjectLocations(locations = [GraphQLValidObjectLocations.Locations.OBJECT])
     class OutputOnly {
         val myField: String = "car"
@@ -103,6 +108,18 @@ class GenerateInputObjectTest : TypeTestHelper() {
         assertDoesNotThrow {
             generateInputObject(generator, InputOnly::class)
         }
+    }
+
+    @Test
+    fun `input only objects are not suffixed with 'Input'`() {
+        val result = generateInputObject(generator, InputOnly::class)
+        assertEquals("InputOnly", result.name)
+    }
+
+    @Test
+    fun `input and object located objects are suffixed with 'Input'`() {
+        val result = generateInputObject(generator, InputAndObjectLocation::class)
+        assertEquals("InputAndObjectLocationInput", result.name)
     }
 
     @Test

--- a/website/docs/schema-generator/writing-schemas/arguments.md
+++ b/website/docs/schema-generator/writing-schemas/arguments.md
@@ -25,7 +25,8 @@ This behavior is true for all arguments except for the special classes for the [
 Query, Mutation, and Subscription function arguments are automatically converted to GraphQL input fields. GraphQL makes a
 distinction between input and output types and requires unique names for all the types. Since we can use the same
 objects for input and output in our Kotlin functions, `graphql-kotlin-schema-generator` will automatically append
-an `Input` suffix to the GraphQL name of input objects.
+an `Input` suffix to the GraphQL name of input objects, unless the type is [restricted to being used for
+input only](../customizing-schemas/restricting-input-output.md).
 
 For example, the following code:
 


### PR DESCRIPTION
### :pencil: Description
Avoid adding the `Input`-suffix for classes restricted to being used as input objects only using the `@GraphQLValidObjectLocations`-annotation. Suffixing the type with `Input` is not necessary, since no name collision can happen here.

### :link: Related Issues
#1324