### PR TITLE
feat: update graphiql packages cdn

### DIFF
--- a/servers/graphql-kotlin-server/src/main/resources/graphql-graphiql.html
+++ b/servers/graphql-kotlin-server/src/main/resources/graphql-graphiql.html
@@ -19,27 +19,27 @@
         }
     </style>
 
-    <link rel="stylesheet" href="https://unpkg.com/graphiql@2.2.0/graphiql.min.css" />
-    <link rel="stylesheet" href="https://unpkg.com/@graphiql/plugin-explorer@0.1.15/dist/style.css" />
-    <link rel="stylesheet" href="https://unpkg.com/@graphiql/plugin-code-exporter@0.1.2/dist/style.css" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/graphiql@2.2.0/graphiql.min.css" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@graphiql/plugin-explorer@0.1.15/dist/style.css" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@graphiql/plugin-code-exporter@0.1.2/dist/style.css" />
 </head>
 
 <body>
 <div id="graphiql">Loading...</div>
 
-<script src="https://unpkg.com/react@17/umd/react.development.js"
+<script src="https://cdn.jsdelivr.net/npm/react@17/umd/react.development.js"
         integrity="sha512-Vf2xGDzpqUOEIKO+X2rgTLWPY+65++WPwCHkX2nFMu9IcstumPsf/uKKRd5prX3wOu8Q0GBylRpsDB26R6ExOg=="
         crossorigin="anonymous"></script>
-<script src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"
+<script src="https://cdn.jsdelivr.net/npm/react-dom@17/umd/react-dom.development.js"
         integrity="sha512-Wr9OKCTtq1anK0hq5bY3X/AvDI5EflDSAh0mE9gma+4hl+kXdTJPKZ3TwLMBcrgUeoY0s3dq9JjhCQc7vddtFg=="
         crossorigin="anonymous"></script>
-<script src="https://unpkg.com/graphiql@2.2.0/graphiql.min.js"
+<script src="https://cdn.jsdelivr.net/npm/graphiql@2.2.0/graphiql.min.js"
         integrity="sha512-FVCV2//UVo1qJ3Kg6kkHLe0Hg+IJhjrGa+aYHh8xD4KmwbbjthIzvaAcCJsQgA43+k+6u7HqORKXMyMt82Srfw=="
         crossorigin="anonymous"></script>
-<script src="https://unpkg.com/@graphiql/plugin-explorer@0.1.15/dist/graphiql-plugin-explorer.umd.js"
+<script src="https://cdn.jsdelivr.net/npm/@graphiql/plugin-explorer@0.1.15/dist/graphiql-plugin-explorer.umd.js"
         integrity="sha512-VQtND1w103C6dmo8VAhbV2DlkFdXKtWpr2nVuYEdj2dFB0UIMYeSbpKDLAD7n+UP+b0Eg79Gn40Onju687384A=="
         crossorigin="anonymous"></script>
-<script src="https://unpkg.com/@graphiql/plugin-code-exporter@0.1.2/dist/graphiql-plugin-code-exporter.umd.js"
+<script src="https://cdn.jsdelivr.net/npm/@graphiql/plugin-code-exporter@0.1.2/dist/graphiql-plugin-code-exporter.umd.js"
         integrity="sha512-bZesuT5p2QZ6cSlpgPxI83Db5G3Bw35RTKz+Z+kc6RUu4/PtPkNddzax0VWA6VoXvIwT8s4i5nQklZ+AGJQD2Q=="
         crossorigin="anonymous"></script>
 


### PR DESCRIPTION
use jsdelivr in favor of unpkg which is being unstable lately because of cloudfare