### PR TITLE
Update `graphiql-plugin-code-exporter.umd.js` checksum

### DIFF
--- a/servers/graphql-kotlin-spring-server/src/main/resources/graphql-graphiql.html
+++ b/servers/graphql-kotlin-spring-server/src/main/resources/graphql-graphiql.html
@@ -40,7 +40,7 @@
         integrity="sha512-Fjas/uSkzvsFjbv4jqU9nt4ulU7LDjiMAXW2YFTYD96NgKS1fhhAsGR4b2k2VaVLsE29aia3vyobAq9TNzusvA=="
         crossorigin="anonymous"></script>
 <script src="https://unpkg.com/@graphiql/plugin-code-exporter/dist/graphiql-plugin-code-exporter.umd.js"
-        integrity="sha512-NwP+k36ExLYeIqp2lniZCblbz/FLJ/lQlBV55B6vafZWIYppwHUp1gCdvlaaUjV95RWPInQy4z/sIa56psJy/g=="
+        integrity="sha512-bZesuT5p2QZ6cSlpgPxI83Db5G3Bw35RTKz+Z+kc6RUu4/PtPkNddzax0VWA6VoXvIwT8s4i5nQklZ+AGJQD2Q=="
         crossorigin="anonymous"></script>
 
 <script>


### PR DESCRIPTION
Opening this in case other bumps into this. GraphiQL started to show errors this morning:

```
Failed to find a valid digest in the 'integrity' attribute for resource 'https://unpkg.com/@graphiql/plugin-code-exporter/dist/graphiql-plugin-code-exporter.umd.js' 
with computed SHA-512 integrity 'bZesuT5p2QZ6cSlpgPxI83Db5G3Bw35RTKz+Z+kc6RUu4/PtPkNddzax0VWA6VoXvIwT8s4i5nQklZ+AGJQD2Q=='.
 The resource has been blocked.
```

I'm not exactly sure what's happening, opening this as draft until we have more information.

Edit: looks like there was a [release 13h ago](https://www.npmjs.com/package/@graphiql/plugin-code-exporter) so that might explain things. Might be worth pinning the version?