### PR TITLE
Add capability to do Argument conversion using ServiceLoader

### DIFF
--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/execution/spi/ArgumentObjectConverter.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/execution/spi/ArgumentObjectConverter.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.generator.execution.spi
+
+import kotlin.reflect.KClass
+
+/**
+ * [ArgumentObjectConverter] allows application and library developers to provide their own implementation
+ * and logic for how to convert the input argument. The [ArgumentObjectConverter] provide a way to extend
+ * this library easily. It is using the service provider spec from [java.util.ServiceLoader].
+ *
+ * In order to use custom implementation(s) of [ArgumentObjectConverter]
+ * 1) you need to implement this interface, and
+ * 2) you need to register some/all of your custom [ArgumentObjectConverter] in the services file.
+ *
+ * All the registered implementations of [ArgumentObjectConverter] are sorted by
+ * the return value of [ArgumentObjectConverter.priority] in ascending order. Default implementation
+ * is provided by [DefaultArgumentObjectConverter] with [DefaultArgumentObjectConverter.priority] == [Int.MAX_VALUE].
+ *
+ */
+interface ArgumentObjectConverter {
+
+    /**
+     * The return value is used to sort all registered [ArgumentObjectConverter] in ascending order.
+     */
+    val priority: Int
+
+    /**
+     * Returns true if this instance of [ArgumentObjectConverter] can convert the input argument to
+     * the provided target class [targetClass], otherwise this method returns false.
+     */
+    fun <T : Any> doesSupport(targetClass: KClass<T>): Boolean
+
+    /**
+     * Converts the [input] to an instance of [targetClass] and
+     * returns an instance of [targetClass].
+     */
+    fun <T : Any> convert(input: Map<String, *>, targetClass: KClass<T>): T
+}

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/execution/spi/DefaultArgumentObjectConverter.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/execution/spi/DefaultArgumentObjectConverter.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2022 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.generator.execution.spi
+
+import com.expediagroup.graphql.generator.exceptions.MultipleConstructorsFound
+import com.expediagroup.graphql.generator.exceptions.PrimaryConstructorNotFound
+import com.expediagroup.graphql.generator.execution.convertArgumentValue
+import com.expediagroup.graphql.generator.internal.extensions.getName
+import com.expediagroup.graphql.generator.internal.extensions.isNotOptionalNullable
+import com.expediagroup.graphql.generator.internal.extensions.isOptionalInputType
+import kotlin.reflect.KClass
+import kotlin.reflect.full.primaryConstructor
+
+/**
+ * Default implementation of [ArgumentObjectConverter] as fallback.
+ * The [DefaultArgumentObjectConverter.priority] of this convert is always [Int.MAX_VALUE].
+ */
+class DefaultArgumentObjectConverter : ArgumentObjectConverter {
+
+    /**
+     * It is always [Int.MAX_VALUE].
+     */
+    override val priority: Int = Int.MAX_VALUE
+
+    /**
+     * It supports all classes, to it always returns true.
+     */
+    override fun <T : Any> doesSupport(targetClass: KClass<T>): Boolean = true
+
+    /**
+     * Default and Fallback implementation to convert [input] to an instance of [targetClass].
+     */
+    override fun <T : Any> convert(input: Map<String, *>, targetClass: KClass<T>): T {
+        val targetConstructor = targetClass.primaryConstructor ?: run {
+            if (targetClass.constructors.size == 1) {
+                targetClass.constructors.first()
+            } else if (targetClass.constructors.size > 1) {
+                throw MultipleConstructorsFound(targetClass)
+            } else {
+                throw PrimaryConstructorNotFound(targetClass)
+            }
+        }
+
+        // filter parameters that are actually in the input in order to rely on parameters default values
+        // in target constructor
+        val constructorParameters = targetConstructor.parameters.filter { parameter ->
+            input.containsKey(parameter.getName()) ||
+                parameter.type.isOptionalInputType() ||
+
+                // for nullable parameters that have no explicit default, we pass in null if not in input
+                parameter.isNotOptionalNullable()
+        }
+        val constructorArguments = constructorParameters.associateWith { parameter ->
+            convertArgumentValue(parameter.getName(), parameter, input)
+        }
+        return targetConstructor.callBy(constructorArguments)
+    }
+}

