### PR TITLE
fix: willAddGraphQLTypeToSchema needs annotations from field

### DIFF
--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/extensions/annotationExtensions.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/extensions/annotationExtensions.kt
@@ -37,7 +37,7 @@ internal fun List<Annotation>.getUnionAnnotation(): GraphQLUnion? = this.filterI
 
 internal fun List<Annotation>.getCustomUnionClassWithMetaUnionAnnotation(): KClass<*>? = this.firstOrNull { it.getMetaUnionAnnotation() != null }?.annotationClass
 
-private fun Annotation.getMetaUnionAnnotation(): GraphQLUnion? = this.annotationClass.annotations.filterIsInstance(GraphQLUnion::class.java).firstOrNull()
+internal fun Annotation.getMetaUnionAnnotation(): GraphQLUnion? = this.annotationClass.annotations.filterIsInstance(GraphQLUnion::class.java).firstOrNull()
 
 internal fun List<Annotation>.getCustomTypeAnnotation(): GraphQLType? = this.filterIsInstance(GraphQLType::class.java).firstOrNull()
 

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateGraphQLType.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateGraphQLType.kt
@@ -70,8 +70,12 @@ private fun objectFromReflection(generator: SchemaGenerator, type: KType, typeIn
          * For a field using the meta union annotation, the `type` is `Any`, but we need to pass the annotation with the meta union annotation as the type
          * since that is really the type generated from reflection and has any potential directives on it needed by the hook
          */
-        val metaUnion: Annotation? = typeInfo.fieldAnnotations.firstOrNull { it.getMetaUnionAnnotation() != null }
-        val resolvedType = if (kClass.isInstance(Any::class) && metaUnion != null) metaUnion.annotationClass.createType() else type
+        val metaUnion = typeInfo.fieldAnnotations.firstOrNull { it.getMetaUnionAnnotation() != null }
+        val resolvedType = if (kClass.isInstance(Any::class) && metaUnion != null) {
+            metaUnion.annotationClass.createType()
+        } else {
+            type
+        }
 
         generator.config.hooks.willAddGraphQLTypeToSchema(resolvedType, graphQLType)
     }

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateGraphQLType.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateGraphQLType.kt
@@ -17,7 +17,6 @@
 package com.expediagroup.graphql.generator.internal.types
 
 import com.expediagroup.graphql.generator.SchemaGenerator
-import com.expediagroup.graphql.generator.annotations.GraphQLUnion
 import com.expediagroup.graphql.generator.extensions.unwrapType
 import com.expediagroup.graphql.generator.internal.extensions.getCustomTypeAnnotation
 import com.expediagroup.graphql.generator.internal.extensions.getCustomUnionClassWithMetaUnionAnnotation
@@ -25,7 +24,6 @@ import com.expediagroup.graphql.generator.internal.extensions.getKClass
 import com.expediagroup.graphql.generator.internal.extensions.getMetaUnionAnnotation
 import com.expediagroup.graphql.generator.internal.extensions.getUnionAnnotation
 import com.expediagroup.graphql.generator.internal.extensions.isAnnotation
-import com.expediagroup.graphql.generator.internal.extensions.isAnnotationUnion
 import com.expediagroup.graphql.generator.internal.extensions.isEnum
 import com.expediagroup.graphql.generator.internal.extensions.isInterface
 import com.expediagroup.graphql.generator.internal.extensions.isListType

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/hooks/SchemaGeneratorHooksTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/hooks/SchemaGeneratorHooksTest.kt
@@ -20,11 +20,13 @@ import com.expediagroup.graphql.generator.SchemaGenerator
 import com.expediagroup.graphql.generator.SchemaGeneratorConfig
 import com.expediagroup.graphql.generator.TopLevelObject
 import com.expediagroup.graphql.generator.annotations.GraphQLIgnore
+import com.expediagroup.graphql.generator.annotations.GraphQLUnion
 import com.expediagroup.graphql.generator.exceptions.EmptyInputObjectTypeException
 import com.expediagroup.graphql.generator.exceptions.EmptyInterfaceTypeException
 import com.expediagroup.graphql.generator.exceptions.EmptyObjectTypeException
 import com.expediagroup.graphql.generator.extensions.deepName
 import com.expediagroup.graphql.generator.getTestSchemaConfigWithHooks
+import com.expediagroup.graphql.generator.internal.extensions.getKClass
 import com.expediagroup.graphql.generator.internal.extensions.getSimpleName
 import com.expediagroup.graphql.generator.test.utils.graphqlUUIDType
 import com.expediagroup.graphql.generator.testSchemaConfig
@@ -36,6 +38,7 @@ import graphql.schema.GraphQLObjectType
 import graphql.schema.GraphQLScalarType
 import graphql.schema.GraphQLSchema
 import graphql.schema.GraphQLType
