### PR TITLE
feat: batchLoaderContext to access to dataFetchingEnvironment

### DIFF
--- a/executions/graphql-kotlin-dataloader-instrumentation/src/main/kotlin/com/expediagroup/graphql/dataloader/instrumentation/extensions/BatchLoaderEnvironmentExtensions.kt
+++ b/executions/graphql-kotlin-dataloader-instrumentation/src/main/kotlin/com/expediagroup/graphql/dataloader/instrumentation/extensions/BatchLoaderEnvironmentExtensions.kt
@@ -1,0 +1,28 @@
+package com.expediagroup.graphql.dataloader.instrumentation.extensions
+
+import graphql.GraphQLContext
+import graphql.schema.DataFetchingEnvironment
+import org.dataloader.BatchLoaderEnvironment
+import org.dataloader.DataLoader
+
+/**
+ * get the [DataFetchingEnvironment] from the [BatchLoaderEnvironment], in order to access to it,
+ * you need to pass your [DataFetchingEnvironment] to the [DataLoader.load] as second argument
+ * Example:
+ * ```
+ * dataloader.load(yourKey, dataFetchingEnvironment)
+ * ```
+ */
+fun BatchLoaderEnvironment.getDataFetchingEnvironment(): DataFetchingEnvironment? =
+    keyContextsList.firstOrNull() as? DataFetchingEnvironment
+
+/**
+ * get the [GraphQLContext] from the [BatchLoaderEnvironment], in order to access to it,
+ * you need to pass your [DataFetchingEnvironment] to the [DataLoader.load] as second argument
+ * Example:
+ * ```
+ * dataloader.load(yourKey, dataFetchingEnvironment)
+ * ```
+ */
+fun BatchLoaderEnvironment.getGraphQLContext(): GraphQLContext? =
+    getDataFetchingEnvironment()?.graphQlContext

--- a/executions/graphql-kotlin-dataloader-instrumentation/src/main/kotlin/com/expediagroup/graphql/dataloader/instrumentation/extensions/BatchLoaderEnvironmentExtensions.kt
+++ b/executions/graphql-kotlin-dataloader-instrumentation/src/main/kotlin/com/expediagroup/graphql/dataloader/instrumentation/extensions/BatchLoaderEnvironmentExtensions.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.expediagroup.graphql.dataloader.instrumentation.extensions
 
 import graphql.GraphQLContext

--- a/executions/graphql-kotlin-dataloader-instrumentation/src/main/kotlin/com/expediagroup/graphql/dataloader/instrumentation/extensions/CompletableFutureExtensions.kt
+++ b/executions/graphql-kotlin-dataloader-instrumentation/src/main/kotlin/com/expediagroup/graphql/dataloader/instrumentation/extensions/CompletableFutureExtensions.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.expediagroup.graphql.dataloader.instrumentation.extensions
 
 import com.expediagroup.graphql.dataloader.KotlinDataLoaderRegistry

--- a/executions/graphql-kotlin-dataloader-instrumentation/src/test/kotlin/com/expediagroup/graphql/dataloader/instrumentation/extensions/BatchLoaderEnvironmentExtensions.kt
+++ b/executions/graphql-kotlin-dataloader-instrumentation/src/test/kotlin/com/expediagroup/graphql/dataloader/instrumentation/extensions/BatchLoaderEnvironmentExtensions.kt
@@ -1,0 +1,45 @@
+package com.expediagroup.graphql.dataloader.instrumentation.extensions
+
+import graphql.GraphQLContext
+import graphql.schema.DataFetchingEnvironment
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.spyk
+import io.mockk.verify
+import org.dataloader.DataLoaderFactory
+import org.junit.jupiter.api.Test
+import java.util.concurrent.CompletableFuture
+
+class BatchLoaderEnvironmentExtensions {
+    @Test
+    fun `BatchLoaderEnvironment should access to the DataFetchingEnvironment`() {
+        val stringMapperDataLoader = DataLoaderFactory.newDataLoader<String, String> { keys, batchLoaderEnvironment ->
+            CompletableFuture.completedFuture(
+                keys.map { key ->
+                    batchLoaderEnvironment.getGraphQLContext()?.get<(String) -> String>("StringModifierLambda")?.invoke(key)
+                }
+            )
+        }
+
+        val stringModifierLambda = spyk(
+            { string: String -> string.uppercase() }
+        )
+
+        val dataFetchingEnvironment = mockk<DataFetchingEnvironment> {
+            every { graphQlContext } returns GraphQLContext.newContext().put(
+                "StringModifierLambda",
+                stringModifierLambda
+            ).build()
+        }
+
+        stringMapperDataLoader.load("hello", dataFetchingEnvironment)
+        stringMapperDataLoader.load("world", dataFetchingEnvironment)
+
+        stringMapperDataLoader.dispatch()
+
+        verify(exactly = 1) {
+            stringModifierLambda("hello")
+            stringModifierLambda("world")
+        }
+    }
+}

--- a/executions/graphql-kotlin-dataloader-instrumentation/src/test/kotlin/com/expediagroup/graphql/dataloader/instrumentation/extensions/BatchLoaderEnvironmentExtensions.kt
+++ b/executions/graphql-kotlin-dataloader-instrumentation/src/test/kotlin/com/expediagroup/graphql/dataloader/instrumentation/extensions/BatchLoaderEnvironmentExtensions.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.expediagroup.graphql.dataloader.instrumentation.extensions
 
 import graphql.GraphQLContext

--- a/executions/graphql-kotlin-dataloader-instrumentation/src/test/kotlin/com/expediagroup/graphql/dataloader/instrumentation/extensions/BatchLoaderEnvironmentExtensionsTest.kt
+++ b/executions/graphql-kotlin-dataloader-instrumentation/src/test/kotlin/com/expediagroup/graphql/dataloader/instrumentation/extensions/BatchLoaderEnvironmentExtensionsTest.kt
@@ -26,7 +26,7 @@ import org.dataloader.DataLoaderFactory
 import org.junit.jupiter.api.Test
 import java.util.concurrent.CompletableFuture
 
-class BatchLoaderEnvironmentExtensions {
+class BatchLoaderEnvironmentExtensionsTest {
     @Test
     fun `BatchLoaderEnvironment should access to the DataFetchingEnvironment`() {
         val stringMapperDataLoader = DataLoaderFactory.newDataLoader<String, String> { keys, batchLoaderEnvironment ->


### PR DESCRIPTION
### :pencil: Description
extension function to allow BatchLoaderContext to access to a GraphQL Execution DataFetchingEnvironment,
specially useful if in your dataLoader you need to access to the DataFetchingEnvironment or the GraphQLContext inside of it to run batch logic, example: auth context, coroutines scope, etc.

```kotlin
DataLoaderFactory.newDataLoader { requests, environment: BatchLoaderEnvironment ->
  val coroutineScope = environment.getGraphQLContext()?.get<CoroutineScope>()
   coroutineScope.async {
     // your batch logic for fetching data
   }.asCompletableFuture()
 }
```

