### PR TITLE
fix(gradle-plugin): compileKotlin does not exist in Multiplatform

### DIFF
--- a/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePlugin.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePlugin.kt
@@ -170,7 +170,12 @@ class GraphQLGradlePlugin : Plugin<Project> {
 
             val configuration = project.configurations.getAt(GENERATE_SDL_CONFIGURATION)
             generateSDLTask.pluginClasspath.setFrom(configuration)
-            generateSDLTask.dependsOn(project.tasks.findByName("compileKotlin") ?: project.tasks.named("compileKotlinJvm"))
+            val compileKotlinTask = project.tasks.findByName("compileKotlin") ?: project.tasks.findByName("compileKotlinJvm")
+            if (compileKotlinTask != null) {
+                generateSDLTask.dependsOn(compileKotlinTask)
+            } else {
+                project.logger.warn("compileKotlin/compileKotlinJvm tasks not found. Unable to auto-configure the generateSDLTask dependency on compile task.")
+            }
         }
 
         if (isAndroidProject) {

--- a/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePlugin.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePlugin.kt
@@ -170,7 +170,7 @@ class GraphQLGradlePlugin : Plugin<Project> {
 
             val configuration = project.configurations.getAt(GENERATE_SDL_CONFIGURATION)
             generateSDLTask.pluginClasspath.setFrom(configuration)
-            generateSDLTask.dependsOn(project.tasks.named("compileKotlin"))
+            generateSDLTask.dependsOn(project.tasks.findByName("compileKotlin") ?: project.tasks.named("compileKotlinJvm"))
         }
 
         if (isAndroidProject) {


### PR DESCRIPTION
Instead the gradle plugin would use compileKotlinJvm.
This is a temporary fix, but in the short-term, it would make the gradle plugin compatible with Multiplatform.

### :pencil: Description
Fix of a Gradle error, that when running with Multiplatform, the Gradle plugin cannot find a task named "compileKotlin", which does not exist in a Multiplatform context.

### :link: Related Issues
#1139
#876