### PR TITLE
migrate build to version catalog

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,10 +39,6 @@ allprojects {
 subprojects {
     val kotlinJvmVersion: String by project
 
-    val detektVersion: String by project
-    val ktlintVersion: String by project
-    val jacocoVersion: String by project
-
     val currentProject = this
 
     apply(plugin = "kotlin")
@@ -66,14 +62,14 @@ subprojects {
             dependsOn(jacocoTestCoverageVerification)
         }
         detekt {
-            toolVersion = detektVersion
+            toolVersion = rootProject.project.libs.versions.detekt.get()
             config = files("${rootProject.projectDir}/detekt.yml")
         }
         ktlint {
-            version.set(ktlintVersion)
+            version.set(rootProject.project.libs.versions.ktlint.core.get())
         }
         jacoco {
-            toolVersion = jacocoVersion
+            toolVersion = rootProject.project.libs.versions.jacoco.get()
         }
         jar {
             manifest {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,11 +37,7 @@ allprojects {
 }
 
 subprojects {
-    val kotlinxCoroutinesVersion: String by project
     val kotlinJvmVersion: String by project
-    val kotlinVersion: String by project
-    val junitVersion: String by project
-    val mockkVersion: String by project
 
     val detektVersion: String by project
     val ktlintVersion: String by project
@@ -178,15 +174,16 @@ subprojects {
         }
     }
 
+    // typesafe accessors to version catalog do not work in the subprojects/allprojects block, need to use rootProject.project
     dependencies {
-        implementation(kotlin("stdlib", kotlinVersion))
-        implementation(kotlin("reflect", kotlinVersion))
-        implementation("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:$kotlinxCoroutinesVersion")
-        testImplementation(kotlin("test", kotlinVersion))
-        testImplementation(kotlin("test-junit5", kotlinVersion))
-        testImplementation("org.junit.jupiter:junit-jupiter-api:$junitVersion")
-        testImplementation("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
-        testImplementation("io.mockk:mockk:$mockkVersion")
+        implementation(rootProject.project.libs.kotlin.stdlib)
+        implementation(rootProject.project.libs.kotlin.reflect)
+        implementation(rootProject.project.libs.kotlinx.coroutines.jdk8)
+        testImplementation(rootProject.project.libs.kotlin.test)
+        testImplementation(rootProject.project.libs.kotlin.junit.test)
+        testImplementation(rootProject.project.libs.junit.api)
+        testImplementation(rootProject.project.libs.junit.engine)
+        testImplementation(rootProject.project.libs.mockk)
     }
 }
 

--- a/clients/graphql-kotlin-client-jackson/build.gradle.kts
+++ b/clients/graphql-kotlin-client-jackson/build.gradle.kts
@@ -1,10 +1,8 @@
 description = "GraphQL client serializer based on Jackson"
 
-val jacksonVersion: String by project
-
 dependencies {
     api(project(path = ":graphql-kotlin-client"))
-    api("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion")
+    api(libs.jackson)
 }
 
 tasks {

--- a/clients/graphql-kotlin-client-serialization/build.gradle.kts
+++ b/clients/graphql-kotlin-client-serialization/build.gradle.kts
@@ -4,13 +4,10 @@ plugins {
     kotlin("plugin.serialization")
 }
 
-val kotlinxCoroutinesVersion: String by project
-val kotlinxSerializationVersion: String by project
-
 dependencies {
     api(project(path = ":graphql-kotlin-client"))
-    api("org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinxCoroutinesVersion")
-    api("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationVersion")
+    api(libs.kotlinx.coroutines.core)
+    api(libs.kotlinx.serialization.json)
 }
 
 tasks {

--- a/clients/graphql-kotlin-client/build.gradle.kts
+++ b/clients/graphql-kotlin-client/build.gradle.kts
@@ -1,7 +1,5 @@
 description = "A lightweight typesafe GraphQL HTTP Client"
 
-val kotlinxCoroutinesVersion: String by project
-
 dependencies {
-    api("org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinxCoroutinesVersion")
+    api(libs.kotlinx.coroutines.core)
 }

--- a/clients/graphql-kotlin-ktor-client/build.gradle.kts
+++ b/clients/graphql-kotlin-ktor-client/build.gradle.kts
@@ -4,18 +4,15 @@ plugins {
     kotlin("plugin.serialization")
 }
 
-val ktorVersion: String by project
-val wireMockVersion: String by project
-
 dependencies {
     api(project(path = ":graphql-kotlin-client"))
     api(project(path = ":graphql-kotlin-client-serialization"))
-    api("io.ktor:ktor-client-cio:$ktorVersion")
-    api("io.ktor:ktor-client-serialization:$ktorVersion")
+    api(libs.ktor.client.cio)
+    api(libs.ktor.client.serialization)
     testImplementation(project(path = ":graphql-kotlin-client-jackson"))
-    testImplementation("io.ktor:ktor-client-okhttp:$ktorVersion")
-    testImplementation("io.ktor:ktor-client-logging:$ktorVersion")
-    testImplementation("com.github.tomakehurst:wiremock-jre8:$wireMockVersion")
+    testImplementation(libs.ktor.client.logging)
+    testImplementation(libs.ktor.client.okhttp)
+    testImplementation(libs.wiremock.jre8)
 }
 
 tasks {

--- a/clients/graphql-kotlin-spring-client/build.gradle.kts
+++ b/clients/graphql-kotlin-spring-client/build.gradle.kts
@@ -4,19 +4,14 @@ plugins {
     kotlin("plugin.serialization")
 }
 
-val kotlinxCoroutinesVersion: String by project
-val springVersion: String by project
-val springBootVersion: String by project
-val wireMockVersion: String by project
-
 dependencies {
     api(project(path = ":graphql-kotlin-client"))
     api(project(path = ":graphql-kotlin-client-jackson"))
-    api("org.jetbrains.kotlinx:kotlinx-coroutines-reactor:$kotlinxCoroutinesVersion")
-    api("org.springframework:spring-webflux:$springVersion")
-    api("org.springframework.boot:spring-boot-starter-reactor-netty:$springBootVersion")
+    api(libs.kotlinx.coroutines.reactor)
+    api(libs.spring.webflux)
+    api(libs.spring.boot.netty)
     testImplementation(project(path = ":graphql-kotlin-client-serialization"))
-    testImplementation("com.github.tomakehurst:wiremock-jre8:$wireMockVersion")
+    testImplementation(libs.wiremock.jre8)
 }
 
 tasks {

--- a/examples/build.gradle.kts
+++ b/examples/build.gradle.kts
@@ -35,7 +35,6 @@ subprojects {
         this.ext[key.toString()] = value
     }
 
-
     apply(plugin = "kotlin")
     apply(plugin = "io.gitlab.arturbosch.detekt")
     apply(plugin = "org.jlleitschuh.gradle.ktlint")

--- a/examples/build.gradle.kts
+++ b/examples/build.gradle.kts
@@ -35,26 +35,19 @@ subprojects {
         this.ext[key.toString()] = value
     }
 
-    val icuVersion: String by project
-    val junitVersion: String by project
-    val kotlinVersion: String by project
-    val kotlinxCoroutinesVersion: String by project
-
-    val detektVersion: String by project
-    val ktlintVersion: String by project
 
     apply(plugin = "kotlin")
     apply(plugin = "io.gitlab.arturbosch.detekt")
     apply(plugin = "org.jlleitschuh.gradle.ktlint")
 
     dependencies {
-        implementation(kotlin("stdlib", kotlinVersion))
-        implementation(kotlin("reflect", kotlinVersion))
-        implementation("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:$kotlinxCoroutinesVersion")
-        implementation("com.ibm.icu:icu4j:$icuVersion")
-        testImplementation(kotlin("test-junit5", kotlinVersion))
-        testImplementation("org.junit.jupiter:junit-jupiter-api:$junitVersion")
-        testImplementation("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
+        implementation(rootProject.project.libs.kotlin.stdlib)
+        implementation(rootProject.project.libs.kotlin.reflect)
+        implementation(rootProject.project.libs.kotlinx.coroutines.jdk8)
+        implementation(rootProject.project.libs.icu)
+        testImplementation(rootProject.project.libs.kotlin.junit.test)
+        testImplementation(rootProject.project.libs.junit.api)
+        testImplementation(rootProject.project.libs.junit.engine)
     }
 
     tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
@@ -66,11 +59,11 @@ subprojects {
 
     tasks {
         detekt {
-            toolVersion = detektVersion
+            toolVersion = rootProject.project.libs.versions.detekt.get()
             config = files(File(rootDir.parent, "detekt.yml").absolutePath)
         }
         ktlint {
-            version.set(ktlintVersion)
+            version.set(rootProject.project.libs.versions.ktlint.core.get())
         }
         jar {
             enabled = false

--- a/examples/client/build.gradle.kts
+++ b/examples/client/build.gradle.kts
@@ -2,10 +2,8 @@ import com.github.tomakehurst.wiremock.standalone.WireMockServerRunner
 import java.net.ServerSocket
 
 buildscript {
-    // cannot access project at this time
-    val wireMockVersion: String = "2.26.2"
     dependencies {
-        classpath("com.github.tomakehurst:wiremock-jre8-standalone:$wireMockVersion")
+        classpath(libs.wiremock.standalone)
     }
 }
 

--- a/examples/client/gradle-client/build.gradle.kts
+++ b/examples/client/gradle-client/build.gradle.kts
@@ -13,8 +13,8 @@ plugins {
 val ktorVersion: String by project
 dependencies {
     implementation("com.expediagroup", "graphql-kotlin-ktor-client")
-    implementation("io.ktor:ktor-client-okhttp:$ktorVersion")
-    implementation("io.ktor:ktor-client-logging-jvm:$ktorVersion")
+    implementation(libs.ktor.client.okhttp)
+    implementation(libs.ktor.client.jvm.logging)
 }
 
 application {

--- a/examples/client/maven-client/build.gradle.kts
+++ b/examples/client/maven-client/build.gradle.kts
@@ -2,23 +2,19 @@ import java.time.Duration
 
 description = "Example usage of Maven plugin to generate GraphQL Kotlin Client"
 
-val kotlinJvmVersion: String by project
-val kotlinVersion: String by project
-val kotlinxCoroutinesVersion: String by project
-val reactorVersion: String by project
-
 dependencies {
     implementation("com.expediagroup", "graphql-kotlin-spring-client")
 }
 
 tasks {
+    val kotlinJvmVersion: String by project
     /* Gradle is used to invoke maven wrapper */
     val mavenEnvironmentVariables = mapOf(
         "graphqlKotlinVersion" to project.version,
         "kotlinJvmTarget" to kotlinJvmVersion,
-        "kotlinVersion" to kotlinVersion,
-        "kotlinxCoroutinesVersion" to kotlinxCoroutinesVersion,
-        "reactorVersion" to reactorVersion
+        "kotlinVersion" to libs.versions.kotlin.get(),
+        "kotlinxCoroutinesVersion" to libs.versions.kotlinx.coroutines.get(),
+        "reactorVersion" to libs.versions.reactor.core.get()
     )
     val wireMockServerPort: Int? = ext.get("wireMockServerPort") as? Int
     val mavenBuild by register("mavenBuild") {

--- a/examples/federation/products-subgraph/build.gradle.kts
+++ b/examples/federation/products-subgraph/build.gradle.kts
@@ -6,10 +6,9 @@ plugins {
     id("com.expediagroup.graphql")
 }
 
-val springBootVersion: String by project
 dependencies {
     implementation("com.expediagroup", "graphql-kotlin-spring-server")
-    testImplementation("org.springframework.boot", "spring-boot-starter-test", springBootVersion)
+    testImplementation(libs.spring.boot.test)
 
     graphqlSDL("com.expediagroup", "graphql-kotlin-federated-hooks-provider")
 }

--- a/examples/federation/reviews-subgraph/build.gradle.kts
+++ b/examples/federation/reviews-subgraph/build.gradle.kts
@@ -6,10 +6,9 @@ plugins {
     id("com.expediagroup.graphql")
 }
 
-val springBootVersion: String by project
 dependencies {
     implementation("com.expediagroup", "graphql-kotlin-spring-server")
-    testImplementation("org.springframework.boot", "spring-boot-starter-test", springBootVersion)
+    testImplementation(libs.spring.boot.test)
 
     graphqlSDL("com.expediagroup", "graphql-kotlin-federated-hooks-provider")
 }

--- a/examples/server/ktor-server/build.gradle.kts
+++ b/examples/server/ktor-server/build.gradle.kts
@@ -9,16 +9,12 @@ application {
     mainClass.set("io.ktor.server.netty.EngineMain")
 }
 
-val kotlinxCoroutinesVersion: String by project
-val ktorVersion: String by project
-val logbackVersion: String by project
-
 dependencies {
     implementation("com.expediagroup", "graphql-kotlin-server")
-    implementation("io.ktor", "ktor-server-core", ktorVersion)
-    implementation("io.ktor", "ktor-server-netty", ktorVersion)
-    implementation("ch.qos.logback", "logback-classic", logbackVersion)
-    implementation("org.jetbrains.kotlinx", "kotlinx-coroutines-jdk8", kotlinxCoroutinesVersion)
+    implementation(libs.ktor.server.core)
+    implementation(libs.ktor.server.netty)
+    implementation(libs.logback)
+    implementation(libs.kotlinx.coroutines.jdk8)
 }
 
 graphql {

--- a/examples/server/ktor-server/gradle.properties
+++ b/examples/server/ktor-server/gradle.properties
@@ -1,1 +1,0 @@
-logbackVersion=1.2.1

--- a/examples/server/spring-server/build.gradle.kts
+++ b/examples/server/spring-server/build.gradle.kts
@@ -6,15 +6,12 @@ plugins {
     id("com.expediagroup.graphql")
 }
 
-val springBootVersion: String by project
-val reactorVersion: String by project
-
 dependencies {
     implementation("com.expediagroup", "graphql-kotlin-spring-server")
     implementation("com.expediagroup", "graphql-kotlin-hooks-provider")
-    implementation("org.springframework.boot", "spring-boot-starter-validation", springBootVersion)
-    testImplementation("org.springframework.boot:spring-boot-starter-test:$springBootVersion")
-    testImplementation("io.projectreactor:reactor-test:$reactorVersion")
+    implementation(libs.spring.boot.validation)
+    testImplementation(libs.spring.boot.test)
+    testImplementation(libs.reactor.test)
 }
 
 graphql {

--- a/examples/settings.gradle.kts
+++ b/examples/settings.gradle.kts
@@ -1,3 +1,18 @@
+dependencyResolutionManagement {
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+
+            // examples specific libs
+            library("ktor-client-jvm-logging", "io.ktor", "ktor-client-logging-jvm").versionRef("ktor")
+            library("ktor-server-core", "io.ktor", "ktor-server-core").versionRef("ktor")
+            library("ktor-server-netty", "io.ktor", "ktor-server-netty").versionRef("ktor")
+            library("logback", "ch.qos.logback", "logback-classic").version("1.2.1")
+            library("spring-boot-validation", "org.springframework.boot", "spring-boot-starter-validation").versionRef("spring-boot")
+        }
+    }
+}
+
 pluginManagement {
     val properties = java.util.Properties()
     properties.load(File(rootDir.parent, "gradle.properties").inputStream())

--- a/executions/graphql-kotlin-automatic-persisted-queries/build.gradle.kts
+++ b/executions/graphql-kotlin-automatic-persisted-queries/build.gradle.kts
@@ -1,12 +1,7 @@
 description = "Automatic Persisted Queries"
 
-val junitVersion: String by project
-val graphQLJavaVersion: String by project
-
 dependencies {
-    api("com.graphql-java:graphql-java:$graphQLJavaVersion")
-    testImplementation("org.junit.jupiter:junit-jupiter-api:$junitVersion")
-    testImplementation("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
+    api(libs.graphql.java)
 }
 
 tasks {

--- a/executions/graphql-kotlin-dataloader-instrumentation/build.gradle.kts
+++ b/executions/graphql-kotlin-dataloader-instrumentation/build.gradle.kts
@@ -1,19 +1,12 @@
 description = "Data Loader Instrumentations"
 
-val junitVersion: String by project
-val graphQLJavaVersion: String by project
-val reactorVersion: String by project
-val reactorExtensionsVersion: String by project
-
 dependencies {
     api(project(path = ":graphql-kotlin-dataloader"))
-    api("com.graphql-java:graphql-java:$graphQLJavaVersion") {
+    api(libs.graphql.java) {
         exclude(group = "com.graphql-java", module = "java-dataloader")
     }
-    testImplementation("io.projectreactor.kotlin:reactor-kotlin-extensions:$reactorExtensionsVersion")
-    testImplementation("io.projectreactor:reactor-core:$reactorVersion")
-    testImplementation("org.junit.jupiter:junit-jupiter-api:$junitVersion")
-    testImplementation("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
+    testImplementation(libs.reactor.core)
+    testImplementation(libs.reactor.extensions)
 }
 
 tasks {

--- a/executions/graphql-kotlin-dataloader/build.gradle.kts
+++ b/executions/graphql-kotlin-dataloader/build.gradle.kts
@@ -1,16 +1,9 @@
 description = "Graphql Kotlin Data Loader"
 
-val junitVersion: String by project
-val graphQLJavaDataLoaderVersion: String by project
-val reactorVersion: String by project
-val reactorExtensionsVersion: String by project
-
 dependencies {
-    api("com.graphql-java:java-dataloader:$graphQLJavaDataLoaderVersion")
-    testImplementation("io.projectreactor.kotlin:reactor-kotlin-extensions:$reactorExtensionsVersion")
-    testImplementation("io.projectreactor:reactor-core:$reactorVersion")
-    testImplementation("org.junit.jupiter:junit-jupiter-api:$junitVersion")
-    testImplementation("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
+    api(libs.dataloader)
+    testImplementation(libs.reactor.core)
+    testImplementation(libs.reactor.extensions)
 }
 
 tasks {

--- a/generator/graphql-kotlin-federation/build.gradle.kts
+++ b/generator/graphql-kotlin-federation/build.gradle.kts
@@ -1,16 +1,11 @@
 description = "Federated GraphQL schema generator"
 
-val junitVersion: String by project
-val federationGraphQLVersion: String by project
-val reactorVersion: String by project
-val reactorExtensionsVersion: String by project
-
 dependencies {
     api(project(path = ":graphql-kotlin-schema-generator"))
-    api("com.apollographql.federation:federation-graphql-java-support:$federationGraphQLVersion")
-    testImplementation("io.projectreactor.kotlin:reactor-kotlin-extensions:$reactorExtensionsVersion")
-    testImplementation("io.projectreactor:reactor-core:$reactorVersion")
-    testImplementation("org.junit.jupiter:junit-jupiter-params:$junitVersion")
+    api(libs.federation)
+    testImplementation(libs.reactor.core)
+    testImplementation(libs.reactor.extensions)
+    testImplementation(libs.junit.params)
 }
 
 tasks {

--- a/generator/graphql-kotlin-schema-generator/build.gradle.kts
+++ b/generator/graphql-kotlin-schema-generator/build.gradle.kts
@@ -1,19 +1,12 @@
 description = "Code-only GraphQL schema generation for Kotlin"
 
-val classGraphVersion: String by project
-val graphQLJavaVersion: String by project
-val kotlinxCoroutinesVersion: String by project
-val rxjavaVersion: String by project
-val junitVersion: String by project
-val slf4jVersion: String by project
-
 dependencies {
-    api("com.graphql-java:graphql-java:$graphQLJavaVersion")
-    api("org.jetbrains.kotlinx:kotlinx-coroutines-reactive:$kotlinxCoroutinesVersion")
-    implementation("io.github.classgraph:classgraph:$classGraphVersion")
-    implementation("org.slf4j:slf4j-api:$slf4jVersion")
-    testImplementation("io.reactivex.rxjava3:rxjava:$rxjavaVersion")
-    testImplementation("org.junit.jupiter:junit-jupiter-params:$junitVersion")
+    api(libs.graphql.java)
+    api(libs.kotlinx.coroutines.reactive)
+    implementation(libs.classgraph)
+    implementation(libs.slf4j)
+    testImplementation(libs.rxjava)
+    testImplementation(libs.junit.params)
 }
 
 tasks {

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,42 +13,12 @@ systemProp.org.gradle.internal.publish.checksums.insecure=true
 # See: https://github.com/gradle/gradle/issues/8139
 org.gradle.jvmargs=-Xmx2g -XX:+HeapDumpOnOutOfMemoryError
 
-# dependencies
-kotlinVersion = 1.7.21
 kotlinJvmVersion = 1.8
-kotlinxCoroutinesVersion = 1.6.4
-kotlinxSerializationVersion = 1.4.1
 
-androidPluginVersion = 7.1.2
-classGraphVersion = 4.8.149
-federationGraphQLVersion = 2.0.7
-graphQLJavaVersion = 19.2
-graphQLJavaDataLoaderVersion = 3.2.0
-jacksonVersion = 2.13.3
-kotlinPoetVersion = 1.12.0
-ktorVersion = 2.0.3
-# reactorVersion should be the same reactor-core version pulled from spring-boot-starter-webflux
-reactorVersion = 3.4.26
-reactorExtensionsVersion = 1.1.9
-slf4jVersion = 1.7.36
-springBootVersion = 2.7.7
-springVersion = 5.3.24
-
-# test dependency versions
-
-# kotlin-compile-testing has to be using the same kotlin version as the kotlinx-serialization compiler
-# https://github.com/tschuchortdev/kotlin-compile-testing the latest version targets kotlin 1.7.10 which blocks updates to newer
-# versions of kotlin, switching to a fork https://github.com/ZacSweers/kotlin-compile-testing
-compileTestingVersion = 0.1.0
-icuVersion=71.1
-junitVersion = 5.8.2
-mockkVersion = 1.12.5
-mustacheVersion = 0.9.10
-rxjavaVersion = 3.1.5
-wireMockVersion = 2.33.2
+## TODO CLEANUP AFTER MIGRATING TO BUILD SRC
+## PLUGINS
+kotlinVersion = 1.7.21
 kotlinxBenchmarkVersion = 0.4.4
-
-# plugin versions
 detektVersion = 1.21.0
 dokkaVersion = 1.6.10
 jacocoVersion = 0.8.8
@@ -59,3 +29,4 @@ mavenPluginDevelopmentVersion = 0.4.0
 nexusPublishPluginVersion = 1.1.0
 pluginPublishPluginVersion = 0.21.0
 # pluginPublishPluginVersion = 1.0.0
+springBootVersion = 2.7.7

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,7 +38,7 @@ detekt = "1.21.0"
 dokka = "1.6.10"
 jacoco = "0.8.8"
 # klint gradle plugin breaks with 0.46.x+
-ktlint = "0.45.2"
+ktlint-core = "0.45.2"
 ktlint-plugin = "10.3.0"
 maven-plugin-development = "0.4.0"
 nexus-publish-plugin = "1.1.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,123 @@
+[versions]
+android-plugin = "7.1.2"
+classgraph = "4.8.149"
+dataloader = "3.2.0"
+federation = "2.0.7"
+graphql-java = "19.2"
+jackson = "2.13.3"
+kotlin = "1.7.21"
+kotlinx-benchmark = "0.4.4"
+kotlinx-coroutines = "1.6.4"
+kotlinx-serialization = "1.4.1"
+ktor = "2.0.3"
+maven-plugin-annotation = "3.6.0"
+maven-plugin-api = "3.6.3"
+maven-project = "2.2.1"
+poet = "1.12.0"
+## reactorVersion should be the same reactor-core version pulled from spring-boot-starter-webflux
+reactor-core = "3.4.26"
+reactor-extensions = "1.1.9"
+slf4j = "1.7.36"
+spring = "5.3.24"
+spring-boot = "2.7.7"
+
+# test dependencies
+# kotlin-compile-testing has to be using the same kotlin version as the kotlinx-serialization compiler
+# https://github.com/tschuchortdev/kotlin-compile-testing the latest version targets kotlin 1.7.10 which blocks updates to newer
+# versions of kotlin, switching to a fork https://github.com/ZacSweers/kotlin-compile-testing
+compile-testing = "0.1.0"
+icu = "71.1"
+junit = "5.8.2"
+mockk = "1.12.5"
+mustache = "0.9.10"
+rxjava = "3.1.5"
+wiremock = "2.33.2"
+
+# plugins
+detekt = "1.21.0"
+dokka = "1.6.10"
+jacoco = "0.8.8"
+# klint gradle plugin breaks with 0.46.x+
+ktlint = "0.45.2"
+ktlint-plugin = "10.3.0"
+maven-plugin-development = "0.4.0"
+nexus-publish-plugin = "1.1.0"
+plugin-publish = "0.21.0"
+
+# ====================
+# LIBRARIES
+# ====================
+[libraries]
+android-plugin = { group = "com.android.tools.build", name = "gradle", version.ref = "android-plugin" }
+classgraph = { group = "io.github.classgraph", name = "classgraph", version.ref = "classgraph" }
+dataloader = { group = "com.graphql-java", name = "java-dataloader", version.ref = "dataloader" }
+federation = { group = "com.apollographql.federation", name = "federation-graphql-java-support", version.ref = "federation" }
+graphql-java = { group = "com.graphql-java", name = "graphql-java", version.ref = "graphql-java" }
+jackson = { group = "com.fasterxml.jackson.module", name = "jackson-module-kotlin", version.ref = "jackson" }
+kotlin-reflect = { group = "org.jetbrains.kotlin", name = "kotlin-reflect", version.ref = "kotlin" }
+kotlin-serialization = { group = "org.jetbrains.kotlin", name = "kotlin-serialization", version.ref= "kotlin" }
+kotlin-stdlib = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", version.ref = "kotlin" }
+kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
+kotlinx-coroutines-jdk8 = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-jdk8", version.ref = "kotlinx-coroutines" }
+kotlinx-coroutines-reactive = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-reactive", version.ref = "kotlinx-coroutines" }
+kotlinx-coroutines-reactor = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-reactor", version.ref = "kotlinx-coroutines" }
+kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
+ktor-client-apache = { group = "io.ktor", name = "ktor-client-apache", version.ref = "ktor" }
+ktor-client-cio = { group = "io.ktor", name = "ktor-client-cio", version.ref = "ktor" }
+ktor-client-content = { group = "io.ktor", name = "ktor-client-content-negotiation", version.ref = "ktor" }
+ktor-client-serialization = { group = "io.ktor", name = "ktor-client-serialization", version.ref = "ktor" }
+ktor-serialization-jackson = { group = "io.ktor", name = "ktor-serialization-jackson", version.ref = "ktor" }
+maven-plugin-annotations = { group = "org.apache.maven.plugin-tools", name = "maven-plugin-annotations", version.ref = "maven-plugin-annotation" }
+maven-plugin-api = { group = "org.apache.maven", name = "maven-plugin-api", version.ref = "maven-plugin-api" }
+maven-project = { group = "org.apache.maven", name = "maven-project", version.ref = "maven-project" }
+poet = { group = "com.squareup", name = "kotlinpoet", version.ref = "poet" }
+slf4j = { group = "org.slf4j", name = "slf4j-api", version.ref = "slf4j" }
+spring-boot-config = { group = "org.springframework.boot", name = "spring-boot-configuration-processor", version.ref = "spring-boot" }
+spring-boot-netty = { group = "org.springframework.boot", name = "spring-boot-starter-reactor-netty", version.ref = "spring-boot" }
+spring-boot-webflux = { group = "org.springframework.boot", name = "spring-boot-starter-webflux", version.ref = "spring-boot" }
+spring-webflux = { group = "org.springframework", name = "spring-webflux", version.ref = "spring" }
+
+# test dependencies
+compile-testing = { group = "dev.zacsweers.kctfork", name = "core", version.ref = "compile-testing" }
+icu = { group = "com.ibm.icu", name = "icu4j", version.ref = "icu" }
+junit-api = { group = "org.junit.jupiter", name = "junit-jupiter-api", version.ref = "junit" }
+junit-engine = { group = "org.junit.jupiter", name = "junit-jupiter-engine", version.ref = "junit" }
+junit-params = { group = "org.junit.jupiter", name = "junit-jupiter-params", version.ref = "junit" }
+kotlin-junit-test = { group = "org.jetbrains.kotlin", name = "kotlin-test-junit5", version.ref = "kotlin" }
+kotlin-test = { group = "org.jetbrains.kotlin", name = "kotlin-test", version.ref = "kotlin" }
+kotlinx-benchmark = { group = "org.jetbrains.kotlinx", name = "kotlinx-benchmark-runtime", version.ref = "kotlinx-benchmark" }
+kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
+ktor-client-logging = { group = "io.ktor", name = "ktor-client-logging", version.ref = "ktor" }
+ktor-client-okhttp = { group = "io.ktor", name = "ktor-client-okhttp", version.ref = "ktor" }
+mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
+mustache = { group = "com.github.spullara.mustache.java", name = "compiler", version.ref = "mustache" }
+reactor-core = { group = "io.projectreactor", name = "reactor-core", version.ref = "reactor-core" }
+reactor-extensions = { group = "io.projectreactor.kotlin", name = "reactor-kotlin-extensions", version.ref = "reactor-extensions" }
+reactor-test = { group = "io.projectreactor", name = "reactor-test", version.ref = "reactor-core" }
+rxjava = { group = "io.reactivex.rxjava3", name = "rxjava", version.ref = "rxjava" }
+spring-boot-test = { group = "org.springframework.boot", name = "spring-boot-starter-test", version.ref = "spring-boot" }
+wiremock-jre8 = { group = "com.github.tomakehurst", name = "wiremock-jre8", version.ref = "wiremock" }
+wiremock-standalone = { group = "com.github.tomakehurst", name = "wiremock-jre8-standalone", version.ref = "wiremock" }
+
+# ====================
+# BUNDLES
+# ====================
+[bundles]
+#groovy = ["groovy-core", "groovy-json", "groovy-nio"]
+
+# ====================
+# PLUGINS
+# ====================
+[plugins]
+benchmark = { id = "org.jetbrains.kotlinx.benchmark", version.ref = "kotlinx-benchmark" }
+detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
+dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+kotlin-spring = { id = "org.jetbrains.kotlin.plugin.spring", version.ref = "kotlin" }
+ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint-plugin" }
+maven-plugin-development = { id = "de.benediktritter.maven-plugin-development", version.ref = "maven-plugin-development" }
+nexus-publish = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "nexus-publish-plugin" }
+plugin-publish = { id = "com.gradle.plugin-publish", version.ref = "plugin-publish" }
+spring-boot = { id = "org.springframework.boot", version.ref = "spring-boot" }

--- a/plugins/client/graphql-kotlin-client-generator/build.gradle.kts
+++ b/plugins/client/graphql-kotlin-client-generator/build.gradle.kts
@@ -1,39 +1,27 @@
 description = "GraphQL Kotlin common utilities to generate a client."
 
-val compileTestingVersion: String by project
-val graphQLJavaVersion: String by project
-val icuVersion: String by project
-val jacksonVersion: String by project
-val junitVersion: String by project
-val kotlinVersion: String by project
-val kotlinPoetVersion: String by project
-val kotlinxSerializationVersion: String by project
-val ktorVersion: String by project
-val slf4jVersion: String by project
-val wireMockVersion: String by project
-
 dependencies {
     api(project(path = ":graphql-kotlin-client"))
-    api("com.graphql-java:graphql-java:$graphQLJavaVersion") {
+    api(libs.graphql.java) {
         exclude(group = "com.graphql-java", module = "java-dataloader")
     }
-    api("com.squareup:kotlinpoet:$kotlinPoetVersion")
-    api("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationVersion")
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion")
-    implementation("io.ktor:ktor-client-apache:$ktorVersion")
-    implementation("io.ktor:ktor-serialization-jackson:$ktorVersion") {
+    api(libs.poet)
+    api(libs.kotlinx.serialization.json)
+    implementation(libs.jackson)
+    implementation(libs.ktor.client.apache)
+    implementation(libs.ktor.serialization.jackson) {
         exclude("com.fasterxml.jackson.core", "jackson-databind")
         exclude("com.fasterxml.jackson.module", "jackson-module-kotlin")
     }
-    implementation("io.ktor:ktor-client-content-negotiation:$ktorVersion")
-    implementation("org.slf4j:slf4j-api:$slf4jVersion")
+    implementation(libs.ktor.client.content)
+    implementation(libs.slf4j)
     testImplementation(project(path = ":graphql-kotlin-client-jackson"))
     testImplementation(project(path = ":graphql-kotlin-client-serialization"))
-    testImplementation("com.github.tomakehurst:wiremock-jre8:$wireMockVersion")
-    testImplementation("dev.zacsweers.kctfork:core:$compileTestingVersion")
-    testImplementation("com.ibm.icu:icu4j:$icuVersion")
-    testImplementation("org.junit.jupiter:junit-jupiter-params:$junitVersion")
-    testImplementation("org.jetbrains.kotlin:kotlin-serialization:$kotlinVersion")
+    testImplementation(libs.wiremock.jre8)
+    testImplementation(libs.compile.testing)
+    testImplementation(libs.icu)
+    testImplementation(libs.junit.params)
+    testImplementation(libs.kotlin.serialization)
 }
 
 tasks {

--- a/plugins/graphql-kotlin-gradle-plugin/build.gradle.kts
+++ b/plugins/graphql-kotlin-gradle-plugin/build.gradle.kts
@@ -7,22 +7,16 @@ plugins {
     id("com.gradle.plugin-publish")
 }
 
-val androidPluginVersion: String by project
-val junitVersion: String by project
-val kotlinxCoroutinesVersion: String by project
-val wireMockVersion: String by project
-val mustacheVersion: String by project
-
 dependencies {
     implementation(kotlin("gradle-plugin-api"))
-    compileOnly("com.android.tools.build:gradle:$androidPluginVersion")
+    compileOnly(libs.android.plugin)
 
     compileOnly(project(":graphql-kotlin-client-generator"))
     compileOnly(project(":graphql-kotlin-sdl-generator"))
 
-    testImplementation("com.github.tomakehurst:wiremock-jre8:$wireMockVersion")
-    testImplementation("com.github.spullara.mustache.java:compiler:$mustacheVersion")
-    testImplementation("org.junit.jupiter:junit-jupiter-params:$junitVersion")
+    testImplementation(libs.wiremock.jre8)
+    testImplementation(libs.mustache)
+    testImplementation(libs.junit.params)
 }
 
 java {
@@ -96,13 +90,10 @@ tasks {
         maxParallelForks = (Runtime.getRuntime().availableProcessors() / 2).takeIf { it > 0 } ?: 1
         dependsOn(":resolveIntegrationTestDependencies")
 
-        val kotlinVersion: String by project
-        val junitVersion: String by project
-        val springBootVersion: String by project
-        systemProperty("androidPluginVersion", androidPluginVersion)
-        systemProperty("kotlinVersion", kotlinVersion)
-        systemProperty("springBootVersion", springBootVersion)
-        systemProperty("junitVersion", junitVersion)
+        systemProperty("androidPluginVersion", libs.versions.android.plugin.get())
+        systemProperty("kotlinVersion", libs.versions.kotlin.get())
+        systemProperty("springBootVersion", libs.versions.spring.boot.get())
+        systemProperty("junitVersion", libs.versions.junit.get())
     }
 
     publishing {

--- a/plugins/graphql-kotlin-maven-plugin/build.gradle.kts
+++ b/plugins/graphql-kotlin-maven-plugin/build.gradle.kts
@@ -3,26 +3,9 @@ import java.time.Duration
 
 description = "GraphQL Kotlin Maven Plugin that can generate type-safe GraphQL Kotlin client and GraphQL schema in SDL format using reflections"
 
-val graphQLJavaVersion: String by project
-val junitVersion: String by project
-val kotlinJvmVersion: String by project
-val kotlinVersion: String by project
-val kotlinxCoroutinesVersion: String by project
-val kotlinPoetVersion: String by project
-val kotlinxSerializationVersion: String by project
-val ktorVersion: String by project
-val reactorVersion: String by project
-
-// maven dependencies
-val mavenPluginApiVersion: String = "3.6.3"
-val mavenPluginAnnotationVersion: String = "3.6.0"
-val mavenProjectVersion: String = "2.2.1"
-
 buildscript {
-    // cannot access project at this time
-    val wireMockVersion: String = "2.26.2"
     dependencies {
-        classpath("com.github.tomakehurst:wiremock-jre8-standalone:$wireMockVersion")
+        classpath(libs.wiremock.standalone)
     }
 }
 
@@ -33,10 +16,10 @@ plugins {
 dependencies {
     api(project(path = ":graphql-kotlin-client-generator"))
     api(project(path = ":graphql-kotlin-sdl-generator"))
-    api("org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinxCoroutinesVersion")
-    implementation("org.apache.maven:maven-plugin-api:$mavenPluginApiVersion")
-    implementation("org.apache.maven:maven-project:$mavenProjectVersion")
-    implementation("org.apache.maven.plugin-tools:maven-plugin-annotations:$mavenPluginAnnotationVersion")
+    api(libs.kotlinx.coroutines.core)
+    implementation(libs.maven.plugin.annotations)
+    implementation(libs.maven.plugin.api)
+    implementation(libs.maven.project)
     testImplementation(project(path = ":graphql-kotlin-spring-server"))
     testImplementation(project(path = ":graphql-kotlin-federated-hooks-provider"))
 }
@@ -51,20 +34,21 @@ tasks {
         }
     }
 
+    val kotlinJvmVersion: String by project
     /*
     Integration tests are run through maven-invoker-plugin which will execute tests under src/integration/<scenario>
      */
     val mavenEnvironmentVariables = mapOf(
         "graphqlKotlinVersion" to project.version,
-        "graphqlJavaVersion" to graphQLJavaVersion,
+        "graphqlJavaVersion" to libs.versions.graphql.java.get(),
         "kotlinJvmTarget" to kotlinJvmVersion,
-        "kotlinVersion" to kotlinVersion,
-        "kotlinxCoroutinesVersion" to kotlinxCoroutinesVersion,
-        "kotlinPoetVersion" to kotlinPoetVersion,
-        "kotlinxSerializationVersion" to kotlinxSerializationVersion,
-        "ktorVersion" to ktorVersion,
-        "reactorVersion" to reactorVersion,
-        "junitVersion" to junitVersion
+        "kotlinVersion" to libs.versions.kotlin.get(),
+        "kotlinxCoroutinesVersion" to libs.versions.kotlinx.coroutines.get(),
+        "kotlinPoetVersion" to libs.versions.poet.get(),
+        "kotlinxSerializationVersion" to libs.versions.kotlinx.serialization.get(),
+        "ktorVersion" to libs.versions.ktor.get(),
+        "reactorVersion" to libs.versions.reactor.core.get(),
+        "junitVersion" to libs.versions.junit.get()
     )
     var wireMockServer: WireMockServerRunner? = null
     var wireMockServerPort: Int? = null

--- a/plugins/schema/graphql-kotlin-sdl-generator/build.gradle.kts
+++ b/plugins/schema/graphql-kotlin-sdl-generator/build.gradle.kts
@@ -1,14 +1,11 @@
 description = "GraphQL Kotlin SDL generator that can be used to generate GraphQL schema from source files."
 
-val classGraphVersion: String by project
-val slf4jVersion: String by project
-
 dependencies {
     implementation(project(path = ":graphql-kotlin-hooks-provider"))
     implementation(project(path = ":graphql-kotlin-server"))
     implementation(project(path = ":graphql-kotlin-federation"))
-    implementation("io.github.classgraph:classgraph:$classGraphVersion")
-    implementation("org.slf4j:slf4j-api:$slf4jVersion")
+    implementation(libs.classgraph)
+    implementation(libs.slf4j)
     testImplementation(project(path = ":graphql-kotlin-spring-server"))
 }
 

--- a/servers/graphql-kotlin-server/build.gradle.kts
+++ b/servers/graphql-kotlin-server/build.gradle.kts
@@ -2,20 +2,16 @@ import kotlinx.benchmark.gradle.JvmBenchmarkTarget
 
 description = "Common code for running a GraphQL server in any HTTP server framework"
 
-val kotlinxCoroutinesVersion: String by project
-val kotlinxBenchmarkVersion: String by project
-
 plugins {
     id("org.jetbrains.kotlinx.benchmark")
 }
 
-val jacksonVersion: String by project
 dependencies {
     api(project(path = ":graphql-kotlin-schema-generator"))
     api(project(path = ":graphql-kotlin-dataloader-instrumentation"))
     api(project(path = ":graphql-kotlin-automatic-persisted-queries"))
-    api("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion")
-    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:$kotlinxCoroutinesVersion")
+    api(libs.jackson)
+    testImplementation(libs.kotlinx.coroutines.test)
 }
 
 // Benchmarks
@@ -25,7 +21,7 @@ sourceSets.create("benchmarks")
 
 kotlin.sourceSets.getByName("benchmarks") {
     dependencies {
-        implementation("org.jetbrains.kotlinx:kotlinx-benchmark-runtime:$kotlinxBenchmarkVersion")
+        implementation(libs.kotlinx.benchmark)
         implementation(sourceSets.main.get().output)
         implementation(sourceSets.main.get().runtimeClasspath)
     }

--- a/servers/graphql-kotlin-spring-server/build.gradle.kts
+++ b/servers/graphql-kotlin-spring-server/build.gradle.kts
@@ -5,22 +5,17 @@ plugins {
     kotlin("kapt")
 }
 
-val kotlinxCoroutinesVersion: String by project
-val springBootVersion: String by project
-val reactorVersion: String by project
-val reactorExtensionsVersion: String by project
-
 dependencies {
     api(project(path = ":graphql-kotlin-server"))
     api(project(path = ":graphql-kotlin-federation"))
-    api("org.springframework.boot:spring-boot-starter-webflux:$springBootVersion")
-    api("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:$kotlinxCoroutinesVersion")
-    api("io.projectreactor.kotlin:reactor-kotlin-extensions:$reactorExtensionsVersion")
-    api("org.jetbrains.kotlinx:kotlinx-coroutines-reactor:$kotlinxCoroutinesVersion")
-    kapt("org.springframework.boot:spring-boot-configuration-processor:$springBootVersion")
-    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:$kotlinxCoroutinesVersion")
-    testImplementation("org.springframework.boot:spring-boot-starter-test:$springBootVersion")
-    testImplementation("io.projectreactor:reactor-test:$reactorVersion")
+    api(libs.spring.boot.webflux)
+    api(libs.kotlinx.coroutines.jdk8)
+    api(libs.kotlinx.coroutines.reactor)
+    api(libs.reactor.extensions)
+    kapt(libs.spring.boot.config)
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.spring.boot.test)
+    testImplementation(libs.reactor.test)
 }
 
 tasks {


### PR DESCRIPTION
### :pencil: Description

[Version Catalog](https://docs.gradle.org/current/userguide/platforms.html#sub:version-catalog) is a preferred mechanism for declaring and sharing project dependencies. Once dependencies are defined in the `libs.versions.toml` file, they can be imported using type safe accessors.

Dependent projects (i.e. `examples`, Gradle plugin integration tests and federation compatibility) can also import same version catalog which further simplifies version management.

### :link: Related Issues
