### PR TITLE
[federation] fix fed2 link directive imports and spec URL

### DIFF
--- a/examples/client/src/integration/wiremock/__files/schema.graphql
+++ b/examples/client/src/integration/wiremock/__files/schema.graphql
@@ -1,4 +1,4 @@
-schema @link(url : "https://specs.apollo.dev/link/v1.0/") @link(import : ["extends", "external", "inaccessible", "key", "link", "override", "provides", "requires", "shareable", "tag", "_FieldSet"], url : "https://www.apollographql.com/docs/federation/federation-spec/"){
+schema @link(import : ["@extends", "@external", "@inaccessible", "@key", "@override", "@provides", "@requires", "@shareable", "@tag", "_FieldSet"], url : "https://specs.apollo.dev/federation/v2.0"){
     query: Query
     mutation: Mutation
 }

--- a/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/FederatedSchemaGeneratorHooks.kt
+++ b/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/FederatedSchemaGeneratorHooks.kt
@@ -135,11 +135,11 @@ open class FederatedSchemaGeneratorHooks(private val resolvers: List<FederatedTy
 
     override fun willBuildSchema(builder: GraphQLSchema.Builder): GraphQLSchema.Builder {
         if (optInFederationV2) {
-            val fed2Imports = federatedDirectiveV2List.map { it.name }
+            val fed2Imports = federatedDirectiveV2List.map { "@${it.name}" }
+                .minus("@$LINK_DIRECTIVE_NAME")
                 .plus(FIELD_SET_SCALAR_NAME)
 
             builder.withSchemaDirective(LINK_DIRECTIVE_TYPE)
-                .withSchemaAppliedDirective(appliedLinkDirective(LINK_SPEC_URL))
                 .withSchemaAppliedDirective(appliedLinkDirective(FEDERATION_SPEC_URL, fed2Imports))
         }
 

--- a/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/directives/LinkDirective.kt
+++ b/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/directives/LinkDirective.kt
@@ -23,7 +23,7 @@ import graphql.schema.GraphQLArgument
 import graphql.schema.GraphQLList
 
 const val LINK_SPEC_URL = "https://specs.apollo.dev/link/v1.0/"
-const val FEDERATION_SPEC_URL = "https://www.apollographql.com/docs/federation/federation-spec/"
+const val FEDERATION_SPEC_URL = "https://specs.apollo.dev/federation/v2.0"
 
 /**
  * ```graphql

--- a/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/FederatedSchemaV2GeneratorTest.kt
+++ b/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/FederatedSchemaV2GeneratorTest.kt
@@ -30,7 +30,7 @@ class FederatedSchemaV2GeneratorTest {
     fun `verify can generate federated schema`() {
         val expectedSchema =
             """
-            schema @link(url : "https://specs.apollo.dev/link/v1.0/") @link(import : ["extends", "external", "inaccessible", "key", "link", "override", "provides", "requires", "shareable", "tag", "_FieldSet"], url : "https://www.apollographql.com/docs/federation/federation-spec/"){
+            schema @link(import : ["@extends", "@external", "@inaccessible", "@key", "@override", "@provides", "@requires", "@shareable", "@tag", "_FieldSet"], url : "https://specs.apollo.dev/federation/v2.0"){
               query: Query
             }
 

--- a/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/execution/ServiceQueryResolverTest.kt
+++ b/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/execution/ServiceQueryResolverTest.kt
@@ -99,7 +99,7 @@ type SelfReferenceObject {
 
 const val FEDERATED_SERVICE_SDL_V2 =
 """
-schema @link(url : "https://specs.apollo.dev/link/v1.0/") @link(import : ["extends", "external", "inaccessible", "key", "link", "override", "provides", "requires", "shareable", "tag", "_FieldSet"], url : "https://www.apollographql.com/docs/federation/federation-spec/"){
+schema @link(import : ["@extends", "@external", "@inaccessible", "@key", "@override", "@provides", "@requires", "@shareable", "@tag", "_FieldSet"], url : "https://specs.apollo.dev/federation/v2.0"){
   query: Query
 }
 


### PR DESCRIPTION
### :pencil: Description

All directive names should be prefixed with `@` as otherwise it leads to composition errors.

### :link: Related Issues
