### PR TITLE
[federation] default to Federation v2

### DIFF
--- a/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/FederatedSchemaGeneratorHooks.kt
+++ b/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/FederatedSchemaGeneratorHooks.kt
@@ -69,7 +69,7 @@ import kotlin.reflect.full.findAnnotation
  */
 open class FederatedSchemaGeneratorHooks(
     private val resolvers: List<FederatedTypeResolver>,
-    private val optInFederationV2: Boolean = false
+    private val optInFederationV2: Boolean = true
 ) : SchemaGeneratorHooks {
     private val validator = FederatedSchemaValidator()
 

--- a/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/FederatedSchemaGeneratorTest.kt
+++ b/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/FederatedSchemaGeneratorTest.kt
@@ -135,7 +135,7 @@ class FederatedSchemaGeneratorTest {
 
         val config = FederatedSchemaGeneratorConfig(
             supportedPackages = listOf("com.expediagroup.graphql.generator.federation.data.queries.federated.v1"),
-            hooks = FederatedSchemaGeneratorHooks(emptyList())
+            hooks = FederatedSchemaGeneratorHooks(emptyList(), optInFederationV2 = false)
         )
 
         val schema = toFederatedSchema(config = config)
@@ -212,7 +212,7 @@ class FederatedSchemaGeneratorTest {
 
         val config = FederatedSchemaGeneratorConfig(
             supportedPackages = listOf("com.expediagroup.graphql.generator.federation.data.queries.simple"),
-            hooks = FederatedSchemaGeneratorHooks(emptyList())
+            hooks = FederatedSchemaGeneratorHooks(emptyList(), optInFederationV2 = false)
         )
 
         val schema = toFederatedSchema(config, listOf(TopLevelObject(SimpleQuery())))
@@ -248,7 +248,7 @@ class FederatedSchemaGeneratorTest {
 
         val config = FederatedSchemaGeneratorConfig(
             supportedPackages = listOf("com.expediagroup.graphql.generator.federation.data.queries.simple"),
-            hooks = FederatedSchemaGeneratorHooks(emptyList())
+            hooks = FederatedSchemaGeneratorHooks(emptyList(), optInFederationV2 = false)
         )
 
         val schema = toFederatedSchema(config, listOf(TopLevelObject(NestedQuery())))

--- a/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePluginIT.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePluginIT.kt
@@ -516,7 +516,7 @@ class GraphQLGradlePluginIT : GraphQLGradlePluginAbstractIT() {
 
         val expectedFederatedSchemaWithCustomScalar =
             """
-            schema {
+            schema @link(import : ["extends", "external", "inaccessible", "key", "override", "provides", "requires", "shareable", "tag", "FieldSet"], url : "https://specs.apollo.dev/federation/v2.0"){
               query: Query
             }
 
@@ -532,6 +532,9 @@ class GraphQLGradlePluginIT : GraphQLGradlePluginAbstractIT() {
             "Marks target field as external meaning it will be resolved by federated schema"
             directive @external on FIELD_DEFINITION
 
+            "Marks location within schema as inaccessible from the GraphQL Gateway"
+            directive @inaccessible on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
             "Directs the executor to include this field or fragment only when the `if` argument is true"
             directive @include(
                 "Included when true."
@@ -539,13 +542,22 @@ class GraphQLGradlePluginIT : GraphQLGradlePluginAbstractIT() {
               ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
             "Space separated list of primary keys needed to access federated object"
-            directive @key(fields: _FieldSet!) repeatable on OBJECT | INTERFACE
+            directive @key(fields: FieldSet!) repeatable on OBJECT | INTERFACE
+
+            "Links definitions within the document to external schemas."
+            directive @link(import: [String], url: String) repeatable on SCHEMA
+
+            "Overrides fields resolution logic from other subgraph. Used for migrating fields from one subgraph to another."
+            directive @override(from: String!) on FIELD_DEFINITION
 
             "Specifies the base type field set that will be selectable by the gateway"
-            directive @provides(fields: _FieldSet!) on FIELD_DEFINITION
+            directive @provides(fields: FieldSet!) on FIELD_DEFINITION
 
             "Specifies required input field set from the base type for a resolver"
-            directive @requires(fields: _FieldSet!) on FIELD_DEFINITION
+            directive @requires(fields: FieldSet!) on FIELD_DEFINITION
+
+            "Indicates that given object and/or field can be resolved by multiple subgraphs"
+            directive @shareable on OBJECT | FIELD_DEFINITION
 
             "Directs the executor to skip this field or fragment when the `if` argument is true."
             directive @skip(
@@ -559,6 +571,9 @@ class GraphQLGradlePluginIT : GraphQLGradlePluginAbstractIT() {
                 url: String!
               ) on SCALAR
 
+            "Allows users to annotate fields and types with additional metadata information"
+            directive @tag(name: String!) repeatable on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
             type Query @extends {
               _service: _Service!
               helloWorld(name: String): String!
@@ -569,11 +584,11 @@ class GraphQLGradlePluginIT : GraphQLGradlePluginAbstractIT() {
               sdl: String!
             }
 
+            "Federation type representing set of fields"
+            scalar FieldSet
+
             "Custom scalar representing UUID"
             scalar UUID
-
-            "Federation type representing set of fields"
-            scalar _FieldSet
             """.trimIndent()
         val buildFileContents =
             """

--- a/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/GraphQLGenerateSDLTaskIT.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/GraphQLGenerateSDLTaskIT.kt
@@ -65,7 +65,7 @@ internal val DEFAULT_SCHEMA =
 
 internal val FEDERATED_SCHEMA =
     """
-    schema {
+    schema @link(import : ["extends", "external", "inaccessible", "key", "override", "provides", "requires", "shareable", "tag", "FieldSet"], url : "https://specs.apollo.dev/federation/v2.0"){
       query: Query
     }
 
@@ -81,6 +81,9 @@ internal val FEDERATED_SCHEMA =
     "Marks target field as external meaning it will be resolved by federated schema"
     directive @external on FIELD_DEFINITION
 
+    "Marks location within schema as inaccessible from the GraphQL Gateway"
+    directive @inaccessible on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
     "Directs the executor to include this field or fragment only when the `if` argument is true"
     directive @include(
         "Included when true."
@@ -88,13 +91,22 @@ internal val FEDERATED_SCHEMA =
       ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
     "Space separated list of primary keys needed to access federated object"
-    directive @key(fields: _FieldSet!) repeatable on OBJECT | INTERFACE
+    directive @key(fields: FieldSet!) repeatable on OBJECT | INTERFACE
+
+    "Links definitions within the document to external schemas."
+    directive @link(import: [String], url: String) repeatable on SCHEMA
+
+    "Overrides fields resolution logic from other subgraph. Used for migrating fields from one subgraph to another."
+    directive @override(from: String!) on FIELD_DEFINITION
 
     "Specifies the base type field set that will be selectable by the gateway"
-    directive @provides(fields: _FieldSet!) on FIELD_DEFINITION
+    directive @provides(fields: FieldSet!) on FIELD_DEFINITION
 
     "Specifies required input field set from the base type for a resolver"
-    directive @requires(fields: _FieldSet!) on FIELD_DEFINITION
+    directive @requires(fields: FieldSet!) on FIELD_DEFINITION
+
+    "Indicates that given object and/or field can be resolved by multiple subgraphs"
+    directive @shareable on OBJECT | FIELD_DEFINITION
 
     "Directs the executor to skip this field or fragment when the `if` argument is true."
     directive @skip(
@@ -108,6 +120,9 @@ internal val FEDERATED_SCHEMA =
         url: String!
       ) on SCALAR
 
+    "Allows users to annotate fields and types with additional metadata information"
+    directive @tag(name: String!) repeatable on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
     type Query @extends {
       _service: _Service!
       helloWorld(name: String): String!
@@ -118,7 +133,7 @@ internal val FEDERATED_SCHEMA =
     }
 
     "Federation type representing set of fields"
-    scalar _FieldSet
+    scalar FieldSet
     """.trimIndent()
 
 class GraphQLGenerateSDLTaskIT : GraphQLGradlePluginAbstractIT() {

--- a/plugins/graphql-kotlin-maven-plugin/src/integration/generate-sdl-federated/src/test/kotlin/com/expediagroup/graphql/plugin/maven/GenerateSDLMojoTest.kt
+++ b/plugins/graphql-kotlin-maven-plugin/src/integration/generate-sdl-federated/src/test/kotlin/com/expediagroup/graphql/plugin/maven/GenerateSDLMojoTest.kt
@@ -36,7 +36,7 @@ class GenerateSDLMojoTest {
         assertTrue(schemaFile.exists(), "schema file was generated")
 
         val expectedSchema = """
-            schema {
+            schema @link(import : ["extends", "external", "inaccessible", "key", "override", "provides", "requires", "shareable", "tag", "FieldSet"], url : "https://specs.apollo.dev/federation/v2.0"){
               query: Query
             }
 
@@ -52,6 +52,9 @@ class GenerateSDLMojoTest {
             "Marks target field as external meaning it will be resolved by federated schema"
             directive @external on FIELD_DEFINITION
 
+            "Marks location within schema as inaccessible from the GraphQL Gateway"
+            directive @inaccessible on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
             "Directs the executor to include this field or fragment only when the `if` argument is true"
             directive @include(
                 "Included when true."
@@ -59,13 +62,22 @@ class GenerateSDLMojoTest {
               ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
             "Space separated list of primary keys needed to access federated object"
-            directive @key(fields: _FieldSet!) repeatable on OBJECT | INTERFACE
+            directive @key(fields: FieldSet!) repeatable on OBJECT | INTERFACE
+
+            "Links definitions within the document to external schemas."
+            directive @link(import: [String], url: String) repeatable on SCHEMA
+
+            "Overrides fields resolution logic from other subgraph. Used for migrating fields from one subgraph to another."
+            directive @override(from: String!) on FIELD_DEFINITION
 
             "Specifies the base type field set that will be selectable by the gateway"
-            directive @provides(fields: _FieldSet!) on FIELD_DEFINITION
+            directive @provides(fields: FieldSet!) on FIELD_DEFINITION
 
             "Specifies required input field set from the base type for a resolver"
-            directive @requires(fields: _FieldSet!) on FIELD_DEFINITION
+            directive @requires(fields: FieldSet!) on FIELD_DEFINITION
+
+            "Indicates that given object and/or field can be resolved by multiple subgraphs"
+            directive @shareable on OBJECT | FIELD_DEFINITION
 
             "Directs the executor to skip this field or fragment when the `if` argument is true."
             directive @skip(
@@ -79,6 +91,9 @@ class GenerateSDLMojoTest {
                 url: String!
               ) on SCALAR
 
+            "Allows users to annotate fields and types with additional metadata information"
+            directive @tag(name: String!) repeatable on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
             type Query @extends {
               _service: _Service!
               helloWorld(name: String): String!
@@ -89,7 +104,7 @@ class GenerateSDLMojoTest {
             }
 
             "Federation type representing set of fields"
-            scalar _FieldSet
+            scalar FieldSet
         """.trimIndent()
         assertEquals(expectedSchema, schemaFile.readText().trim())
     }

--- a/plugins/graphql-kotlin-maven-plugin/src/integration/generate-sdl-hooks/src/test/kotlin/com/expediagroup/graphql/plugin/maven/GenerateSDLMojoTest.kt
+++ b/plugins/graphql-kotlin-maven-plugin/src/integration/generate-sdl-hooks/src/test/kotlin/com/expediagroup/graphql/plugin/maven/GenerateSDLMojoTest.kt
@@ -36,7 +36,7 @@ class GenerateSDLMojoTest {
         assertTrue(schemaFile.exists(), "schema file was generated")
 
         val expectedSchema = """
-            schema {
+            schema @link(import : ["extends", "external", "inaccessible", "key", "override", "provides", "requires", "shareable", "tag", "FieldSet"], url : "https://specs.apollo.dev/federation/v2.0"){
               query: Query
             }
 
@@ -52,6 +52,9 @@ class GenerateSDLMojoTest {
             "Marks target field as external meaning it will be resolved by federated schema"
             directive @external on FIELD_DEFINITION
 
+            "Marks location within schema as inaccessible from the GraphQL Gateway"
+            directive @inaccessible on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
             "Directs the executor to include this field or fragment only when the `if` argument is true"
             directive @include(
                 "Included when true."
@@ -59,13 +62,22 @@ class GenerateSDLMojoTest {
               ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
             "Space separated list of primary keys needed to access federated object"
-            directive @key(fields: _FieldSet!) repeatable on OBJECT | INTERFACE
+            directive @key(fields: FieldSet!) repeatable on OBJECT | INTERFACE
+
+            "Links definitions within the document to external schemas."
+            directive @link(import: [String], url: String) repeatable on SCHEMA
+
+            "Overrides fields resolution logic from other subgraph. Used for migrating fields from one subgraph to another."
+            directive @override(from: String!) on FIELD_DEFINITION
 
             "Specifies the base type field set that will be selectable by the gateway"
-            directive @provides(fields: _FieldSet!) on FIELD_DEFINITION
+            directive @provides(fields: FieldSet!) on FIELD_DEFINITION
 
             "Specifies required input field set from the base type for a resolver"
-            directive @requires(fields: _FieldSet!) on FIELD_DEFINITION
+            directive @requires(fields: FieldSet!) on FIELD_DEFINITION
+
+            "Indicates that given object and/or field can be resolved by multiple subgraphs"
+            directive @shareable on OBJECT | FIELD_DEFINITION
 
             "Directs the executor to skip this field or fragment when the `if` argument is true."
             directive @skip(
@@ -79,6 +91,9 @@ class GenerateSDLMojoTest {
                 url: String!
               ) on SCALAR
 
+            "Allows users to annotate fields and types with additional metadata information"
+            directive @tag(name: String!) repeatable on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
             type Query @extends {
               _service: _Service!
               helloWorld(name: String): String!
@@ -89,11 +104,11 @@ class GenerateSDLMojoTest {
               sdl: String!
             }
 
+            "Federation type representing set of fields"
+            scalar FieldSet
+
             "Custom scalar representing UUID"
             scalar UUID
-
-            "Federation type representing set of fields"
-            scalar _FieldSet
         """.trimIndent()
         assertEquals(expectedSchema, schemaFile.readText().trim())
     }

--- a/plugins/schema/graphql-kotlin-sdl-generator/src/integrationTest/kotlin/com/expediagroup/graphql/plugin/schema/GenerateCustomSDLTest.kt
+++ b/plugins/schema/graphql-kotlin-sdl-generator/src/integrationTest/kotlin/com/expediagroup/graphql/plugin/schema/GenerateCustomSDLTest.kt
@@ -25,7 +25,7 @@ class GenerateCustomSDLTest {
     fun `verify we can generate SDL using custom hooks provider`() {
         val expectedSchema =
             """
-                schema {
+                schema @link(import : ["extends", "external", "inaccessible", "key", "override", "provides", "requires", "shareable", "tag", "FieldSet"], url : "https://specs.apollo.dev/federation/v2.0"){
                   query: Query
                 }
 
@@ -41,6 +41,9 @@ class GenerateCustomSDLTest {
                 "Marks target field as external meaning it will be resolved by federated schema"
                 directive @external on FIELD_DEFINITION
 
+                "Marks location within schema as inaccessible from the GraphQL Gateway"
+                directive @inaccessible on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
                 "Directs the executor to include this field or fragment only when the `if` argument is true"
                 directive @include(
                     "Included when true."
@@ -48,13 +51,22 @@ class GenerateCustomSDLTest {
                   ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
                 "Space separated list of primary keys needed to access federated object"
-                directive @key(fields: _FieldSet!) repeatable on OBJECT | INTERFACE
+                directive @key(fields: FieldSet!) repeatable on OBJECT | INTERFACE
+
+                "Links definitions within the document to external schemas."
+                directive @link(import: [String], url: String) repeatable on SCHEMA
+
+                "Overrides fields resolution logic from other subgraph. Used for migrating fields from one subgraph to another."
+                directive @override(from: String!) on FIELD_DEFINITION
 
                 "Specifies the base type field set that will be selectable by the gateway"
-                directive @provides(fields: _FieldSet!) on FIELD_DEFINITION
+                directive @provides(fields: FieldSet!) on FIELD_DEFINITION
 
                 "Specifies required input field set from the base type for a resolver"
-                directive @requires(fields: _FieldSet!) on FIELD_DEFINITION
+                directive @requires(fields: FieldSet!) on FIELD_DEFINITION
+
+                "Indicates that given object and/or field can be resolved by multiple subgraphs"
+                directive @shareable on OBJECT | FIELD_DEFINITION
 
                 "Directs the executor to skip this field or fragment when the `if` argument is true."
                 directive @skip(
@@ -68,6 +80,9 @@ class GenerateCustomSDLTest {
                     url: String!
                   ) on SCALAR
 
+                "Allows users to annotate fields and types with additional metadata information"
+                directive @tag(name: String!) repeatable on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
                 type Query @extends {
                   _service: _Service!
                   helloWorld(name: String): String!
@@ -78,11 +93,11 @@ class GenerateCustomSDLTest {
                   sdl: String!
                 }
 
+                "Federation type representing set of fields"
+                scalar FieldSet
+
                 "Custom scalar representing UUID"
                 scalar UUID
-
-                "Federation type representing set of fields"
-                scalar _FieldSet
             """.trimIndent()
         val generatedSchema = generateSDL(listOf("com.expediagroup.graphql.plugin.test"))
 

--- a/servers/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/server/spring/GraphQLConfigurationProperties.kt
+++ b/servers/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/server/spring/GraphQLConfigurationProperties.kt
@@ -49,7 +49,7 @@ data class GraphQLConfigurationProperties(
         /**
          * Boolean flag indicating whether we want to generate Federation v2 compatible schema.
          */
-        val optInV2: Boolean = false,
+        val optInV2: Boolean = true,
 
         /**
          * Federation tracing config

--- a/website/docs/schema-generator/federation/apollo-federation.mdx
+++ b/website/docs/schema-generator/federation/apollo-federation.mdx
@@ -25,11 +25,12 @@ Federation v2 is an evolution of the Federation spec to make it more powerful, f
 v2 schemas are similar in many ways, Federation v2 relaxes some of the constraints and adds additional capabilities. See
 [Apollo documentation](https://www.apollographql.com/docs/federation/federation-2/new-in-federation-2/) for details.
 
-By default, `graphql-kotlin-federation` library will generate Federation v1 compatible schema. In order to generate v2
-compatible schema you have to explicitly opt-in by specifying `optInFederationV2 = true` on your instance of `FederatedSchemaGeneratorHooks`.
+By default, `graphql-kotlin-federation` library will generate Federation v2 compatible schema. In order to generate v1
+compatible schema you have to explicitly opt-out by specifying `optInFederationV2 = false` on your instance of
+`FederatedSchemaGeneratorHooks`.
 
 ```kotlin
-val myHooks = FederatedSchemaGeneratorHooks(resolvers = myFederatedResolvers, optInFederationV2 = true)
+val myHooks = FederatedSchemaGeneratorHooks(resolvers = myFederatedResolvers)
 val myConfig = FederatedSchemaGeneratorConfig(
   supportedPackages = "com.example",
   hooks = myHooks
@@ -42,7 +43,8 @@ toFederatedSchema(
 ```
 
 :::note
-Federation v2 compatible schemas, can be generated using `graphql-kotlin-spring-server` by configuring `graphql.federation.optInV2 = true` property.
+When generating federated schemas, `graphql-kotlin-spring-server` defaults to Federation v2. If you want to generate Federation
+v1 schema, you have to explicitly opt-out by configuring `graphql.federation.optInV2 = false` property.
 :::
 
 ## Install
@@ -105,7 +107,7 @@ class Query {
 
 val config = FederatedSchemaGeneratorConfig(
   supportedPackages = "com.example",
-  hooks = FederatedSchemaGeneratorHooks(emptyList(), optInFederationV2 = true)
+  hooks = FederatedSchemaGeneratorHooks(emptyList())
 )
 
 toFederatedSchema(
@@ -117,34 +119,41 @@ toFederatedSchema(
 will generate
 
 ```graphql
-# Federation spec types
-scalar _Any
-scalar FieldSet
-
-union _Entity
-
-type _Service {
-   sdl: String!
+schema @link(import : ["extends", "external", "inaccessible", "key", "override", "provides", "requires", "shareable", "tag", "FieldSet"], url : "https://specs.apollo.dev/federation/v2.0"){
+  query: Query
 }
 
-directive @external on FIELD_DEFINITION
-directive @requires(fields: FieldSet) on FIELD_DEFINITION
-directive @provides(fields: FieldSet) on FIELD_DEFINITION
-directive @key(fields: FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
 directive @extends on OBJECT | INTERFACE
+directive @external on FIELD_DEFINITION
+directive @inaccessible on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @key(fields: FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @link(import: [String], url: String) repeatable on SCHEMA
+directive @override(from: String!) on FIELD_DEFINITION
+directive @provides(fields: FieldSet!) on FIELD_DEFINITION
+directive @requires(fields: FieldSet!) on FIELD_DEFINITION
+directive @shareable on OBJECT | FIELD_DEFINITION
+directive @tag(name: String!) repeatable on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
-# Schema types
-type Query @extends {
+type Query {
    getUsers: [User!]!
 
    _entities(representations: [_Any!]!): [_Entity]!
    _service: _Service!
 }
 
-type User @key(fields : "id") {
+type User @key(fields : "id", resolvable : true) {
    id: ID!
    name: String!
 }
+
+union _Entity = User
+
+type _Service {
+   sdl: String!
+}
+
+scalar FieldSet
+scalar _Any
 ```
 
 ## Limitations


### PR DESCRIPTION
### :pencil: Description

We introduced Federation v2 support with opt-in mechanism in the `graphql-kotlin` v6 release. With v7 we can default to Federation v2 and subsequently drop Fed v1 support in `graphql-kotlin` v8.

### :link: Related Issues

Resolves: https://github.com/ExpediaGroup/graphql-kotlin/issues/1561