### PR TITLE
feat: support argument types without primaryConstructor

### DIFF
--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/exceptions/MultipleConstructorsFound.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/exceptions/MultipleConstructorsFound.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2022 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.generator.exceptions
+
+import kotlin.reflect.KClass
+
+/**
+ * Thrown when multiple constructors of an input class were located.
+ */
+class MultipleConstructorsFound(klazz: KClass<*>) : GraphQLKotlinException("Invalid input object ${klazz.simpleName} - multiple public constructors found")

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/execution/convertArgumentValue.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/execution/convertArgumentValue.kt
@@ -16,6 +16,7 @@
 
 package com.expediagroup.graphql.generator.execution
 
+import com.expediagroup.graphql.generator.exceptions.MultipleConstructorsFound
 import com.expediagroup.graphql.generator.exceptions.PrimaryConstructorNotFound
 import com.expediagroup.graphql.generator.internal.extensions.getGraphQLName
 import com.expediagroup.graphql.generator.internal.extensions.getKClass
@@ -93,9 +94,16 @@ private fun convertValue(
  * the only thing left to parse is object maps into the nested Kotlin classes
  */
 private fun <T : Any> mapToKotlinObject(input: Map<String, *>, targetClass: KClass<T>): T {
-    val targetConstructor = targetClass.primaryConstructor
-        ?: targetClass.constructors.firstOrNull()
-        ?: throw PrimaryConstructorNotFound(targetClass)
+
+    val targetConstructor = targetClass.primaryConstructor ?: run {
+        if (targetClass.constructors.size == 1) {
+            targetClass.constructors.first()
+        } else if (targetClass.constructors.size > 1) {
+            throw MultipleConstructorsFound(targetClass)
+        } else {
+            throw PrimaryConstructorNotFound(targetClass)
+        }
+    }
 
     val constructorParameters = targetConstructor.parameters
     // filter parameters that are actually in the input in order to rely on parameters default values

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/execution/convertArgumentValue.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/execution/convertArgumentValue.kt
@@ -93,9 +93,9 @@ private fun convertValue(
  * the only thing left to parse is object maps into the nested Kotlin classes
  */
 private fun <T : Any> mapToKotlinObject(input: Map<String, *>, targetClass: KClass<T>): T {
-    val targetConstructor = targetClass.primaryConstructor ?: run {
-        targetClass.constructors.firstOrNull()
-    } ?: throw PrimaryConstructorNotFound(targetClass)
+    val targetConstructor = targetClass.primaryConstructor
+        ?: targetClass.constructors.firstOrNull()
+        ?: throw PrimaryConstructorNotFound(targetClass)
 
     val constructorParameters = targetConstructor.parameters
     // filter parameters that are actually in the input in order to rely on parameters default values

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/execution/convertArgumentValue.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/execution/convertArgumentValue.kt
@@ -93,7 +93,10 @@ private fun convertValue(
  * the only thing left to parse is object maps into the nested Kotlin classes
  */
 private fun <T : Any> mapToKotlinObject(input: Map<String, *>, targetClass: KClass<T>): T {
-    val targetConstructor = targetClass.primaryConstructor ?: throw PrimaryConstructorNotFound(targetClass)
+    val targetConstructor = targetClass.primaryConstructor ?: run {
+        targetClass.constructors.firstOrNull()
+    } ?: throw PrimaryConstructorNotFound(targetClass)
+
     val constructorParameters = targetConstructor.parameters
     // filter parameters that are actually in the input in order to rely on parameters default values
     // in target constructor

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/execution/ConvertArgumentValueTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/execution/ConvertArgumentValueTest.kt
@@ -117,6 +117,23 @@ class ConvertArgumentValueTest {
         assertEquals("nested default value", castResult.nested?.value)
     }
 
+    @Test
+    fun `generic map object is parsed without using primary constructor`() {
+        val kParam = assertNotNull(TestFunctions::inputObjectNoPrimaryConstructor.findParameterByName("input"))
+        val result = convertArgumentValue(
+            "input",
+            kParam,
+            mapOf(
+                "input" to mapOf(
+                    "value" to "hello"
+                )
+            )
+        )
+
+        val castResult = assertIs<TestInputNoPrimaryConstructor>(result)
+        assertEquals("hello", castResult.value)
+    }
+
     /**
      * this will be solved in Kotlin 1.7
      * "KotlinReflectionInternalError" when using `callBy` on constructor that has inline class parameters
@@ -241,6 +258,7 @@ class ConvertArgumentValueTest {
         fun enumInput(input: Foo): String = TODO()
         fun idInput(input: ID): String = TODO()
         fun inputObject(input: TestInput): String = TODO()
+        fun inputObjectNoPrimaryConstructor(input: TestInputNoPrimaryConstructor): String = TODO()
         fun inputObjectNested(input: TestInputNested): String = TODO()
         fun inputObjectNullableScalar(input: TestInputNullableScalar): String = TODO()
         fun inputObjectNotNullableScalar(input: TestInputNotNullableScalar): String = TODO()
@@ -257,8 +275,13 @@ class ConvertArgumentValueTest {
     class TestInputNestedType(val value: String = "nested default value")
     class TestInputNullableScalar(val foo: String? = null, val id: ID? = null)
     class TestInputNotNullableScalar(val foo: String, val id: ID = ID("1234"))
-
     class TestInputRenamed(@GraphQLName("bar") val foo: String)
+    class TestInputNoPrimaryConstructor {
+        val value: String
+        constructor(value: String) {
+            this.value = value
+        }
+    }
 
     enum class Foo {
         BAR,

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/execution/ConvertArgumentValueTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/execution/ConvertArgumentValueTest.kt
@@ -17,6 +17,7 @@
 package com.expediagroup.graphql.generator.execution
 
 import com.expediagroup.graphql.generator.annotations.GraphQLName
+import com.expediagroup.graphql.generator.exceptions.MultipleConstructorsFound
 import com.expediagroup.graphql.generator.scalars.ID
 import graphql.schema.DataFetchingEnvironment
 import io.mockk.every
@@ -132,6 +133,22 @@ class ConvertArgumentValueTest {
 
         val castResult = assertIs<TestInputNoPrimaryConstructor>(result)
         assertEquals("hello", castResult.value)
+    }
+
+    @Test
+    fun `exception is thrown when multiple constructors were found`() {
+        val kParam = assertNotNull(TestFunctions::inputObjectMultipleConstructors.findParameterByName("input"))
+        assertThrows<MultipleConstructorsFound> {
+            convertArgumentValue(
+                "input",
+                kParam,
+                mapOf(
+                    "input" to mapOf(
+                        "value" to "hello"
+                    )
+                )
+            )
+        }
     }
 
     /**
@@ -259,6 +276,7 @@ class ConvertArgumentValueTest {
         fun idInput(input: ID): String = TODO()
         fun inputObject(input: TestInput): String = TODO()
         fun inputObjectNoPrimaryConstructor(input: TestInputNoPrimaryConstructor): String = TODO()
+        fun inputObjectMultipleConstructors(input: TestInputMultipleConstructors): String = TODO()
         fun inputObjectNested(input: TestInputNested): String = TODO()
         fun inputObjectNullableScalar(input: TestInputNullableScalar): String = TODO()
         fun inputObjectNotNullableScalar(input: TestInputNotNullableScalar): String = TODO()
@@ -278,6 +296,17 @@ class ConvertArgumentValueTest {
     class TestInputRenamed(@GraphQLName("bar") val foo: String)
     class TestInputNoPrimaryConstructor {
         val value: String
+        constructor(value: String) {
+            this.value = value
+        }
+    }
+    class TestInputMultipleConstructors {
+        val value: String
+
+        constructor() {
+            this.value = "Default Value"
+        }
+
         constructor(value: String) {
             this.value = value
         }


### PR DESCRIPTION
### :pencil: Description
there are some use cases where no primary constructor will be defined, like in java classes, for those cases if no primaryConstructor is found use the first element on the constructors list, otherwise throw the error

### :link: Related Issues
https://github.com/ExpediaGroup/graphql-kotlin/issues/1515
