### PR TITLE
[ktor server] simplify KtorGraphQLRequestParser

### DIFF
--- a/servers/graphql-kotlin-ktor-server/src/main/kotlin/com/expediagroup/graphql/server/ktor/KtorGraphQLRequestParser.kt
+++ b/servers/graphql-kotlin-ktor-server/src/main/kotlin/com/expediagroup/graphql/server/ktor/KtorGraphQLRequestParser.kt
@@ -24,7 +24,7 @@ import com.fasterxml.jackson.databind.type.MapType
 import com.fasterxml.jackson.databind.type.TypeFactory
 import io.ktor.http.HttpMethod
 import io.ktor.server.request.ApplicationRequest
-import io.ktor.server.request.receiveText
+import io.ktor.server.request.receive
 import java.io.IOException
 
 internal const val REQUEST_PARAM_QUERY = "query"
@@ -39,7 +39,6 @@ class KtorGraphQLRequestParser(
 ) : GraphQLRequestParser<ApplicationRequest> {
 
     private val mapTypeReference: MapType = TypeFactory.defaultInstance().constructMapType(HashMap::class.java, String::class.java, Any::class.java)
-//    private val graphQLContentType: ContentType = ContentType.parse("application/graphql-response+json")
 
     override suspend fun parseRequest(request: ApplicationRequest): GraphQLServerRequest? = when (request.local.method) {
         HttpMethod.Get -> parseGetRequest(request)
@@ -61,9 +60,8 @@ class KtorGraphQLRequestParser(
     }
 
     private suspend fun parsePostRequest(request: ApplicationRequest): GraphQLServerRequest? = try {
-        val rawRequest = request.call.receiveText()
-        mapper.readValue(rawRequest, GraphQLServerRequest::class.java)
+        request.call.receive()
     } catch (e: IOException) {
-        throw IllegalStateException("Invalid HTTP request - unable to parse GraphQL request from POST payload")
+        throw IllegalStateException("Invalid HTTP request - unable to parse GraphQL request from POST payload", e)
     }
 }

--- a/servers/graphql-kotlin-ktor-server/src/test/kotlin/com/expediagroup/graphql/server/ktor/KtorGraphQLRequestParserTest.kt
+++ b/servers/graphql-kotlin-ktor-server/src/test/kotlin/com/expediagroup/graphql/server/ktor/KtorGraphQLRequestParserTest.kt
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.ktor.http.HttpMethod
 import io.ktor.server.request.ApplicationRequest
 import io.ktor.server.testing.TestApplicationRequest
-import io.ktor.utils.io.ByteReadChannel
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
@@ -93,7 +92,7 @@ class KtorGraphQLRequestParserTest {
         val serverRequest = mockk<TestApplicationRequest>(relaxed = true) {
             every { call } returns mockk(relaxed = true) {
                 every { attributes.getOrNull<Any>(any()) } returns null
-                coEvery { request.pipeline.execute(any(), any()) } returns ByteReadChannel(mapper.writeValueAsBytes(mockRequest))
+                coEvery { request.pipeline.execute(any(), any()) } returns mockRequest
             }
             every { local.method } returns HttpMethod.Post
         }
@@ -115,7 +114,7 @@ class KtorGraphQLRequestParserTest {
         val serverRequest = mockk<TestApplicationRequest>(relaxed = true) {
             every { call } returns mockk(relaxed = true) {
                 every { attributes.getOrNull<Any>(any()) } returns null
-                coEvery { request.pipeline.execute(any(), any()) } returns ByteReadChannel(mapper.writeValueAsBytes(mockRequest))
+                coEvery { request.pipeline.execute(any(), any()) } returns mockRequest
             }
             every { local.method } returns HttpMethod.Post
         }
@@ -138,8 +137,3 @@ class KtorGraphQLRequestParserTest {
         assertNull(secondRequest.variables)
     }
 }
-
-/*
-    @Suppress("BlockingMethodInNonBlockingContext")
-
- */


### PR DESCRIPTION
### :pencil: Description

We can rely on `ContentNegotiation` plugin to automatically parse incoming requests for us. We don't have to read incoming requests as plain text and then attempt to manually map it.

### :link: Related Issues
