### PR TITLE
feat: allow graphql java version range until v18

### DIFF
--- a/generator/graphql-kotlin-schema-generator/build.gradle.kts
+++ b/generator/graphql-kotlin-schema-generator/build.gradle.kts
@@ -11,7 +11,7 @@ val slf4jVersion: String by project
 dependencies {
     api("com.graphql-java:graphql-java") {
         version {
-            strictly(graphQLJavaVersion)
+            strictly("[$graphQLJavaVersion, 18.0)")
         }
     }
     api("org.jetbrains.kotlinx:kotlinx-coroutines-reactive:$kotlinCoroutinesVersion")

--- a/generator/graphql-kotlin-schema-generator/build.gradle.kts
+++ b/generator/graphql-kotlin-schema-generator/build.gradle.kts
@@ -11,7 +11,7 @@ val slf4jVersion: String by project
 dependencies {
     api("com.graphql-java:graphql-java") {
         version {
-            strictly("[$graphQLJavaVersion, 18.0)")
+            strictly("[$graphQLJavaVersion, 18.0[")
         }
     }
     api("org.jetbrains.kotlinx:kotlinx-coroutines-reactive:$kotlinCoroutinesVersion")


### PR DESCRIPTION
### :pencil: Description
allow minor releases of `graphql-java` from 17.2 until 18.0
[version declaration syntax](https://docs.gradle.org/current/userguide/single_versions.html)