### PR TITLE
[generator] fix Federation _service query definition

### DIFF
--- a/generator/graphql-kotlin-federation/README.md
+++ b/generator/graphql-kotlin-federation/README.md
@@ -75,7 +75,7 @@ type Product @key(fields : "id") {
 
 type Query {
   _entities(representations: [_Any!]!): [_Entity]!
-  _service: _Service
+  _service: _Service!
   product(id: Int!): Product!
 }
 
@@ -129,7 +129,7 @@ type Product @extends @key(fields : "id") {
 
 type Query {
   _entities(representations: [_Any!]!): [_Entity]!
-  _service: _Service
+  _service: _Service!
 }
 
 type Review {

--- a/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/FederatedSchemaGeneratorHooks.kt
+++ b/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/FederatedSchemaGeneratorHooks.kt
@@ -55,7 +55,7 @@ import kotlin.reflect.full.findAnnotation
 open class FederatedSchemaGeneratorHooks(private val resolvers: List<FederatedTypeResolver<*>>) : SchemaGeneratorHooks {
     private val scalarDefinitionRegex = "(^\".+\"$[\\r\\n])?^scalar (_FieldSet|_Any)$[\\r\\n]*".toRegex(setOf(RegexOption.MULTILINE, RegexOption.IGNORE_CASE))
     private val emptyQueryRegex = "^type Query @extends \\s*\\{\\s*}\\s*".toRegex(setOf(RegexOption.MULTILINE, RegexOption.IGNORE_CASE))
-    private val serviceFieldRegex = "\\s*_service: _Service".toRegex(setOf(RegexOption.MULTILINE, RegexOption.IGNORE_CASE))
+    private val serviceFieldRegex = "\\s*_service: _Service!".toRegex(setOf(RegexOption.MULTILINE, RegexOption.IGNORE_CASE))
     private val serviceTypeRegex = "^type _Service\\s*\\{\\s*sdl: String!\\s*}\\s*".toRegex(setOf(RegexOption.MULTILINE, RegexOption.IGNORE_CASE))
     private val validator = FederatedSchemaValidator()
 

--- a/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/directives/FieldSet.kt
+++ b/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/directives/FieldSet.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Expedia, Inc
+ * Copyright 2022 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,6 @@
 
 package com.expediagroup.graphql.generator.federation.directives
 
-import com.expediagroup.graphql.generator.federation.types.FIELD_SET_SCALAR_TYPE
-import graphql.schema.GraphQLArgument
-import graphql.schema.GraphQLNonNull
-
 /**
  * Annotation representing _FieldSet scalar type that is used to represent a set of fields.
  *
@@ -33,10 +29,3 @@ import graphql.schema.GraphQLNonNull
  * @see [com.expediagroup.graphql.generator.federation.types.FIELD_SET_SCALAR_TYPE]
  */
 annotation class FieldSet(val value: String)
-
-internal const val FIELD_SET_ARGUMENT_NAME = "fields"
-
-internal val FIELD_SET_ARGUMENT = GraphQLArgument.newArgument()
-    .name(FIELD_SET_ARGUMENT_NAME)
-    .type(GraphQLNonNull(FIELD_SET_SCALAR_TYPE))
-    .build()

--- a/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/directives/KeyDirective.kt
+++ b/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/directives/KeyDirective.kt
@@ -17,6 +17,7 @@
 package com.expediagroup.graphql.generator.federation.directives
 
 import com.expediagroup.graphql.generator.annotations.GraphQLDirective
+import com.expediagroup.graphql.generator.federation.types.FIELD_SET_ARGUMENT
 import graphql.introspection.Introspection.DirectiveLocation
 
 /**

--- a/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/directives/ProvidesDirective.kt
+++ b/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/directives/ProvidesDirective.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Expedia, Inc
+ * Copyright 2022 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package com.expediagroup.graphql.generator.federation.directives
 
 import com.expediagroup.graphql.generator.annotations.GraphQLDirective
+import com.expediagroup.graphql.generator.federation.types.FIELD_SET_ARGUMENT
 import graphql.introspection.Introspection.DirectiveLocation
 
 /**

--- a/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/directives/RequiresDirective.kt
+++ b/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/directives/RequiresDirective.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Expedia, Inc
+ * Copyright 2022 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package com.expediagroup.graphql.generator.federation.directives
 
 import com.expediagroup.graphql.generator.annotations.GraphQLDirective
+import com.expediagroup.graphql.generator.federation.types.FIELD_SET_ARGUMENT
 import graphql.introspection.Introspection.DirectiveLocation
 
 /**

--- a/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/types/_FieldSet.kt
+++ b/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/types/_FieldSet.kt
@@ -25,7 +25,12 @@ import graphql.language.Value
 import graphql.schema.Coercing
 import graphql.schema.CoercingParseLiteralException
 import graphql.schema.CoercingSerializeException
+import graphql.schema.GraphQLArgument
+import graphql.schema.GraphQLNonNull
 import graphql.schema.GraphQLScalarType
+
+internal const val FIELD_SET_SCALAR_NAME = "_FieldSet"
+internal const val FIELD_SET_ARGUMENT_NAME = "fields"
 
 /**
  * Custom scalar type that is used to represent a set of fields. Grammatically, a field set is a selection set minus the braces.
@@ -33,9 +38,14 @@ import graphql.schema.GraphQLScalarType
  * "id organization { id }".
  */
 internal val FIELD_SET_SCALAR_TYPE: GraphQLScalarType = GraphQLScalarType.newScalar(Scalars.GraphQLString)
-    .name("_FieldSet")
+    .name(FIELD_SET_SCALAR_NAME)
     .description("Federation type representing set of fields")
     .coercing(FieldSetCoercing)
+    .build()
+
+internal val FIELD_SET_ARGUMENT = GraphQLArgument.newArgument()
+    .name(FIELD_SET_ARGUMENT_NAME)
+    .type(GraphQLNonNull(FIELD_SET_SCALAR_TYPE))
     .build()
 
 private object FieldSetCoercing : Coercing<FieldSet, String> {

--- a/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/types/_Service.kt
+++ b/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/types/_Service.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Expedia, Inc
+ * Copyright 2022 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ private val SERVICE_OBJECT_TYPE = GraphQLObjectType.newObject()
 
 internal val SERVICE_FIELD_DEFINITION: GraphQLFieldDefinition = GraphQLFieldDefinition.newFieldDefinition()
     .name("_service")
-    .type(SERVICE_OBJECT_TYPE)
+    .type(GraphQLNonNull.nonNull(SERVICE_OBJECT_TYPE))
     .build()
 
 @Suppress("ClassNaming", "ClassName")

--- a/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/validation/validateDirective.kt
+++ b/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/validation/validateDirective.kt
@@ -16,8 +16,8 @@
 
 package com.expediagroup.graphql.generator.federation.validation
 
-import com.expediagroup.graphql.generator.federation.directives.FIELD_SET_ARGUMENT_NAME
 import com.expediagroup.graphql.generator.federation.directives.FieldSet
+import com.expediagroup.graphql.generator.federation.types.FIELD_SET_ARGUMENT_NAME
 import graphql.schema.GraphQLAppliedDirective
 import graphql.schema.GraphQLFieldDefinition
 

--- a/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/FederatedSchemaGeneratorTest.kt
+++ b/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/FederatedSchemaGeneratorTest.kt
@@ -99,7 +99,7 @@ private val FEDERATED_SDL =
     type Query @extends {
       "Union of all types that use the @key directive, including both types native to the schema and extended types"
       _entities(representations: [_Any!]!): [_Entity]!
-      _service: _Service
+      _service: _Service!
     }
 
     type Review {
@@ -193,7 +193,7 @@ class FederatedSchemaGeneratorTest {
               ) on SCALAR
 
             type Query @extends {
-              _service: _Service
+              _service: _Service!
               hello(name: String!): String!
             }
 
@@ -223,7 +223,7 @@ class FederatedSchemaGeneratorTest {
             }
 
             type Query {
-              _service: _Service
+              _service: _Service!
               getSimpleNestedObject: [SelfReferenceObject]!
             }
 

--- a/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/types/ServiceTest.kt
+++ b/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/types/ServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Expedia, Inc
+ * Copyright 2022 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,9 @@ class ServiceTest {
         val serviceField = SERVICE_FIELD_DEFINITION
         assertEquals(expected = "_service", actual = serviceField.name)
 
-        val serviceObject = serviceField.type as? GraphQLObjectType
+        val wrappedServiceObject = serviceField.type as? GraphQLNonNull
+        assertNotNull(wrappedServiceObject)
+        val serviceObject = wrappedServiceObject.wrappedType as? GraphQLObjectType
         assertNotNull(serviceObject)
         assertEquals(expected = "_Service", actual = serviceObject.name)
         assertEquals(expected = 1, actual = serviceObject.fieldDefinitions.size)

--- a/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePluginIT.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePluginIT.kt
@@ -560,7 +560,7 @@ class GraphQLGradlePluginIT : GraphQLGradlePluginAbstractIT() {
               ) on SCALAR
 
             type Query @extends {
-              _service: _Service
+              _service: _Service!
               helloWorld(name: String): String!
               randomUUID: UUID!
             }

--- a/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/GraphQLGenerateSDLTaskIT.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/GraphQLGenerateSDLTaskIT.kt
@@ -109,7 +109,7 @@ internal val FEDERATED_SCHEMA =
       ) on SCALAR
 
     type Query @extends {
-      _service: _Service
+      _service: _Service!
       helloWorld(name: String): String!
     }
 

--- a/plugins/graphql-kotlin-maven-plugin/src/integration/generate-sdl-federated/src/test/kotlin/com/expediagroup/graphql/plugin/maven/GenerateSDLMojoTest.kt
+++ b/plugins/graphql-kotlin-maven-plugin/src/integration/generate-sdl-federated/src/test/kotlin/com/expediagroup/graphql/plugin/maven/GenerateSDLMojoTest.kt
@@ -80,7 +80,7 @@ class GenerateSDLMojoTest {
               ) on SCALAR
 
             type Query @extends {
-              _service: _Service
+              _service: _Service!
               helloWorld(name: String): String!
             }
 

--- a/plugins/graphql-kotlin-maven-plugin/src/integration/generate-sdl-hooks/src/test/kotlin/com/expediagroup/graphql/plugin/maven/GenerateSDLMojoTest.kt
+++ b/plugins/graphql-kotlin-maven-plugin/src/integration/generate-sdl-hooks/src/test/kotlin/com/expediagroup/graphql/plugin/maven/GenerateSDLMojoTest.kt
@@ -80,7 +80,7 @@ class GenerateSDLMojoTest {
               ) on SCALAR
 
             type Query @extends {
-              _service: _Service
+              _service: _Service!
               helloWorld(name: String): String!
               randomUUID: UUID!
             }

--- a/plugins/schema/graphql-kotlin-sdl-generator/src/integrationTest/kotlin/com/expediagroup/graphql/plugin/schema/GenerateCustomSDLTest.kt
+++ b/plugins/schema/graphql-kotlin-sdl-generator/src/integrationTest/kotlin/com/expediagroup/graphql/plugin/schema/GenerateCustomSDLTest.kt
@@ -69,7 +69,7 @@ class GenerateCustomSDLTest {
                   ) on SCALAR
 
                 type Query @extends {
-                  _service: _Service
+                  _service: _Service!
                   helloWorld(name: String): String!
                   randomUUID: UUID!
                 }

--- a/website/docs/schema-generator/federation/federated-schemas.md
+++ b/website/docs/schema-generator/federation/federated-schemas.md
@@ -64,7 +64,7 @@ type Product @key(fields : "id") {
 
 type Query @extends {
   _entities(representations: [_Any!]!): [_Entity]!
-  _service: _Service
+  _service: _Service!
   product(id: Int!): Product
 }
 
@@ -126,7 +126,7 @@ type Product @extends @key(fields : "id") {
 
 type Query @extends {
   _entities(representations: [_Any!]!): [_Entity]!
-  _service: _Service
+  _service: _Service!
 }
 
 type Review {


### PR DESCRIPTION
### :pencil: Description

Per [Apollo Federation Spec](https://www.apollographql.com/docs/federation/federation-spec/), `_service` should return non-nullable `_Service` object type.

### :link: Related Issues
N/A