### PR TITLE
[federation] fix @key fed v2 definition

### DIFF
--- a/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/directives/KeyDirective.kt
+++ b/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/directives/KeyDirective.kt
@@ -28,7 +28,7 @@ import graphql.schema.GraphQLArgument
  * directive @key(fields: _FieldSet!) repeatable on OBJECT | INTERFACE
  *
  * # federation v2 definition
- * directive @key(fields: _FieldSet!, resolvable: Boolean) repeatable on OBJECT | INTERFACE
+ * directive @key(fields: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
  * ```
  *
  * The @key directive is used to indicate a combination of fields that can be used to uniquely identify and fetch an object or interface. Key directive should be specified on the root entity type as
@@ -116,6 +116,7 @@ internal val KEY_DIRECTIVE_TYPE_V2: graphql.schema.GraphQLDirective = graphql.sc
         GraphQLArgument.newArgument()
             .name("resolvable")
             .type(Scalars.GraphQLBoolean)
+            .defaultValueProgrammatic(true)
     )
     .repeatable(true)
     .build()

--- a/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/FederatedSchemaV2GeneratorTest.kt
+++ b/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/FederatedSchemaV2GeneratorTest.kt
@@ -55,7 +55,7 @@ private val FEDERATED_SDL_V2 =
       ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
     "Space separated list of primary keys needed to access federated object"
-    directive @key(fields: _FieldSet!, resolvable: Boolean) repeatable on OBJECT | INTERFACE
+    directive @key(fields: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
 
     "Links definitions within the document to external schemas."
     directive @link(import: [String], url: String) repeatable on SCHEMA

--- a/website/docs/schema-generator/federation/federated-directives.md
+++ b/website/docs/schema-generator/federation/federated-directives.md
@@ -168,7 +168,7 @@ type Product {
 directive @key(fields: _FieldSet!) repeatable on OBJECT | INTERFACE
 
 # federation v2 definition
-directive @key(fields: _FieldSet!, resolvable: Boolean) repeatable on OBJECT | INTERFACE
+directive @key(fields: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
 ```
 
 The `@key` directive is used to indicate a combination of fields that can be used to uniquely identify and fetch an


### PR DESCRIPTION
### :pencil: Description

Missed default value for the `resolvable` argument. Updated definition

```kotlin
directive @key(fields: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
```

### :link: Related Issues

N/A