### PR TITLE
Revert "feat(generator): avoid adding `input`-suffix for input-only classes"

### DIFF
--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/extensions/kClassExtensions.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/extensions/kClassExtensions.kt
@@ -16,7 +16,6 @@
 
 package com.expediagroup.graphql.generator.internal.extensions
 
-import com.expediagroup.graphql.generator.annotations.GraphQLValidObjectLocations
 import com.expediagroup.graphql.generator.exceptions.CouldNotGetNameOfKClassException
 import com.expediagroup.graphql.generator.hooks.SchemaGeneratorHooks
 import com.expediagroup.graphql.generator.internal.filters.functionFilters
@@ -29,7 +28,6 @@ import kotlin.reflect.KProperty
 import kotlin.reflect.KVisibility
 import kotlin.reflect.full.declaredMemberFunctions
 import kotlin.reflect.full.declaredMemberProperties
-import kotlin.reflect.full.findAnnotation
 import kotlin.reflect.full.findParameterByName
 import kotlin.reflect.full.isSubclassOf
 import kotlin.reflect.full.memberFunctions
@@ -91,21 +89,10 @@ internal fun KClass<*>.getSimpleName(isInputClass: Boolean = false): String {
         ?: throw CouldNotGetNameOfKClassException(this)
 
     return when {
-        isInputClass -> {
-            if (name.endsWith(INPUT_SUFFIX, true) || this.isInputOnlyLocationRestricted()) {
-                name
-            } else {
-                "$name$INPUT_SUFFIX"
-            }
-        }
+        isInputClass -> if (name.endsWith(INPUT_SUFFIX, true)) name else "$name$INPUT_SUFFIX"
         else -> name
     }
 }
-
-private fun KClass<*>.isInputOnlyLocationRestricted(): Boolean = findAnnotation<GraphQLValidObjectLocations>()
-    ?.locations
-    ?.all { it == GraphQLValidObjectLocations.Locations.INPUT_OBJECT }
-    ?: false
 
 internal fun KClass<*>.getQualifiedName(): String = this.qualifiedName.orEmpty()
 

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/types/GenerateInputObjectTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/types/GenerateInputObjectTest.kt
@@ -50,11 +50,6 @@ class GenerateInputObjectTest : TypeTestHelper() {
         val myField: String = "car"
     }
 
-    @GraphQLValidObjectLocations(locations = [GraphQLValidObjectLocations.Locations.INPUT_OBJECT, GraphQLValidObjectLocations.Locations.OBJECT])
-    class InputAndObjectLocation {
-        val myField: String = "car"
-    }
-
     @GraphQLValidObjectLocations(locations = [GraphQLValidObjectLocations.Locations.OBJECT])
     class OutputOnly {
         val myField: String = "car"
@@ -108,18 +103,6 @@ class GenerateInputObjectTest : TypeTestHelper() {
         assertDoesNotThrow {
             generateInputObject(generator, InputOnly::class)
         }
-    }
-
-    @Test
-    fun `input only objects are not suffixed with 'Input'`() {
-        val result = generateInputObject(generator, InputOnly::class)
-        assertEquals("InputOnly", result.name)
-    }
-
-    @Test
-    fun `input and object located objects are suffixed with 'Input'`() {
-        val result = generateInputObject(generator, InputAndObjectLocation::class)
-        assertEquals("InputAndObjectLocationInput", result.name)
     }
 
     @Test

--- a/website/docs/schema-generator/writing-schemas/arguments.md
+++ b/website/docs/schema-generator/writing-schemas/arguments.md
@@ -25,8 +25,7 @@ This behavior is true for all arguments except for the special classes for the [
 Query, Mutation, and Subscription function arguments are automatically converted to GraphQL input fields. GraphQL makes a
 distinction between input and output types and requires unique names for all the types. Since we can use the same
 objects for input and output in our Kotlin functions, `graphql-kotlin-schema-generator` will automatically append
-an `Input` suffix to the GraphQL name of input objects, unless the type is [restricted to being used for
-input only](../customizing-schemas/restricting-input-output.md).
+an `Input` suffix to the GraphQL name of input objects.
 
 For example, the following code:
 


### PR DESCRIPTION
After some discussion we decided to revert this PR given that will cause a Breaking Change and we don't see a particular improvement in doing this, indeed we believe that adding semantics (the Input suffix) to the type, will help to have a more verbose schema.