### PR TITLE
feat: filter arguments that are in the input

### DIFF
--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/execution/convertArgumentValue.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/execution/convertArgumentValue.kt
@@ -93,10 +93,11 @@ private fun convertValue(
  */
 private fun <T : Any> mapToKotlinObject(input: Map<String, *>, targetClass: KClass<T>): T {
     val targetConstructor = targetClass.primaryConstructor ?: throw PrimaryConstructorNotFound(targetClass)
+    val constructorParameters = targetConstructor.parameters
     // filter parameters that are actually in the input in order to rely on parameters default values
     // in target constructor
-    val constructorParametersInInput = targetConstructor.parameters.filter { parameter ->
-        input.containsKey(parameter.getName())
+    val constructorParametersInInput = constructorParameters.filter { parameter ->
+        input.containsKey(parameter.getName()) || parameter.type.isOptionalInputType()
     }
     val constructorArguments = constructorParametersInInput.associateWith { parameter ->
         convertArgumentValue(parameter.getName(), parameter, input)

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/execution/FunctionDataFetcherTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/execution/FunctionDataFetcherTest.kt
@@ -152,7 +152,7 @@ class FunctionDataFetcherTest {
     }
 
     @Test
-    fun `default values are overridden when arument is passed in`() {
+    fun `default values are overridden when argument is passed in`() {
         val dataFetcher = FunctionDataFetcher(target = null, fn = MyClass::printDefault)
         val mockEnvironment: DataFetchingEnvironment = mockk {
             every { getSource<Any>() } returns MyClass()
@@ -313,7 +313,7 @@ class FunctionDataFetcherTest {
     @Test
     fun `optional inputs inside class return undefined when arguments are empty`() {
         val dataFetcher = FunctionDataFetcher(target = MyClass(), fn = MyClass::optionalWrapperClass)
-        val mockEnvironment: DataFetchingEnvironment = mockk {
+        val mockEnvironment = mockk<DataFetchingEnvironment> {
             every { arguments } returns mapOf("input" to mapOf("required" to "hello"))
             every { containsArgument("input") } returns true
         }

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/test/integration/OptionalInputTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/test/integration/OptionalInputTest.kt
@@ -41,12 +41,12 @@ class OptionalInputTest {
             Arguments.of("{ optionalObjectInput }", "input object was not specified"),
             Arguments.of("{ optionalObjectInput(input: null) }", "input object value: null"),
             Arguments.of("{ optionalObjectInput(input: { id: 1, name: \"ABC\" } )  }", "input object value: SimpleArgument(id=1, name=ABC)"),
-            Arguments.of("{ optionaListScalarInput }", "input was not specified"),
-            Arguments.of("{ optionaListScalarInput(input: null) }", "input value: null"),
-            Arguments.of("{ optionaListScalarInput(input: [\"ABC\"] )  }", "input value: [ABC]"),
-            Arguments.of("{ optionaListInputObject }", "input was not specified"),
-            Arguments.of("{ optionaListInputObject(input: null) }", "input value: null"),
-            Arguments.of("{ optionaListInputObject(input: [{id: 1, name: \"ABC\"}] )  }", "input value: [SimpleArgument(id=1, name=ABC)]"),
+            Arguments.of("{ optionalListScalarInput }", "input was not specified"),
+            Arguments.of("{ optionalListScalarInput(input: null) }", "input value: null"),
+            Arguments.of("{ optionalListScalarInput(input: [\"ABC\"] )  }", "input value: [ABC]"),
+            Arguments.of("{ optionalListInputObject }", "input was not specified"),
+            Arguments.of("{ optionalListInputObject(input: null) }", "input value: null"),
+            Arguments.of("{ optionalListInputObject(input: [{id: 1, name: \"ABC\"}] )  }", "input value: [SimpleArgument(id=1, name=ABC)]"),
             Arguments.of("{ inputWithOptionalScalarValues(input: { required: \"ABC\" }) }", "argument with optional scalar was not specified"),
             Arguments.of("{ inputWithOptionalScalarValues(input: { required: \"ABC\" optional: null }) }", "argument scalar value: null"),
             Arguments.of("{ inputWithOptionalScalarValues(input: { required: \"ABC\" optional: 1 }) }", "argument scalar value: 1"),
@@ -100,12 +100,12 @@ class OptionalInputQuery {
         is OptionalInput.Defined<SimpleArgument> -> "input object value: ${input.value}"
     }
 
-    fun optionaListScalarInput(input: OptionalInput<List<String>>): String = when (input) {
+    fun optionalListScalarInput(input: OptionalInput<List<String>>): String = when (input) {
         is OptionalInput.Undefined -> "input was not specified"
         is OptionalInput.Defined -> "input value: ${input.value}"
     }
 
-    fun optionaListInputObject(input: OptionalInput<List<SimpleArgument>>): String = when (input) {
+    fun optionalListInputObject(input: OptionalInput<List<SimpleArgument>>): String = when (input) {
         is OptionalInput.Undefined -> "input was not specified"
         is OptionalInput.Defined -> "input value: ${input.value}"
     }

--- a/website/docs/schema-generator/writing-schemas/arguments.md
+++ b/website/docs/schema-generator/writing-schemas/arguments.md
@@ -112,9 +112,9 @@ If you need logic to determine when a client passed in a value vs when the defau
 Default values with custom scalars are not supported, regardless if the type is nullable or non-nullable, as they use kotlin value classes,
 `callBy` does not support invoking constructors that have value classes as arguments.
 
-See: https://youtrack.jetbrains.com/issue/KT-27598,
+See: https://youtrack.jetbrains.com/issue/KT-27598
 
-which was partially fixed in:https://github.com/JetBrains/kotlin/pull/4746
+which was partially fixed in: https://github.com/JetBrains/kotlin/pull/4746
 
 This will be fixed once `graphql-kotlin` updates to kotlin 1.7
 :::

--- a/website/docs/schema-generator/writing-schemas/arguments.md
+++ b/website/docs/schema-generator/writing-schemas/arguments.md
@@ -107,3 +107,14 @@ query PrintMessages {
 ```
 
 If you need logic to determine when a client passed in a value vs when the default value was used (aka the argument was missing in the request), see [optional undefined arguments](../execution/optional-undefined-arguments.md).
+
+:::info
+Default values with custom scalars are not supported, regardless if the type is nullable or non-nullable, as they use kotlin value classes,
+`callBy` does not support invoking constructors that have value classes as arguments.
+
+See: https://youtrack.jetbrains.com/issue/KT-27598,
+
+which was partially fixed in:https://github.com/JetBrains/kotlin/pull/4746
+
+This will be fixed once `graphql-kotlin` updates to kotlin 1.7
+:::


### PR DESCRIPTION
### :pencil: Description
filtering `targetConstructor` parameters to use the ones that are actually provided in the `inputMap` that way we can  rely on the default values for the parameters that are not specified

**IMPORTANT**

There is 1 scenario where default values is not going to work: 
Custom Scalars as they use kotlin value classes, regardless if the type is nullable or non nullable, `callBy` does not support constructors that have inline class parameters

see: 
https://youtrack.jetbrains.com/issue/KT-27598
it was partially fixed in: 
https://github.com/JetBrains/kotlin/pull/4746

will be included in kotlin 1.7


### :link: Related Issues
https://github.com/ExpediaGroup/graphql-kotlin/issues/1503