### PR TITLE
docs: arguments spelling mistake

### DIFF
--- a/website/versioned_docs/version-6.x.x/schema-generator/execution/contextual-data.md
+++ b/website/versioned_docs/version-6.x.x/schema-generator/execution/contextual-data.md
@@ -63,7 +63,7 @@ Note that the argument that implements `GraphQLContext` is not reflected in the 
 ## Handling Context Errors
 
 The [GraphQLContextFactory](../../server/graphql-context-factory.md) may return `null`. If your factory implementation never returns `null`, then there is no need to change your schema.
-If the factory could return `null`, then the context arugments in your schema should be nullable so a runtime exception is not thrown.
+If the factory could return `null`, then the context arguments in your schema should be nullable so a runtime exception is not thrown.
 
 ```kotlin
 class ContextualQuery : Query {


### PR DESCRIPTION
### :pencil: Description
Fixed a tiny spelling mistake in the contextual-data documentation.
