### PR TITLE
feat: graphQL errors per federated type element in batch

### DIFF
--- a/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/execution/FederatedTypeResolver.kt
+++ b/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/execution/FederatedTypeResolver.kt
@@ -25,7 +25,7 @@ package com.expediagroup.graphql.generator.federation.execution
 sealed interface FederatedTypeResolver {
     /**
      * This is the GraphQL name of the type. It is used when running the resolvers and inspecting the
-     * GraphQL "__typename" property during the entities requests
+     * GraphQL "__typename" property during the entities requests.
      */
     val typeName: String
 }

--- a/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/execution/FederatedTypeSuspendResolver.kt
+++ b/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/execution/FederatedTypeSuspendResolver.kt
@@ -19,9 +19,6 @@ package com.expediagroup.graphql.generator.federation.execution
 import graphql.schema.DataFetchingEnvironment
 
 interface FederatedTypeSuspendResolver<out T> : FederatedTypeResolver {
-
-    override val typeName: String
-
     /**
      * Resolves underlying federated types by using suspending functions
      *

--- a/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/execution/resolverexecutor/FederatedTypePromiseResolverExecutorTest.kt
+++ b/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/execution/resolverexecutor/FederatedTypePromiseResolverExecutorTest.kt
@@ -18,6 +18,7 @@ package com.expediagroup.graphql.generator.federation.execution.resolverexecutor
 
 import com.expediagroup.graphql.generator.federation.exception.FederatedRequestFailure
 import com.expediagroup.graphql.generator.federation.execution.FederatedTypePromiseResolver
+import graphql.GraphQLContext
 import graphql.schema.DataFetchingEnvironment
 import io.mockk.coEvery
 import io.mockk.every
@@ -27,11 +28,11 @@ import org.junit.jupiter.api.Test
 import reactor.kotlin.core.publisher.toMono
 import java.time.Duration
 import kotlin.test.assertEquals
-import kotlin.test.assertTrue
+import kotlin.test.assertIs
 
 class FederatedTypePromiseResolverExecutorTest {
     @Test
-    fun `resolver executor should call the resolver`() {
+    fun `resolver executor should invoke the resolver and provide results in order`() {
         val environment = mockk<DataFetchingEnvironment>()
         val mockResolverA = mockk<FederatedTypePromiseResolver<*>> {
             every { typeName } returns "MyTypeA"
@@ -82,21 +83,36 @@ class FederatedTypePromiseResolverExecutorTest {
 
     @Test
     fun `resolver maps the value to a failure when the federated resolver throws an exception`() {
-        val representation = emptyMap<String, Any>()
-        val indexedRequests: List<IndexedValue<Map<String, Any>>> = listOf(IndexedValue(7, representation))
-        val mockResolver: FederatedTypePromiseResolver<*> = mockk {
+        val representation1 = mapOf("__typename" to "MyType", "id" to 1)
+        val representation2 = mapOf("__typename" to "MyType", "id" to 2)
+
+        val indexedRequests: List<IndexedValue<Map<String, Any>>> = listOf(
+            IndexedValue(1, representation1),
+            IndexedValue(2, representation2)
+        )
+
+        val mockResolver = mockk<FederatedTypePromiseResolver<*>> {
             every { typeName } returns "MyType"
-            every { resolve(any(), any()) } throws Exception("custom exception")
+            every { resolve(any(), representation1) } returns "MyType1".toMono().delayElement(Duration.ofMillis(100)).toFuture()
+            every { resolve(any(), representation2) } throws Exception("custom exception")
         }
 
         val resolvableEntity = ResolvableEntity("MyType", indexedRequests, mockResolver)
-        val environment = mockk<DataFetchingEnvironment>()
+        val environment = mockk<DataFetchingEnvironment> {
+            every { graphQlContext } returns GraphQLContext.newContext().build()
+        }
 
         val result = FederatedTypePromiseResolverExecutor.execute(listOf(resolvableEntity), environment).get()
-        assertTrue(result.isNotEmpty())
-        val mappedValue = result.first()
-        val response = mappedValue[7]
-        assertTrue(response is FederatedRequestFailure)
-        verify(exactly = 1) { mockResolver.resolve(any(), any()) }
+        assertEquals(1, result.size)
+
+        val resolverResults = result[0]
+
+        assertEquals("MyType1", resolverResults[1])
+        assertIs<FederatedRequestFailure>(resolverResults[2])
+
+        verify(exactly = 1) {
+            mockResolver.resolve(any(), representation1)
+            mockResolver.resolve(any(), representation2)
+        }
     }
 }


### PR DESCRIPTION
### :pencil: Description
Allowing each element in a `_entities` query batch to fail (by throwing an exception) without breaking the execution of the other representations

### :link: Related Issues
https://github.com/ExpediaGroup/graphql-kotlin/issues/1563