### PR TITLE
feat: make builder use null graphQLContext if null was provided

### DIFF
--- a/servers/graphql-kotlin-server/src/main/kotlin/com/expediagroup/graphql/server/extensions/requestExtensions.kt
+++ b/servers/graphql-kotlin-server/src/main/kotlin/com/expediagroup/graphql/server/extensions/requestExtensions.kt
@@ -36,7 +36,7 @@ fun GraphQLRequest.toExecutionInput(
         .extensions(this.extensions ?: emptyMap())
         .dataLoaderRegistry(dataLoaderRegistry ?: KotlinDataLoaderRegistry())
         .also { builder ->
-            graphQLContext?.let { builder.context(it) }
+            builder.context(graphQLContext)
             graphQLContextMap?.let { builder.graphQLContext(it) }
         }
         .build()

--- a/servers/graphql-kotlin-server/src/test/kotlin/com/expediagroup/graphql/server/extensions/RequestExtensionsKtTest.kt
+++ b/servers/graphql-kotlin-server/src/test/kotlin/com/expediagroup/graphql/server/extensions/RequestExtensionsKtTest.kt
@@ -24,6 +24,7 @@ import org.dataloader.DataLoader
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class RequestExtensionsKtTest {
@@ -80,6 +81,7 @@ class RequestExtensionsKtTest {
 
         val executionInput = request.toExecutionInput(graphQLContextMap = context)
         assertEquals(1, executionInput.graphQLContext.get("foo"))
+        assertNull(executionInput.context)
     }
 
     @Test


### PR DESCRIPTION
### :pencil: Description
graphql-java [ExecutionInput Builder](https://github.com/graphql-java/graphql-java/blob/master/src/main/java/graphql/ExecutionInput.java#L222) assings new `graphQLContext` map to the deprecated `context` Object if `context` was not specified, because of that the schema generation will fail when some deprecated resolvers that are still using the [GraphQLContext interface](https://github.com/ExpediaGroup/graphql-kotlin/blob/6.x.x/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/execution/GraphQLContext.kt#L26) making the reflections to fail with `ClassCastException` (expecting an implementation of the interface but getting a GraphQLContext map class impl)