### PR TITLE
[federation] fix service SDL to include schema @link info

### DIFF
--- a/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/FederatedSchemaGeneratorHooks.kt
+++ b/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/FederatedSchemaGeneratorHooks.kt
@@ -209,7 +209,7 @@ open class FederatedSchemaGeneratorHooks(private val resolvers: List<FederatedTy
         val directivesToInclude: List<String> = federatedDirectiveList().map { it.name }.plus(DEPRECATED_DIRECTIVE_NAME)
         val customDirectivePredicate: Predicate<String> = Predicate { directivesToInclude.contains(it) }
         return schema.print(
-            includeDefaultSchemaDefinition = false,
+            includeDefaultSchemaDefinition = optInFederationV2,
             includeDirectiveDefinitions = false,
             includeDirectivesFilter = customDirectivePredicate
         ).replace(scalarDefinitionRegex, "")


### PR DESCRIPTION
### :pencil: Description

`_service { sdl }` query in Federation v2 should include schema `@link` information.

### :link: Related Issues

Resolves: https://github.com/ExpediaGroup/graphql-kotlin/issues/1476