### PR TITLE
[build] use reusable workflows to simplify actions

### DIFF
--- a/.github/workflows/build-examples.yml
+++ b/.github/workflows/build-examples.yml
@@ -1,0 +1,45 @@
+name: Build and Test Examples
+
+on:
+  workflow_call:
+
+jobs:
+  build:
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: examples
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@v1
+
+      - name: Set up Java 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: 11
+          distribution: 'zulu'
+
+      - name: Set up Gradle cache
+        uses: gradle/gradle-build-action@v2
+
+      - name: Set up Maven cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-maven-
+
+      - name: Build examples with Gradle
+        run: ./gradlew clean build
+
+      - name: Archive examples failure build reports
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: build-examples-reports
+          path: ./examples/**/build/reports
+          retention-days: 7

--- a/.github/workflows/build-libraries.yml
+++ b/.github/workflows/build-libraries.yml
@@ -1,0 +1,38 @@
+name: Build and Test Libraries
+
+on:
+  workflow_call:
+
+jobs:
+  build:
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@v1
+
+      - name: Set up Java 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: 11
+          distribution: 'zulu'
+
+      - name: Set up Gradle cache
+        uses: gradle/gradle-build-action@v2
+
+      - name: Build libraries with Gradle
+        run: ./gradlew clean build
+
+      - name: Archive failure build reports
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: build-reports
+          path: |
+            ./**/build/reports
+            plugins/graphql-kotlin-maven-plugin/build/integration/**/build.log
+            plugins/graphql-kotlin-maven-plugin/build/integration/**/target/surefire-reports
+          retention-days: 7

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -9,50 +9,12 @@ on:
       - 'website/**'
 
 jobs:
-  build:
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
+  build-libraries:
+    uses: ./.github/workflows/build-libraries.yml
 
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@v1
-
-      - name: Set up Java 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: 11
-          distribution: 'zulu'
-
-      - name: Set up Gradle cache
-        uses: gradle/gradle-build-action@v2
-
-      - name: Build libraries with Gradle
-        run: ./gradlew clean build
-
-      - name: Archive failure build reports
-        uses: actions/upload-artifact@v3
-        if: failure()
-        with:
-          name: build-reports
-          path: |
-            ./**/build/reports
-            plugins/graphql-kotlin-maven-plugin/build/integration/**/build.log
-            plugins/graphql-kotlin-maven-plugin/build/integration/**/target/surefire-reports
-          retention-days: 7
-
-      - name: Build examples with Gradle
-        working-directory: examples
-        run: ./gradlew clean build
-
-      - name: Archive examples failure build reports
-        uses: actions/upload-artifact@v3
-        if: failure()
-        with:
-          name: build-examples-reports
-          path: ./examples/**/build/reports
-          retention-days: 7
+  build-examples:
+    needs: build-libraries
+    uses: ./.github/workflows/build-examples.yml
 
   release-notes:
     timeout-minutes: 10

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -10,55 +10,9 @@ on:
       - '*.md'
 
 jobs:
-  build:
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
+  build-libraries:
+    uses: ./.github/workflows/build-libraries.yml
 
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@v1
-
-      - name: Set up Java 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: 11
-          distribution: 'zulu'
-
-      - name: Set up Gradle cache
-        uses: gradle/gradle-build-action@v2
-
-      # Used by maven-plugin integration tests
-      - name: Set up Maven cache
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-maven-
-
-      - name: Build library with Gradle
-        run: ./gradlew clean build
-
-      - name: Archive failure build reports
-        uses: actions/upload-artifact@v3
-        if: failure()
-        with:
-          name: build-reports
-          path: |
-            ./**/build/reports
-            plugins/graphql-kotlin-maven-plugin/build/integration/**/build.log
-            plugins/graphql-kotlin-maven-plugin/build/integration/**/target/surefire-reports
-          retention-days: 7
-
-      - name: Build examples with Gradle
-        working-directory: examples
-        run: ./gradlew clean build
-
-      - name: Archive examples failure build reports
-        uses: actions/upload-artifact@v3
-        if: failure()
-        with:
-          name: build-examples-reports
-          path: ./examples/**/build/reports
-          retention-days: 7
+  build-examples:
+    needs: build-libraries
+    uses: ./.github/workflows/build-examples.yml

--- a/examples/client/maven-client/build.gradle.kts
+++ b/examples/client/maven-client/build.gradle.kts
@@ -22,6 +22,7 @@ tasks {
     )
     val wireMockServerPort: Int? = ext.get("wireMockServerPort") as? Int
     val mavenBuild by register("mavenBuild") {
+        dependsOn(gradle.includedBuild("graphql-kotlin").task(":resolveIntegrationTestDependencies"))
         timeout.set(Duration.ofSeconds(500))
         doLast {
             exec {


### PR DESCRIPTION
### :pencil: Description

CI and PR builds are very similar so we use reusable workflows to keep the build logic in single place. By separating regular build and examples build into separate jobs, we can now re-run those individually as needed.

See: https://docs.github.com/en/actions/using-workflows/reusing-workflows

### :link: Related Issues
