### PR TITLE
[federation] remove unnecessary extends on Fed 2 Query

### DIFF
--- a/examples/client/src/integration/wiremock/__files/schema.graphql
+++ b/examples/client/src/integration/wiremock/__files/schema.graphql
@@ -155,7 +155,7 @@ type ProductVariation {
     id: ID!
 }
 
-type Query @extends {
+type Query {
     "Union of all types that use the @key directive, including both types native to the schema and extended types"
     _entities(representations: [_Any!]!): [_Entity]!
     _service: _Service!

--- a/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/FederatedSchemaGeneratorHooks.kt
+++ b/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/FederatedSchemaGeneratorHooks.kt
@@ -204,7 +204,11 @@ open class FederatedSchemaGeneratorHooks(
      */
     override fun didGenerateQueryObject(type: GraphQLObjectType): GraphQLObjectType = GraphQLObjectType.newObject(type)
         .field(SERVICE_FIELD_DEFINITION)
-        .withAppliedDirective(EXTENDS_DIRECTIVE_TYPE.toAppliedDirective())
+        .also {
+            if (!optInFederationV2) {
+                it.withAppliedDirective(EXTENDS_DIRECTIVE_TYPE.toAppliedDirective())
+            }
+        }
         .build()
 
     /**

--- a/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/FederatedSchemaV2GeneratorTest.kt
+++ b/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/FederatedSchemaV2GeneratorTest.kt
@@ -116,7 +116,7 @@ class FederatedSchemaV2GeneratorTest {
               value: String!
             }
 
-            type Query @extends {
+            type Query {
               "Union of all types that use the @key directive, including both types native to the schema and extended types"
               _entities(representations: [_Any!]!): [_Entity]!
               _service: _Service!

--- a/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/execution/ServiceQueryResolverTest.kt
+++ b/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/execution/ServiceQueryResolverTest.kt
@@ -120,7 +120,7 @@ directive @shareable on OBJECT | FIELD_DEFINITION
 "Allows users to annotate fields and types with additional metadata information"
 directive @tag(name: String!) repeatable on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
-type Query @extends {
+type Query {
   _service: _Service!
   getSimpleNestedObject: [SelfReferenceObject]!
   hello(name: String!): String!
@@ -204,7 +204,7 @@ type CustomScalar {
   value: String!
 }
 
-type Query @extends {
+type Query {
   "Union of all types that use the @key directive, including both types native to the schema and extended types"
   _entities(representations: [_Any!]!): [_Entity]!
   _service: _Service!

--- a/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePluginIT.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePluginIT.kt
@@ -574,7 +574,7 @@ class GraphQLGradlePluginIT : GraphQLGradlePluginAbstractIT() {
             "Allows users to annotate fields and types with additional metadata information"
             directive @tag(name: String!) repeatable on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
-            type Query @extends {
+            type Query {
               _service: _Service!
               helloWorld(name: String): String!
               randomUUID: UUID!

--- a/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/GraphQLGenerateSDLTaskIT.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/GraphQLGenerateSDLTaskIT.kt
@@ -123,7 +123,7 @@ internal val FEDERATED_SCHEMA =
     "Allows users to annotate fields and types with additional metadata information"
     directive @tag(name: String!) repeatable on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
-    type Query @extends {
+    type Query {
       _service: _Service!
       helloWorld(name: String): String!
     }

--- a/plugins/graphql-kotlin-maven-plugin/src/integration/generate-sdl-federated/src/test/kotlin/com/expediagroup/graphql/plugin/maven/GenerateSDLMojoTest.kt
+++ b/plugins/graphql-kotlin-maven-plugin/src/integration/generate-sdl-federated/src/test/kotlin/com/expediagroup/graphql/plugin/maven/GenerateSDLMojoTest.kt
@@ -94,7 +94,7 @@ class GenerateSDLMojoTest {
             "Allows users to annotate fields and types with additional metadata information"
             directive @tag(name: String!) repeatable on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
-            type Query @extends {
+            type Query {
               _service: _Service!
               helloWorld(name: String): String!
             }

--- a/plugins/graphql-kotlin-maven-plugin/src/integration/generate-sdl-hooks/src/test/kotlin/com/expediagroup/graphql/plugin/maven/GenerateSDLMojoTest.kt
+++ b/plugins/graphql-kotlin-maven-plugin/src/integration/generate-sdl-hooks/src/test/kotlin/com/expediagroup/graphql/plugin/maven/GenerateSDLMojoTest.kt
@@ -94,7 +94,7 @@ class GenerateSDLMojoTest {
             "Allows users to annotate fields and types with additional metadata information"
             directive @tag(name: String!) repeatable on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
-            type Query @extends {
+            type Query {
               _service: _Service!
               helloWorld(name: String): String!
               randomUUID: UUID!

--- a/plugins/schema/graphql-kotlin-sdl-generator/src/integrationTest/kotlin/com/expediagroup/graphql/plugin/schema/GenerateCustomSDLTest.kt
+++ b/plugins/schema/graphql-kotlin-sdl-generator/src/integrationTest/kotlin/com/expediagroup/graphql/plugin/schema/GenerateCustomSDLTest.kt
@@ -83,7 +83,7 @@ class GenerateCustomSDLTest {
                 "Allows users to annotate fields and types with additional metadata information"
                 directive @tag(name: String!) repeatable on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
-                type Query @extends {
+                type Query {
                   _service: _Service!
                   helloWorld(name: String): String!
                   randomUUID: UUID!

--- a/website/docs/schema-generator/federation/federated-schemas.md
+++ b/website/docs/schema-generator/federation/federated-schemas.md
@@ -62,7 +62,7 @@ type Product @key(fields : "id") {
   id: Int!
 }
 
-type Query @extends {
+type Query {
   _entities(representations: [_Any!]!): [_Entity]!
   _service: _Service!
   product(id: Int!): Product
@@ -121,12 +121,12 @@ schema {
 
 union _Entity = Product
 
-type Product @extends @key(fields : "id") {
-  id: Int! @external
+type Product @key(fields : "id") {
+  id: Int!
   reviews: [Review!]!
 }
 
-type Query @extends {
+type Query {
   _entities(representations: [_Any!]!): [_Entity]!
   _service: _Service!
 }


### PR DESCRIPTION
### :pencil: Description

`@extends` is no longer needed in Fed 2. 

### :link: Related Issues

Missed this in previous validation rule cleanup (https://github.com/ExpediaGroup/graphql-kotlin/pull/1581).