+import graphql.schema.GraphQLUnionType
 import graphql.schema.validation.InvalidSchemaException
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.reactive.asPublisher
@@ -221,19 +224,25 @@ class SchemaGeneratorHooksTest {
             override fun willAddGraphQLTypeToSchema(type: KType, generatedType: GraphQLType): GraphQLType {
                 hookCalled = true
                 return when {
-                    generatedType is GraphQLObjectType && generatedType.name == "SomeData" -> GraphQLObjectType.newObject(generatedType).description("My custom description").build()
-                    generatedType is GraphQLInterfaceType && generatedType.name == "RandomData" ->
+                    generatedType is GraphQLObjectType && generatedType.name == "SomeData" && type.getKClass() == SomeData::class ->
+                        GraphQLObjectType.newObject(generatedType).description("My custom description").build()
+                    generatedType is GraphQLInterfaceType && generatedType.name == "RandomData" &&  type.getKClass() == RandomData::class ->
                         GraphQLInterfaceType.newInterface(generatedType).description("My custom interface description").build()
+                    generatedType is GraphQLUnionType && generatedType.name == "MyMetaUnion" && type.getKClass() == MyMetaUnion::class ->
+                        GraphQLUnionType.newUnionType(generatedType).description("My meta union description").build()
+                    generatedType is GraphQLUnionType && generatedType.name == "MyAdditionalMetaUnion" && type.getKClass() == MyAdditionalMetaUnion::class ->
+                        GraphQLUnionType.newUnionType(generatedType).description("My additional meta union description").build()
                     else -> generatedType
                 }
             }
         }
 
         val hooks = MockSchemaGeneratorHooks()
-        val schema = toSchema(
-            queries = listOf(TopLevelObject(TestQuery())),
-            config = getTestSchemaConfigWithHooks(hooks)
-        )
+        val generator = SchemaGenerator(getTestSchemaConfigWithHooks(hooks))
+        val schema = generator.use {
+            it.generateSchema(queries = listOf(TopLevelObject(TestQuery())), additionalTypes = setOf(MyAdditionalMetaUnion::class.createType()))
+        }
+
         assertTrue(hooks.hookCalled)
 
         val type = schema.getObjectType("SomeData")
@@ -243,6 +252,14 @@ class SchemaGeneratorHooksTest {
         val interfaceType = schema.getType("RandomData") as? GraphQLInterfaceType
         assertNotNull(interfaceType)
         assertEquals(expected = "My custom interface description", actual = interfaceType.description)
+
+        val metaUnionType = schema.getType("MyMetaUnion") as? GraphQLUnionType
+        assertNotNull(metaUnionType)
+        assertEquals(expected = "My meta union description", actual = metaUnionType.description)
+
+        val additionalMetaUnionType = schema.getType("MyAdditionalMetaUnion") as? GraphQLUnionType
+        assertNotNull(additionalMetaUnionType)
+        assertEquals(expected = "My additional meta union description", actual = additionalMetaUnionType.description)
     }
 
     @Test
@@ -346,7 +363,15 @@ class SchemaGeneratorHooksTest {
 
     class TestQuery {
         fun query(): SomeData = SomeData("someData", 0)
+        @MyMetaUnion
+        fun unionQuery(): Any = SomeData("someData", 0)
     }
+
+    @GraphQLUnion(name = "MyMetaUnion", possibleTypes = [SomeData::class])
+    annotation class MyMetaUnion
+
+    @GraphQLUnion(name = "MyAdditionalMetaUnion", possibleTypes = [SomeData::class])
+    annotation class MyAdditionalMetaUnion
 
     class TestSubscription {
         fun subscription(): Publisher<SomeData> = flowOf(SomeData("someData", 0)).asPublisher()

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/hooks/SchemaGeneratorHooksTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/hooks/SchemaGeneratorHooksTest.kt
@@ -226,7 +226,7 @@ class SchemaGeneratorHooksTest {
                 return when {
                     generatedType is GraphQLObjectType && generatedType.name == "SomeData" && type.getKClass() == SomeData::class ->
                         GraphQLObjectType.newObject(generatedType).description("My custom description").build()
-                    generatedType is GraphQLInterfaceType && generatedType.name == "RandomData" &&  type.getKClass() == RandomData::class ->
+                    generatedType is GraphQLInterfaceType && generatedType.name == "RandomData" && type.getKClass() == RandomData::class ->
                         GraphQLInterfaceType.newInterface(generatedType).description("My custom interface description").build()
                     generatedType is GraphQLUnionType && generatedType.name == "MyMetaUnion" && type.getKClass() == MyMetaUnion::class ->
                         GraphQLUnionType.newUnionType(generatedType).description("My meta union description").build()

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/extensions/AnnotationExtensionsTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/extensions/AnnotationExtensionsTest.kt
@@ -110,6 +110,10 @@ class AnnotationExtensionsTest {
         assertNull(WithAnnotations::class.findMemberProperty("id")?.annotations?.getUnionAnnotation())
         @Suppress("DEPRECATION")
         assertNull(WithAnnotations::class.findMemberProperty("id")?.annotations?.getCustomUnionClassWithMetaUnionAnnotation())
+        @Suppress("DEPRECATION")
+        assertNotNull(WithAnnotations::class.findMemberProperty("metaUnion")?.annotations?.firstOrNull { it is MetaUnion }?.getMetaUnionAnnotation())
+        @Suppress("DEPRECATION")
+        assertNull(WithAnnotations::class.findMemberProperty("union")?.annotations?.firstOrNull { it is GraphQLUnion }?.getMetaUnionAnnotation())
     }
 
     private fun KClass<*>.findMemberProperty(name: String) = this.declaredMemberProperties.find { it.name == name }


### PR DESCRIPTION
### :pencil: Description
When using the `@GraphQLUnion` as a meta annotation, the KType is `Any` when the type for the field is being generated by reflection. The correct type is actually the annotation on the field with the `@GraphQLUnion` meta annotation. In this case, the type passed to the hook needs to be that annotation since that is the class with other annotations on it, which could be needed by the hook.

### :link: Related Issues
