### PR TITLE
chore: update federation-jvm version to 2.2.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 android-plugin = "7.1.2"
 classgraph = "4.8.149"
 dataloader = "3.2.0"
-federation = "2.1.0"
+federation = "2.2.0"
 graphql-java = "19.2"
 jackson = "2.13.3"
 kotlin = "1.7.21"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 android-plugin = "7.1.2"
 classgraph = "4.8.149"
 dataloader = "3.2.0"
-federation = "2.0.7"
+federation = "2.1.0"
 graphql-java = "19.2"
 jackson = "2.13.3"
 kotlin = "1.7.21"


### PR DESCRIPTION
### :pencil: Description
[CVE-2022-3171](https://devhub.checkmarx.com/cve-details/CVE-2022-3171/?utm_source=jetbrains&utm_medium=referral&utm_campaign=idea&utm_term=maven)

### :link: Related Issues
https://github.com/ExpediaGroup/graphql-kotlin/issues/1608