### PR TITLE
fix(ktor-server): move plugin install to routing context

### DIFF
--- a/servers/graphql-kotlin-ktor-server/src/main/kotlin/com/expediagroup/graphql/server/ktor/GraphQL.kt
+++ b/servers/graphql-kotlin-ktor-server/src/main/kotlin/com/expediagroup/graphql/server/ktor/GraphQL.kt
@@ -145,14 +145,14 @@ class GraphQL(config: GraphQLConfiguration) {
                 pipeline.log.info("\n${plugin.schema.print()}")
             }
 
-            // install content negotiation
-            pipeline.install(ContentNegotiation) {
-                jackson(streamRequestBody = config.server.streamingResponse) {
-                    apply(config.server.jacksonConfiguration)
-                }
-            }
             // install routing
             pipeline.routing {
+                // install content negotiation
+                install(ContentNegotiation) {
+                    jackson(streamRequestBody = config.server.streamingResponse) {
+                        apply(config.server.jacksonConfiguration)
+                    }
+                }
                 get(config.routes.endpoint) {
                     plugin.server.executeRequest(call)
                 }


### PR DESCRIPTION
### :pencil: Description
Fixes that a plugin is applied globally, which is not really needed in this context

### :link: Related Issues
fixes #1683
