### PR TITLE
fix: graphiql bundle version

### DIFF
--- a/servers/graphql-kotlin-spring-server/src/main/resources/graphql-graphiql.html
+++ b/servers/graphql-kotlin-spring-server/src/main/resources/graphql-graphiql.html
@@ -33,7 +33,7 @@
 <script src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"
         integrity="sha512-Wr9OKCTtq1anK0hq5bY3X/AvDI5EflDSAh0mE9gma+4hl+kXdTJPKZ3TwLMBcrgUeoY0s3dq9JjhCQc7vddtFg=="
         crossorigin="anonymous"></script>
-<script src="https://unpkg.com/graphiql/graphiql.min.js"
+<script src="https://unpkg.com/graphiql@2.2.0/graphiql.min.js"
         integrity="sha512-FVCV2//UVo1qJ3Kg6kkHLe0Hg+IJhjrGa+aYHh8xD4KmwbbjthIzvaAcCJsQgA43+k+6u7HqORKXMyMt82Srfw=="
         crossorigin="anonymous"></script>
 <script src="https://unpkg.com/@graphiql/plugin-explorer@0.1.12/dist/graphiql-plugin-explorer.umd.js"


### PR DESCRIPTION
### :pencil: Description
GraphiQL is breaking because the integrity hash is for a specific version but the script tag is attempting to download the newest version, which is no longer 2.2.0. This PR pins graphiQL bundle to 2.2.0 version.