### PR TITLE
fix: fixed federation link imports

### DIFF
--- a/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/FederatedSchemaGeneratorHooks.kt
+++ b/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/FederatedSchemaGeneratorHooks.kt
@@ -141,8 +141,8 @@ open class FederatedSchemaGeneratorHooks(private val resolvers: List<FederatedTy
             builder.additionalDirective(it)
         }
         if (optInFederationV2) {
-            val fed2Imports = federatedDirectiveV2List.map { it.name }
-                .minus(LINK_DIRECTIVE_NAME)
+            val fed2Imports = federatedDirectiveV2List.map { "@${it.name}" }
+                .minus("@$LINK_DIRECTIVE_NAME")
                 .plus(FIELD_SET_SCALAR_NAME)
 
             builder.withSchemaDirective(LINK_DIRECTIVE_TYPE)

--- a/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/FederatedSchemaV2GeneratorTest.kt
+++ b/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/FederatedSchemaV2GeneratorTest.kt
@@ -30,7 +30,7 @@ class FederatedSchemaV2GeneratorTest {
     fun `verify can generate federated schema`() {
         val expectedSchema =
             """
-            schema @link(import : ["extends", "external", "inaccessible", "key", "override", "provides", "requires", "shareable", "tag", "FieldSet"], url : "https://specs.apollo.dev/federation/v2.0"){
+            schema @link(import : ["@extends", "@external", "@inaccessible", "@key", "@override", "@provides", "@requires", "@shareable", "@tag", "FieldSet"], url : "https://specs.apollo.dev/federation/v2.0"){
               query: Query
             }
 

--- a/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/execution/ServiceQueryResolverTest.kt
+++ b/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/execution/ServiceQueryResolverTest.kt
@@ -99,7 +99,7 @@ type SelfReferenceObject {
 
 const val FEDERATED_SERVICE_SDL_V2 =
 """
-schema @link(import : ["extends", "external", "inaccessible", "key", "override", "provides", "requires", "shareable", "tag", "FieldSet"], url : "https://specs.apollo.dev/federation/v2.0"){
+schema @link(import : ["@extends", "@external", "@inaccessible", "@key", "@override", "@provides", "@requires", "@shareable", "@tag", "FieldSet"], url : "https://specs.apollo.dev/federation/v2.0"){
   query: Query
 }
 


### PR DESCRIPTION
### :pencil: Description

This was fixed in https://github.com/ExpediaGroup/graphql-kotlin/pull/1593 and broken again in https://github.com/ExpediaGroup/graphql-kotlin/pull/1618.
