### PR TITLE
chore: #1549 upgrade to kotlin 1.7.20

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,10 +15,9 @@ org.gradle.jvmargs=-Xmx2g -XX:+HeapDumpOnOutOfMemoryError
 
 # dependencies
 kotlinJvmVersion = 1.8
-kotlinVersion = 1.6.21
+kotlinVersion = 1.7.20
 kotlinCoroutinesVersion = 1.6.4
-# kotlinx-serialization 1.3.3 calls Kotlin 1.7 API
-kotlinxSerializationVersion = 1.3.2
+kotlinxSerializationVersion = 1.3.3
 
 androidPluginVersion = 7.1.2
 classGraphVersion = 4.8.149
@@ -26,8 +25,7 @@ federationGraphQLVersion = 2.0.7
 graphQLJavaVersion = 19.2
 graphQLJavaDataLoaderVersion = 3.2.0
 jacksonVersion = 2.13.3
-# KotlinPoet v1.12.0+ requires Kotlin v1.7
-kotlinPoetVersion = 1.11.0
+kotlinPoetVersion = 1.12.0
 ktorVersion = 2.0.3
 reactorVersion = 3.4.21
 reactorExtensionsVersion = 1.1.7
@@ -37,12 +35,10 @@ springVersion = 5.3.22
 
 # test dependency versions
 # kotlin-compile-testing has to be using the same kotlin version as the kotlinx-serialization compiler
-# kotlin-compile-testing v1.4.9+ requires Kotlin v1.7
-compileTestingVersion = 1.4.8
+compileTestingVersion = 1.4.9
 icuVersion=71.1
 junitVersion = 5.8.2
-# mockk v1.12.5+ requires Kotlin 1.7
-mockkVersion = 1.12.4
+mockkVersion = 1.12.5
 mustacheVersion = 0.9.10
 rxjavaVersion = 3.1.5
 wireMockVersion = 2.33.2
@@ -52,8 +48,7 @@ kotlinxBenchmarkVersion = 0.4.4
 detektVersion = 1.21.0
 dokkaVersion = 1.6.10
 jacocoVersion = 0.8.8
-# ktlint v0.46.0+ requires Kotlin 1.7
-ktlintVersion = 0.45.2
+ktlintVersion = 0.46.0
 ktlintPluginVersion = 10.3.0
 mavenPluginDevelopmentVersion = 0.4.0
 nexusPublishPluginVersion = 1.1.0


### PR DESCRIPTION
### :pencil: Description

- Upgrade to Kotlin 1.7.20
- Upgrade the rest of the dependencies related to the kotlin version
- Delete references to kotlin 1.7 limitation according to #1564

### :link: Related Issues
 
- #1564
