### PR TITLE
[client] update Jackson client to always annotate input fields

### DIFF
--- a/clients/graphql-kotlin-client-jackson/src/test/kotlin/com/expediagroup/graphql/client/jackson/GraphQLClientJacksonSerializerTest.kt
+++ b/clients/graphql-kotlin-client-jackson/src/test/kotlin/com/expediagroup/graphql/client/jackson/GraphQLClientJacksonSerializerTest.kt
@@ -297,7 +297,12 @@ class GraphQLClientJacksonSerializerTest {
             |    "requiredInput" : 123,
             |    "nullableListNullableElements" : [ null ],
             |    "nullableElementList" : [ "foo", null ],
-            |    "nonNullableElementList" : [ ]
+            |    "nonNullableElementList" : [ ],
+            |    "inputObject" : {
+            |      "isNotBoolean" : "yes",
+            |      "NOT" : false,
+            |      "pID" : "1"
+            |    }
             |  },
             |  "query" : "INPUT_QUERY",
             |  "operationName" : "InputQuery"

--- a/clients/graphql-kotlin-client-jackson/src/test/kotlin/com/expediagroup/graphql/client/jackson/data/EmptyInputQuery.kt
+++ b/clients/graphql-kotlin-client-jackson/src/test/kotlin/com/expediagroup/graphql/client/jackson/data/EmptyInputQuery.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Expedia, Inc
+ * Copyright 2022 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package com.expediagroup.graphql.client.jackson.data
 
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
+import com.fasterxml.jackson.annotation.JsonProperty
 import kotlin.reflect.KClass
 
 class EmptyInputQuery(
@@ -30,6 +31,7 @@ class EmptyInputQuery(
     override fun responseType(): KClass<Result> = Result::class
 
     data class Variables(
+        @get:JsonProperty("nullable")
         val nullable: Int? = null
     )
 

--- a/clients/graphql-kotlin-client-jackson/src/test/kotlin/com/expediagroup/graphql/client/jackson/data/EntitiesQuery.kt
+++ b/clients/graphql-kotlin-client-jackson/src/test/kotlin/com/expediagroup/graphql/client/jackson/data/EntitiesQuery.kt
@@ -19,6 +19,7 @@ package com.expediagroup.graphql.client.jackson.data
 import com.expediagroup.graphql.client.jackson.data.entitiesquery._Entity
 import com.expediagroup.graphql.client.jackson.data.scalars.AnyToAnyConverter
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
+import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.fasterxml.jackson.databind.annotation.JsonSerialize
 import kotlin.reflect.KClass
@@ -35,6 +36,7 @@ class EntitiesQuery(
     data class Variables(
         @JsonSerialize(contentConverter = AnyToAnyConverter::class)
         @JsonDeserialize(contentConverter = AnyToAnyConverter::class)
+        @get:JsonProperty("representations")
         public val representations: List<Any>,
     )
 

--- a/clients/graphql-kotlin-client-jackson/src/test/kotlin/com/expediagroup/graphql/client/jackson/data/EnumQuery.kt
+++ b/clients/graphql-kotlin-client-jackson/src/test/kotlin/com/expediagroup/graphql/client/jackson/data/EnumQuery.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Expedia, Inc
+ * Copyright 2022 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package com.expediagroup.graphql.client.jackson.data
 
 import com.expediagroup.graphql.client.jackson.data.enums.TestEnum
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
+import com.fasterxml.jackson.annotation.JsonProperty
 import kotlin.reflect.KClass
 
 class EnumQuery(
@@ -30,6 +31,7 @@ class EnumQuery(
     override fun responseType(): KClass<Result> = Result::class
 
     data class Variables(
+        @get:JsonProperty("enum")
         val enum: TestEnum? = null
     )
 

--- a/clients/graphql-kotlin-client-jackson/src/test/kotlin/com/expediagroup/graphql/client/jackson/data/InputQuery.kt
+++ b/clients/graphql-kotlin-client-jackson/src/test/kotlin/com/expediagroup/graphql/client/jackson/data/InputQuery.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Expedia, Inc
+ * Copyright 2022 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,9 @@
 
 package com.expediagroup.graphql.client.jackson.data
 
+import com.expediagroup.graphql.client.jackson.data.inputs.InputObject
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
+import com.fasterxml.jackson.annotation.JsonProperty
 import kotlin.String
 import kotlin.collections.List
 import kotlin.reflect.KClass
@@ -31,12 +33,20 @@ class InputQuery(
     override fun responseType(): KClass<Result> = Result::class
 
     data class Variables(
+        @get:JsonProperty("requiredInput")
         val requiredInput: Int,
+        @get:JsonProperty("nullableId")
         val nullableId: Int? = null,
+        @get:JsonProperty("nullableListNullableElements")
         val nullableListNullableElements: List<String?>? = null,
+        @get:JsonProperty("nullableListNonNullableElements")
         val nullableListNonNullableElements: List<String>? = null,
+        @get:JsonProperty("nullableElementList")
         val nullableElementList: List<String?>,
-        val nonNullableElementList: List<String>
+        @get:JsonProperty("nonNullableElementList")
+        val nonNullableElementList: List<String>,
+        @get:JsonProperty("inputObject")
+        val inputObject: InputObject = InputObject()
     )
 
     data class Result(

--- a/clients/graphql-kotlin-client-jackson/src/test/kotlin/com/expediagroup/graphql/client/jackson/data/OptionalInputQuery.kt
+++ b/clients/graphql-kotlin-client-jackson/src/test/kotlin/com/expediagroup/graphql/client/jackson/data/OptionalInputQuery.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Expedia, Inc
+ * Copyright 2022 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package com.expediagroup.graphql.client.jackson.data
 
 import com.expediagroup.graphql.client.jackson.types.OptionalInput
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
+import com.fasterxml.jackson.annotation.JsonProperty
 import kotlin.reflect.KClass
 
 class OptionalInputQuery(
@@ -30,9 +31,13 @@ class OptionalInputQuery(
     override fun responseType(): KClass<Result> = Result::class
 
     data class Variables(
+        @get:JsonProperty("requiredInput")
         val requiredInput: Int,
+        @get:JsonProperty("optionalIntInput")
         val optionalIntInput: OptionalInput<Int> = OptionalInput.Undefined,
+        @get:JsonProperty("optionalStringInput")
         val optionalStringInput: OptionalInput<String> = OptionalInput.Undefined,
+        @get:JsonProperty("optionalBooleanInput")
         val optionalBooleanInput: OptionalInput<Boolean> = OptionalInput.Undefined
     )
 

--- a/clients/graphql-kotlin-client-jackson/src/test/kotlin/com/expediagroup/graphql/client/jackson/data/ScalarQuery.kt
+++ b/clients/graphql-kotlin-client-jackson/src/test/kotlin/com/expediagroup/graphql/client/jackson/data/ScalarQuery.kt
@@ -19,6 +19,7 @@ package com.expediagroup.graphql.client.jackson.data
 import com.expediagroup.graphql.client.jackson.data.scalars.AnyToUUIDConverter
 import com.expediagroup.graphql.client.jackson.data.scalars.UUIDToAnyConverter
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
+import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.fasterxml.jackson.databind.annotation.JsonSerialize
 import java.util.UUID
@@ -37,9 +38,11 @@ class ScalarQuery(
     override fun responseType(): KClass<Result> = Result::class
 
     data class Variables(
+        @get:JsonProperty("alias")
         val alias: ID? = null,
         @JsonSerialize(converter = UUIDToAnyConverter::class)
         @JsonDeserialize(converter = AnyToUUIDConverter::class)
+        @get:JsonProperty("custom")
         val custom: UUID? = null
     )
 

--- a/clients/graphql-kotlin-client-jackson/src/test/kotlin/com/expediagroup/graphql/client/jackson/data/inputs/InputObject.kt
+++ b/clients/graphql-kotlin-client-jackson/src/test/kotlin/com/expediagroup/graphql/client/jackson/data/inputs/InputObject.kt
@@ -14,27 +14,16 @@
  * limitations under the License.
  */
 
-package com.expediagroup.graphql.client.jackson.data
+package com.expediagroup.graphql.client.jackson.data.inputs
 
-import com.expediagroup.graphql.client.types.GraphQLClientRequest
+import com.expediagroup.graphql.client.jackson.data.ID
 import com.fasterxml.jackson.annotation.JsonProperty
-import kotlin.reflect.KClass
 
-class FirstQuery(
-    override val variables: Variables
-) : GraphQLClientRequest<FirstQuery.Result> {
-    override val query: String = "FIRST_QUERY"
-
-    override val operationName: String = "FirstQuery"
-
-    override fun responseType(): KClass<Result> = Result::class
-
-    data class Variables(
-        @get:JsonProperty("input")
-        val input: Float? = null
-    )
-
-    data class Result(
-        val stringResult: String
-    )
-}
+data class InputObject(
+    @get:JsonProperty("isNotBoolean")
+    val isNotBoolean: String = "yes",
+    @get:JsonProperty("NOT")
+    val NOT: Boolean = false,
+    @get:JsonProperty("pID")
+    val pID: ID = "1",
+)

--- a/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/types/generateGraphQLInputObjectTypeSpec.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/types/generateGraphQLInputObjectTypeSpec.kt
@@ -20,6 +20,7 @@ import com.expediagroup.graphql.client.Generated
 import com.expediagroup.graphql.plugin.client.generator.GraphQLClientGeneratorContext
 import com.expediagroup.graphql.plugin.client.generator.GraphQLSerializer
 import com.expediagroup.graphql.plugin.client.generator.ScalarConverterInfo
+import com.fasterxml.jackson.annotation.JsonProperty
 import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.BOOLEAN
 import com.squareup.kotlinpoet.ClassName
@@ -165,6 +166,17 @@ internal fun createInputPropertySpec(
                 }
             } else {
                 builder.addAnnotations(scalarAnnotations)
+            }
+
+            if (context.serializer == GraphQLSerializer.JACKSON) {
+                // always add @get:JsonProperty annotation as a workaround to Jackson limitations
+                // related to JavaBean naming conventions
+                builder.addAnnotation(
+                    AnnotationSpec.builder(JsonProperty::class)
+                        .useSiteTarget(AnnotationSpec.UseSiteTarget.GET)
+                        .addMember("value = \"$graphqlFieldName\"")
+                        .build()
+                )
             }
         }
         .build()

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/custom_scalar_input/CustomScalarInputQuery.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/custom_scalar_input/CustomScalarInputQuery.kt
@@ -8,6 +8,7 @@ import com.expediagroup.graphql.generated.inputs.ScalarWrapperInput
 import com.expediagroup.graphql.generated.scalars.AnyToULocaleConverter
 import com.expediagroup.graphql.generated.scalars.OptionalScalarInputSerializer
 import com.expediagroup.graphql.generated.scalars.ULocaleToAnyConverter
+import com.fasterxml.jackson.`annotation`.JsonProperty
 import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonSerialize
 import com.ibm.icu.util.ULocale
@@ -33,9 +34,12 @@ public class CustomScalarInputQuery(
   public data class Variables(
     @JsonSerialize(converter = ULocaleToAnyConverter::class)
     @JsonDeserialize(converter = AnyToULocaleConverter::class)
+    @get:JsonProperty(value = "requiredLocale")
     public val requiredLocale: ULocale,
     @JsonSerialize(using = OptionalScalarInputSerializer::class)
+    @get:JsonProperty(value = "optionalLocale")
     public val optionalLocale: OptionalInput<ULocale> = OptionalInput.Undefined,
+    @get:JsonProperty(value = "scalarWrapper")
     public val scalarWrapper: OptionalInput<ScalarWrapperInput> = OptionalInput.Undefined,
   )
 

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/custom_scalar_input/inputs/ScalarWrapperInput.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/custom_scalar_input/inputs/ScalarWrapperInput.kt
@@ -7,6 +7,7 @@ import com.expediagroup.graphql.generated.ID
 import com.expediagroup.graphql.generated.scalars.AnyToULocaleConverter
 import com.expediagroup.graphql.generated.scalars.OptionalScalarInputSerializer
 import com.expediagroup.graphql.generated.scalars.ULocaleToAnyConverter
+import com.fasterxml.jackson.`annotation`.JsonProperty
 import com.fasterxml.jackson.databind.`annotation`.JsonDeserialize
 import com.fasterxml.jackson.databind.`annotation`.JsonSerialize
 import com.ibm.icu.util.ULocale
@@ -25,51 +26,62 @@ public data class ScalarWrapperInput(
   /**
    * A signed 32-bit nullable integer value
    */
+  @get:JsonProperty(value = "count")
   public val count: OptionalInput<Int> = OptionalInput.Undefined,
   /**
    * Custom scalar of UUID
    */
   @JsonSerialize(using = OptionalScalarInputSerializer::class)
+  @get:JsonProperty(value = "custom")
   public val custom: OptionalInput<UUID> = OptionalInput.Undefined,
   /**
    * List of custom scalar UUIDs
    */
   @JsonSerialize(using = OptionalScalarInputSerializer::class)
+  @get:JsonProperty(value = "customList")
   public val customList: OptionalInput<List<UUID>> = OptionalInput.Undefined,
   /**
    * ID represents unique identifier that is not intended to be human readable
    */
+  @get:JsonProperty(value = "id")
   public val id: ID,
   /**
    * Optional ID
    */
+  @get:JsonProperty(value = "optionalId")
   public val optionalId: OptionalInput<ID> = OptionalInput.Undefined,
   /**
    * UTF-8 character sequence
    */
+  @get:JsonProperty(value = "name")
   public val name: String,
   /**
    * Optional list of names
    */
+  @get:JsonProperty(value = "nameList")
   public val nameList: OptionalInput<List<String>> = OptionalInput.Undefined,
   /**
    * A nullable signed double-precision floating-point value
    */
+  @get:JsonProperty(value = "rating")
   public val rating: OptionalInput<Double> = OptionalInput.Undefined,
   /**
    * Either true or false
    */
+  @get:JsonProperty(value = "valid")
   public val valid: Boolean,
   /**
    * Custom scalar of Locale
    */
   @JsonSerialize(converter = ULocaleToAnyConverter::class)
   @JsonDeserialize(converter = AnyToULocaleConverter::class)
+  @get:JsonProperty(value = "locale")
   public val locale: ULocale,
   /**
    * List of custom scalar Locales
    */
   @JsonSerialize(contentConverter = ULocaleToAnyConverter::class)
   @JsonDeserialize(contentConverter = AnyToULocaleConverter::class)
+  @get:JsonProperty(value = "listLocale")
   public val listLocale: List<ULocale>,
 )

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/variables/JacksonInputQuery.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/variables/JacksonInputQuery.kt
@@ -5,6 +5,7 @@ import com.expediagroup.graphql.client.jackson.types.OptionalInput
 import com.expediagroup.graphql.client.jackson.types.OptionalInput.Undefined
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
 import com.expediagroup.graphql.generated.inputs.SimpleArgumentInput
+import com.fasterxml.jackson.`annotation`.JsonProperty
 import kotlin.Boolean
 import kotlin.String
 import kotlin.reflect.KClass
@@ -25,6 +26,7 @@ public class JacksonInputQuery(
 
   @Generated
   public data class Variables(
+    @get:JsonProperty(value = "input")
     public val input: OptionalInput<SimpleArgumentInput> = OptionalInput.Undefined,
   )
 

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/variables/inputs/SimpleArgumentInput.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/jackson/variables/inputs/SimpleArgumentInput.kt
@@ -3,6 +3,7 @@ package com.expediagroup.graphql.generated.inputs
 import com.expediagroup.graphql.client.Generated
 import com.expediagroup.graphql.client.jackson.types.OptionalInput
 import com.expediagroup.graphql.client.jackson.types.OptionalInput.Undefined
+import com.fasterxml.jackson.`annotation`.JsonProperty
 import kotlin.Double
 import kotlin.String
 
@@ -14,13 +15,16 @@ public data class SimpleArgumentInput(
   /**
    * Maximum value for test criteria
    */
+  @get:JsonProperty(value = "max")
   public val max: OptionalInput<Double> = OptionalInput.Undefined,
   /**
    * Minimum value for test criteria
    */
+  @get:JsonProperty(value = "min")
   public val min: OptionalInput<Double> = OptionalInput.Undefined,
   /**
    * New value to be set
    */
+  @get:JsonProperty(value = "newName")
   public val newName: OptionalInput<String> = OptionalInput.Undefined,
 )

--- a/plugins/client/graphql-kotlin-client-generator/src/test/kotlin/com/expediagroup/graphql/plugin/client/generator/GenerateJacksonClientIT.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/kotlin/com/expediagroup/graphql/plugin/client/generator/GenerateJacksonClientIT.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Expedia, Inc
+ * Copyright 2022 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
### :pencil: Description

Update Jackson client generation logic to always annotate input fields with `@get:JsonProperty`. This is a workaround to Jackson limitations due to its reliance on reflections to find getters/setters following JavaBean naming conventions.

Given a simple data class:

```kotlin
data class Foo(
  val isBoolean: Boolean = true,
  val isNotBoolean: String = "yes",
  val NOT: Boolean = true,
  val pID: Int = 1
)
```

It would be serialized as (before this change):

```json
{
  "isBoolean" : true,
  "not" : true,
  "pid" : 1
}
```

After this change:

```json
{
  "isBoolean" : true,
  "isNotBoolean" : "yes",
  "NOT" : true,
  "pID" : 1
}
```

### :link: Related Issues

* resolves https://github.com/ExpediaGroup/graphql-kotlin/issues/1486
* resolves https://github.com/ExpediaGroup/graphql-kotlin/issues/1569
* resolves https://github.com/ExpediaGroup/graphql-kotlin/issues/1578