### PR TITLE
minor: Allow SpringGraphQLSubscriptionHandler to be extended

### DIFF
--- a/servers/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/server/spring/subscriptions/SpringGraphQLSubscriptionHandler.kt
+++ b/servers/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/server/spring/subscriptions/SpringGraphQLSubscriptionHandler.kt
@@ -38,7 +38,7 @@ open class SpringGraphQLSubscriptionHandler(
     private val dataLoaderRegistryFactory: KotlinDataLoaderRegistryFactory? = null
 ) {
 
-    fun executeSubscription(
+    open fun executeSubscription(
         graphQLRequest: GraphQLRequest,
         context: GraphQLContext?,
         graphQLContext: Map<*, Any> = emptyMap<Any, Any>()


### PR DESCRIPTION
### :pencil: Description

Per issue #1522, the subscription handler likely was meant to be able
to be extended with the `executeSubscription` method overridden.

### :link: Related Issues

Resolves #1522
