### PR TITLE
add custom java mapping support to FunctionDataFetcher

### DIFF
--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/execution/FunctionDataFetcher.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/execution/FunctionDataFetcher.kt
@@ -23,8 +23,6 @@ import com.expediagroup.graphql.generator.internal.extensions.isGraphQLContext
 import com.expediagroup.graphql.generator.internal.extensions.isOptionalInputType
 import graphql.schema.DataFetcher
 import graphql.schema.DataFetchingEnvironment
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.future.future
 import java.lang.reflect.InvocationTargetException
 import java.util.concurrent.CompletableFuture
 import kotlin.coroutines.EmptyCoroutineContext
@@ -33,6 +31,8 @@ import kotlin.reflect.KParameter
 import kotlin.reflect.full.callSuspendBy
 import kotlin.reflect.full.instanceParameter
 import kotlin.reflect.full.valueParameters
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.future.future
 
 /**
  * Simple DataFetcher that invokes target function on the given object.
@@ -98,12 +98,14 @@ open class FunctionDataFetcher(
             else -> {
                 val name = param.getName()
                 if (environment.containsArgument(name) || param.type.isOptionalInputType()) {
-                    param to convertArgumentValue(name, param, environment.arguments)
+                    param to convertArgumentValue(name, param, environment.arguments, ::mapToJavaObject)
                 } else {
                     null
                 }
             }
         }
+
+    protected open fun mapToJavaObject(arguments: Map<String, *>, clazz: Class<*>): Any? = null
 
     /**
      * Once all parameters values are properly converted, this function will be called to run a suspendable function using

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/execution/ConvertArgumentValueTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/execution/ConvertArgumentValueTest.kt
@@ -31,17 +31,20 @@ import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 
 class ConvertArgumentValueTest {
+
+    val mapToJavaObject: (Map<String, *>, Class<*>) -> Any? = { _, _ -> null }
+
     @Test
     fun `string input is parsed`() {
         val kParam = assertNotNull(TestFunctions::stringInput.findParameterByName("input"))
-        val result = convertArgumentValue("input", kParam, mapOf("input" to "hello"))
+        val result = convertArgumentValue("input", kParam, mapOf("input" to "hello"), mapToJavaObject)
         assertEquals("hello", result)
     }
 
     @Test
     fun `pre-parsed object is returned`() {
         val kParam = assertNotNull(TestFunctions::inputObject.findParameterByName("input"))
-        val result = convertArgumentValue("input", kParam, mapOf("input" to TestInput("hello")))
+        val result = convertArgumentValue("input", kParam, mapOf("input" to TestInput("hello")), mapToJavaObject)
         val castResult = assertIs<TestInput>(result)
         assertEquals("hello", castResult.foo)
     }
@@ -50,7 +53,7 @@ class ConvertArgumentValueTest {
     fun `enum object is parsed`() {
         val kParam = assertNotNull(TestFunctions::enumInput.findParameterByName("input"))
         val inputValue = "BAR"
-        val result = convertArgumentValue("input", kParam, mapOf("input" to inputValue))
+        val result = convertArgumentValue("input", kParam, mapOf("input" to inputValue), mapToJavaObject)
         val castResult = assertIs<Foo>(result)
         assertEquals(Foo.BAR, castResult)
     }
@@ -59,7 +62,7 @@ class ConvertArgumentValueTest {
     fun `renamed enum object is parsed`() {
         val kParam = assertNotNull(TestFunctions::enumInput.findParameterByName("input"))
         val inputValue = "baz"
-        val result = convertArgumentValue("input", kParam, mapOf("input" to inputValue))
+        val result = convertArgumentValue("input", kParam, mapOf("input" to inputValue), mapToJavaObject)
         val castResult = assertIs<Foo>(result)
         assertEquals(Foo.BAZ, castResult)
     }
@@ -73,7 +76,7 @@ class ConvertArgumentValueTest {
             "baz" to listOf("!"),
             "qux" to "1234"
         )
-        val result = convertArgumentValue("input", kParam, mapOf("input" to inputValue))
+        val result = convertArgumentValue("input", kParam, mapOf("input" to inputValue), mapToJavaObject)
         val castResult = assertIs<TestInput>(result)
         assertEquals("hello", castResult.foo)
         assertEquals("world", castResult.bar)
@@ -91,7 +94,8 @@ class ConvertArgumentValueTest {
                 "input" to mapOf(
                     "foo" to "hello"
                 )
-            )
+            ),
+            mapToJavaObject
         )
 
         val castResult = assertIs<TestInput>(result)
@@ -109,7 +113,8 @@ class ConvertArgumentValueTest {
             kParam,
             mapOf(
                 "input" to emptyMap<String, Any>()
-            )
+            ),
+            mapToJavaObject
         )
 
         val castResult = assertIs<TestInputNested>(result)
@@ -128,7 +133,8 @@ class ConvertArgumentValueTest {
                 "input" to mapOf(
                     "value" to "hello"
                 )
-            )
+            ),
+            mapToJavaObject
         )
 
         val castResult = assertIs<TestInputNoPrimaryConstructor>(result)
@@ -146,7 +152,8 @@ class ConvertArgumentValueTest {
                     "input" to mapOf(
                         "value" to "hello"
                     )
-                )
+                ),
+                mapToJavaObject
             )
         }
     }
@@ -168,7 +175,8 @@ class ConvertArgumentValueTest {
                     "input" to mapOf(
                         "foo" to "foo"
                     )
-                )
+                ),
+                mapToJavaObject
             )
         }
     }
@@ -190,7 +198,8 @@ class ConvertArgumentValueTest {
                     "input" to mapOf(
                         "foo" to "foo"
                     )
-                )
+                ),
+                mapToJavaObject
             )
         }
     }
@@ -198,21 +207,21 @@ class ConvertArgumentValueTest {
     @Test
     fun `list string input is parsed`() {
         val kParam = assertNotNull(TestFunctions::listStringInput.findParameterByName("input"))
-        val result = convertArgumentValue("input", kParam, mapOf("input" to listOf("hello")))
+        val result = convertArgumentValue("input", kParam, mapOf("input" to listOf("hello")), mapToJavaObject)
         assertEquals(listOf("hello"), result)
     }
 
     @Test
     fun `optional input when undefined is parsed`() {
         val kParam = assertNotNull(TestFunctions::optionalInput.findParameterByName("input"))
-        val result = convertArgumentValue("input", kParam, mapOf())
+        val result = convertArgumentValue("input", kParam, mapOf(), mapToJavaObject)
         assertEquals(OptionalInput.Undefined, result)
     }
 
     @Test
     fun `optional input with defined null is parsed`() {
         val kParam = assertNotNull(TestFunctions::optionalInput.findParameterByName("input"))
-        val result = convertArgumentValue("input", kParam, mapOf("input" to null))
+        val result = convertArgumentValue("input", kParam, mapOf("input" to null), mapToJavaObject)
         val castResult = assertIs<OptionalInput.Defined<*>>(result)
         assertEquals(null, castResult.value)
     }
@@ -223,7 +232,7 @@ class ConvertArgumentValueTest {
         val mockEnv = mockk<DataFetchingEnvironment> {
             every { containsArgument("input") } returns true
         }
-        val result = convertArgumentValue("input", kParam, mapOf("input" to "hello"))
+        val result = convertArgumentValue("input", kParam, mapOf("input" to "hello"), mapToJavaObject)
         val castResult = assertIs<OptionalInput.Defined<*>>(result)
         assertEquals("hello", castResult.value)
     }
@@ -231,7 +240,7 @@ class ConvertArgumentValueTest {
     @Test
     fun `optional input with object is parsed`() {
         val kParam = assertNotNull(TestFunctions::optionalInputObject.findParameterByName("input"))
-        val result = convertArgumentValue("input", kParam, mapOf("input" to TestInput("hello")))
+        val result = convertArgumentValue("input", kParam, mapOf("input" to TestInput("hello")), mapToJavaObject)
         val castResult = assertIs<OptionalInput.Defined<*>>(result)
         val castResult2 = assertIs<TestInput>(castResult.value)
         assertEquals("hello", castResult2.foo)
@@ -240,7 +249,7 @@ class ConvertArgumentValueTest {
     @Test
     fun `optional input with list object is parsed`() {
         val kParam = assertNotNull(TestFunctions::optionalInputListObject.findParameterByName("input"))
-        val result = convertArgumentValue("input", kParam, mapOf("input" to listOf(TestInput("hello"))))
+        val result = convertArgumentValue("input", kParam, mapOf("input" to listOf(TestInput("hello"))), mapToJavaObject)
         val castResult = assertIs<OptionalInput.Defined<*>>(result)
         val castResult2 = assertIs<List<TestInput>>(castResult.value)
         assertEquals("hello", castResult2.firstOrNull()?.foo)
@@ -249,7 +258,7 @@ class ConvertArgumentValueTest {
     @Test
     fun `id input is parsed`() {
         val kParam = assertNotNull(TestFunctions::idInput.findParameterByName("input"))
-        val result = convertArgumentValue("input", kParam, mapOf("input" to "1234"))
+        val result = convertArgumentValue("input", kParam, mapOf("input" to "1234"), mapToJavaObject)
         assertIs<ID>(result)
         assertEquals("1234", result.value)
     }
@@ -264,7 +273,8 @@ class ConvertArgumentValueTest {
                 "input" to mapOf(
                     "bar" to "renamed"
                 )
-            )
+            ),
+            mapToJavaObject
         )
 
         val castResult = assertIs<TestInputRenamed>(result)

--- a/servers/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/server/spring/execution/SpringDataFetcher.kt
+++ b/servers/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/server/spring/execution/SpringDataFetcher.kt
@@ -18,14 +18,14 @@ package com.expediagroup.graphql.server.spring.execution
 
 import com.expediagroup.graphql.generator.execution.FunctionDataFetcher
 import graphql.schema.DataFetchingEnvironment
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.beans.factory.annotation.Qualifier
-import org.springframework.context.ApplicationContext
 import kotlin.reflect.KFunction
 import kotlin.reflect.KParameter
 import kotlin.reflect.full.findAnnotation
 import kotlin.reflect.full.hasAnnotation
 import kotlin.reflect.jvm.javaType
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.context.ApplicationContext
 
 /**
  * Spring aware function data fetcher that automatically autowires Spring beans as function parameters.


### PR DESCRIPTION
### :pencil: Description
@dariuszkuc @samuelAndalon
it's only a *draft* to evaluate if this way is an option as well. I added a function for java object mapping. The default implementation results `null` but it can overwritten in custom `FunctionDataFetcher`. I updated my little playground project as well.

I'm going to add tests as well. actually it is only a draft.


### :link: Related Issues
https://github.com/ExpediaGroup/graphql-kotlin/issues/1515