### PR TITLE
build: set permissions for release drafter

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -31,6 +31,9 @@ jobs:
   release-notes:
     timeout-minutes: 10
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
     steps:
       - name: Release Drafter
         uses: release-drafter/release-drafter@v5


### PR DESCRIPTION
### :pencil: Description

We are using https://github.com/release-drafter/release-drafter which requires `contents: write` + `pull-requests: read` permissions.

### :link: Related Issues

N/A