--- a/generator/graphql-kotlin-schema-generator/src/main/resources/META-INF/services/com.expediagroup.graphql.generator.execution.spi.ArgumentObjectConverter
+++ b/generator/graphql-kotlin-schema-generator/src/main/resources/META-INF/services/com.expediagroup.graphql.generator.execution.spi.ArgumentObjectConverter
@@ -1,0 +1,1 @@
+com.expediagroup.graphql.generator.execution.spi.DefaultArgumentObjectConverter

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/execution/DummyArgumentObjectConverter.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/execution/DummyArgumentObjectConverter.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.generator.execution
+
+import com.expediagroup.graphql.generator.execution.spi.ArgumentObjectConverter
+import kotlin.reflect.KClass
+import kotlin.reflect.full.isSubclassOf
+
+class DummyArgumentObjectConverter : ArgumentObjectConverter {
+    override val priority: Int = -1
+
+    override fun <T : Any> doesSupport(targetClass: KClass<T>): Boolean = targetClass
+        .isSubclassOf(ConvertArgumentValueTest.TestInputCustomConverted::class)
+
+    override fun <T : Any> convert(input: Map<String, *>, targetClass: KClass<T>): T {
+        @Suppress("UNCHECKED_CAST")
+        return ConvertArgumentValueTest.TestInputCustomConverted(
+            input[ConvertArgumentValueTest.TestInputCustomConverted::class.toString()].toString() + ArgumentObjectConverter::class
+        ) as T
+    }
+}

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/execution/spi/DefaultArgumentObjectConverterTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/execution/spi/DefaultArgumentObjectConverterTest.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.generator.execution.spi
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class DefaultArgumentObjectConverterTest {
+
+    private val defaultArgumentObjectConverter = DefaultArgumentObjectConverter()
+
+    @Test
+    fun `default priority is always zero (0)`() {
+        assertEquals(Int.MAX_VALUE, defaultArgumentObjectConverter.priority)
+    }
+
+    @Test
+    fun `doesSupport always return true`() {
+        assertTrue(defaultArgumentObjectConverter.doesSupport(DefaultArgumentObjectConverterTest::class))
+        assertTrue(defaultArgumentObjectConverter.doesSupport(DefaultArgumentObjectConverter::class))
+        assertTrue(defaultArgumentObjectConverter.doesSupport(Map::class))
+    }
+}

--- a/generator/graphql-kotlin-schema-generator/src/test/resources/META-INF/services/com.expediagroup.graphql.generator.execution.spi.ArgumentObjectConverter
+++ b/generator/graphql-kotlin-schema-generator/src/test/resources/META-INF/services/com.expediagroup.graphql.generator.execution.spi.ArgumentObjectConverter
@@ -1,0 +1,1 @@
+com.expediagroup.graphql.generator.execution.DummyArgumentObjectConverter

--- a/website/docs/schema-generator/execution/argument-object-converter.md
+++ b/website/docs/schema-generator/execution/argument-object-converter.md
@@ -1,0 +1,47 @@
+---
+id: argument-object-converter
+title: Argument Object Converter
+---
+`ArgumentObjectConverter` allows application and library developers to provide their own implementation
+and logic for how to convert the input argument. The `ArgumentObjectConverter` provide a way to extend
+this library easily. It is using the service provider spec from `java.util.ServiceLoader`.
+By default, `graphql-kotlin-schema-generator` provides `DefaultArgumentObjectConverter` to convert the input argument
+value to the corresponding JVM object.
+
+## Custom `ArgumentObjectConverter`
+
+In order to use your custom implementations of the interface `ArgumentObjectConverter` you need to register your
+custom implementations in the service file at
+`META-INF/services/com.expediagroup.graphql.generator.execution.spi.ArgumentObjectConverter`
+in your jar file with the fully qualified name of the class. You can put multiple implementation of the interface in
+the service file.
+
+### Example
+
+Assume you want to provide a custom input object converter for class `Foo`.
+You implement the interface `ArgumentObjectConverter` like `FooArgumentObjectConverter`:
+
+```kotlin
+package com.example.graphql.converters
+
+data class Foo(val bar: String)
+
+class FooArgumentObjectConverter : ArgumentObjectConverter {
+    override val priority: Int = -1
+
+    override fun <T : Any> doesSupport(targetClass: KClass<T>): Boolean = targetClass
+            .isSubclassOf(Foo::class)
+
+    override fun <T : Any> convert(input: Map<String, *>, targetClass: KClass<T>): T {
+        return Foo(bar = input["baz"])
+    }
+}
+```
+
+You register your class `ArgumentObjectConverter` in the service provider file at
+`META-INF/services/com.expediagroup.graphql.generator.execution.spi.ArgumentObjectConverter` with the content:
+
+```text
+# Line comment
+com.example.graphql.converters.FooArgumentObjectConverter
+```

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -49,6 +49,7 @@ module.exports = {
           'schema-generator/execution/exceptions',
           'schema-generator/execution/data-fetching-environment',
           'schema-generator/execution/contextual-data',
+          'schema-generator/execution/argument-object-converter',
           'schema-generator/execution/optional-undefined-arguments',
           'schema-generator/execution/subscriptions',
           'schema-generator/execution/introspection'


### PR DESCRIPTION
…ObjectConverter

### :pencil: Description
`ArgumentObjectConverter` allows application and library developers to provide their own implementation
and logic for how to convert the input argument. The `ArgumentObjectConverter` provide a way to extend
this library easily. It is using the service provider spec from `java.util.ServiceLoader`.
By default, `graphql-kotlin-schema-generator` provides `DefaultArgumentObjectConverter` to convert the input argument
value to the corresponding JVM object.

### :link: Related Links

[ServiceLoader JavaDoc](https://docs.oracle.com/javase/7/docs/api/java/util/ServiceLoader.html)
[Java Service Provider Interface @ baeldung](https://www.baeldung.com/java-spi)
