### PR TITLE
Deprecate with @GraphQLDeprecated

### DIFF
--- a/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/server/spring/model/Widget.kt
+++ b/examples/server/spring-server/src/main/kotlin/com/expediagroup/graphql/examples/server/spring/model/Widget.kt
@@ -16,6 +16,7 @@
 
 package com.expediagroup.graphql.examples.server.spring.model
 
+import com.expediagroup.graphql.generator.annotations.GraphQLDeprecated
 import com.expediagroup.graphql.generator.annotations.GraphQLDescription
 import com.expediagroup.graphql.generator.annotations.GraphQLIgnore
 
@@ -25,7 +26,7 @@ data class Widget(
     @GraphQLDescription("The widget's value that can be null")
     var value: Int? = null,
 
-    @Deprecated(message = "This field is deprecated", replaceWith = ReplaceWith("value"))
+    @GraphQLDeprecated(message = "This field is deprecated", replaceWith = ReplaceWith("value"))
     @GraphQLDescription("The widget's deprecated value that shouldn't be used")
     val deprecatedValue: Int? = value,
 

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/annotations/GraphQLDeprecated.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/annotations/GraphQLDeprecated.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Expedia, Inc
+ * Copyright 2022 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/annotations/GraphQLDeprecated.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/annotations/GraphQLDeprecated.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.generator.annotations
+
+/**
+ * Marks the query or property as deprecated Like `@kotlin.Deprecated`
+ * Unlike @Deprecated your own code isn't marked as deprecated
+ */
+annotation class GraphQLDeprecated(val message: String, val replaceWith: ReplaceWith = ReplaceWith(""))

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/extensions/annotationExtensions.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/extensions/annotationExtensions.kt
@@ -16,6 +16,7 @@
 
 package com.expediagroup.graphql.generator.internal.extensions
 
+import com.expediagroup.graphql.generator.annotations.GraphQLDeprecated
 import com.expediagroup.graphql.generator.annotations.GraphQLDescription
 import com.expediagroup.graphql.generator.annotations.GraphQLIgnore
 import com.expediagroup.graphql.generator.annotations.GraphQLName
@@ -29,7 +30,9 @@ internal fun KAnnotatedElement.getGraphQLDescription(): String? = this.findAnnot
 
 internal fun KAnnotatedElement.getGraphQLName(): String? = this.findAnnotation<GraphQLName>()?.value
 
-internal fun KAnnotatedElement.getDeprecationReason(): String? = this.findAnnotation<Deprecated>()?.getReason()
+internal fun KAnnotatedElement.getDeprecationReason(): String? =
+    this.findAnnotation<Deprecated>()?.getReason()
+        ?: this.findAnnotation<GraphQLDeprecated>()?.getReason()
 
 internal fun KAnnotatedElement.isGraphQLIgnored(): Boolean = this.findAnnotation<GraphQLIgnore>() != null
 
@@ -41,14 +44,12 @@ internal fun Annotation.getMetaUnionAnnotation(): GraphQLUnion? = this.annotatio
 
 internal fun List<Annotation>.getCustomTypeAnnotation(): GraphQLType? = this.filterIsInstance(GraphQLType::class.java).firstOrNull()
 
-internal fun Deprecated.getReason(): String {
-    val builder = StringBuilder()
-    builder.append(this.message)
+internal fun GraphQLDeprecated.getReason(): String = when {
+    replaceWith.expression.isBlank() -> message
+    else -> "$message, replace with ${replaceWith.expression}"
+}
 
-    if (this.replaceWith.expression.isBlank().not()) {
-        builder.append(", replace with ")
-        builder.append(this.replaceWith.expression)
-    }
-
-    return builder.toString()
+internal fun Deprecated.getReason(): String = when {
+    replaceWith.expression.isBlank() -> message
+    else -> "$message, replace with ${replaceWith.expression}"
 }

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/extensions/fieldExtenstions.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/extensions/fieldExtenstions.kt
@@ -16,12 +16,15 @@
 
 package com.expediagroup.graphql.generator.internal.extensions
 
+import com.expediagroup.graphql.generator.annotations.GraphQLDeprecated
 import com.expediagroup.graphql.generator.annotations.GraphQLDescription
 import com.expediagroup.graphql.generator.annotations.GraphQLName
 import java.lang.reflect.Field
 
 internal fun Field.getGraphQLDescription(): String? = this.getAnnotation(GraphQLDescription::class.java)?.value
 
-internal fun Field.getDeprecationReason(): String? = this.getDeclaredAnnotation(Deprecated::class.java)?.getReason()
+internal fun Field.getDeprecationReason(): String? =
+    this.getDeclaredAnnotation(Deprecated::class.java)?.getReason()
+        ?: this.getDeclaredAnnotation(GraphQLDeprecated::class.java)?.getReason()
 
 internal fun Field.getGraphQLName(): String = this.getAnnotation(GraphQLName::class.java)?.value ?: this.name

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/extensions/AnnotationExtensionsTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/extensions/AnnotationExtensionsTest.kt
@@ -56,7 +56,6 @@ class AnnotationExtensionsTest {
     annotation class MetaUnion
 
     @GraphQLDeprecated("class deprecated", ReplaceWith("WithAnnotations"))
-    @GraphQLIgnore
     private data class WithGraphQLDeprecated(
         @property:GraphQLDeprecated("property deprecated", ReplaceWith("uuid"))
         val id: String,

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/extensions/AnnotationExtensionsTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/extensions/AnnotationExtensionsTest.kt
@@ -16,6 +16,7 @@
 
 package com.expediagroup.graphql.generator.internal.extensions
 
+import com.expediagroup.graphql.generator.annotations.GraphQLDeprecated
 import com.expediagroup.graphql.generator.annotations.GraphQLDescription
 import com.expediagroup.graphql.generator.annotations.GraphQLIgnore
 import com.expediagroup.graphql.generator.annotations.GraphQLName
@@ -54,6 +55,14 @@ class AnnotationExtensionsTest {
     @GraphQLUnion(name = "MetaUnion", possibleTypes = [NoAnnotations::class])
     annotation class MetaUnion
 
+    @GraphQLDeprecated("class deprecated", ReplaceWith("WithAnnotations"))
+    @GraphQLIgnore
+    private data class WithGraphQLDeprecated(
+        @property:GraphQLDeprecated("property deprecated", ReplaceWith("uuid"))
+        val id: String,
+        val uuid: String,
+    )
+
     @Test
     fun `verify @GraphQLName on classes`() {
         @Suppress("DEPRECATION")
@@ -87,6 +96,15 @@ class AnnotationExtensionsTest {
         assertEquals(expected = "property deprecated", actual = classPropertyDeprecation)
         assertNull(NoAnnotations::class.getDeprecationReason())
         assertNull(NoAnnotations::class.findMemberProperty("id")?.getDeprecationReason())
+    }
+
+    @Test
+    fun `verify @GraphQLDeprecated`() {
+        val classDeprecation = WithGraphQLDeprecated::class.getDeprecationReason()
+        val classPropertyDeprecation = WithGraphQLDeprecated::class.findMemberProperty("id")?.getDeprecationReason()
+
+        assertEquals(expected = "class deprecated, replace with WithAnnotations", actual = classDeprecation)
+        assertEquals(expected = "property deprecated, replace with uuid", actual = classPropertyDeprecation)
     }
 
     @Test

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/extensions/FieldExtenstionsKtTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/extensions/FieldExtenstionsKtTest.kt
@@ -16,6 +16,7 @@
 
 package com.expediagroup.graphql.generator.internal.extensions
 
+import com.expediagroup.graphql.generator.annotations.GraphQLDeprecated
 import com.expediagroup.graphql.generator.annotations.GraphQLDescription
 import com.expediagroup.graphql.generator.annotations.GraphQLName
 import org.junit.jupiter.api.Test
@@ -29,7 +30,9 @@ class FieldExtenstionsKtTest {
         @Deprecated("do not use", ReplaceWith("TWO"))
         @GraphQLName("customOne")
         ONE,
-        TWO
+        TWO,
+        @GraphQLDeprecated("do not use", ReplaceWith("TWO"))
+        THREE
     }
 
     @Test
@@ -43,6 +46,12 @@ class FieldExtenstionsKtTest {
     @Test
     fun `verify @Deprecated on fields`() {
         val propertyDeprecation = AnnotatedEnum::class.java.getField("ONE").getDeprecationReason()
+        assertEquals(expected = "do not use, replace with TWO", actual = propertyDeprecation)
+    }
+
+    @Test
+    fun `verify @GraphQLDeprecated on fields`() {
+        val propertyDeprecation = AnnotatedEnum::class.java.getField("THREE").getDeprecationReason()
         assertEquals(expected = "do not use, replace with TWO", actual = propertyDeprecation)
     }
 

--- a/website/docs/schema-generator/customizing-schemas/annotations.md
+++ b/website/docs/schema-generator/customizing-schemas/annotations.md
@@ -10,5 +10,5 @@ for things that can't be directly derived from Kotlin reflection.
 - [@GraphQLIgnore](./excluding-fields) - Exclude field from the GraphQL schema
 - [@GraphQLName](./renaming-fields) - Override the name used for the type
 - Kotlin built in [@Deprecated](./deprecating-schema) - Apply the GraphQL `@deprecated` directive on the field
-- [@GraphQLDeprecated](./deprecating-schema) - Same but when you don't want to deprecated only for the client, not in your own code
+- [@GraphQLDeprecated](./deprecating-schema) - Apply the GraphQL `@deprecated` directive but only in the schema, not in your own Kotlin code with `@Deprecated`
 - [@GraphQLType](./custom-type-reference) - Allows specifying a return type that is not the Kotlin code

--- a/website/docs/schema-generator/customizing-schemas/annotations.md
+++ b/website/docs/schema-generator/customizing-schemas/annotations.md
@@ -10,4 +10,5 @@ for things that can't be directly derived from Kotlin reflection.
 - [@GraphQLIgnore](./excluding-fields) - Exclude field from the GraphQL schema
 - [@GraphQLName](./renaming-fields) - Override the name used for the type
 - Kotlin built in [@Deprecated](./deprecating-schema) - Apply the GraphQL `@deprecated` directive on the field
+- [@GraphQLDeprecated](./deprecating-schema) - Same but when you don't want to deprecated only for the client, not in your own code
 - [@GraphQLType](./custom-type-reference) - Allows specifying a return type that is not the Kotlin code

--- a/website/docs/schema-generator/customizing-schemas/deprecating-schema.md
+++ b/website/docs/schema-generator/customizing-schemas/deprecating-schema.md
@@ -35,14 +35,7 @@ type Query {
 
 ## GraphQLDeprecated
 
-A side-effect of using `@Deprecated` is that it marks your own code as being deprecated, which may not be what you want.
-
-![](https://user-images.githubusercontent.com/459464/182555658-49c5252a-b421-437a-b7a7-93c17d778a09.png)
-
-Find yourself using `Suppress("DEPRECATION")` everywhere?
-
-Then you may want to use `@GraphQLDeprecated` instead. It works just the same:
-
+A side-effect of using `@Deprecated` is that it marks your own Kotlin code as being deprecated, which may not be what you want. Using `@GraphQLDeprecated` you can add the `@deprecated` directive to the GraphQL schema, but not have your Kotlin code show up as deprecated in your editor.
 
 ```kotlin
 class SimpleQuery {
@@ -51,4 +44,3 @@ class SimpleQuery {
 
   fun shinyNewQuery(): Boolean = true
 }
-```

--- a/website/docs/schema-generator/customizing-schemas/deprecating-schema.md
+++ b/website/docs/schema-generator/customizing-schemas/deprecating-schema.md
@@ -2,8 +2,16 @@
 id: deprecating-schema
 title: Deprecating Schema
 ---
-GraphQL schemas can have fields marked as deprecated. Instead of creating a custom annotation,
-`graphql-kotlin-schema-generator` just looks for the `kotlin.Deprecated` annotation and will use that annotation message
+
+GraphQL schemas supports deprecation directive on
+the fields (which correspond to Kotlin properties and functions), input fields and enum values.
+
+Deprecation of arguments is currently not supported [in Kotlin](https://youtrack.jetbrains.com/issue/KT-25643).
+
+## Kotlin.Deprecated
+
+Instead of creating a custom annotation,
+`graphql-kotlin-schema-generator` just looks for the `@kotlin.Deprecated` annotation and will use that annotation message
 for the deprecated reason.
 
 ```kotlin
@@ -25,7 +33,22 @@ type Query {
 }
 ```
 
-While you can deprecate any fields/functions/classes in your Kotlin code, GraphQL only supports deprecation directive on
-the fields (which correspond to Kotlin properties and functions), input fields and enum values.
+## GraphQLDeprecated
 
-Deprecation of arguments is currently not supported [in Kotlin](https://youtrack.jetbrains.com/issue/KT-25643).
+A side-effect of using `@Deprecated` is that it marks your own code as being deprecated, which may not be what you want.
+
+![](https://user-images.githubusercontent.com/459464/182555658-49c5252a-b421-437a-b7a7-93c17d778a09.png)
+
+Find yourself using `Suppress("DEPRECATION")` everywhere?
+
+Then you may want to use `@GraphQLDeprecated` instead. It works just the same:
+
+
+```kotlin
+class SimpleQuery {
+  @GraphQLDeprecated(message = "this query is deprecated", replaceWith = ReplaceWith("shinyNewQuery"))
+  fun simpleDeprecatedQuery(): Boolean = false
+
+  fun shinyNewQuery(): Boolean = true
+}
+```

--- a/website/docs/schema-generator/customizing-schemas/directives.md
+++ b/website/docs/schema-generator/customizing-schemas/directives.md
@@ -12,7 +12,7 @@ spec](https://graphql.github.io/graphql-spec/draft/#sec-Type-System.Directives) 
 ## Default Directives
 
 `@deprecated` - schema directive used to represent deprecated portion of the schema.
-See [@Deprecated](deprecating-schema.md) annotation documentation for more details
+See [@Deprecated and @GraphQLDeprecated](deprecating-schema.md) annotation documentation for more details
 
 ```graphql
 type Query {


### PR DESCRIPTION
### :pencil: Description

Works the same than @Depcreated (which is still fine and supported)
but doesn't deprecate your own code, only deprecate in the client

### :link: Related Issues

Resolves #1492 
