### PR TITLE
[executions] do not apply data loader instrumentation if execution is a Mutation

### DIFF
--- a/executions/graphql-kotlin-dataloader-instrumentation/src/main/kotlin/com/expediagroup/graphql/dataloader/instrumentation/extensions/ExecutionContextExtensions.kt
+++ b/executions/graphql-kotlin-dataloader-instrumentation/src/main/kotlin/com/expediagroup/graphql/dataloader/instrumentation/extensions/ExecutionContextExtensions.kt
@@ -19,6 +19,7 @@ package com.expediagroup.graphql.dataloader.instrumentation.extensions
 import graphql.analysis.QueryTraverser
 import graphql.analysis.QueryVisitorFieldEnvironment
 import graphql.execution.ExecutionContext
+import graphql.language.OperationDefinition
 import kotlin.math.max
 
 /**
@@ -41,3 +42,6 @@ internal fun ExecutionContext.getDocumentHeight(): Int {
             0
         )
 }
+
+internal fun ExecutionContext.isMutation(): Boolean =
+    this.operationDefinition.operation == OperationDefinition.Operation.MUTATION

--- a/executions/graphql-kotlin-dataloader-instrumentation/src/main/kotlin/com/expediagroup/graphql/dataloader/instrumentation/extensions/ExecutionContextExtensions.kt
+++ b/executions/graphql-kotlin-dataloader-instrumentation/src/main/kotlin/com/expediagroup/graphql/dataloader/instrumentation/extensions/ExecutionContextExtensions.kt
@@ -43,5 +43,9 @@ internal fun ExecutionContext.getDocumentHeight(): Int {
         )
 }
 
+/**
+ * Checks if the [ExecutionContext] is a [OperationDefinition.Operation.MUTATION]
+ * @return Boolean indicating if GraphQL Operation is a Mutation
+ */
 internal fun ExecutionContext.isMutation(): Boolean =
     this.operationDefinition.operation == OperationDefinition.Operation.MUTATION

--- a/executions/graphql-kotlin-dataloader-instrumentation/src/main/kotlin/com/expediagroup/graphql/dataloader/instrumentation/level/execution/AbstractExecutionLevelDispatchedInstrumentation.kt
+++ b/executions/graphql-kotlin-dataloader-instrumentation/src/main/kotlin/com/expediagroup/graphql/dataloader/instrumentation/level/execution/AbstractExecutionLevelDispatchedInstrumentation.kt
@@ -17,10 +17,12 @@
 package com.expediagroup.graphql.dataloader.instrumentation.level.execution
 
 import com.expediagroup.graphql.dataloader.instrumentation.NoOpExecutionStrategyInstrumentationContext
+import com.expediagroup.graphql.dataloader.instrumentation.extensions.isMutation
 import com.expediagroup.graphql.dataloader.instrumentation.level.state.ExecutionLevelDispatchedState
 import com.expediagroup.graphql.dataloader.instrumentation.level.state.Level
 import graphql.ExecutionInput
 import graphql.ExecutionResult
+import graphql.execution.ExecutionContext
 import graphql.execution.instrumentation.ExecutionStrategyInstrumentationContext
 import graphql.execution.instrumentation.InstrumentationContext
 import graphql.execution.instrumentation.SimpleInstrumentation
@@ -54,16 +56,16 @@ abstract class AbstractExecutionLevelDispatchedInstrumentation : SimpleInstrumen
     override fun beginExecuteOperation(
         parameters: InstrumentationExecuteOperationParameters
     ): InstrumentationContext<ExecutionResult> =
-        parameters.executionContext
-            .graphQLContext.get<ExecutionLevelDispatchedState>(ExecutionLevelDispatchedState::class)
+        parameters.executionContext.takeIf { !it.isMutation() }
+            ?.graphQLContext?.get<ExecutionLevelDispatchedState>(ExecutionLevelDispatchedState::class)
             ?.beginExecuteOperation(parameters)
             ?: SimpleInstrumentationContext.noOp()
 
     override fun beginExecutionStrategy(
         parameters: InstrumentationExecutionStrategyParameters
     ): ExecutionStrategyInstrumentationContext =
