### PR TITLE
Add context to dataloader creation

### DIFF
--- a/executions/graphql-kotlin-dataloader/build.gradle.kts
+++ b/executions/graphql-kotlin-dataloader/build.gradle.kts
@@ -7,6 +7,7 @@ val reactorExtensionsVersion: String by project
 
 dependencies {
     api("com.graphql-java:java-dataloader:$graphQLJavaDataLoaderVersion")
+    testImplementation(project(path = ":graphql-kotlin-schema-generator"))
     testImplementation("io.projectreactor.kotlin:reactor-kotlin-extensions:$reactorExtensionsVersion")
     testImplementation("io.projectreactor:reactor-core:$reactorVersion")
     testImplementation("org.junit.jupiter:junit-jupiter-api:$junitVersion")

--- a/executions/graphql-kotlin-dataloader/src/main/kotlin/com/expediagroup/graphql/dataloader/KotlinDataLoader.kt
+++ b/executions/graphql-kotlin-dataloader/src/main/kotlin/com/expediagroup/graphql/dataloader/KotlinDataLoader.kt
@@ -17,6 +17,7 @@
 package com.expediagroup.graphql.dataloader
 
 import org.dataloader.DataLoader
+import org.dataloader.DataLoaderOptions
 
 /**
  * Wrapper around the [DataLoader] class so we can have common logic around registering the loaders
@@ -24,5 +25,10 @@ import org.dataloader.DataLoader
  */
 interface KotlinDataLoader<K, V> {
     val dataLoaderName: String
-    fun getDataLoader(): DataLoader<K, V>
+    fun getDataLoader(options: DataLoaderOptions): DataLoader<K, V> = getDataLoader()
+    @Deprecated(
+        "Should use getDataLoader(options) instead",
+        replaceWith = ReplaceWith("getDataLoader(DataLoaderOptions.newOptions)")
+    )
+    fun getDataLoader(): DataLoader<K, V> = TODO("${this::class} needs to implement getDataLoader")
 }

--- a/executions/graphql-kotlin-dataloader/src/main/kotlin/com/expediagroup/graphql/dataloader/KotlinDataLoaderOptionsFactory.kt
+++ b/executions/graphql-kotlin-dataloader/src/main/kotlin/com/expediagroup/graphql/dataloader/KotlinDataLoaderOptionsFactory.kt
@@ -1,0 +1,7 @@
+package com.expediagroup.graphql.dataloader
+
+import org.dataloader.DataLoaderOptions
+
+open class KotlinDataLoaderOptionsFactory {
+    open fun generate(contextMap: Map<*, Any>): DataLoaderOptions = DataLoaderOptions.newOptions()
+}

--- a/executions/graphql-kotlin-dataloader/src/main/kotlin/com/expediagroup/graphql/dataloader/KotlinDataLoaderRegistryFactory.kt
+++ b/executions/graphql-kotlin-dataloader/src/main/kotlin/com/expediagroup/graphql/dataloader/KotlinDataLoaderRegistryFactory.kt
@@ -16,6 +16,7 @@
 
 package com.expediagroup.graphql.dataloader
 
+import org.dataloader.DataLoaderOptions
 import org.dataloader.DataLoaderRegistry
 
 /**
@@ -30,12 +31,12 @@ class KotlinDataLoaderRegistryFactory(
     /**
      * Generate [KotlinDataLoaderRegistry] to be used for GraphQL request execution.
      */
-    fun generate(): KotlinDataLoaderRegistry {
+    fun generate(options: DataLoaderOptions = DataLoaderOptions.newOptions()): KotlinDataLoaderRegistry {
         val registry = DataLoaderRegistry()
         dataLoaders.forEach { dataLoader ->
             registry.register(
                 dataLoader.dataLoaderName,
-                dataLoader.getDataLoader()
+                dataLoader.getDataLoader(options)
             )
         }
         return KotlinDataLoaderRegistry(registry)

--- a/executions/graphql-kotlin-dataloader/src/test/kotlin/com/expediagroup/graphql/dataloader/KotlinDataLoaderRegistryTest.kt
+++ b/executions/graphql-kotlin-dataloader/src/test/kotlin/com/expediagroup/graphql/dataloader/KotlinDataLoaderRegistryTest.kt
@@ -18,6 +18,7 @@ package com.expediagroup.graphql.dataloader
 
 import org.dataloader.DataLoader
 import org.dataloader.DataLoaderFactory
+import org.dataloader.DataLoaderOptions
 import org.junit.jupiter.api.Test
 import reactor.kotlin.core.publisher.toFlux
 import java.time.Duration
@@ -30,14 +31,14 @@ class KotlinDataLoaderRegistryTest {
     fun `Decorator will keep track of DataLoaders futures`() {
         val stringToUpperCaseDataLoader: KotlinDataLoader<String, String> = object : KotlinDataLoader<String, String> {
             override val dataLoaderName: String = "ToUppercaseDataLoader"
-            override fun getDataLoader(): DataLoader<String, String> = DataLoaderFactory.newDataLoader { keys ->
+            override fun getDataLoader(options: DataLoaderOptions): DataLoader<String, String> = DataLoaderFactory.newDataLoader { keys ->
                 keys.toFlux().map(String::uppercase).collectList().delayElement(Duration.ofMillis(300)).toFuture()
             }
         }
 
         val stringToLowerCaseDataLoader: KotlinDataLoader<String, String> = object : KotlinDataLoader<String, String> {
             override val dataLoaderName: String = "ToLowercaseDataLoader"
-            override fun getDataLoader(): DataLoader<String, String> = DataLoaderFactory.newDataLoader { keys ->
+            override fun getDataLoader(options: DataLoaderOptions): DataLoader<String, String> = DataLoaderFactory.newDataLoader { keys ->
                 keys.toFlux().map(String::lowercase).collectList().delayElement(Duration.ofMillis(300)).toFuture()
             }
         }

--- a/servers/graphql-kotlin-server/src/main/kotlin/com/expediagroup/graphql/server/execution/GraphQLRequestHandler.kt
+++ b/servers/graphql-kotlin-server/src/main/kotlin/com/expediagroup/graphql/server/execution/GraphQLRequestHandler.kt
@@ -16,6 +16,7 @@
 
 package com.expediagroup.graphql.server.execution
 
+import com.expediagroup.graphql.dataloader.KotlinDataLoaderOptionsFactory
 import com.expediagroup.graphql.dataloader.KotlinDataLoaderRegistry
 import com.expediagroup.graphql.dataloader.KotlinDataLoaderRegistryFactory
 import com.expediagroup.graphql.dataloader.instrumentation.level.DataLoaderLevelDispatchedInstrumentation
@@ -45,7 +46,8 @@ import kotlinx.coroutines.supervisorScope
 
 open class GraphQLRequestHandler(
     private val graphQL: GraphQL,
-    private val dataLoaderRegistryFactory: KotlinDataLoaderRegistryFactory? = null
+    private val dataLoaderRegistryFactory: KotlinDataLoaderRegistryFactory? = null,
+    private val dataLoaderOptions: KotlinDataLoaderOptionsFactory = KotlinDataLoaderOptionsFactory()
 ) {
 
     private val batchDataLoaderInstrumentationType: Class<Instrumentation>? =
@@ -71,7 +73,7 @@ open class GraphQLRequestHandler(
         context: GraphQLContext? = null,
         graphQLContext: Map<*, Any> = emptyMap<Any, Any>()
     ): GraphQLServerResponse {
-        val dataLoaderRegistry = dataLoaderRegistryFactory?.generate()
+        val dataLoaderRegistry = dataLoaderRegistryFactory?.generate(dataLoaderOptions.generate(graphQLContext))
         return when (graphQLRequest) {
             is GraphQLRequest -> {
                 val batchGraphQLContext = graphQLContext + getBatchContext(1, dataLoaderRegistry)

--- a/servers/graphql-kotlin-server/src/test/kotlin/com/expediagroup/graphql/server/extensions/RequestExtensionsKtTest.kt
+++ b/servers/graphql-kotlin-server/src/test/kotlin/com/expediagroup/graphql/server/extensions/RequestExtensionsKtTest.kt
@@ -21,6 +21,7 @@ import com.expediagroup.graphql.dataloader.KotlinDataLoaderRegistryFactory
 import com.expediagroup.graphql.server.types.GraphQLRequest
 import io.mockk.mockk
 import org.dataloader.DataLoader
+import org.dataloader.DataLoaderOptions
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -64,7 +65,7 @@ class RequestExtensionsKtTest {
         val dataLoaderRegistry = KotlinDataLoaderRegistryFactory(
             object : KotlinDataLoader<String, String> {
                 override val dataLoaderName: String = "abc"
-                override fun getDataLoader(): DataLoader<String, String> = mockk()
+                override fun getDataLoader(options: DataLoaderOptions): DataLoader<String, String> = mockk()
             }
         ).generate()
 

--- a/servers/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/server/spring/subscriptions/SpringGraphQLSubscriptionHandler.kt
+++ b/servers/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/server/spring/subscriptions/SpringGraphQLSubscriptionHandler.kt
@@ -16,6 +16,7 @@
 
 package com.expediagroup.graphql.server.spring.subscriptions
 
+import com.expediagroup.graphql.dataloader.KotlinDataLoaderOptionsFactory
 import com.expediagroup.graphql.dataloader.KotlinDataLoaderRegistryFactory
 import com.expediagroup.graphql.generator.execution.GraphQLContext
 import com.expediagroup.graphql.server.extensions.toExecutionInput
@@ -35,7 +36,8 @@ import kotlinx.coroutines.flow.map
  */
 open class SpringGraphQLSubscriptionHandler(
     private val graphQL: GraphQL,
-    private val dataLoaderRegistryFactory: KotlinDataLoaderRegistryFactory? = null
+    private val dataLoaderRegistryFactory: KotlinDataLoaderRegistryFactory? = null,
+    private val dataLoaderOptions: KotlinDataLoaderOptionsFactory = KotlinDataLoaderOptionsFactory()
 ) {
 
     fun executeSubscription(
@@ -43,7 +45,7 @@ open class SpringGraphQLSubscriptionHandler(
         context: GraphQLContext?,
         graphQLContext: Map<*, Any> = emptyMap<Any, Any>()
     ): Flow<GraphQLResponse<*>> {
-        val dataLoaderRegistry = dataLoaderRegistryFactory?.generate()
+        val dataLoaderRegistry = dataLoaderRegistryFactory?.generate(dataLoaderOptions.generate(graphQLContext))
         val input = graphQLRequest.toExecutionInput(dataLoaderRegistry, context, graphQLContext)
 
         return graphQL.execute(input)

--- a/servers/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/server/spring/SchemaConfigurationTest.kt
+++ b/servers/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/server/spring/SchemaConfigurationTest.kt
@@ -16,6 +16,8 @@
 
 package com.expediagroup.graphql.server.spring
 
+import com.expediagroup.graphql.dataloader.KotlinDataLoader
+import com.expediagroup.graphql.dataloader.KotlinDataLoaderRegistryFactory
 import com.expediagroup.graphql.generator.SchemaGeneratorConfig
 import com.expediagroup.graphql.generator.TopLevelObject
 import com.expediagroup.graphql.generator.annotations.GraphQLDescription
@@ -23,8 +25,6 @@ import com.expediagroup.graphql.generator.execution.KotlinDataFetcherFactoryProv
 import com.expediagroup.graphql.generator.toSchema
 import com.expediagroup.graphql.server.execution.GraphQLContextFactory
 import com.expediagroup.graphql.server.execution.GraphQLRequestHandler
-import com.expediagroup.graphql.dataloader.KotlinDataLoader
-import com.expediagroup.graphql.dataloader.KotlinDataLoaderRegistryFactory
 import com.expediagroup.graphql.server.extensions.getValueFromDataLoader
 import com.expediagroup.graphql.server.operations.Query
 import com.expediagroup.graphql.server.spring.execution.SpringGraphQLContextFactory


### PR DESCRIPTION
To allow setting the GraphQLContext as the
batch context in a dataloader, pass it through
the KotlinDataLoaderRegistryFactory.generate()
call.


( discussed in https://kotlinlang.slack.com/archives/CQLNT7B29/p1659112178486379?thread_ts=1659049940.071919&cid=CQLNT7B29 )
