### PR TITLE
build: set permissions to deploy GH pages

### DIFF
--- a/.github/workflows/publish-latest-docs.yml
+++ b/.github/workflows/publish-latest-docs.yml
@@ -9,6 +9,8 @@ on:
 
 jobs:
   publish-docs:
+    permissions:
+      contents: write
     timeout-minutes: 10
     runs-on: ubuntu-latest
     if: github.repository == 'ExpediaGroup/graphql-kotlin'


### PR DESCRIPTION
### :pencil: Description

We are using https://github.com/peaceiris/actions-gh-pages which requires `contents: write` permission.

We could potentially refactor this to use more generic `actions/upload-pages-artifact` + `actions/deploy-pages` that require more scoped permissions but unsure how much value it gets us.

### :link: Related Issues

We won't be able to publish new GH pages until this is fixed -> see https://github.com/ExpediaGroup/graphql-kotlin/actions/runs/4427684966/jobs/7765655027#step:6:1258