### PR TITLE
feat: add missing async leafs use case to sync exhaustion

### DIFF
--- a/executions/graphql-kotlin-dataloader-instrumentation/src/main/kotlin/com/expediagroup/graphql/dataloader/instrumentation/syncexhaustion/state/ExecutionBatchState.kt
+++ b/executions/graphql-kotlin-dataloader-instrumentation/src/main/kotlin/com/expediagroup/graphql/dataloader/instrumentation/syncexhaustion/state/ExecutionBatchState.kt
@@ -206,7 +206,7 @@ class ExecutionBatchState {
                 state.isCompletedComplexObject() -> {
                     isSyncExecutionExhausted(state.executionStrategyPaths.first())
                 }
-                state.isCompletedLeafOrNull() || state.isAsyncDispatchedNotLeaf() -> {
+                state.isCompletedLeafOrNull() || state.isAsyncDispatched() -> {
                     true
                 }
                 else -> false

--- a/executions/graphql-kotlin-dataloader-instrumentation/src/main/kotlin/com/expediagroup/graphql/dataloader/instrumentation/syncexhaustion/state/ExecutionStrategyState.kt
+++ b/executions/graphql-kotlin-dataloader-instrumentation/src/main/kotlin/com/expediagroup/graphql/dataloader/instrumentation/syncexhaustion/state/ExecutionStrategyState.kt
@@ -172,18 +172,16 @@ class ExecutionStrategyState(
          * }
          * ```
          */
-        fun addExecutionStrategyPath(
-            executionStrategyPath: String
-        ) {
+        fun addExecutionStrategyPath(executionStrategyPath: String) {
             executionStrategyPaths.add(executionStrategyPath)
         }
 
         /**
-         * field [fetchState] is completed with a non null [result] and
+         * field [fetchState] is completed with a non-null [result] and
          * [graphQLType] is not a leaf [GraphQLList] and
-         * all non null complex objects inside the [result] list started their own executionStrategy
+         * all non-null complex objects inside the [result] list started their own executionStrategy
          *
-         * @return Boolean indicating if above sentence result
+         * @return Boolean indicating if above conditions met
          */
         fun isCompletedListOfComplexObjects(): Boolean =
             fetchState == FieldFetchState.COMPLETED && result != null &&
@@ -191,10 +189,10 @@ class ExecutionStrategyState(
                 (result as? List<*>)?.filterNotNull()?.size == executionStrategyPaths.size
 
         /**
-         * field [fetchState] is completed with a non null [result] and
+         * field [fetchState] is completed with a non-null [result] and
          * [graphQLType] is not a leaf complex type which executionStrategy was started.
          *
-         * @return Boolean indicating if above sentence result
+         * @return Boolean indicating if above conditions met
          */
         fun isCompletedComplexObject(): Boolean =
             fetchState == FieldFetchState.COMPLETED && result != null &&
@@ -202,20 +200,22 @@ class ExecutionStrategyState(
                 executionStrategyPaths.isNotEmpty()
 
         /**
-         * field [fetchState] is completed and [graphQLType] is a Leaf or null.
+         * field [fetchState] is [FieldFetchState.COMPLETED]
+         * field [graphQLType] is a Leaf or null.
          *
-         * @return Boolean indicating if above sentence result
+         * @return Boolean indicating if above conditions met
          */
         fun isCompletedLeafOrNull(): Boolean =
             fetchState == FieldFetchState.COMPLETED &&
                 (GraphQLTypeUtil.isLeaf(graphQLType) || result == null)
 
         /**
-         * field [fetchType] is Async and [fetchState] is dispatched and
-         * is not a leaf
+         * field [fetchType] is [FieldFetchType.ASYNC],
+         * field [fetchState] is [FieldFetchState.DISPATCHED]
+         *
+         * @return Boolean indicating if above conditions met
          */
-        fun isAsyncDispatchedNotLeaf(): Boolean =
-            fetchType == FieldFetchType.ASYNC && fetchState == FieldFetchState.DISPATCHED &&
-                !GraphQLTypeUtil.isLeaf(graphQLType)
+        fun isAsyncDispatched(): Boolean =
+            fetchType == FieldFetchType.ASYNC && fetchState == FieldFetchState.DISPATCHED
     }
 }

--- a/executions/graphql-kotlin-dataloader-instrumentation/src/test/kotlin/com/expediagroup/graphql/dataloader/instrumentation/fixture/AstronautGraphQL.kt
+++ b/executions/graphql-kotlin-dataloader-instrumentation/src/test/kotlin/com/expediagroup/graphql/dataloader/instrumentation/fixture/AstronautGraphQL.kt
@@ -67,6 +67,7 @@ object AstronautGraphQL {
             missions(ids: [ID!]): [Mission]!
             address: Address!
             phoneNumber: String!
+            twitter: String!
         }
         type Astronaut {
             id: ID!

--- a/executions/graphql-kotlin-dataloader-instrumentation/src/test/kotlin/com/expediagroup/graphql/dataloader/instrumentation/fixture/domain/Nasa.kt
+++ b/executions/graphql-kotlin-dataloader-instrumentation/src/test/kotlin/com/expediagroup/graphql/dataloader/instrumentation/fixture/domain/Nasa.kt
@@ -16,12 +16,19 @@
 
 package com.expediagroup.graphql.dataloader.instrumentation.fixture.domain
 
+import reactor.kotlin.core.publisher.toMono
+import java.time.Duration
+import java.util.concurrent.CompletableFuture
+
 data class Address(
     val street: String = "300 E Street SW",
     val zipCode: String = "98004"
 )
 
-data class Nasa(
+class Nasa(
     val address: Address = Address(),
     val phoneNumber: String = "+1 123-456-7890"
-)
+) {
+    fun getTwitter(): CompletableFuture<String> =
+        "https://twitter.com/NASA".toMono().delayElement(Duration.ofMillis(100)).toFuture()
+}

--- a/executions/graphql-kotlin-dataloader-instrumentation/src/test/kotlin/com/expediagroup/graphql/dataloader/instrumentation/syncexhaustion/DataLoaderSyncExecutionExhaustedInstrumentationTest.kt
+++ b/executions/graphql-kotlin-dataloader-instrumentation/src/test/kotlin/com/expediagroup/graphql/dataloader/instrumentation/syncexhaustion/DataLoaderSyncExecutionExhaustedInstrumentationTest.kt
@@ -186,6 +186,44 @@ class DataLoaderSyncExecutionExhaustedInstrumentationTest {
     }
 
     @Test
+    fun `Instrumentation should batch transactions after exhausting a single ExecutionInput with async Leafs`() {
+        val queries = listOf(
+            """
+                fragment AstronautFragment on Astronaut { name missions { designation } }
+                query ComplexQuery {
+                    astronaut1: astronaut(id: 1) { ...AstronautFragment }
+                    nasa {
+                        astronaut(id: 2) {...AstronautFragment }
+                        phoneNumber
+                        twitter
+                    }
+                }
+            """.trimIndent()
+        )
+
+        val (results, kotlinDataLoaderRegistry) = AstronautGraphQL.execute(
+            graphQL,
+            queries,
+            DataLoaderInstrumentationStrategy.SYNC_EXHAUSTION
+        )
+
+        assertEquals(1, results.size)
+
+        val astronautStatistics = kotlinDataLoaderRegistry.dataLoadersMap["AstronautDataLoader"]?.statistics
+        val missionsByAstronautStatistics = kotlinDataLoaderRegistry.dataLoadersMap["MissionsByAstronautDataLoader"]?.statistics
+
+        assertEquals(1, astronautStatistics?.batchInvokeCount)
+        assertEquals(2, astronautStatistics?.batchLoadCount)
+
+        assertEquals(1, missionsByAstronautStatistics?.batchInvokeCount)
+        assertEquals(2, missionsByAstronautStatistics?.batchLoadCount)
+
+        verify(exactly = 3) {
+            kotlinDataLoaderRegistry.dispatchAll()
+        }
+    }
+
+    @Test
     fun `Instrumentation should batch transactions after exhausting multiple ExecutionInput`() {
         val queries = listOf(
             """


### PR DESCRIPTION
### :pencil: Description
the `DataLoaderSyncExecutionExhaustedInstrumentation` is missing one use case that we didn't account for, which is calculating when a Leaf (Scalar, Enum) field is Asynchronous and it was Dispatched

### :link: Related Issues
https://github.com/ExpediaGroup/graphql-kotlin/issues/1610