### PR TITLE
[build] update to latest dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -99,7 +99,7 @@ subprojects {
             sourceCompatibility = JavaVersion.VERSION_1_8
         }
 
-        // published artifacts
+        // published sources and javadoc artifacts
         val jarComponent = currentProject.components.getByName("java")
         val sourcesJar by registering(Jar::class) {
             archiveClassifier.set("sources")
@@ -149,12 +149,15 @@ subprojects {
                         }
                     }
                 }
-                create<MavenPublication>("mavenJava") {
-                    from(jarComponent)
-                    artifact(sourcesJar.get())
-                    // no need to publish javadocs for SNAPSHOT builds
-                    if (rootProject.extra["isReleaseVersion"] as Boolean) {
-                        artifact(javadocJar.get())
+                // com.gradle.plugin-publish creates publication automatically
+                if (currentProject.name != "graphql-kotlin-gradle-plugin") {
+                    create<MavenPublication>("mavenJava") {
+                        from(jarComponent)
+                        artifact(sourcesJar.get())
+                        // no need to publish javadocs for SNAPSHOT builds
+                        if (rootProject.extra["isReleaseVersion"] as Boolean) {
+                            artifact(javadocJar.get())
+                        }
                     }
                 }
             }

--- a/examples/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/execution/FlowSubscriptionExecutionStrategy.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/execution/FlowSubscriptionExecutionStrategy.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Expedia, Inc
+ * Copyright 2022 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,7 +58,10 @@ class FlowSubscriptionExecutionStrategy(dfe: DataFetcherExceptionHandler) : Exec
         val instrumentation = executionContext.instrumentation
         val instrumentationParameters = InstrumentationExecutionStrategyParameters(executionContext, parameters)
         val executionStrategyCtx = ExecutionStrategyInstrumentationContext.nonNullCtx(
-            instrumentation.beginExecutionStrategy(instrumentationParameters, executionContext.instrumentationState)
+            instrumentation.beginExecutionStrategy(
+                instrumentationParameters,
+                executionContext.instrumentationState
+            )
         )
 
         val sourceEventStream = createSourceEventStream(executionContext, parameters)
@@ -147,7 +150,9 @@ class FlowSubscriptionExecutionStrategy(dfe: DataFetcherExceptionHandler) : Exec
 
         val i13nFieldParameters = InstrumentationFieldParameters(executionContext) { subscribedFieldStepInfo }
         val subscribedFieldCtx = SimpleInstrumentationContext.nonNullCtx(
-            instrumentation.beginSubscribedFieldEvent(i13nFieldParameters, executionContext.instrumentationState)
+            instrumentation.beginSubscribedFieldEvent(
+                i13nFieldParameters, executionContext.instrumentationState
+            )
         )
 
         val fetchedValue = unboxPossibleDataFetcherResult(newExecutionContext, parameters, eventPayload)
@@ -162,12 +167,12 @@ class FlowSubscriptionExecutionStrategy(dfe: DataFetcherExceptionHandler) : Exec
         overallResult.whenComplete(subscribedFieldCtx::onCompleted)
 
         // allow them to instrument each ER should they want to
-        val i13ExecutionParameters = InstrumentationExecutionParameters(
+        val i13nExecutionParameters = InstrumentationExecutionParameters(
             executionContext.executionInput, executionContext.graphQLSchema, executionContext.instrumentationState
         )
 
         return overallResult.thenCompose { executionResult ->
-            instrumentation.instrumentExecutionResult(executionResult, i13ExecutionParameters, executionContext.instrumentationState)
+            instrumentation.instrumentExecutionResult(executionResult, i13nExecutionParameters, executionContext.instrumentationState)
         }
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,40 +16,46 @@ org.gradle.jvmargs=-Xmx2g -XX:+HeapDumpOnOutOfMemoryError
 # dependencies
 kotlinJvmVersion = 1.8
 kotlinVersion = 1.6.21
-kotlinCoroutinesVersion = 1.6.1
+kotlinCoroutinesVersion = 1.6.4
+# kotlinx-serialization 1.3.3 calls Kotlin 1.7 API
 kotlinxSerializationVersion = 1.3.2
 
 androidPluginVersion = 7.1.2
-classGraphVersion = 4.8.143
-federationGraphQLVersion = 0.9.0
+classGraphVersion = 4.8.149
+federationGraphQLVersion = 2.0.3
 graphQLJavaVersion = 19.0
 graphQLJavaDataLoaderVersion = 3.2.0
-jacksonVersion = 2.13.2
+jacksonVersion = 2.13.3
+# KotlinPoet v1.12.0+ requires Kotlin v1.7
 kotlinPoetVersion = 1.11.0
-ktorVersion = 2.0.0
-reactorVersion = 3.4.18
-reactorExtensionsVersion = 1.1.6
+ktorVersion = 2.0.3
+reactorVersion = 3.4.21
+reactorExtensionsVersion = 1.1.7
 slf4jVersion = 1.7.36
-springBootVersion = 2.7.0
-springVersion = 5.3.20
+springBootVersion = 2.7.2
+springVersion = 5.3.22
 
 # test dependency versions
 # kotlin-compile-testing has to be using the same kotlin version as the kotlinx-serialization compiler
+# kotlin-compile-testing v1.4.9+ requires Kotlin v1.7
 compileTestingVersion = 1.4.8
 icuVersion=71.1
 junitVersion = 5.8.2
-mockkVersion = 1.12.3
+# mockk v1.12.5+ requires Kotlin 1.7
+mockkVersion = 1.12.4
 mustacheVersion = 0.9.10
-rxjavaVersion = 3.1.4
-wireMockVersion = 2.32.0
-kotlinxBenchmarkVersion = 0.4.2
+rxjavaVersion = 3.1.5
+wireMockVersion = 2.33.2
+kotlinxBenchmarkVersion = 0.4.4
 
 # plugin versions
-detektVersion = 1.19.0
+detektVersion = 1.21.0
 dokkaVersion = 1.6.10
 jacocoVersion = 0.8.8
+# ktlint v0.46.0+ requires Kotlin 1.7
 ktlintVersion = 0.45.2
-ktlintPluginVersion = 10.2.1
+ktlintPluginVersion = 10.3.0
 mavenPluginDevelopmentVersion = 0.4.0
 nexusPublishPluginVersion = 1.1.0
 pluginPublishPluginVersion = 0.21.0
+# pluginPublishPluginVersion = 1.0.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,7 +22,7 @@ kotlinxSerializationVersion = 1.3.2
 
 androidPluginVersion = 7.1.2
 classGraphVersion = 4.8.149
-federationGraphQLVersion = 2.0.3
+federationGraphQLVersion = 2.0.4
 graphQLJavaVersion = 19.0
 graphQLJavaDataLoaderVersion = 3.2.0
 jacksonVersion = 2.13.3

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/plugins/graphql-kotlin-gradle-plugin/build.gradle.kts
+++ b/plugins/graphql-kotlin-gradle-plugin/build.gradle.kts
@@ -25,10 +25,19 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-params:$junitVersion")
 }
 
+java {
+    withSourcesJar()
+    if (rootProject.extra["isReleaseVersion"] as Boolean) {
+        withJavadocJar()
+    }
+}
+
 gradlePlugin {
     plugins {
         register("graphQLPlugin") {
             id = "com.expediagroup.graphql"
+            displayName = "GraphQL Kotlin Gradle Plugin"
+            description = "Gradle Plugin that can generate type-safe GraphQL Kotlin client and GraphQL schema in SDL format using reflections"
             implementationClass = "com.expediagroup.graphql.plugin.gradle.GraphQLGradlePlugin"
         }
     }
@@ -37,14 +46,7 @@ gradlePlugin {
 pluginBundle {
     website = "https://expediagroup.github.io/graphql-kotlin"
     vcsUrl = "https://github.com/ExpediaGroup/graphql-kotlin"
-
-    (plugins) {
-        "graphQLPlugin" {
-            displayName = "GraphQL Kotlin Gradle Plugin"
-            description = "Gradle Plugin that can generate type-safe GraphQL Kotlin client and GraphQL schema in SDL format using reflections"
-            tags = listOf("graphql", "kotlin", "graphql-client", "schema-generator", "sdl")
-        }
-    }
+    tags = listOf("graphql", "kotlin", "graphql-client", "schema-generator", "sdl")
 }
 
 sourceSets {
@@ -84,19 +86,6 @@ tasks {
             System.setProperty("gradle.publish.secret", System.getenv("PLUGIN_PORTAL_SECRET"))
         }
     }
-    publishing {
-        publications {
-            afterEvaluate {
-                named<MavenPublication>("graphQLPluginPluginMarkerMaven") {
-                    // update auto-generated pom.xml for plugin marker with required information
-                    pom {
-                        name.set(artifactId)
-                        description.set("Plugin descriptor for GraphQL Kotlin Gradle plugin")
-                    }
-                }
-            }
-        }
-    }
     test {
         // ensure we always run tests by setting new inputs
         //
@@ -114,5 +103,19 @@ tasks {
         systemProperty("kotlinVersion", kotlinVersion)
         systemProperty("springBootVersion", springBootVersion)
         systemProperty("junitVersion", junitVersion)
+    }
+
+    publishing {
+        afterEvaluate {
+            publications {
+                named<MavenPublication>("graphQLPluginPluginMarkerMaven") {
+                    // update auto-generated pom.xml for plugin marker with required information
+                    pom {
+                        name.set(artifactId)
+                        description.set("Plugin descriptor for GraphQL Kotlin Gradle plugin")
+                    }
+                }
+            }
+        }
     }
 }

--- a/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGenerateClientIT.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGenerateClientIT.kt
@@ -42,11 +42,15 @@ class GraphQLGenerateClientIT {
             .withPluginClasspath()
             .withArguments(
                 "build",
-                "--stacktrace",
-                "-PGRAPHQL_KOTLIN_VERSION=$DEFAULT_PLUGIN_VERSION",
-                "-PKOTLIN_VERSION=$kotlinVersion",
-                "-PJUNIT_VERSION=$junitVersion",
-                "-PMOCKK_VERSION=$mockkVersion"
+                "--stacktrace"
+            )
+            .withEnvironment(
+                mapOf(
+                    "GRAPHQL_KOTLIN_VERSION" to DEFAULT_PLUGIN_VERSION,
+                    "KOTLIN_VERSION" to kotlinVersion,
+                    "JUNIT_VERSION" to junitVersion,
+                    "MOCKK_VERSION" to mockkVersion
+                )
             )
             .forwardOutput()
             .build()

--- a/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePluginAndroidIT.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePluginAndroidIT.kt
@@ -44,10 +44,7 @@ class GraphQLGradlePluginAndroidIT {
             .withPluginClasspath()
             .withArguments(
                 "build",
-                "--stacktrace",
-                "-PGRAPHQL_KOTLIN_VERSION=$DEFAULT_PLUGIN_VERSION",
-                "-PKOTLIN_VERSION=$kotlinVersion",
-                "-PANDROID_PLUGIN_VERSION=$androidPluginVersion"
+                "--stacktrace"
             )
             .withEnvironment(
                 mapOf(

--- a/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePluginAndroidIT.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePluginAndroidIT.kt
@@ -50,7 +50,8 @@ class GraphQLGradlePluginAndroidIT {
                 mapOf(
                     "GRAPHQL_KOTLIN_VERSION" to DEFAULT_PLUGIN_VERSION,
                     "KOTLIN_VERSION" to kotlinVersion,
-                    "ANDROID_PLUGIN_VERSION" to androidPluginVersion
+                    "ANDROID_PLUGIN_VERSION" to androidPluginVersion,
+                    "ANDROID_SDK_ROOT" to System.getenv("ANDROID_SDK_ROOT")
                 )
             )
             .forwardOutput()

--- a/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePluginAndroidIT.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePluginAndroidIT.kt
@@ -42,7 +42,20 @@ class GraphQLGradlePluginAndroidIT {
         val buildResult = GradleRunner.create()
             .withProjectDir(testProjectDirectory)
             .withPluginClasspath()
-            .withArguments("build", "--stacktrace", "-PGRAPHQL_KOTLIN_VERSION=$DEFAULT_PLUGIN_VERSION", "-PKOTLIN_VERSION=$kotlinVersion", "-PANDROID_PLUGIN_VERSION=$androidPluginVersion")
+            .withArguments(
+                "build",
+                "--stacktrace",
+                "-PGRAPHQL_KOTLIN_VERSION=$DEFAULT_PLUGIN_VERSION",
+                "-PKOTLIN_VERSION=$kotlinVersion",
+                "-PANDROID_PLUGIN_VERSION=$androidPluginVersion"
+            )
+            .withEnvironment(
+                mapOf(
+                    "GRAPHQL_KOTLIN_VERSION" to DEFAULT_PLUGIN_VERSION,
+                    "KOTLIN_VERSION" to kotlinVersion,
+                    "ANDROID_PLUGIN_VERSION" to androidPluginVersion
+                )
+            )
             .forwardOutput()
             .build()
 


### PR DESCRIPTION
### :pencil: Description

Update to the latest dependencies. 

Fixed duplicate publication from `graphql-kotlin-gradle-plugin` - this was a warning before but latest version of `com.gradle.plugin-publish` treats it as a failure

NOTE: I did not update project to Kotlin v1.7 as I think that as a library we should target older version to allow for largest adoption.

### :link: Related Issues
