### PR TITLE
feat: pass graphQLContext as fallback if deprecated context is null

### DIFF
--- a/servers/graphql-kotlin-server/src/main/kotlin/com/expediagroup/graphql/server/extensions/dataFetchingEnvironmentExtensions.kt
+++ b/servers/graphql-kotlin-server/src/main/kotlin/com/expediagroup/graphql/server/extensions/dataFetchingEnvironmentExtensions.kt
@@ -29,18 +29,20 @@ import java.util.concurrent.CompletableFuture
  * Helper method to get a value from a registered DataLoader.
  * The provided key should be the cache key object used to save the value for that particular data loader.
  */
-fun <K, V> DataFetchingEnvironment.getValueFromDataLoader(dataLoaderName: String, key: K): CompletableFuture<V> {
-    val loader = getDataLoader<K, V>(dataLoaderName) ?: throw MissingDataLoaderException(dataLoaderName)
-    return loader.load(key, this.getContext())
-}
+fun <K, V> DataFetchingEnvironment.getValueFromDataLoader(dataLoaderName: String, key: K): CompletableFuture<V> =
+    getDataLoader<K, V>(dataLoaderName)?.load(
+        key,
+        this.getContext() ?: this.graphQlContext
+    ) ?: throw MissingDataLoaderException(dataLoaderName)
 
 /**
 * Helper method to get values from a registered DataLoader.
 */
-fun <K, V> DataFetchingEnvironment.getValuesFromDataLoader(dataLoaderName: String, keys: List<K>): CompletableFuture<List<V>> {
-    val loader = getDataLoader<K, V>(dataLoaderName) ?: throw MissingDataLoaderException(dataLoaderName)
-    return loader.loadMany(keys, listOf(this.getContext()))
-}
+fun <K, V> DataFetchingEnvironment.getValuesFromDataLoader(dataLoaderName: String, keys: List<K>): CompletableFuture<List<V>> =
+    getDataLoader<K, V>(dataLoaderName)?.loadMany(
+        keys,
+        listOf(this.getContext() ?: this.graphQlContext)
+    ) ?: throw MissingDataLoaderException(dataLoaderName)
 
 /**
  * Returns a value from the graphQLContext by KClass key


### PR DESCRIPTION
### :link: Related Issues
https://github.com/ExpediaGroup/graphql-kotlin/issues/1649

will update both pre-release and 6.x.x docs in a separate PR against master