### PR TITLE
[federation] use federation-jvm ServiceSDLPrinter

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -22,8 +22,8 @@ kotlinxSerializationVersion = 1.3.2
 
 androidPluginVersion = 7.1.2
 classGraphVersion = 4.8.149
-federationGraphQLVersion = 2.0.4
-graphQLJavaVersion = 19.1
+federationGraphQLVersion = 2.0.7
+graphQLJavaVersion = 19.2
 graphQLJavaDataLoaderVersion = 3.2.0
 jacksonVersion = 2.13.3
 # KotlinPoet v1.12.0+ requires Kotlin v1.7


### PR DESCRIPTION
### :pencil: Description

Updated `FederatedSchemaGeneratorHooks` to use `ServiceSDLPrinter` provided by the `federation-jvm` in favor of our custom printer logic.

### :link: Related Issues
