### PR TITLE
[server] add injected SchemaPrinter to allow SDL endpoint customization

### DIFF
--- a/servers/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/server/spring/GraphQLSchemaConfiguration.kt
+++ b/servers/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/server/spring/GraphQLSchemaConfiguration.kt
@@ -39,6 +39,7 @@ import graphql.execution.instrumentation.ChainedInstrumentation
 import graphql.execution.instrumentation.Instrumentation
 import graphql.execution.preparsed.PreparsedDocumentProvider
 import graphql.schema.GraphQLSchema
+import graphql.schema.idl.SchemaPrinter
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean
@@ -159,4 +160,18 @@ class GraphQLSchemaConfiguration {
         contextFactory,
         requestHandler
     )
+
+    @Bean
+    @ConditionalOnMissingBean
+    fun schemaPrinter(): SchemaPrinter {
+        return SchemaPrinter(
+            SchemaPrinter.Options.defaultOptions()
+                .includeIntrospectionTypes(false)
+                .includeScalarTypes(true)
+                .includeSchemaDefinition(true)
+                .includeDirectives(true)
+                .includeDirectives { true }
+                .includeDirectiveDefinitions(true)
+        )
+    }
 }

--- a/servers/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/server/spring/GraphQLSchemaConfiguration.kt
+++ b/servers/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/server/spring/GraphQLSchemaConfiguration.kt
@@ -163,7 +163,16 @@ class GraphQLSchemaConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    fun schemaPrinter(): SchemaPrinter {
+    fun schemaPrinter(): SchemaPrinter  = 
+      SchemaPrinter(
+            SchemaPrinter.Options.defaultOptions()
+                .includeIntrospectionTypes(false)
+                .includeScalarTypes(true)
+                .includeSchemaDefinition(true)
+                .includeDirectives(true)
+                .includeDirectives { true }
+                .includeDirectiveDefinitions(true)
+        )
         return SchemaPrinter(
             SchemaPrinter.Options.defaultOptions()
                 .includeIntrospectionTypes(false)

--- a/servers/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/server/spring/SdlRouteConfiguration.kt
+++ b/servers/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/server/spring/SdlRouteConfiguration.kt
@@ -16,8 +16,8 @@
 
 package com.expediagroup.graphql.server.spring
 
-import com.expediagroup.graphql.generator.extensions.print
 import graphql.schema.GraphQLSchema
+import graphql.schema.idl.SchemaPrinter
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -33,10 +33,11 @@ import org.springframework.web.reactive.function.server.coRouter
 @Import(GraphQLSchemaConfiguration::class)
 class SdlRouteConfiguration(
     private val config: GraphQLConfigurationProperties,
+    schemaPrinter: SchemaPrinter,
     schema: GraphQLSchema
 ) {
 
-    private val sdl = schema.print()
+    private val sdl = schemaPrinter.print(schema)
 
     @Bean
     @ConditionalOnProperty(value = ["graphql.sdl.enabled"], havingValue = "true", matchIfMissing = true)

--- a/servers/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/server/spring/SchemaConfigurationTest.kt
+++ b/servers/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/server/spring/SchemaConfigurationTest.kt
@@ -36,6 +36,7 @@ import graphql.execution.instrumentation.tracing.TracingInstrumentation
 import graphql.schema.DataFetchingEnvironment
 import graphql.schema.GraphQLSchema
 import graphql.schema.GraphQLTypeUtil
+import graphql.schema.idl.SchemaPrinter
 import io.mockk.mockk
 import org.assertj.core.api.AssertionsForInterfaceTypes.assertThat
 import org.dataloader.DataLoader
@@ -77,6 +78,8 @@ class SchemaConfigurationTest {
                 assertNotNull(helloWorldQuery)
                 assertEquals("String", GraphQLTypeUtil.unwrapAll(helloWorldQuery.type).name)
 
+                assertThat(ctx).hasSingleBean(SchemaPrinter::class.java)
+
                 assertThat(ctx).hasSingleBean(GraphQL::class.java)
                 val graphQL = ctx.getBean(GraphQL::class.java)
                 val result = graphQL.execute("query { hello }").toSpecification()
@@ -111,6 +114,10 @@ class SchemaConfigurationTest {
                 assertThat(ctx).hasSingleBean(GraphQLSchema::class.java)
                 assertThat(ctx).getBean(GraphQLSchema::class.java)
                     .isSameAs(customConfiguration.mySchema())
+
+                assertThat(ctx).hasSingleBean(SchemaPrinter::class.java)
+                assertThat(ctx).getBean(SchemaPrinter::class.java)
+                    .isSameAs(customConfiguration.myCustomSchemaPrinter())
 
                 assertThat(ctx).hasSingleBean(GraphQL::class.java)
                 assertThat(ctx).getBean(GraphQL::class.java)
@@ -173,6 +180,9 @@ class SchemaConfigurationTest {
 
         @Bean
         fun myDataLoaderRegistryFactory(): KotlinDataLoaderRegistryFactory = mockk()
+
+        @Bean
+        fun myCustomSchemaPrinter(): SchemaPrinter = mockk(relaxed = true)
     }
 
     class BasicQuery : Query {


### PR DESCRIPTION
✅ [Contributing.md](https://github.com/ExpediaGroup/graphql-kotlin/blob/master/CONTRIBUTING.md) has followed for this change.

### :pencil: Description
This change adds in an automatically configured SchemaPrinter bean to enable users of the spring server to provide their own SchemaPrinter (either one configured with different options, or an overriding implementation) to be used with the SDL endpoint.

I encountered this issue #689 while seeking to do the same thing (change the sort order of properties in the generated schema). The suggested resolution there was:

>However, the schema generator just returns a GraphQLSchema object so once you have that you could create a custom implementation of the [SchemaPrinter](https://github.com/graphql-java/graphql-java/blob/master/src/main/java/graphql/schema/idl/SchemaPrinter.java) and print the output in any way you want.

However in a slight variation of the problem, we run integration tests checking our expected schema against our SDL endpoint to guard against unexpected schema changes. Previous to these changes the SDL endpoint just relies on a hardcoded default Schema Printer implementation and set of options. Which means even a custom schema printing implementation does not get reflected in the SDL endpoint

I believe the only documentation changes that would be required would be on the [spring beans page](https://opensource.expediagroup.com/graphql-kotlin/docs/server/spring-server/spring-beans) to indicate the new default bean and its interaction with the SDL endpoint.

I also considered related changes in the graphql-kotlin-sdl-generator's [GenerateSDL.kt](https://github.com/ExpediaGroup/graphql-kotlin/blob/095b056b74d52237b73cef872fdbd851c019039c/plugins/schema/graphql-kotlin-sdl-generator/src/main/kotlin/com/expediagroup/graphql/plugin/schema/GenerateSDL.kt#L107) but did not see as natural of extension point, as [SchemaGeneratorHooks](https://github.com/ExpediaGroup/graphql-kotlin/blob/master/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/hooks/SchemaGeneratorHooks.kt) did not necessarily feel like a completely natural extension point. I'd definitely be open to hearing any suggestions for how to contribute that corresponding change.

### :link: Related Issues
In addition to the above mentioned #689, I believe this change would also fulfill part but not all of the ask in #1118.