### PR TITLE
[examples] Remove unrecognized JVM option

### DIFF
--- a/examples/gradle.properties
+++ b/examples/gradle.properties
@@ -8,4 +8,4 @@ kapt.incremental.apt=true
 
 # Increase the memory to run on GH Actions
 # See: https://github.com/gradle/gradle/issues/8139
-org.gradle.jvmargs=-Xmx2g -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError
+org.gradle.jvmargs=-Xmx2g -XX:+HeapDumpOnOutOfMemoryError


### PR DESCRIPTION
### :pencil: Description
This option is failing builds locally for the examples project

### :link: Related Issues

