### PR TITLE
feat: mark ExecutionResult and Throwable as nullable

### DIFF
--- a/executions/graphql-kotlin-dataloader-instrumentation/src/main/kotlin/com/expediagroup/graphql/dataloader/instrumentation/level/state/ExecutionLevelDispatchedState.kt
+++ b/executions/graphql-kotlin-dataloader-instrumentation/src/main/kotlin/com/expediagroup/graphql/dataloader/instrumentation/level/state/ExecutionLevelDispatchedState.kt
@@ -80,7 +80,7 @@ class ExecutionLevelDispatchedState(
             override fun onDispatched(result: CompletableFuture<ExecutionResult>) {
             }
 
-            override fun onCompleted(result: ExecutionResult, t: Throwable) {
+            override fun onCompleted(result: ExecutionResult?, t: Throwable?) {
             }
 
             override fun onFieldValuesInfo(fieldValueInfoList: List<FieldValueInfo>) {


### PR DESCRIPTION
### :pencil: Description
both `result` and `exception (t)` can be null depending on the execution result

this could cause some noise of implementation using this instrumentation