-        parameters.executionContext
-            .graphQLContext.get<ExecutionLevelDispatchedState>(ExecutionLevelDispatchedState::class)
+        parameters.executionContext.takeIf { !it.isMutation() }
+            ?.graphQLContext?.get<ExecutionLevelDispatchedState>(ExecutionLevelDispatchedState::class)
             ?.beginExecutionStrategy(
                 parameters,
                 this.getOnLevelDispatchedCallback(
@@ -78,8 +80,8 @@ abstract class AbstractExecutionLevelDispatchedInstrumentation : SimpleInstrumen
     override fun beginFieldFetch(
         parameters: InstrumentationFieldFetchParameters
     ): InstrumentationContext<Any> =
-        parameters.executionContext
-            .graphQLContext.get<ExecutionLevelDispatchedState>(ExecutionLevelDispatchedState::class)
+        parameters.executionContext.takeIf { !it.isMutation() }
+            ?.graphQLContext?.get<ExecutionLevelDispatchedState>(ExecutionLevelDispatchedState::class)
             ?.beginFieldFetch(
                 parameters,
                 this.getOnLevelDispatchedCallback(
@@ -95,8 +97,8 @@ abstract class AbstractExecutionLevelDispatchedInstrumentation : SimpleInstrumen
         dataFetcher: DataFetcher<*>,
         parameters: InstrumentationFieldFetchParameters
     ): DataFetcher<*> =
-        parameters.executionContext
-            .graphQLContext.get<ExecutionLevelDispatchedState>(ExecutionLevelDispatchedState::class)
+        parameters.executionContext.takeIf { !it.isMutation() }
+            ?.graphQLContext?.get<ExecutionLevelDispatchedState>(ExecutionLevelDispatchedState::class)
             ?.instrumentDataFetcher(dataFetcher, parameters)
             ?: dataFetcher
 }

--- a/executions/graphql-kotlin-dataloader-instrumentation/src/main/kotlin/com/expediagroup/graphql/dataloader/instrumentation/level/execution/AbstractExecutionLevelDispatchedInstrumentation.kt
+++ b/executions/graphql-kotlin-dataloader-instrumentation/src/main/kotlin/com/expediagroup/graphql/dataloader/instrumentation/level/execution/AbstractExecutionLevelDispatchedInstrumentation.kt
@@ -22,7 +22,6 @@ import com.expediagroup.graphql.dataloader.instrumentation.level.state.Execution
 import com.expediagroup.graphql.dataloader.instrumentation.level.state.Level
 import graphql.ExecutionInput
 import graphql.ExecutionResult
-import graphql.execution.ExecutionContext
 import graphql.execution.instrumentation.ExecutionStrategyInstrumentationContext
 import graphql.execution.instrumentation.InstrumentationContext
 import graphql.execution.instrumentation.SimpleInstrumentation

--- a/executions/graphql-kotlin-dataloader-instrumentation/src/main/kotlin/com/expediagroup/graphql/dataloader/instrumentation/syncexhaustion/execution/AbstractSyncExecutionExhaustedInstrumentation.kt
+++ b/executions/graphql-kotlin-dataloader-instrumentation/src/main/kotlin/com/expediagroup/graphql/dataloader/instrumentation/syncexhaustion/execution/AbstractSyncExecutionExhaustedInstrumentation.kt
@@ -17,6 +17,7 @@
 package com.expediagroup.graphql.dataloader.instrumentation.syncexhaustion.execution
 
 import com.expediagroup.graphql.dataloader.instrumentation.NoOpExecutionStrategyInstrumentationContext
+import com.expediagroup.graphql.dataloader.instrumentation.extensions.isMutation
 import com.expediagroup.graphql.dataloader.instrumentation.syncexhaustion.state.SyncExecutionExhaustedState
 import graphql.ExecutionInput
 import graphql.ExecutionResult
@@ -54,24 +55,24 @@ abstract class AbstractSyncExecutionExhaustedInstrumentation : SimpleInstrumenta
     override fun beginExecuteOperation(
         parameters: InstrumentationExecuteOperationParameters
     ): InstrumentationContext<ExecutionResult> =
-        parameters.executionContext
-            .graphQLContext.get<SyncExecutionExhaustedState>(SyncExecutionExhaustedState::class)
+        parameters.executionContext.takeIf { !it.isMutation() }
+            ?.graphQLContext?.get<SyncExecutionExhaustedState>(SyncExecutionExhaustedState::class)
             ?.beginExecuteOperation(parameters)
             ?: SimpleInstrumentationContext.noOp()
 
     override fun beginExecutionStrategy(
         parameters: InstrumentationExecutionStrategyParameters
     ): ExecutionStrategyInstrumentationContext =
-        parameters.executionContext
-            .graphQLContext.get<SyncExecutionExhaustedState>(SyncExecutionExhaustedState::class)
+        parameters.executionContext.takeIf { !it.isMutation() }
+            ?.graphQLContext?.get<SyncExecutionExhaustedState>(SyncExecutionExhaustedState::class)
             ?.beginExecutionStrategy(parameters)
             ?: NoOpExecutionStrategyInstrumentationContext
 
     override fun beginFieldFetch(
         parameters: InstrumentationFieldFetchParameters
     ): InstrumentationContext<Any> =
-        parameters.executionContext
-            .graphQLContext.get<SyncExecutionExhaustedState>(SyncExecutionExhaustedState::class)
+        parameters.executionContext.takeIf { !it.isMutation() }
+            ?.graphQLContext?.get<SyncExecutionExhaustedState>(SyncExecutionExhaustedState::class)
             ?.beginFieldFetch(
                 parameters,
                 this.getOnSyncExecutionExhaustedCallback(

--- a/executions/graphql-kotlin-dataloader-instrumentation/src/test/kotlin/com/expediagroup/graphql/dataloader/instrumentation/fixture/AstronautGraphQL.kt
+++ b/executions/graphql-kotlin-dataloader-instrumentation/src/test/kotlin/com/expediagroup/graphql/dataloader/instrumentation/fixture/AstronautGraphQL.kt
@@ -22,6 +22,7 @@ import com.expediagroup.graphql.dataloader.instrumentation.fixture.datafetcher.A
 import com.expediagroup.graphql.dataloader.instrumentation.fixture.domain.Astronaut
 import com.expediagroup.graphql.dataloader.instrumentation.fixture.datafetcher.AstronautService
 import com.expediagroup.graphql.dataloader.instrumentation.fixture.datafetcher.AstronautServiceRequest
+import com.expediagroup.graphql.dataloader.instrumentation.fixture.datafetcher.CreateAstronautServiceRequest
 import com.expediagroup.graphql.dataloader.instrumentation.fixture.datafetcher.MissionDataLoader
 import com.expediagroup.graphql.dataloader.instrumentation.fixture.datafetcher.MissionService
 import com.expediagroup.graphql.dataloader.instrumentation.fixture.datafetcher.MissionServiceRequest
@@ -55,6 +56,9 @@ object AstronautGraphQL {
             astronauts(ids: [ID!]): [Astronaut]!
             missions(ids: [ID!]): [Mission]!
             nasa: Nasa!
+        }
+        type Mutation {
+            createAstronaut(name: String!): Astronaut!
         }
         type Nasa {
             astronaut(id: ID!): Astronaut
@@ -91,6 +95,14 @@ object AstronautGraphQL {
         astronautService.getAstronaut(
             AstronautServiceRequest(
                 environment.getArgument<String>("id").toInt()
+            ),
+            environment
+        )
+    }
+    private val createAstronautDataFetcher = DataFetcher { environment ->
+        astronautService.createAstronaut(
+            CreateAstronautServiceRequest(
+                environment.getArgument("name")
             ),
             environment
         )
@@ -154,6 +166,10 @@ object AstronautGraphQL {
                 .dataFetcher("astronauts", astronautsDataFetcher)
                 .dataFetcher("missions", missionsDataFetcher)
                 .dataFetcher("nasa") { Nasa() }
+        )
+        type(
+            TypeRuntimeWiring.newTypeWiring("Mutation")
+                .dataFetcher("createAstronaut", createAstronautDataFetcher)
         )
         type(
             TypeRuntimeWiring.newTypeWiring("Astronaut")

--- a/executions/graphql-kotlin-dataloader-instrumentation/src/test/kotlin/com/expediagroup/graphql/dataloader/instrumentation/fixture/datafetcher/AstronautService.kt
+++ b/executions/graphql-kotlin-dataloader-instrumentation/src/test/kotlin/com/expediagroup/graphql/dataloader/instrumentation/fixture/datafetcher/AstronautService.kt
@@ -28,10 +28,13 @@ import org.dataloader.DataLoader
 import org.dataloader.DataLoaderFactory
 import org.dataloader.DataLoaderOptions
 import org.dataloader.stats.SimpleStatisticsCollector
+import reactor.kotlin.core.publisher.toMono
+import java.time.Duration
 import java.util.Optional
 import java.util.concurrent.CompletableFuture
 
 data class AstronautServiceRequest(val id: Int)
+data class CreateAstronautServiceRequest(val name: String)
 
 class AstronautDataLoader : KotlinDataLoader<AstronautServiceRequest, Astronaut?> {
     override val dataLoaderName: String = "AstronautDataLoader"
@@ -56,6 +59,12 @@ class AstronautService {
         environment
             .getDataLoader<AstronautServiceRequest, Astronaut>("AstronautDataLoader")
             .load(request)
+
+    fun createAstronaut(
+        request: CreateAstronautServiceRequest,
+        environment: DataFetchingEnvironment
+    ): CompletableFuture<Astronaut> =
+        Astronaut(100, request.name).toMono().delayElement(Duration.ofMillis(100)).toFuture()
 
     fun getAstronauts(
         requests: List<AstronautServiceRequest>,


### PR DESCRIPTION
### :pencil: Description
As `graphql-java` documentation highlights

https://www.graphql-java.com/documentation/batching#data-loader-only-works-with-asyncexecutionstrategy

`DataLoader` instrumentation only works with `AsyncExecutionStrategy`, so `Mutation` operations are excluded since those are executed with `AsyncSerialExecutionStrategy`