### PR TITLE
[docs] custom scalars & optional/nullable types

### DIFF
--- a/website/docs/schema-generator/writing-schemas/arguments.md
+++ b/website/docs/schema-generator/writing-schemas/arguments.md
@@ -116,5 +116,7 @@ See: https://youtrack.jetbrains.com/issue/KT-27598
 
 which was partially fixed in: https://github.com/JetBrains/kotlin/pull/4746
 
-This will be fixed once `graphql-kotlin` updates to kotlin 1.7
+This will be fixed once `graphql-kotlin` updates to kotlin 1.7.
+
+More info: https://github.com/ExpediaGroup/graphql-kotlin/issues/1564
 :::


### PR DESCRIPTION
### :pencil: Description
As part of an issue created within graphql-kotlin, we need to update the graphql-kotlin v6.x.x documentation stating that the custom scalars combined with optional/nullable types on constructors are not supported.

As a comment, this issue will get addressed once the update to Kotlin v1.7 is done.

### :link: Related Issues
https://github.com/ExpediaGroup/graphql-kotlin/issues/1564

![image](https://user-images.githubusercontent.com/30264289/194936935-90c492ee-424f-4afe-bf39-e55b36420d73.png)


