### PR TITLE
Configure client generate parser options

### DIFF
--- a/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generateClient.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generateClient.kt
@@ -16,11 +16,9 @@
 
 package com.expediagroup.graphql.plugin.client
 
-import com.expediagroup.graphql.plugin.client.generator.GraphQLClientGenerator
-import com.expediagroup.graphql.plugin.client.generator.GraphQLClientGeneratorConfig
-import com.expediagroup.graphql.plugin.client.generator.GraphQLScalar
-import com.expediagroup.graphql.plugin.client.generator.GraphQLSerializer
+import com.expediagroup.graphql.plugin.client.generator.*
 import com.squareup.kotlinpoet.FileSpec
+import graphql.parser.ParserOptions
 import java.io.File
 
 /**
@@ -33,7 +31,8 @@ fun generateClient(
     serializer: GraphQLSerializer = GraphQLSerializer.JACKSON,
     schemaPath: String,
     queries: List<File>,
-    useOptionalInputWrapper: Boolean = false
+    useOptionalInputWrapper: Boolean = false,
+    parserOptions: ParserOptions.Builder.() -> Unit = {}
 ): List<FileSpec> {
     val customScalars = customScalarsMap.associateBy { it.scalar }
     val config = GraphQLClientGeneratorConfig(
@@ -41,7 +40,8 @@ fun generateClient(
         allowDeprecated = allowDeprecated,
         customScalarMap = customScalars,
         serializer = serializer,
-        useOptionalInputWrapper = useOptionalInputWrapper
+        useOptionalInputWrapper = useOptionalInputWrapper,
+        parserOptions = parserOptions
     )
     val generator = GraphQLClientGenerator(schemaPath, config)
     return generator.generate(queries)

--- a/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generateClient.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generateClient.kt
@@ -16,7 +16,10 @@
 
 package com.expediagroup.graphql.plugin.client
 
-import com.expediagroup.graphql.plugin.client.generator.*
+import com.expediagroup.graphql.plugin.client.generator.GraphQLScalar
+import com.expediagroup.graphql.plugin.client.generator.GraphQLSerializer
+import com.expediagroup.graphql.plugin.client.generator.GraphQLClientGeneratorConfig
+import com.expediagroup.graphql.plugin.client.generator.GraphQLClientGenerator
 import com.squareup.kotlinpoet.FileSpec
 import graphql.parser.ParserOptions
 import java.io.File

--- a/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/GraphQLClientGenerator.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/GraphQLClientGenerator.kt
@@ -33,6 +33,7 @@ import com.squareup.kotlinpoet.TypeSpec
 import graphql.language.ObjectTypeDefinition
 import graphql.language.OperationDefinition
 import graphql.parser.Parser
+import graphql.parser.ParserOptions
 import graphql.schema.idl.SchemaParser
 import graphql.schema.idl.TypeDefinitionRegistry
 import kotlinx.serialization.Required
@@ -53,6 +54,7 @@ class GraphQLClientGenerator(
     private val sharedTypes: MutableMap<ClassName, List<TypeSpec>> = mutableMapOf()
     private var generateOptionalSerializer: Boolean = false
     private val graphQLSchema: TypeDefinitionRegistry
+    private val parserOptions: ParserOptions = ParserOptions.newParserOptions().also { this.config.parserOptions(it) }.build()
 
     init {
         graphQLSchema = parseSchema(schemaPath)
@@ -92,7 +94,7 @@ class GraphQLClientGenerator(
      */
     internal fun generate(queryFile: File): List<FileSpec> {
         val queryConst = queryFile.readText().trim()
-        val queryDocument = documentParser.parseDocument(queryConst)
+        val queryDocument = documentParser.parseDocument(queryConst, parserOptions)
 
         val operationDefinitions = queryDocument.definitions.filterIsInstance(OperationDefinition::class.java)
         if (operationDefinitions.size > 1) {

--- a/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/GraphQLClientGeneratorConfig.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/GraphQLClientGeneratorConfig.kt
@@ -17,6 +17,7 @@
 package com.expediagroup.graphql.plugin.client.generator
 
 import com.squareup.kotlinpoet.ClassName
+import graphql.parser.ParserOptions
 
 /**
  * GraphQL client generator configuration.
@@ -31,7 +32,9 @@ data class GraphQLClientGeneratorConfig(
     /** Type of JSON serializer to be used. */
     val serializer: GraphQLSerializer = GraphQLSerializer.JACKSON,
     /** Explicit opt-in flag to enable support for optional inputs. */
-    val useOptionalInputWrapper: Boolean = false
+    val useOptionalInputWrapper: Boolean = false,
+    /** Set parser options for processing GraphQL queries and schema definition language documents */
+    val parserOptions: ParserOptions.Builder.() -> Unit = {}
 )
 
 /**

--- a/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePlugin.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePlugin.kt
@@ -93,6 +93,7 @@ class GraphQLGradlePlugin : Plugin<Project> {
                 generateClientTask.queryFiles.setFrom(extension.clientExtension.queryFiles)
                 generateClientTask.serializer.convention(extension.clientExtension.serializer)
                 generateClientTask.useOptionalInputWrapper.convention(extension.clientExtension.useOptionalInputWrapper)
+                generateClientTask.parserOptions.convention(extension.clientExtension.parserOptions)
 
                 when {
                     extension.clientExtension.endpoint != null -> {

--- a/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLPluginExtension.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLPluginExtension.kt
@@ -16,6 +16,7 @@
 
 package com.expediagroup.graphql.plugin.gradle
 
+import com.expediagroup.graphql.plugin.gradle.config.GraphQLParserOptions
 import com.expediagroup.graphql.plugin.gradle.config.GraphQLScalar
 import com.expediagroup.graphql.plugin.gradle.config.GraphQLSerializer
 import com.expediagroup.graphql.plugin.gradle.config.TimeoutConfiguration
@@ -83,6 +84,17 @@ open class GraphQLPluginClientExtension {
 
     fun timeout(action: Action<TimeoutConfiguration>) {
         action.execute(timeoutConfig)
+    }
+
+    /** Configure options for parsing GraphQL queries and schema definition language documents. */
+    internal val parserOptions: GraphQLParserOptions = GraphQLParserOptions()
+
+    /**
+     * Configure options for parsing GraphQL queries and schema definition language documents. Settings
+     * here override the defaults set by GraphQL Java.
+     */
+    fun parserOptions(action: Action<GraphQLParserOptions>) {
+        action.execute(parserOptions)
     }
 }
 

--- a/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/actions/GenerateClientAction.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/actions/GenerateClientAction.kt
@@ -39,8 +39,24 @@ abstract class GenerateClientAction : WorkAction<GenerateClientParameters> {
         val queryFiles = parameters.queryFiles.get()
         val targetDirectory = parameters.targetDirectory.get()
         val useOptionalInputWrapper = parameters.useOptionalInputWrapper.get()
+        val parserOptions = parameters.parserOptions.get()
 
-        generateClient(targetPackage, allowDeprecated, customScalarMap, serializer, schemaPath, queryFiles, useOptionalInputWrapper).forEach {
+        generateClient(
+            targetPackage,
+            allowDeprecated,
+            customScalarMap,
+            serializer,
+            schemaPath,
+            queryFiles,
+            useOptionalInputWrapper,
+            parserOptions = {
+                parserOptions.maxTokens?.let { maxTokens(it) }
+                parserOptions.maxWhitespaceTokens?.let { maxWhitespaceTokens(it) }
+                parserOptions.captureIgnoredChars?.let { captureIgnoredChars(it) }
+                parserOptions.captureSourceLocation?.let { captureSourceLocation(it) }
+                parserOptions.captureLineComments?.let { captureLineComments(it) }
+            }
+        ).forEach {
             it.writeTo(targetDirectory)
         }
     }

--- a/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/config/GraphQLParserOptions.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/config/GraphQLParserOptions.kt
@@ -1,0 +1,20 @@
+package com.expediagroup.graphql.plugin.gradle.config
+
+import java.io.Serializable
+
+/**
+ * Configure options for parsing GraphQL queries and schema definition language documents. Settings
+ * here override the defaults set by GraphQL Java.
+ */
+data class GraphQLParserOptions(
+    /** Modify the maximum number of tokens read to prevent processing extremely large queries */
+    var maxTokens: Int? = null,
+    /** Modify the maximum number of whitespace tokens read to prevent processing extremely large queries */
+    var maxWhitespaceTokens: Int? = null,
+    /** Memory usage is significantly reduced by not capturing ignored characters, especially in SDL parsing. */
+    var captureIgnoredChars: Boolean? = null,
+    /** Single-line comments do not have any semantic meaning in GraphQL source documents and can be ignored */
+    var captureLineComments: Boolean? = null,
+    /** Memory usage is reduced by not setting SourceLocations on AST nodes, especially in SDL parsing. */
+    var captureSourceLocation: Boolean? = null
+) : Serializable

--- a/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/config/GraphQLParserOptions.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/config/GraphQLParserOptions.kt
@@ -8,13 +8,13 @@ import java.io.Serializable
  */
 data class GraphQLParserOptions(
     /** Modify the maximum number of tokens read to prevent processing extremely large queries */
-    var maxTokens: Int? = 15000,
+    var maxTokens: Int? = null,
     /** Modify the maximum number of whitespace tokens read to prevent processing extremely large queries */
-    var maxWhitespaceTokens: Int? = 200000,
+    var maxWhitespaceTokens: Int? = null,
     /** Memory usage is significantly reduced by not capturing ignored characters, especially in SDL parsing. */
-    var captureIgnoredChars: Boolean? = false,
+    var captureIgnoredChars: Boolean? = null,
     /** Single-line comments do not have any semantic meaning in GraphQL source documents and can be ignored */
-    var captureLineComments: Boolean? = true,
+    var captureLineComments: Boolean? = null,
     /** Memory usage is reduced by not setting SourceLocations on AST nodes, especially in SDL parsing. */
-    var captureSourceLocation: Boolean? = true
+    var captureSourceLocation: Boolean? = null
 ) : Serializable

--- a/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/config/GraphQLParserOptions.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/config/GraphQLParserOptions.kt
@@ -8,13 +8,13 @@ import java.io.Serializable
  */
 data class GraphQLParserOptions(
     /** Modify the maximum number of tokens read to prevent processing extremely large queries */
-    var maxTokens: Int? = null,
+    var maxTokens: Int? = 15000,
     /** Modify the maximum number of whitespace tokens read to prevent processing extremely large queries */
-    var maxWhitespaceTokens: Int? = null,
+    var maxWhitespaceTokens: Int? = 200000,
     /** Memory usage is significantly reduced by not capturing ignored characters, especially in SDL parsing. */
-    var captureIgnoredChars: Boolean? = null,
+    var captureIgnoredChars: Boolean? = false,
     /** Single-line comments do not have any semantic meaning in GraphQL source documents and can be ignored */
-    var captureLineComments: Boolean? = null,
+    var captureLineComments: Boolean? = true,
     /** Memory usage is reduced by not setting SourceLocations on AST nodes, especially in SDL parsing. */
-    var captureSourceLocation: Boolean? = null
+    var captureSourceLocation: Boolean? = true
 ) : Serializable

--- a/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/parameters/GenerateClientParameters.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/parameters/GenerateClientParameters.kt
@@ -16,6 +16,7 @@
 
 package com.expediagroup.graphql.plugin.gradle.parameters
 
+import com.expediagroup.graphql.plugin.gradle.config.GraphQLParserOptions
 import com.expediagroup.graphql.plugin.gradle.config.GraphQLScalar
 import com.expediagroup.graphql.plugin.gradle.config.GraphQLSerializer
 import org.gradle.api.provider.ListProperty
@@ -44,4 +45,6 @@ interface GenerateClientParameters : WorkParameters {
     val targetDirectory: Property<File>
     /** Explicit opt-in flag to wrap nullable arguments in OptionalInput that supports both null and undefined values. */
     val useOptionalInputWrapper: Property<Boolean>
+    /** Set parser options for processing GraphQL queries and schema definition language documents */
+    val parserOptions: Property<GraphQLParserOptions>
 }

--- a/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/AbstractGenerateClientTask.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/AbstractGenerateClientTask.kt
@@ -17,6 +17,7 @@
 package com.expediagroup.graphql.plugin.gradle.tasks
 
 import com.expediagroup.graphql.plugin.gradle.actions.GenerateClientAction
+import com.expediagroup.graphql.plugin.gradle.config.GraphQLParserOptions
 import com.expediagroup.graphql.plugin.gradle.config.GraphQLScalar
 import com.expediagroup.graphql.plugin.gradle.config.GraphQLSerializer
 import org.gradle.api.DefaultTask
@@ -117,6 +118,10 @@ abstract class AbstractGenerateClientTask : DefaultTask() {
     @Option(option = "useOptionalInputWrapper", description = "Opt-in flag to wrap nullable arguments in OptionalInput that supports both null and undefined.")
     val useOptionalInputWrapper: Property<Boolean> = project.objects.property(Boolean::class.java)
 
+    @Input
+    @Optional
+    val parserOptions: Property<GraphQLParserOptions> = project.objects.property(GraphQLParserOptions::class.java)
+
     @OutputDirectory
     val outputDirectory: DirectoryProperty = project.objects.directoryProperty()
 
@@ -131,6 +136,7 @@ abstract class AbstractGenerateClientTask : DefaultTask() {
         customScalars.convention(emptyList())
         serializer.convention(GraphQLSerializer.JACKSON)
         useOptionalInputWrapper.convention(false)
+        parserOptions.convention(GraphQLParserOptions())
     }
 
     @Suppress("EXPERIMENTAL_API_USAGE")
@@ -177,6 +183,7 @@ abstract class AbstractGenerateClientTask : DefaultTask() {
             parameters.queryFiles.set(targetQueryFiles)
             parameters.targetDirectory.set(targetDirectory)
             parameters.useOptionalInputWrapper.set(useOptionalInputWrapper)
+            parameters.parserOptions.set(parserOptions)
         }
         workQueue.await()
         logger.debug("successfully generated GraphQL HTTP client")
@@ -191,6 +198,7 @@ abstract class AbstractGenerateClientTask : DefaultTask() {
         }
         logger.debug("  packageName = $packageName")
         logger.debug("  allowDeprecatedFields = $allowDeprecatedFields")
+        logger.debug("  parserOptions = $parserOptions")
         logger.debug("  converters")
         customScalars.get().forEach { (customScalar, type, converter) ->
             logger.debug("    - custom scalar = $customScalar")

--- a/plugins/graphql-kotlin-maven-plugin/src/integration/generate-client/pom.xml
+++ b/plugins/graphql-kotlin-maven-plugin/src/integration/generate-client/pom.xml
@@ -78,6 +78,13 @@
                         <configuration>
                             <packageName>com.expediagroup.graphql.plugin.generated</packageName>
                             <schemaFile>schema.graphql</schemaFile>
+                            <parserOptions>
+                                <maxTokens>15000</maxTokens>
+                                <maxWhitespaceTokens>200000</maxWhitespaceTokens>
+                                <captureIgnoredChars>false</captureIgnoredChars>
+                                <captureLineComments>false</captureLineComments>
+                                <captureSourceLocation>true</captureSourceLocation>
+                            </parserOptions>
                         </configuration>
                     </execution>
                 </executions>

--- a/plugins/graphql-kotlin-maven-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/maven/GenerateClientAbstractMojo.kt
+++ b/plugins/graphql-kotlin-maven-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/maven/GenerateClientAbstractMojo.kt
@@ -88,7 +88,7 @@ abstract class GenerateClientAbstractMojo : AbstractMojo() {
      * ```
      */
     @Parameter(name = "parserOptions")
-    private var parserOptions: ParserOptions? = ParserOptions()
+    private var parserOptions: ParserOptions? = null
 
     /**
      * Directory file containing GraphQL queries. Instead of specifying a directory you can also specify list of query file by using
@@ -218,21 +218,21 @@ class CustomScalar {
 class ParserOptions {
     /** Modify the maximum number of tokens read to prevent processing extremely large queries */
     @Parameter
-    var maxTokens: Int? = 15000
+    var maxTokens: Int? = null
 
     /** Modify the maximum number of whitespace tokens read to prevent processing extremely large queries */
     @Parameter
-    var maxWhitespaceTokens: Int? = 200000
+    var maxWhitespaceTokens: Int? = null
 
     /** Memory usage is significantly reduced by not capturing ignored characters, especially in SDL parsing. */
     @Parameter
-    var captureIgnoredChars: Boolean? = false
+    var captureIgnoredChars: Boolean? = null
 
     /** Single-line comments do not have any semantic meaning in GraphQL source documents and can be ignored */
     @Parameter
-    var captureLineComments: Boolean? = true
+    var captureLineComments: Boolean? = null
 
     /** Memory usage is reduced by not setting SourceLocations on AST nodes, especially in SDL parsing. */
     @Parameter
-    var captureSourceLocation: Boolean? = true
+    var captureSourceLocation: Boolean? = null
 }

--- a/plugins/graphql-kotlin-maven-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/maven/GenerateClientAbstractMojo.kt
+++ b/plugins/graphql-kotlin-maven-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/maven/GenerateClientAbstractMojo.kt
@@ -74,6 +74,23 @@ abstract class GenerateClientAbstractMojo : AbstractMojo() {
     private var customScalars: List<CustomScalar> = mutableListOf()
 
     /**
+     * Configure options for parsing GraphQL queries and schema definition language documents. Settings
+     * here override the defaults set by GraphQL Java.
+     *
+     * ```xml
+     * <parserOptions>
+     *     <maxTokens>15000</maxTokens>
+     *     <maxWhitespaceTokens>200000</maxWhitespaceTokens>
+     *     <captureIgnoredChars>false</captureIgnoredChars>
+     *     <captureLineComments>false</captureLineComments>
+     *     <captureSourceLocation>true</captureSourceLocation>
+     * </parserOptions>
+     * ```
+     */
+    @Parameter(name = "parserOptions")
+    private var parserOptions: GraphQLParserOptions = GraphQLParserOptions()
+
+    /**
      * Directory file containing GraphQL queries. Instead of specifying a directory you can also specify list of query file by using
      * [queryFiles] property instead.
      */
@@ -116,7 +133,13 @@ abstract class GenerateClientAbstractMojo : AbstractMojo() {
 
         logConfiguration(schemaPath, targetQueryFiles)
         val customGraphQLScalars = customScalars.map { GraphQLScalar(it.scalar, it.type, it.converter) }
-        generateClient(packageName, allowDeprecatedFields, customGraphQLScalars, serializer, schemaPath, targetQueryFiles, useOptionalInputWrapper).forEach {
+        generateClient(packageName, allowDeprecatedFields, customGraphQLScalars, serializer, schemaPath, targetQueryFiles, useOptionalInputWrapper, parserOptions = {
+            parserOptions.maxTokens?.let { maxTokens(it) }
+            parserOptions.maxWhitespaceTokens?.let { maxWhitespaceTokens(it) }
+            parserOptions.captureIgnoredChars?.let { captureIgnoredChars(it) }
+            parserOptions.captureLineComments?.let { captureLineComments(it) }
+            parserOptions.captureSourceLocation?.let { captureSourceLocation(it) }
+        }).forEach {
             it.writeTo(outputDirectory)
         }
 
@@ -176,4 +199,30 @@ class CustomScalar {
     /** Fully qualified class name of a custom converter used to convert to/from raw JSON and [type] */
     @Parameter
     lateinit var converter: String
+}
+
+/**
+ * Configure options for parsing GraphQL queries and schema definition language documents. Settings
+ * here override the defaults set by GraphQL Java.
+ */
+class GraphQLParserOptions {
+    /** Modify the maximum number of tokens read to prevent processing extremely large queries */
+    @Parameter
+    var maxTokens: Int? = null
+
+    /** Modify the maximum number of whitespace tokens read to prevent processing extremely large queries */
+    @Parameter
+    var maxWhitespaceTokens: Int? = null
+
+    /** Memory usage is significantly reduced by not capturing ignored characters, especially in SDL parsing. */
+    @Parameter
+    var captureIgnoredChars: Boolean? = null
+
+    /** Single-line comments do not have any semantic meaning in GraphQL source documents and can be ignored */
+    @Parameter
+    var captureLineComments: Boolean? = null
+
+    /** Memory usage is reduced by not setting SourceLocations on AST nodes, especially in SDL parsing. */
+    @Parameter
+    var captureSourceLocation: Boolean? = null
 }

--- a/website/docs/plugins/gradle-plugin-tasks.mdx
+++ b/website/docs/plugins/gradle-plugin-tasks.mdx
@@ -207,12 +207,12 @@ graphql {
             options.maxTokens = 15000
             // Override the maximum number of whitespace tokens read to prevent processing extremely large queries.
             options.maxWhitespaceTokens = 200000
-            // Single-line comments do not have any semantic meaning in GraphQL source documents and can be ignored
-            options.captureLineComments = false
             // Memory usage is significantly reduced by not capturing ignored characters, especially in SDL parsing.
             options.captureIgnoredChars = false
             // Memory usage is reduced by not setting SourceLocations on AST nodes, especially in SDL parsing.
             options.captureSourceLocation = true
+            // Single-line comments do not have any semantic meaning in GraphQL source documents and can be ignored
+            options.captureLineComments = true
         }
         // Opt-in flag to wrap nullable arguments in OptionalInput that distinguish between null and undefined value.
         useOptionalInputWrapper = false
@@ -279,20 +279,40 @@ resulting generated code will be automatically added to the project main source 
 
 **Properties**
 
-| Property | Type | Required | Description |
-| -------- | ---- | -------- | ----------- |
-| `allowDeprecatedFields` | Boolean | | Boolean flag indicating whether selection of deprecated fields is allowed or not.<br/>**Default value is:** `false`.<br/>**Command line property is**: `allowDeprecatedFields`. |
-| `customScalars` | `List<GraphQLScalar>` | | List of custom GraphQL scalar to converter mappings containing information about corresponding Java type and converter that should be used to serialize/deserialize values. |
-| `packageName` | String | yes | Target package name for generated code.<br/>**Command line property is**: `packageName`. |
-| `queryFiles` | FileCollection | | List of query files to be processed. Instead of a list of files to be processed you can specify `queryFileDirectory` directory instead. If this property is specified it will take precedence over the corresponding directory property. |
-| `queryFileDirectory` | Directory | | Directory file containing GraphQL queries. Instead of specifying a directory you can also specify list of query file by using `queryFiles` property instead.<br/>**Default value is:** `src/main/resources`. |
-| `serializer` | GraphQLSerializer | | JSON serializer that will be used to generate the data classes.<br/>**Default value is:** `GraphQLSerializer.JACKSON`. |
-| `schemaFile` | File | yes | GraphQL schema file that will be used to generate client code. |
-| `useOptionalInputWrapper` | Boolean | | Boolean opt-in flag to wrap nullable arguments in `OptionalInput` that distinguish between `null` and undefined/omitted value.<br/>**Default value is:** `false`.<br/>**Command line property is**: `useOptionalInputWrapper` |
-| `parserOptions` | GraphQLParserOptions | | Configures the settings used when parsing GraphQL queries and schema definition language documents. |
+| Property                  | Type                  | Required | Description                                                                                                                                                                                                                              |
+|---------------------------|-----------------------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `allowDeprecatedFields`   | Boolean               |          | Boolean flag indicating whether selection of deprecated fields is allowed or not.<br/>**Default value is:** `false`.<br/>**Command line property is**: `allowDeprecatedFields`.                                                          |
+| `customScalars`           | `List<GraphQLScalar>` |          | List of custom GraphQL scalar to converter mappings containing information about corresponding Java type and converter that should be used to serialize/deserialize values.                                                              |
+| `packageName`             | String                | yes      | Target package name for generated code.<br/>**Command line property is**: `packageName`.                                                                                                                                                 |
+| `parserOptions`           | GraphQLParserOptions  |          | Configures the settings used when parsing GraphQL queries and schema definition language documents.                                                                                                                                      |
+| `queryFiles`              | FileCollection        |          | List of query files to be processed. Instead of a list of files to be processed you can specify `queryFileDirectory` directory instead. If this property is specified it will take precedence over the corresponding directory property. |
+| `queryFileDirectory`      | Directory             |          | Directory file containing GraphQL queries. Instead of specifying a directory you can also specify list of query file by using `queryFiles` property instead.<br/>**Default value is:** `src/main/resources`.                             |
+| `schemaFile`              | File                  | yes      | GraphQL schema file that will be used to generate client code.                                                                                                                                                                           |
+| `serializer`              | GraphQLSerializer     |          | JSON serializer that will be used to generate the data classes.<br/>**Default value is:** `GraphQLSerializer.JACKSON`.                                                                                                                   |
+| `useOptionalInputWrapper` | Boolean               |          | Boolean opt-in flag to wrap nullable arguments in `OptionalInput` that distinguish between `null` and undefined/omitted value.<br/>**Default value is:** `false`.<br/>**Command line property is**: `useOptionalInputWrapper`            |
 
 By default, this task will generate Jackson compatible data models. See [client serialization documentation](../client/client-serialization.mdx)
 for details on how to update this process to use `kotlinx.serialization` instead.
+
+**Parameter Details**
+
+  * *parserOptions* - Configure options for parsing GraphQL queries and schema definition language documents. Settings here override the defaults set by GraphQL Java.
+
+  ```kotlin
+    // Override options that GraphQL Java uses when parsing GraphQL queries and schema definition language documents.
+    parserOptions {
+        // Override the maximum number of tokens read to prevent processing extremely large queries.
+        maxTokens = 15000
+        // Override the maximum number of whitespace tokens read to prevent processing extremely large queries.
+        maxWhitespaceTokens = 200000
+        // Memory usage is significantly reduced by not capturing ignored characters, especially in SDL parsing.
+        captureIgnoredChars = false
+        // Memory usage is reduced by not setting SourceLocations on AST nodes, especially in SDL parsing.
+        captureSourceLocation = true
+        // Single-line comments do not have any semantic meaning in GraphQL source documents and can be ignored
+        captureLineComments = true
+    }
+  ```
 
 ### graphqlGenerateSDL
 
@@ -329,20 +349,40 @@ test source set.
 
 **Properties**
 
-| Property | Type | Required | Description |
-| -------- | ---- | -------- | ----------- |
-| `allowDeprecatedFields` | Boolean | | Boolean flag indicating whether selection of deprecated fields is allowed or not.<br/>**Default value is:** `false`.<br/>**Command line property is**: `allowDeprecatedFields`. |
-| `customScalars` | `List<GraphQLScalar>` | | List of custom GraphQL scalar to converter mappings containing information about corresponding Java type and converter that should be used to serialize/deserialize values. |
-| `packageName` | String | yes | Target package name for generated code.<br/>**Command line property is**: `packageName`. |
-| `queryFiles` | FileCollection | | List of query files to be processed. Instead of a list of files to be processed you can specify `queryFileDirectory` directory instead. If this property is specified it will take precedence over the corresponding directory property. |
-| `queryFileDirectory` | Directory | | Directory file containing GraphQL queries. Instead of specifying a directory you can also specify list of query file by using `queryFiles` property instead.<br/>**Default value is:** `src/test/resources`. |
-| `serializer` | GraphQLSerializer | | JSON serializer that will be used to generate the data classes.<br/>**Default value is:** `GraphQLSerializer.JACKSON`. |
-| `schemaFile` | File | yes | GraphQL schema file that will be used to generate client code. |
-| `useOptionalInputWrapper` | Boolean | | Boolean opt-in flag to wrap nullable arguments in `OptionalInput` that distinguish between `null` and undefined/omitted value.<br/>**Default value is:** `false`.<br/>**Command line property is**: `useOptionalInputWrapper` |
-| `parserOptions` | GraphQLParserOptions | | Configures the settings used when parsing GraphQL queries and schema definition language documents. |
+| Property                  | Type                  | Required | Description                                                                                                                                                                                                                              |
+|---------------------------|-----------------------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `allowDeprecatedFields`   | Boolean               |          | Boolean flag indicating whether selection of deprecated fields is allowed or not.<br/>**Default value is:** `false`.<br/>**Command line property is**: `allowDeprecatedFields`.                                                          |
+| `customScalars`           | `List<GraphQLScalar>` |          | List of custom GraphQL scalar to converter mappings containing information about corresponding Java type and converter that should be used to serialize/deserialize values.                                                              |
+| `packageName`             | String                | yes      | Target package name for generated code.<br/>**Command line property is**: `packageName`.                                                                                                                                                 |
+| `parserOptions`           | GraphQLParserOptions  |          | Configures the settings used when parsing GraphQL queries and schema definition language documents.                                                                                                                                      |
+| `queryFiles`              | FileCollection        |          | List of query files to be processed. Instead of a list of files to be processed you can specify `queryFileDirectory` directory instead. If this property is specified it will take precedence over the corresponding directory property. |
+| `queryFileDirectory`      | Directory             |          | Directory file containing GraphQL queries. Instead of specifying a directory you can also specify list of query file by using `queryFiles` property instead.<br/>**Default value is:** `src/test/resources`.                             |
+| `schemaFile`              | File                  | yes      | GraphQL schema file that will be used to generate client code.                                                                                                                                                                           |
+| `serializer`              | GraphQLSerializer     |          | JSON serializer that will be used to generate the data classes.<br/>**Default value is:** `GraphQLSerializer.JACKSON`.                                                                                                                   |
+| `useOptionalInputWrapper` | Boolean               |          | Boolean opt-in flag to wrap nullable arguments in `OptionalInput` that distinguish between `null` and undefined/omitted value.<br/>**Default value is:** `false`.<br/>**Command line property is**: `useOptionalInputWrapper`            |
 
 By default, this task will generate Jackson compatible data models. See [client serialization documentation](../client/client-serialization.mdx)
 for details on how to update this process to use `kotlinx.serialization` instead.
+
+**Parameter Details**
+
+  * *parserOptions* - Configure options for parsing GraphQL queries and schema definition language documents. Settings here override the defaults set by GraphQL Java.
+
+  ```kotlin
+    // Override options that GraphQL Java uses when parsing GraphQL queries and schema definition language documents.
+    parserOptions {
+        // Override the maximum number of tokens read to prevent processing extremely large queries.
+        maxTokens = 15000
+        // Override the maximum number of whitespace tokens read to prevent processing extremely large queries.
+        maxWhitespaceTokens = 200000
+        // Memory usage is significantly reduced by not capturing ignored characters, especially in SDL parsing.
+        captureIgnoredChars = false
+        // Memory usage is reduced by not setting SourceLocations on AST nodes, especially in SDL parsing.
+        captureSourceLocation = true
+        // Single-line comments do not have any semantic meaning in GraphQL source documents and can be ignored
+        captureLineComments = true
+    }
+  ```
 
 ### graphqlIntrospectSchema
 

--- a/website/docs/plugins/gradle-plugin-tasks.mdx
+++ b/website/docs/plugins/gradle-plugin-tasks.mdx
@@ -142,6 +142,19 @@ graphql {
         // Read timeout in milliseconds
         read = 15_000
     }
+    // Override options that GraphQL Java uses when parsing GraphQL queries and schema definition language documents.
+    parserOptions {
+        // Override the maximum number of tokens read to prevent processing extremely large queries.
+        maxTokens = 15000
+        // Override the maximum number of whitespace tokens read to prevent processing extremely large queries.
+        maxWhitespaceTokens = 200000
+        // Single-line comments do not have any semantic meaning in GraphQL source documents and can be ignored
+        captureLineComments = false
+        // Memory usage is significantly reduced by not capturing ignored characters, especially in SDL parsing.
+        captureIgnoredChars = false
+        // Memory usage is reduced by not setting SourceLocations on AST nodes, especially in SDL parsing.
+        captureSourceLocation = true
+    }
     // Opt-in flag to wrap nullable arguments in OptionalInput that distinguish between null and undefined value.
     useOptionalInputWrapper = false
   }
@@ -187,6 +200,19 @@ graphql {
             // Connect timeout in milliseconds
             t.connect = 5000
             t.read = 15000
+        }
+        // Override options that GraphQL Java uses when parsing GraphQL queries and schema definition language documents.
+        parserOptions { options ->
+            // Override the maximum number of tokens read to prevent processing extremely large queries.
+            options.maxTokens = 15000
+            // Override the maximum number of whitespace tokens read to prevent processing extremely large queries.
+            options.maxWhitespaceTokens = 200000
+            // Single-line comments do not have any semantic meaning in GraphQL source documents and can be ignored
+            options.captureLineComments = false
+            // Memory usage is significantly reduced by not capturing ignored characters, especially in SDL parsing.
+            options.captureIgnoredChars = false
+            // Memory usage is reduced by not setting SourceLocations on AST nodes, especially in SDL parsing.
+            options.captureSourceLocation = true
         }
         // Opt-in flag to wrap nullable arguments in OptionalInput that distinguish between null and undefined value.
         useOptionalInputWrapper = false
@@ -263,6 +289,7 @@ resulting generated code will be automatically added to the project main source 
 | `serializer` | GraphQLSerializer | | JSON serializer that will be used to generate the data classes.<br/>**Default value is:** `GraphQLSerializer.JACKSON`. |
 | `schemaFile` | File | yes | GraphQL schema file that will be used to generate client code. |
 | `useOptionalInputWrapper` | Boolean | | Boolean opt-in flag to wrap nullable arguments in `OptionalInput` that distinguish between `null` and undefined/omitted value.<br/>**Default value is:** `false`.<br/>**Command line property is**: `useOptionalInputWrapper` |
+| `parserOptions` | GraphQLParserOptions | | Configures the settings used when parsing GraphQL queries and schema definition language documents. |
 
 By default, this task will generate Jackson compatible data models. See [client serialization documentation](../client/client-serialization.mdx)
 for details on how to update this process to use `kotlinx.serialization` instead.
@@ -312,6 +339,7 @@ test source set.
 | `serializer` | GraphQLSerializer | | JSON serializer that will be used to generate the data classes.<br/>**Default value is:** `GraphQLSerializer.JACKSON`. |
 | `schemaFile` | File | yes | GraphQL schema file that will be used to generate client code. |
 | `useOptionalInputWrapper` | Boolean | | Boolean opt-in flag to wrap nullable arguments in `OptionalInput` that distinguish between `null` and undefined/omitted value.<br/>**Default value is:** `false`.<br/>**Command line property is**: `useOptionalInputWrapper` |
+| `parserOptions` | GraphQLParserOptions | | Configures the settings used when parsing GraphQL queries and schema definition language documents. |
 
 By default, this task will generate Jackson compatible data models. See [client serialization documentation](../client/client-serialization.mdx)
 for details on how to update this process to use `kotlinx.serialization` instead.

--- a/website/docs/plugins/maven-plugin-goals.md
+++ b/website/docs/plugins/maven-plugin-goals.md
@@ -68,12 +68,12 @@ Generate GraphQL client code based on the provided GraphQL schema and target que
 | `customScalars`           | `List<CustomScalar>` |          | List of custom GraphQL scalar to converter mappings containing information about corresponding Java type and converter that should be used to serialize/deserialize values.                                                                                    |
 | `outputDirectory`         | File                 |          | Target directory where to store generated files.<br/>**Default value is**: `${project.build.directory}/generated-sources/graphql`                                                                                                                              |
 | `packageName`             | String               | yes      | Target package name for generated code.<br/>**User property is**: `graphql.packageName`.                                                                                                                                                                       |
+| `parserOptions`           | GraphQLParserOptions |          | Configures the settings used when parsing GraphQL queries and schema definition language documents.                                                                                                                                                            |
 | `queryFileDirectory`      | File                 |          | Directory file containing GraphQL queries. Instead of specifying a directory you can also specify list of query file by using `queryFiles` property instead.<br/>**Default value is:** `src/main/resources`.                                                   |
 | `queryFiles`              | `List<File>`         |          | List of query files to be processed. Instead of a list of files to be processed you can also specify `queryFileDirectory` directory containing all the files. If this property is specified it will take precedence over the corresponding directory property. |
-| `serializer`              | GraphQLSerializer    |          | JSON serializer that will be used to generate the data classes.<br/>**Default value is:** `GraphQLSerializer.JACKSON`.                                                                                                                                         |
 | `schemaFile`              | String               |          | GraphQL schema file that will be used to generate client code.<br/>**Default value is**: `${project.build.directory}/schema.graphql`<br/>**User property is**: `graphql.schemaFile`.                                                                           |
+| `serializer`              | GraphQLSerializer    |          | JSON serializer that will be used to generate the data classes.<br/>**Default value is:** `GraphQLSerializer.JACKSON`.                                                                                                                                         |
 | `useOptionalInputWrapper` | Boolean              |          | Boolean opt-in flag to wrap nullable arguments in `OptionalInput` that distinguish between `null` and undefined/omitted value.<br/>**Default value is:** `false`.<br/>**User property is**: `graphql.useOptionalInputWrapper`                                  |
-| `parserOptions`           | GraphQLParserOptions |          | Configures the settings used when parsing GraphQL queries and schema definition language documents.                                                                                                                                                            |
 
 **Parameter Details**
 
@@ -104,7 +104,7 @@ Generate GraphQL client code based on the provided GraphQL schema and target que
         <!-- Memory usage is significantly reduced by not capturing ignored characters, especially in SDL parsing -->
         <captureIgnoredChars>false</captureIgnoredChars>
         <!-- Single-line comments do not have any semantic meaning in GraphQL source documents and can be ignored -->
-        <captureLineComments>false</captureLineComments>
+        <captureLineComments>true</captureLineComments>
         <!-- Memory usage is reduced by not setting SourceLocations on AST nodes, especially in SDL parsing. -->
         <captureSourceLocation>true</captureSourceLocation>
     </parserOptions>
@@ -179,6 +179,23 @@ Generate GraphQL test client code based on the provided GraphQL schema and targe
 </customScalars>
 
 ```
+
+* *parserOptions* - Configure options for parsing GraphQL queries and schema definition language documents. Settings here override the defaults set by GraphQL Java.
+
+  ```xml
+    <parserOptions>
+        <!-- Modify the maximum number of tokens read to prevent processing extremely large queries -->
+        <maxTokens>15000</maxTokens>
+        <!-- Modify the maximum number of whitespace tokens read to prevent processing extremely large queries -->
+        <maxWhitespaceTokens>200000</maxWhitespaceTokens>
+        <!-- Memory usage is significantly reduced by not capturing ignored characters, especially in SDL parsing -->
+        <captureIgnoredChars>false</captureIgnoredChars>
+        <!-- Single-line comments do not have any semantic meaning in GraphQL source documents and can be ignored -->
+        <captureLineComments>true</captureLineComments>
+        <!-- Memory usage is reduced by not setting SourceLocations on AST nodes, especially in SDL parsing. -->
+        <captureSourceLocation>true</captureSourceLocation>
+    </parserOptions>
+  ```
 
 ### introspect-schema
 

--- a/website/docs/plugins/maven-plugin-goals.md
+++ b/website/docs/plugins/maven-plugin-goals.md
@@ -62,17 +62,18 @@ Generate GraphQL client code based on the provided GraphQL schema and target que
 
 **Parameters**
 
-| Property | Type | Required | Description |
-| -------- | ---- | -------- | ----------- |
-| `allowDeprecatedFields` | Boolean | | Boolean flag indicating whether selection of deprecated fields is allowed or not.<br/>**Default value is:** `false`.<br/>**User property is**: `graphql.allowDeprecatedFields`. |
-| `customScalars` | `List<CustomScalar>` | | List of custom GraphQL scalar to converter mappings containing information about corresponding Java type and converter that should be used to serialize/deserialize values. |
-| `outputDirectory` | File | | Target directory where to store generated files.<br/>**Default value is**: `${project.build.directory}/generated-sources/graphql` |
-| `packageName` | String | yes | Target package name for generated code.<br/>**User property is**: `graphql.packageName`. |
-| `queryFileDirectory` | File | | Directory file containing GraphQL queries. Instead of specifying a directory you can also specify list of query file by using `queryFiles` property instead.<br/>**Default value is:** `src/main/resources`. |
-| `queryFiles` | `List<File>` | | List of query files to be processed. Instead of a list of files to be processed you can also specify `queryFileDirectory` directory containing all the files. If this property is specified it will take precedence over the corresponding directory property. |
-| `serializer` | GraphQLSerializer | | JSON serializer that will be used to generate the data classes.<br/>**Default value is:** `GraphQLSerializer.JACKSON`. |
-| `schemaFile` | String | | GraphQL schema file that will be used to generate client code.<br/>**Default value is**: `${project.build.directory}/schema.graphql`<br/>**User property is**: `graphql.schemaFile`. |
-| `useOptionalInputWrapper` | Boolean | | Boolean opt-in flag to wrap nullable arguments in `OptionalInput` that distinguish between `null` and undefined/omitted value.<br/>**Default value is:** `false`.<br/>**User property is**: `graphql.useOptionalInputWrapper` |
+| Property                  | Type                 | Required | Description                                                                                                                                                                                                                                                    |
+|---------------------------|----------------------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `allowDeprecatedFields`   | Boolean              |          | Boolean flag indicating whether selection of deprecated fields is allowed or not.<br/>**Default value is:** `false`.<br/>**User property is**: `graphql.allowDeprecatedFields`.                                                                                |
+| `customScalars`           | `List<CustomScalar>` |          | List of custom GraphQL scalar to converter mappings containing information about corresponding Java type and converter that should be used to serialize/deserialize values.                                                                                    |
+| `outputDirectory`         | File                 |          | Target directory where to store generated files.<br/>**Default value is**: `${project.build.directory}/generated-sources/graphql`                                                                                                                              |
+| `packageName`             | String               | yes      | Target package name for generated code.<br/>**User property is**: `graphql.packageName`.                                                                                                                                                                       |
+| `queryFileDirectory`      | File                 |          | Directory file containing GraphQL queries. Instead of specifying a directory you can also specify list of query file by using `queryFiles` property instead.<br/>**Default value is:** `src/main/resources`.                                                   |
+| `queryFiles`              | `List<File>`         |          | List of query files to be processed. Instead of a list of files to be processed you can also specify `queryFileDirectory` directory containing all the files. If this property is specified it will take precedence over the corresponding directory property. |
+| `serializer`              | GraphQLSerializer    |          | JSON serializer that will be used to generate the data classes.<br/>**Default value is:** `GraphQLSerializer.JACKSON`.                                                                                                                                         |
+| `schemaFile`              | String               |          | GraphQL schema file that will be used to generate client code.<br/>**Default value is**: `${project.build.directory}/schema.graphql`<br/>**User property is**: `graphql.schemaFile`.                                                                           |
+| `useOptionalInputWrapper` | Boolean              |          | Boolean opt-in flag to wrap nullable arguments in `OptionalInput` that distinguish between `null` and undefined/omitted value.<br/>**Default value is:** `false`.<br/>**User property is**: `graphql.useOptionalInputWrapper`                                  |
+| `parserOptions`           | GraphQLParserOptions |          | Configures the settings used when parsing GraphQL queries and schema definition language documents.                                                                                                                                                            |
 
 **Parameter Details**
 
@@ -91,6 +92,22 @@ Generate GraphQL client code based on the provided GraphQL schema and target que
           <converter>com.example.UUIDScalarConverter</converter>
       </customScalar>
   </customScalars>
+  ```
+  * *parserOptions* - Configure options for parsing GraphQL queries and schema definition language documents. Settings here override the defaults set by GraphQL Java.
+
+  ```xml
+    <parserOptions>
+        <!-- Modify the maximum number of tokens read to prevent processing extremely large queries -->
+        <maxTokens>15000</maxTokens>
+        <!-- Modify the maximum number of whitespace tokens read to prevent processing extremely large queries -->
+        <maxWhitespaceTokens>200000</maxWhitespaceTokens>
+        <!-- Memory usage is significantly reduced by not capturing ignored characters, especially in SDL parsing -->
+        <captureIgnoredChars>false</captureIgnoredChars>
+        <!-- Single-line comments do not have any semantic meaning in GraphQL source documents and can be ignored -->
+        <captureLineComments>false</captureLineComments>
+        <!-- Memory usage is reduced by not setting SourceLocations on AST nodes, especially in SDL parsing. -->
+        <captureSourceLocation>true</captureSourceLocation>
+    </parserOptions>
   ```
 
 ### generate-sdl


### PR DESCRIPTION
### :pencil: Description

Allows a user of the client generator to set the parser options for graphql-java. The base `generateClient()` function accepts a function type with receiver to customise the builder object, whilst the gradle and maven plugins provide an explicit list of (current) options permitted by graphql-java, with the exception of the [parsingListener](https://github.com/graphql-java/graphql-java/blob/13ab0009bd42b591bb4a542cd9c780a53515321d/src/main/java/graphql/parser/ParserOptions.java#L289).

### :link: Related Issues

Resolves #1526 

### Notes

- I've picked fairly simple naming, but if we suspect any ambiguity of uses, or future collisions, it would be good to call that out so that it's clear this is configuration for the client generation only.
- Rather than abstract over `ParserOptions.Builder` the client module now exposes this in it's public API, and would therefore inherit breaking changes made to this class.
