### PR TITLE
feat: new GraalVM reflect metadata generator

### DIFF
--- a/plugins/server/graphql-kotlin-graalvm-metadata-generator/build.gradle.kts
+++ b/plugins/server/graphql-kotlin-graalvm-metadata-generator/build.gradle.kts
@@ -1,0 +1,74 @@
+description = "GraalVM metadata generator for GraphQL Kotlin servers"
+
+plugins {
+    id("com.expediagroup.graphql.conventions")
+}
+
+dependencies {
+    implementation(projects.graphqlKotlinHooksProvider)
+    implementation(projects.graphqlKotlinServer)
+    implementation(projects.graphqlKotlinFederation)
+    implementation(libs.classgraph)
+    implementation(libs.slf4j)
+}
+
+testing {
+    suites {
+        val test by getting(JvmTestSuite::class) {
+            useJUnitJupiter()
+        }
+
+        val integrationTest by registering(JvmTestSuite::class) {
+            dependencies {
+                implementation(project())
+            }
+
+            targets {
+                all {
+                    testTask.configure {
+                        shouldRunAfter(test)
+                    }
+                }
+            }
+
+            sources {
+                java {
+                    setSrcDirs(listOf("src/integrationTest/kotlin"))
+                }
+                resources {
+                    setSrcDirs(listOf("src/integrationTest/resources"))
+                }
+                compileClasspath += sourceSets["test"].compileClasspath
+                runtimeClasspath += compileClasspath + sourceSets["test"].runtimeClasspath
+            }
+        }
+    }
+}
+
+tasks {
+    jacocoTestReport {
+        // we need to explicitly add integrationTest coverage info
+        executionData.setFrom(fileTree(buildDir).include("/jacoco/*.exec"))
+    }
+    jacocoTestCoverageVerification {
+        // we need to explicitly add integrationTest coverage info
+        executionData.setFrom(fileTree(buildDir).include("/jacoco/*.exec"))
+        violationRules {
+            rule {
+                limit {
+                    counter = "INSTRUCTION"
+                    value = "COVEREDRATIO"
+                    minimum = "0.85".toBigDecimal()
+                }
+                limit {
+                    counter = "BRANCH"
+                    value = "COVEREDRATIO"
+                    minimum = "0.60".toBigDecimal()
+                }
+            }
+        }
+    }
+    check {
+        dependsOn(testing.suites.named("integrationTest"))
+    }
+}

--- a/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/integrationTest/kotlin/com/expediagroup/graphql/plugin/graalvm/custom/CustomScalarQuery.kt
+++ b/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/integrationTest/kotlin/com/expediagroup/graphql/plugin/graalvm/custom/CustomScalarQuery.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2023 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.plugin.graalvm.custom
+
+import com.expediagroup.graphql.server.operations.Query
+import java.util.UUID
+
+class CustomScalarQuery : Query {
+    fun customScalar(): UUID = TODO()
+    fun customScalarArg(arg: UUID): UUID = TODO()
+    fun optionalCustomScalarArg(arg: UUID? = null): UUID? = TODO()
+}

--- a/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/integrationTest/kotlin/com/expediagroup/graphql/plugin/graalvm/custom/GenerateGraalVmCustomScalarMetadataTest.kt
+++ b/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/integrationTest/kotlin/com/expediagroup/graphql/plugin/graalvm/custom/GenerateGraalVmCustomScalarMetadataTest.kt
@@ -17,8 +17,9 @@
 package com.expediagroup.graphql.plugin.graalvm.custom
 
 import com.expediagroup.graphql.plugin.graalvm.ClassMetadata
+import com.expediagroup.graphql.plugin.graalvm.DefaultMetadataLoader.loadDefaultReflectMetadata
 import com.expediagroup.graphql.plugin.graalvm.MethodMetadata
-import com.expediagroup.graphql.plugin.graalvm.generateGraalVmReflectMetadata
+import com.expediagroup.graphql.plugin.graalvm.generateGraalVmMetadata
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.junit.jupiter.api.Assertions
@@ -52,11 +53,12 @@ class GenerateGraalVmCustomScalarMetadataTest {
             )
         )
 
-        val actual = generateGraalVmReflectMetadata(supportedPackages = listOf("com.expediagroup.graphql.plugin.graalvm.custom"))
+        val actual = generateGraalVmMetadata(supportedPackages = listOf("com.expediagroup.graphql.plugin.graalvm.custom"))
+        val defaults = loadDefaultReflectMetadata()
 
         val mapper = jacksonObjectMapper()
             .setSerializationInclusion(JsonInclude.Include.NON_NULL)
         val writer = mapper.writerWithDefaultPrettyPrinter()
-        Assertions.assertEquals(writer.writeValueAsString(expected), writer.writeValueAsString(actual))
+        Assertions.assertEquals(writer.writeValueAsString(expected + defaults), writer.writeValueAsString(actual))
     }
 }

--- a/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/integrationTest/kotlin/com/expediagroup/graphql/plugin/graalvm/custom/GenerateGraalVmCustomScalarMetadataTest.kt
+++ b/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/integrationTest/kotlin/com/expediagroup/graphql/plugin/graalvm/custom/GenerateGraalVmCustomScalarMetadataTest.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2023 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.plugin.graalvm.custom
+
+import com.expediagroup.graphql.plugin.graalvm.ClassMetadata
+import com.expediagroup.graphql.plugin.graalvm.MethodMetadata
+import com.expediagroup.graphql.plugin.graalvm.generateGraalVmReflectMetadata
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+class GenerateGraalVmCustomScalarMetadataTest {
+
+    @Test
+    fun `verifies we can generate valid reflect metadata for query with custom scalars`() {
+        val expected = listOf(
+            ClassMetadata(
+                name = "com.expediagroup.graphql.plugin.graalvm.custom.CustomScalarQuery",
+                methods = listOf(
+                    MethodMetadata(
+                        name = "customScalar",
+                        parameterTypes = listOf()
+                    ),
+                    MethodMetadata(
+                        name = "customScalarArg",
+                        parameterTypes = listOf("java.util.UUID")
+                    ),
+                    MethodMetadata(
+                        name = "optionalCustomScalarArg",
+                        parameterTypes = listOf("java.util.UUID")
+                    ),
+                    MethodMetadata(
+                        name = "optionalCustomScalarArg\$default",
+                        parameterTypes = listOf("com.expediagroup.graphql.plugin.graalvm.custom.CustomScalarQuery", "java.util.UUID", "int", "java.lang.Object")
+                    )
+                )
+            )
+        )
+
+        val actual = generateGraalVmReflectMetadata(supportedPackages = listOf("com.expediagroup.graphql.plugin.graalvm.custom"))
+
+        val mapper = jacksonObjectMapper()
+            .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+        val writer = mapper.writerWithDefaultPrettyPrinter()
+        Assertions.assertEquals(writer.writeValueAsString(expected), writer.writeValueAsString(actual))
+    }
+}

--- a/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/integrationTest/kotlin/com/expediagroup/graphql/plugin/graalvm/federated/FederatedEntity.kt
+++ b/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/integrationTest/kotlin/com/expediagroup/graphql/plugin/graalvm/federated/FederatedEntity.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.plugin.graalvm.federated
+
+import com.expediagroup.graphql.generator.federation.directives.ExternalDirective
+import com.expediagroup.graphql.generator.federation.directives.FieldSet
+import com.expediagroup.graphql.generator.federation.directives.KeyDirective
+import com.expediagroup.graphql.generator.federation.directives.RequiresDirective
+import kotlin.properties.Delegates
+
+@KeyDirective(fields = FieldSet("id"))
+data class FederatedEntity(val id: Int) {
+    @ExternalDirective
+    var externalField: String by Delegates.notNull()
+
+    @RequiresDirective(FieldSet("externalField"))
+    fun federatedFunction(arg: String): String = TODO()
+}

--- a/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/integrationTest/kotlin/com/expediagroup/graphql/plugin/graalvm/federated/GenerateGraalVmEntityMetadataTest.kt
+++ b/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/integrationTest/kotlin/com/expediagroup/graphql/plugin/graalvm/federated/GenerateGraalVmEntityMetadataTest.kt
@@ -17,8 +17,9 @@
 package com.expediagroup.graphql.plugin.graalvm.federated
 
 import com.expediagroup.graphql.plugin.graalvm.ClassMetadata
+import com.expediagroup.graphql.plugin.graalvm.DefaultMetadataLoader.loadDefaultReflectMetadata
 import com.expediagroup.graphql.plugin.graalvm.MethodMetadata
-import com.expediagroup.graphql.plugin.graalvm.generateGraalVmReflectMetadata
+import com.expediagroup.graphql.plugin.graalvm.generateGraalVmMetadata
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.junit.jupiter.api.Assertions
@@ -49,11 +50,12 @@ class GenerateGraalVmEntityMetadataTest {
             )
         )
 
-        val actual = generateGraalVmReflectMetadata(supportedPackages = listOf("com.expediagroup.graphql.plugin.graalvm.federated"))
+        val actual = generateGraalVmMetadata(supportedPackages = listOf("com.expediagroup.graphql.plugin.graalvm.federated"))
+        val defaults = loadDefaultReflectMetadata()
 
         val mapper = jacksonObjectMapper()
             .setSerializationInclusion(JsonInclude.Include.NON_NULL)
         val writer = mapper.writerWithDefaultPrettyPrinter()
-        Assertions.assertEquals(writer.writeValueAsString(expected), writer.writeValueAsString(actual))
+        Assertions.assertEquals(writer.writeValueAsString(expected + defaults), writer.writeValueAsString(actual))
     }
 }

--- a/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/integrationTest/kotlin/com/expediagroup/graphql/plugin/graalvm/federated/GenerateGraalVmEntityMetadataTest.kt
+++ b/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/integrationTest/kotlin/com/expediagroup/graphql/plugin/graalvm/federated/GenerateGraalVmEntityMetadataTest.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2023 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.plugin.graalvm.federated
+
+import com.expediagroup.graphql.plugin.graalvm.ClassMetadata
+import com.expediagroup.graphql.plugin.graalvm.MethodMetadata
+import com.expediagroup.graphql.plugin.graalvm.generateGraalVmReflectMetadata
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+class GenerateGraalVmEntityMetadataTest {
+
+    @Test
+    fun `verifies we can generate valid reflect metadata for federated entities`() {
+        val expected = listOf(
+            ClassMetadata(
+                name = "com.expediagroup.graphql.plugin.graalvm.federated.FederatedEntity",
+                allDeclaredFields = true,
+                methods = listOf(
+                    MethodMetadata(
+                        name = "federatedFunction",
+                        parameterTypes = listOf("java.lang.String")
+                    ),
+                    MethodMetadata(
+                        name = "getExternalField",
+                        parameterTypes = listOf()
+                    ),
+                    MethodMetadata(
+                        name = "getId",
+                        parameterTypes = listOf()
+                    )
+                )
+            )
+        )
+
+        val actual = generateGraalVmReflectMetadata(supportedPackages = listOf("com.expediagroup.graphql.plugin.graalvm.federated"))
+
+        val mapper = jacksonObjectMapper()
+            .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+        val writer = mapper.writerWithDefaultPrettyPrinter()
+        Assertions.assertEquals(writer.writeValueAsString(expected), writer.writeValueAsString(actual))
+    }
+}

--- a/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/integrationTest/kotlin/com/expediagroup/graphql/plugin/graalvm/hooks/CustomFederatedHooks.kt
+++ b/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/integrationTest/kotlin/com/expediagroup/graphql/plugin/graalvm/hooks/CustomFederatedHooks.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.plugin.graalvm.hooks
+
+import com.expediagroup.graphql.generator.federation.FederatedSchemaGeneratorHooks
+import graphql.language.StringValue
+import graphql.schema.Coercing
+import graphql.schema.CoercingParseLiteralException
+import graphql.schema.CoercingParseValueException
+import graphql.schema.GraphQLScalarType
+import graphql.schema.GraphQLType
+import java.util.UUID
+import kotlin.reflect.KType
+
+private val graphqlUUIDType = GraphQLScalarType.newScalar()
+    .name("UUID")
+    .description("Custom scalar representing UUID")
+    .coercing(object : Coercing<UUID, String> {
+        override fun parseValue(input: Any): UUID = try {
+            UUID.fromString(serialize(input))
+        } catch (e: Exception) {
+            throw CoercingParseValueException("Unable to convert value $input to UUID")
+        }
+
+        override fun parseLiteral(input: Any): UUID {
+            val uuidString = (input as? StringValue)?.value
+            return if (uuidString != null) {
+                UUID.fromString(uuidString)
+            } else {
+                throw CoercingParseLiteralException("Unable to convert literal $input to UUID")
+            }
+        }
+
+        override fun serialize(dataFetcherResult: Any): String = dataFetcherResult.toString()
+    })
+    .build()
+
+class CustomFederatedHooks : FederatedSchemaGeneratorHooks(emptyList()) {
+
+    override fun willGenerateGraphQLType(type: KType): GraphQLType? = when (type.classifier) {
+        UUID::class -> graphqlUUIDType
+        else -> super.willGenerateGraphQLType(type)
+    }
+}

--- a/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/integrationTest/kotlin/com/expediagroup/graphql/plugin/graalvm/hooks/TestSchemaGeneratorHooksProvider.kt
+++ b/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/integrationTest/kotlin/com/expediagroup/graphql/plugin/graalvm/hooks/TestSchemaGeneratorHooksProvider.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2023 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.plugin.graalvm.hooks
+
+import com.expediagroup.graphql.generator.hooks.SchemaGeneratorHooks
+import com.expediagroup.graphql.plugin.schema.hooks.SchemaGeneratorHooksProvider
+
+class TestSchemaGeneratorHooksProvider : SchemaGeneratorHooksProvider {
+
+    override fun hooks(): SchemaGeneratorHooks = CustomFederatedHooks()
+}

--- a/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/integrationTest/resources/META-INF/services/com.expediagroup.graphql.plugin.schema.hooks.SchemaGeneratorHooksProvider
+++ b/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/integrationTest/resources/META-INF/services/com.expediagroup.graphql.plugin.schema.hooks.SchemaGeneratorHooksProvider
@@ -1,0 +1,1 @@
+com.expediagroup.graphql.plugin.graalvm.hooks.TestSchemaGeneratorHooksProvider

--- a/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/main/kotlin/com/expediagroup/graphql/plugin/graalvm/DefaultMetadataLoader.kt
+++ b/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/main/kotlin/com/expediagroup/graphql/plugin/graalvm/DefaultMetadataLoader.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.plugin.graalvm
+
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import java.io.InputStream
+
+private const val DEFAULT_REFLECT_CONFIG = "default-reflect-config.json"
+private const val DEFAULT_RESOURCE_CONFIG = "default-resource-config.json"
+
+object DefaultMetadataLoader {
+    /**
+     * Load default GraalVM reflect metadata required to run native graphql-kotlin servers
+     */
+    fun loadDefaultReflectMetadata(): List<ClassMetadata> {
+        val defaultResources = DefaultMetadataLoader.javaClass.classLoader.getResourceAsStream(DEFAULT_REFLECT_CONFIG)
+            ?: throw IllegalStateException("Unable to load graphql-kotlin GraalVM reflect metadata")
+        val mapper = jacksonObjectMapper()
+        return mapper.readValue(defaultResources, object : TypeReference<List<ClassMetadata>>() {})
+    }
+
+    /**
+     * Open up InputStream to default GraalVM resource config file to be used with graphql-kotlin servers.
+     */
+    fun defaultResourceMetadataStream(): InputStream =
+        DefaultMetadataLoader.javaClass.classLoader.getResourceAsStream(DEFAULT_RESOURCE_CONFIG)
+            ?: throw IllegalStateException("Unable to load graphql-kotlin GraalVM resources metadata")
+}

--- a/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/main/kotlin/com/expediagroup/graphql/plugin/graalvm/GenerateGraalVmMetadata.kt
+++ b/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/main/kotlin/com/expediagroup/graphql/plugin/graalvm/GenerateGraalVmMetadata.kt
@@ -49,7 +49,7 @@ fun generateGraalVmMetadata(supportedPackages: List<String>): List<ClassMetadata
 /**
  * Generate GraalVM reflect metadata for the underlying GraphQL schema.
  */
-fun generateGraalVmReflectMetadata(supportedPackages: List<String>): List<ClassMetadata> {
+internal fun generateGraalVmReflectMetadata(supportedPackages: List<String>): List<ClassMetadata> {
     val hooksProviders = ServiceLoader.load(SchemaGeneratorHooksProvider::class.java).toList()
     val hooks = when {
         hooksProviders.isEmpty() -> {

--- a/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/main/kotlin/com/expediagroup/graphql/plugin/graalvm/GenerateGraalVmMetadata.kt
+++ b/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/main/kotlin/com/expediagroup/graphql/plugin/graalvm/GenerateGraalVmMetadata.kt
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2023 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.plugin.graalvm
+
+import com.expediagroup.graphql.generator.SchemaGeneratorConfig
+import com.expediagroup.graphql.generator.TopLevelObject
+import com.expediagroup.graphql.generator.federation.FederatedSchemaGeneratorConfig
+import com.expediagroup.graphql.generator.federation.FederatedSchemaGeneratorHooks
+import com.expediagroup.graphql.generator.federation.toFederatedSchema
+import com.expediagroup.graphql.generator.hooks.NoopSchemaGeneratorHooks
+import com.expediagroup.graphql.generator.toSchema
+import com.expediagroup.graphql.plugin.graalvm.DefaultMetadataLoader.loadDefaultReflectMetadata
+import com.expediagroup.graphql.plugin.schema.hooks.SchemaGeneratorHooksProvider
+import com.expediagroup.graphql.server.Schema
+import com.expediagroup.graphql.server.operations.Mutation
+import com.expediagroup.graphql.server.operations.Query
+import com.expediagroup.graphql.server.operations.Subscription
+import io.github.classgraph.ClassGraph
+import io.github.classgraph.ScanResult
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import java.util.ServiceLoader
+
+private val logger: Logger = LoggerFactory.getLogger("generateGraalVmMetadata")
+
+/**
+ * Generate GraalVM reflect metadata for the underlying GraphQL schema.
+ */
+fun generateGraalVmMetadata(supportedPackages: List<String>): List<ClassMetadata> {
+    val defaultMetadata: List<ClassMetadata> = loadDefaultReflectMetadata()
+    val reflectMetadata: List<ClassMetadata> = generateGraalVmReflectMetadata(supportedPackages)
+    return reflectMetadata + defaultMetadata
+}
+
+/**
+ * Generate GraalVM reflect metadata for the underlying GraphQL schema.
+ */
+fun generateGraalVmReflectMetadata(supportedPackages: List<String>): List<ClassMetadata> {
+    val hooksProviders = ServiceLoader.load(SchemaGeneratorHooksProvider::class.java).toList()
+    val hooks = when {
+        hooksProviders.isEmpty() -> {
+            logger.warn("No SchemaGeneratorHooksProvider were found, defaulting to NoopSchemaGeneratorHooks")
+            NoopSchemaGeneratorHooks
+        }
+        hooksProviders.size > 1 -> {
+            throw RuntimeException("Cannot generate SDL as multiple SchemaGeneratorHooksProviders were found on the classpath")
+        }
+        else -> {
+            val provider = hooksProviders.first()
+            logger.debug("SchemaGeneratorHooksProvider found, ${provider.javaClass.simpleName} will be used to generate the hooks")
+            provider.hooks()
+        }
+    }
+
+    val rootObjects: TopLevelObjects = defaultTopLevelObjects(supportedPackages)
+    val dataFetcherFactoryProvider = MetadataCapturingDataFetcherFactoryProvider(supportedPackages)
+    val typeResolver = MetadataCapturingGraphQLTypeResolver(supportedPackages)
+
+    if (hooks is FederatedSchemaGeneratorHooks) {
+        logger.debug("Generating federated schema using hooks = ${hooks.javaClass.simpleName}")
+        logger.debug("  query classes = ${rootObjects.queries.map { it.kClass }}")
+        logger.debug("  mutation classes = ${rootObjects.mutations.map { it.kClass }}")
+        logger.debug("  subscription classes = ${rootObjects.subscriptions.map { it.kClass }}")
+        val config = FederatedSchemaGeneratorConfig(
+            supportedPackages = supportedPackages,
+            hooks = hooks,
+            dataFetcherFactoryProvider = dataFetcherFactoryProvider,
+            typeResolver = typeResolver
+        )
+        toFederatedSchema(
+            config = config,
+            queries = rootObjects.queries,
+            mutations = rootObjects.mutations,
+            subscriptions = rootObjects.subscriptions,
+            schemaObject = rootObjects.schemaObject
+        )
+    } else {
+        logger.debug("Generating schema using hooks = ${hooks.javaClass.simpleName}")
+        logger.debug("  query classes = ${rootObjects.queries.map { it.kClass }}")
+        logger.debug("  mutation classes = ${rootObjects.mutations.map { it.kClass }}")
+        logger.debug("  subscription classes = ${rootObjects.subscriptions.map { it.kClass }}")
+        val config = SchemaGeneratorConfig(
+            supportedPackages = supportedPackages,
+            hooks = hooks,
+            dataFetcherFactoryProvider = dataFetcherFactoryProvider,
+            typeResolver = typeResolver
+        )
+        toSchema(
+            config = config,
+            queries = rootObjects.queries,
+            mutations = rootObjects.mutations,
+            subscriptions = rootObjects.subscriptions,
+            schemaObject = rootObjects.schemaObject
+        )
+    }
+
+    typeResolver.close()
+    val result = dataFetcherFactoryProvider.reflectMetadata() + typeResolver.supertypes.map { ClassMetadata(name = it) }
+    return result.sortedBy { it.name }
+}
+
+private fun defaultTopLevelObjects(supportedPackages: List<String>): TopLevelObjects {
+    val scanResult = ClassGraph()
+        .enableAllInfo()
+        .acceptPackages(*supportedPackages.toTypedArray())
+        .scan()
+
+    val queries = findTopLevelObjects(scanResult, Query::class.java)
+    val mutations = findTopLevelObjects(scanResult, Mutation::class.java)
+    val subscriptions = findTopLevelObjects(scanResult, Subscription::class.java)
+    val schemaObject = findTopLevelObjects(scanResult, Schema::class.java).firstOrNull()
+
+    scanResult.close()
+    return TopLevelObjects(queries, mutations, subscriptions, schemaObject)
+}
+
+private fun findTopLevelObjects(scanResult: ScanResult, markupClass: Class<*>): List<TopLevelObject> =
+    scanResult.getClassesImplementing(markupClass.name)
+        .map { it.loadClass() }
+        .map { TopLevelObject(null, it.kotlin) }

--- a/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/main/kotlin/com/expediagroup/graphql/plugin/graalvm/MetadataCapturingDataFetcherFactoryProvider.kt
+++ b/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/main/kotlin/com/expediagroup/graphql/plugin/graalvm/MetadataCapturingDataFetcherFactoryProvider.kt
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2023 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.plugin.graalvm
+
+import com.expediagroup.graphql.generator.execution.SimpleKotlinDataFetcherFactoryProvider
+import graphql.schema.DataFetcherFactory
+import kotlin.reflect.KClass
+import kotlin.reflect.KFunction
+import kotlin.reflect.KProperty
+import kotlin.reflect.javaType
+import kotlin.reflect.jvm.javaMethod
+
+internal class MetadataCapturingDataFetcherFactoryProvider(val supportedPackages: List<String>) : SimpleKotlinDataFetcherFactoryProvider() {
+
+    private val reflectMetadataMap: MutableMap<String, MutableClassMetadata> = HashMap()
+    private val additionalInputTypes: MutableSet<String> = HashSet()
+    // we need to capture enums
+    private val additionalTypes: MutableSet<String> = HashSet()
+
+    @OptIn(ExperimentalStdlibApi::class)
+    override fun functionDataFetcherFactory(target: Any?, kClass: KClass<*>, kFunction: KFunction<*>): DataFetcherFactory<Any?> {
+        val methodName = kFunction.javaMethod!!.name
+        val classMetadata = reflectMetadataMap.getOrPut(kClass.java.name) { MutableClassMetadata(name = kClass.java.name, methods = ArrayList()) }
+        val methodArguments = kFunction.javaMethod?.parameters?.map { it.type.name } ?: emptyList()
+        val parameterizedArguments = kFunction.parameters.mapNotNull { it.type.arguments.firstOrNull() }.map { it.type!!.javaType.typeName }
+
+        additionalInputTypes.addAll(methodArguments)
+        additionalInputTypes.addAll(parameterizedArguments)
+        additionalTypes.add(kFunction.returnType.javaType.typeName)
+        classMetadata.methods?.add(
+            MethodMetadata(
+                name = methodName,
+                parameterTypes = methodArguments
+            )
+        )
+        // add synthetic methods
+        kClass.java.methods.filter { it.name.startsWith("$methodName$") }.forEach { defaultMethod ->
+            val syntheticMethodArgs = defaultMethod.parameters?.map { it.type.name } ?: emptyList()
+            classMetadata.methods?.add(
+                MethodMetadata(
+                    name = defaultMethod.name,
+                    parameterTypes = syntheticMethodArgs
+                )
+            )
+        }
+        return super.functionDataFetcherFactory(target, kClass, kFunction)
+    }
+
+    override fun propertyDataFetcherFactory(kClass: KClass<*>, kProperty: KProperty<*>): DataFetcherFactory<Any?> {
+        val classMetadata = reflectMetadataMap.getOrPut(kClass.java.name) { MutableClassMetadata(name = kClass.java.name, methods = ArrayList()) }
+        classMetadata.allDeclaredFields = true
+        classMetadata.methods?.add(
+            MethodMetadata(
+                name = kProperty.getter.javaMethod!!.name
+            )
+        )
+        additionalTypes.add(kProperty.returnType.javaClass.name)
+        return super.propertyDataFetcherFactory(kClass, kProperty)
+    }
+
+    fun reflectMetadata(): List<ClassMetadata> {
+        additionalTypes.filter { kClass -> supportedPackages.any { pkg -> kClass.startsWith(pkg) } }
+            .forEach { kClass ->
+                val existingMetadata = reflectMetadataMap[kClass]
+                val javaClass = Class.forName(kClass)
+                if (javaClass.isEnum && existingMetadata == null) {
+                    val fields = javaClass.enumConstants.map { it as Enum<*> }.map { enumValue -> FieldMetadata(enumValue.name) }.sortedBy { it.name }
+                    reflectMetadataMap[kClass] = MutableClassMetadata(name = kClass, fields = fields)
+                }
+            }
+
+        additionalInputTypes.filter { kClass -> supportedPackages.any { pkg -> kClass.startsWith(pkg) } }
+            .forEach { kClass ->
+                val existingMetadata = reflectMetadataMap[kClass]
+                val javaClass = Class.forName(kClass)
+                if (existingMetadata == null) {
+                    if (javaClass.isEnum) {
+                        val fields = javaClass.enumConstants.map { it as Enum<*> }.map { enumValue -> FieldMetadata(enumValue.name) }.sortedBy { it.name }
+                        reflectMetadataMap[kClass] = MutableClassMetadata(name = kClass, fields = fields)
+                    } else {
+                        reflectMetadataMap[kClass] = MutableClassMetadata(
+                            name = kClass,
+                            allPublicConstructors = true
+                        )
+                    }
+                } else if (!javaClass.isEnum) {
+                    existingMetadata.allPublicConstructors = true
+                }
+            }
+
+        return reflectMetadataMap.values.map { it.toClassMetadata() }.sortedBy { it.name }
+    }
+}

--- a/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/main/kotlin/com/expediagroup/graphql/plugin/graalvm/MetadataCapturingGraphQLTypeResolver.kt
+++ b/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/main/kotlin/com/expediagroup/graphql/plugin/graalvm/MetadataCapturingGraphQLTypeResolver.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.plugin.graalvm
+
+import com.expediagroup.graphql.generator.federation.FederatedClasspathTypeResolver
+import com.expediagroup.graphql.generator.internal.state.ClassScanner
+import kotlin.reflect.KClass
+
+internal class MetadataCapturingGraphQLTypeResolver(supportedPackages: List<String>) : FederatedClasspathTypeResolver(
+    ClassScanner(supportedPackages)
+) {
+    val supertypes: MutableSet<String> = HashSet()
+
+    override fun getSubTypesOf(kclass: KClass<*>): List<KClass<*>> {
+        supertypes.add(kclass.java.name)
+        return super.getSubTypesOf(kclass)
+    }
+}

--- a/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/main/kotlin/com/expediagroup/graphql/plugin/graalvm/ReflectMetadata.kt
+++ b/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/main/kotlin/com/expediagroup/graphql/plugin/graalvm/ReflectMetadata.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2023 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.plugin.graalvm
+
+/**
+ * GraalVM reflect metadata for classes.
+ */
+data class ClassMetadata(
+    val name: String,
+    val allDeclaredFields: Boolean? = null,
+    val allPublicConstructors: Boolean? = null,
+    val queryAllDeclaredMethods: Boolean? = null,
+    val queryAllDeclaredConstructors: Boolean? = null,
+    val fields: List<FieldMetadata>? = null,
+    val methods: List<MethodMetadata>? = null
+)
+
+internal data class MutableClassMetadata(
+    val name: String,
+    var allDeclaredFields: Boolean? = null,
+    var allPublicConstructors: Boolean? = null,
+    var queryAllDeclaredMethods: Boolean? = null,
+    var queryAllDeclaredConstructors: Boolean? = null,
+    val fields: List<FieldMetadata>? = null,
+    val methods: MutableList<MethodMetadata>? = null
+)
+
+internal fun MutableClassMetadata.toClassMetadata() = ClassMetadata(
+    name,
+    allDeclaredFields,
+    allPublicConstructors,
+    queryAllDeclaredMethods,
+    queryAllDeclaredConstructors,
+    fields,
+    methods?.sortedBy { method -> method.name }
+)
+
+/**
+ * GraalVM reflect metadata for class fields.
+ */
+data class FieldMetadata(val name: String)
+
+/**
+ * GraalVM reflect metadata for class methods.
+ */
+data class MethodMetadata(val name: String, val parameterTypes: List<String> = emptyList())

--- a/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/main/kotlin/com/expediagroup/graphql/plugin/graalvm/TopLevelObjects.kt
+++ b/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/main/kotlin/com/expediagroup/graphql/plugin/graalvm/TopLevelObjects.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2023 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.plugin.graalvm
+
+import com.expediagroup.graphql.generator.TopLevelObject
+
+data class TopLevelObjects(
+    val queries: List<TopLevelObject>,
+    val mutations: List<TopLevelObject> = emptyList(),
+    val subscriptions: List<TopLevelObject> = emptyList(),
+    val schemaObject: TopLevelObject? = null
+)

--- a/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/main/resources/default-reflect-config.json
+++ b/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/main/resources/default-reflect-config.json
@@ -1,0 +1,76 @@
+[
+{
+  "name":"com.expediagroup.graphql.generator.scalars.ID",
+  "methods":[
+    {"name":"box-impl","parameterTypes":["java.lang.String"] },
+    {"name":"constructor-impl","parameterTypes":["java.lang.String"] },
+    {"name":"unbox-impl","parameterTypes":[] }
+  ]
+},
+{
+  "name":"com.expediagroup.graphql.server.operations.Mutation"
+},
+{
+  "name":"com.expediagroup.graphql.server.operations.Query"
+},
+{
+  "name":"com.expediagroup.graphql.server.types.GraphQLRequest",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "methods":[
+    {"name":"<init>","parameterTypes":["java.lang.String","java.lang.String","java.util.Map","java.util.Map"] },
+    {"name":"<init>","parameterTypes":["java.lang.String","java.lang.String","java.util.Map","java.util.Map","int","kotlin.jvm.internal.DefaultConstructorMarker"] }
+  ]
+},
+{
+  "name":"com.expediagroup.graphql.server.types.GraphQLResponse",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "methods":[
+    {"name":"<init>","parameterTypes":["java.lang.Object","java.util.List","java.util.Map"] },
+    {"name":"getData","parameterTypes":[] },
+    {"name":"getErrors","parameterTypes":[] },
+    {"name":"getExtensions","parameterTypes":[] }
+  ]
+},
+{
+  "name":"com.expediagroup.graphql.server.types.GraphQLServerError",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "methods":[
+    {"name":"<init>","parameterTypes":["java.lang.String","java.util.List","java.util.List","java.util.Map"] },
+    {"name":"getExtensions","parameterTypes":[] },
+    {"name":"getLocations","parameterTypes":[] },
+    {"name":"getMessage","parameterTypes":[] },
+    {"name":"getPath","parameterTypes":[] }
+  ]
+},
+{
+  "name":"com.expediagroup.graphql.server.types.GraphQLServerRequest",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true
+},
+{
+  "name":"com.expediagroup.graphql.server.types.GraphQLServerRequestDeserializer",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"com.expediagroup.graphql.server.types.GraphQLServerResponse",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true
+},
+{
+  "name":"com.expediagroup.graphql.server.types.GraphQLSourceLocation",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "methods":[
+    {"name":"<init>","parameterTypes":["int","int"] },
+    {"name":"getColumn","parameterTypes":[] },
+    {"name":"getLine","parameterTypes":[] }
+  ]
+}
+]

--- a/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/main/resources/default-resource-config.json
+++ b/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/main/resources/default-resource-config.json
@@ -1,0 +1,21 @@
+{
+  "resources":{
+    "includes":[
+      {
+        "condition": {
+          "typeReachable": "ch.qos.logback.classic.Logger"
+        },
+        "pattern":"\\QMETA-INF/services/ch.qos.logback.classic.spi.Configurator\\E"
+      },
+      {
+        "condition": {
+          "typeReachable": "org.slf4j.Logger"
+        },
+        "pattern":"\\QMETA-INF/services/org.slf4j.spi.SLF4JServiceProvider\\E"
+      },
+      {
+        "pattern":"\\Qgraphql-graphiql.html\\E"
+      }
+    ]
+  }
+}

--- a/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/test/kotlin/com/expediagroup/graphql/plugin/graalvm/boxed/BoxedArgQuery.kt
+++ b/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/test/kotlin/com/expediagroup/graphql/plugin/graalvm/boxed/BoxedArgQuery.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2023 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.plugin.graalvm.boxed
+
+import com.expediagroup.graphql.server.operations.Query
+
+class BoxedArgQuery : Query {
+    fun optionalStringArg(arg: String? = null): String? = TODO()
+    fun optionalIntArg(arg: Int? = null): Int? = TODO()
+    fun optionalDoubleArg(arg: Double? = null): Double? = TODO()
+    fun optionalBooleanArg(arg: Boolean? = null): Boolean? = TODO()
+}

--- a/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/test/kotlin/com/expediagroup/graphql/plugin/graalvm/boxed/GenerateGraalVmBoxedMetadataTest.kt
+++ b/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/test/kotlin/com/expediagroup/graphql/plugin/graalvm/boxed/GenerateGraalVmBoxedMetadataTest.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2023 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.plugin.graalvm.boxed
+
+import com.expediagroup.graphql.plugin.graalvm.ClassMetadata
+import com.expediagroup.graphql.plugin.graalvm.MethodMetadata
+import com.expediagroup.graphql.plugin.graalvm.generateGraalVmReflectMetadata
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+class GenerateGraalVmBoxedMetadataTest {
+
+    @Test
+    fun `verifies we can generate valid reflect metadata for query with boxed primitives`() {
+        val expected = listOf(
+            ClassMetadata(
+                name = "com.expediagroup.graphql.plugin.graalvm.boxed.BoxedArgQuery",
+                methods = listOf(
+                    MethodMetadata(
+                        name = "optionalBooleanArg",
+                        parameterTypes = listOf("java.lang.Boolean")
+                    ),
+                    MethodMetadata(
+                        name = "optionalBooleanArg\$default",
+                        parameterTypes = listOf("com.expediagroup.graphql.plugin.graalvm.boxed.BoxedArgQuery", "java.lang.Boolean", "int", "java.lang.Object")
+                    ),
+                    MethodMetadata(
+                        name = "optionalDoubleArg",
+                        parameterTypes = listOf("java.lang.Double")
+                    ),
+                    MethodMetadata(
+                        name = "optionalDoubleArg\$default",
+                        parameterTypes = listOf("com.expediagroup.graphql.plugin.graalvm.boxed.BoxedArgQuery", "java.lang.Double", "int", "java.lang.Object")
+                    ),
+                    MethodMetadata(
+                        name = "optionalIntArg",
+                        parameterTypes = listOf("java.lang.Integer")
+                    ),
+                    MethodMetadata(
+                        name = "optionalIntArg\$default",
+                        parameterTypes = listOf("com.expediagroup.graphql.plugin.graalvm.boxed.BoxedArgQuery", "java.lang.Integer", "int", "java.lang.Object")
+                    ),
+                    MethodMetadata(
+                        name = "optionalStringArg",
+                        parameterTypes = listOf("java.lang.String")
+                    ),
+                    MethodMetadata(
+                        name = "optionalStringArg\$default",
+                        parameterTypes = listOf("com.expediagroup.graphql.plugin.graalvm.boxed.BoxedArgQuery", "java.lang.String", "int", "java.lang.Object")
+                    )
+                )
+            )
+        )
+
+        val actual = generateGraalVmReflectMetadata(supportedPackages = listOf("com.expediagroup.graphql.plugin.graalvm.boxed"))
+
+        val mapper = jacksonObjectMapper()
+            .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+        val writer = mapper.writerWithDefaultPrettyPrinter()
+        Assertions.assertEquals(writer.writeValueAsString(expected), writer.writeValueAsString(actual))
+    }
+}

--- a/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/test/kotlin/com/expediagroup/graphql/plugin/graalvm/coroutine/CoroutineQuery.kt
+++ b/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/test/kotlin/com/expediagroup/graphql/plugin/graalvm/coroutine/CoroutineQuery.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2023 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.plugin.graalvm.coroutine
+
+import com.expediagroup.graphql.server.operations.Query
+
+class CoroutineQuery : Query {
+    suspend fun suspendableQuery(): Int = TODO()
+}

--- a/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/test/kotlin/com/expediagroup/graphql/plugin/graalvm/coroutine/GenerateGraalVmCoroutineMetadataTest.kt
+++ b/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/test/kotlin/com/expediagroup/graphql/plugin/graalvm/coroutine/GenerateGraalVmCoroutineMetadataTest.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.plugin.graalvm.coroutine
+
+import com.expediagroup.graphql.plugin.graalvm.ClassMetadata
+import com.expediagroup.graphql.plugin.graalvm.MethodMetadata
+import com.expediagroup.graphql.plugin.graalvm.generateGraalVmReflectMetadata
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+class GenerateGraalVmCoroutineMetadataTest {
+
+    @Test
+    fun `verifies we can generate valid reflect metadata for a suspendable query`() {
+        val expected = listOf(
+            ClassMetadata(
+                name = "com.expediagroup.graphql.plugin.graalvm.coroutine.CoroutineQuery",
+                methods = listOf(
+                    MethodMetadata(
+                        name = "suspendableQuery",
+                        parameterTypes = listOf("kotlin.coroutines.Continuation")
+                    )
+                )
+            )
+        )
+
+        val actual = generateGraalVmReflectMetadata(supportedPackages = listOf("com.expediagroup.graphql.plugin.graalvm.coroutine"))
+
+        val mapper = jacksonObjectMapper()
+            .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+        val writer = mapper.writerWithDefaultPrettyPrinter()
+        Assertions.assertEquals(writer.writeValueAsString(expected), writer.writeValueAsString(actual))
+    }
+}

--- a/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/test/kotlin/com/expediagroup/graphql/plugin/graalvm/enums/EnumQuery.kt
+++ b/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/test/kotlin/com/expediagroup/graphql/plugin/graalvm/enums/EnumQuery.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2023 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.plugin.graalvm.enums
+
+import com.expediagroup.graphql.server.operations.Query
+
+class EnumQuery : Query {
+    fun enumQuery(): BinaryEnum = TODO()
+    fun enumArgQuery(arg: BinaryEnum): BinaryEnum = TODO()
+    fun optionalEnumArg(arg: BinaryEnum? = null): BinaryEnum? = TODO()
+}
+
+enum class BinaryEnum {
+    ZERO,
+    ONE
+}

--- a/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/test/kotlin/com/expediagroup/graphql/plugin/graalvm/enums/GenerateGraalVmEnumMetadataTest.kt
+++ b/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/test/kotlin/com/expediagroup/graphql/plugin/graalvm/enums/GenerateGraalVmEnumMetadataTest.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2023 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.plugin.graalvm.enums
+
+import com.expediagroup.graphql.plugin.graalvm.ClassMetadata
+import com.expediagroup.graphql.plugin.graalvm.FieldMetadata
+import com.expediagroup.graphql.plugin.graalvm.MethodMetadata
+import com.expediagroup.graphql.plugin.graalvm.generateGraalVmReflectMetadata
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+class GenerateGraalVmEnumMetadataTest {
+
+    @Test
+    fun `verifies we can generate valid reflect metadata for query with enums`() {
+        val expected = listOf(
+            ClassMetadata(
+                name = "com.expediagroup.graphql.plugin.graalvm.enums.BinaryEnum",
+                fields = listOf(
+                    FieldMetadata(
+                        name = "ONE"
+                    ),
+                    FieldMetadata(
+                        name = "ZERO"
+                    )
+                )
+            ),
+            ClassMetadata(
+                name = "com.expediagroup.graphql.plugin.graalvm.enums.EnumQuery",
+                methods = listOf(
+                    MethodMetadata(
+                        name = "enumArgQuery",
+                        parameterTypes = listOf("com.expediagroup.graphql.plugin.graalvm.enums.BinaryEnum")
+                    ),
+                    MethodMetadata(
+                        name = "enumQuery",
+                        parameterTypes = listOf()
+                    ),
+                    MethodMetadata(
+                        name = "optionalEnumArg",
+                        parameterTypes = listOf("com.expediagroup.graphql.plugin.graalvm.enums.BinaryEnum")
+                    ),
+                    MethodMetadata(
+                        name = "optionalEnumArg\$default",
+                        parameterTypes = listOf("com.expediagroup.graphql.plugin.graalvm.enums.EnumQuery", "com.expediagroup.graphql.plugin.graalvm.enums.BinaryEnum", "int", "java.lang.Object")
+                    )
+                )
+            )
+        )
+
+        val actual = generateGraalVmReflectMetadata(supportedPackages = listOf("com.expediagroup.graphql.plugin.graalvm.enums"))
+
+        val mapper = jacksonObjectMapper()
+            .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+        val writer = mapper.writerWithDefaultPrettyPrinter()
+        Assertions.assertEquals(writer.writeValueAsString(expected), writer.writeValueAsString(actual))
+    }
+}

--- a/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/test/kotlin/com/expediagroup/graphql/plugin/graalvm/id/GenerateGraalVmIdMetadataTest.kt
+++ b/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/test/kotlin/com/expediagroup/graphql/plugin/graalvm/id/GenerateGraalVmIdMetadataTest.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2023 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.plugin.graalvm.id
+
+import com.expediagroup.graphql.plugin.graalvm.ClassMetadata
+import com.expediagroup.graphql.plugin.graalvm.MethodMetadata
+import com.expediagroup.graphql.plugin.graalvm.generateGraalVmReflectMetadata
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+class GenerateGraalVmIdMetadataTest {
+
+    @Test
+    fun `verifies we can generate valid reflect metadata for query with id arguments`() {
+        val expected = listOf(
+            ClassMetadata(
+                name = "com.expediagroup.graphql.plugin.graalvm.id.IdQuery",
+                methods = listOf(
+                    MethodMetadata(
+                        name = "idArg-INmHlMY",
+                        parameterTypes = listOf("java.lang.String")
+                    ),
+                    MethodMetadata(
+                        name = "idQuery-CJxqpO8",
+                        parameterTypes = listOf()
+                    ),
+                    MethodMetadata(
+                        name = "optionalIdArg-uTautsM",
+                        parameterTypes = listOf("java.lang.String")
+                    ),
+                    MethodMetadata(
+                        name = "optionalIdArg-uTautsM\$default",
+                        parameterTypes = listOf("com.expediagroup.graphql.plugin.graalvm.id.IdQuery", "java.lang.String", "int", "java.lang.Object")
+                    ),
+                    MethodMetadata(
+                        name = "wrapped",
+                        parameterTypes = listOf("com.expediagroup.graphql.plugin.graalvm.id.Wrapped")
+                    )
+                )
+            ),
+            ClassMetadata(
+                name = "com.expediagroup.graphql.plugin.graalvm.id.Wrapped",
+                allDeclaredFields = true,
+                allPublicConstructors = true,
+                methods = listOf(
+                    MethodMetadata(
+                        name = "getId-CJxqpO8",
+                        parameterTypes = listOf()
+                    )
+                )
+            )
+        )
+
+        val actual = generateGraalVmReflectMetadata(supportedPackages = listOf("com.expediagroup.graphql.plugin.graalvm.id"))
+
+        val mapper = jacksonObjectMapper()
+            .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+        val writer = mapper.writerWithDefaultPrettyPrinter()
+        Assertions.assertEquals(writer.writeValueAsString(expected), writer.writeValueAsString(actual))
+    }
+}

--- a/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/test/kotlin/com/expediagroup/graphql/plugin/graalvm/id/IdQuery.kt
+++ b/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/test/kotlin/com/expediagroup/graphql/plugin/graalvm/id/IdQuery.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2023 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.plugin.graalvm.id
+
+import com.expediagroup.graphql.generator.scalars.ID
+import com.expediagroup.graphql.server.operations.Query
+
+class IdQuery : Query {
+    fun idQuery(): ID = TODO()
+    fun idArg(arg: ID): ID = TODO()
+    fun optionalIdArg(arg: ID? = null): ID? = TODO()
+    fun wrapped(arg: Wrapped): Wrapped = TODO()
+}
+
+data class Wrapped(val id: ID)

--- a/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/test/kotlin/com/expediagroup/graphql/plugin/graalvm/inner/GenerateGraalVmInnerClassMetadataTest.kt
+++ b/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/test/kotlin/com/expediagroup/graphql/plugin/graalvm/inner/GenerateGraalVmInnerClassMetadataTest.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2023 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.plugin.graalvm.inner
+
+import com.expediagroup.graphql.plugin.graalvm.ClassMetadata
+import com.expediagroup.graphql.plugin.graalvm.MethodMetadata
+import com.expediagroup.graphql.plugin.graalvm.generateGraalVmReflectMetadata
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+class GenerateGraalVmInnerClassMetadataTest {
+
+    @Test
+    fun `verifies we can generate valid reflect metadata for query referencing inner class`() {
+        val expected = listOf(
+            ClassMetadata(
+                name = "com.expediagroup.graphql.plugin.graalvm.inner.InnerClassQuery",
+                methods = listOf(
+                    MethodMetadata(
+                        name = "innerClassArg",
+                        parameterTypes = listOf("com.expediagroup.graphql.plugin.graalvm.inner.InnerClassQuery\$InnerClass")
+                    ),
+                    MethodMetadata(
+                        name = "innerClassQuery",
+                        parameterTypes = listOf()
+                    )
+                )
+            ),
+            ClassMetadata(
+                name = "com.expediagroup.graphql.plugin.graalvm.inner.InnerClassQuery\$InnerClass",
+                allDeclaredFields = true,
+                allPublicConstructors = true,
+                methods = listOf(
+                    MethodMetadata(
+                        name = "getProp",
+                        parameterTypes = listOf()
+                    )
+                )
+            )
+        )
+
+        val actual = generateGraalVmReflectMetadata(supportedPackages = listOf("com.expediagroup.graphql.plugin.graalvm.inner"))
+
+        val mapper = jacksonObjectMapper()
+            .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+        val writer = mapper.writerWithDefaultPrettyPrinter()
+        Assertions.assertEquals(writer.writeValueAsString(expected), writer.writeValueAsString(actual))
+    }
+}

--- a/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/test/kotlin/com/expediagroup/graphql/plugin/graalvm/inner/InnerClassQuery.kt
+++ b/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/test/kotlin/com/expediagroup/graphql/plugin/graalvm/inner/InnerClassQuery.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2023 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.plugin.graalvm.inner
+
+import com.expediagroup.graphql.server.operations.Query
+
+class InnerClassQuery : Query {
+    fun innerClassArg(arg: InnerClass): String = TODO()
+    fun innerClassQuery(): InnerClass = TODO()
+
+    data class InnerClass(val prop: Int? = null)
+}

--- a/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/test/kotlin/com/expediagroup/graphql/plugin/graalvm/intf/GenerateGraalVmInterfaceMetadataTest.kt
+++ b/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/test/kotlin/com/expediagroup/graphql/plugin/graalvm/intf/GenerateGraalVmInterfaceMetadataTest.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2023 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.plugin.graalvm.intf
+
+import com.expediagroup.graphql.plugin.graalvm.ClassMetadata
+import com.expediagroup.graphql.plugin.graalvm.MethodMetadata
+import com.expediagroup.graphql.plugin.graalvm.generateGraalVmReflectMetadata
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+class GenerateGraalVmInterfaceMetadataTest {
+
+    @Test
+    fun `verifies we can generate valid reflect metadata for query referencing interfaces`() {
+        val expected = listOf(
+            ClassMetadata(
+                name = "com.expediagroup.graphql.plugin.graalvm.intf.FirstImpl",
+                methods = listOf(
+                    MethodMetadata(
+                        name = "common",
+                        parameterTypes = listOf()
+                    ),
+                    MethodMetadata(
+                        name = "specific",
+                        parameterTypes = listOf()
+                    )
+                )
+            ),
+            ClassMetadata(
+                name = "com.expediagroup.graphql.plugin.graalvm.intf.InterfaceQuery",
+                methods = listOf(
+                    MethodMetadata(
+                        name = "interfaceQuery",
+                        parameterTypes = listOf()
+                    )
+                )
+            ),
+            ClassMetadata(
+                name = "com.expediagroup.graphql.plugin.graalvm.intf.SecondImpl",
+                methods = listOf(
+                    MethodMetadata(
+                        name = "common",
+                        parameterTypes = listOf()
+                    ),
+                    MethodMetadata(
+                        name = "unique-CJxqpO8",
+                        parameterTypes = listOf()
+                    )
+                )
+            ),
+            ClassMetadata(
+                name = "com.expediagroup.graphql.plugin.graalvm.intf.TestInterface"
+            )
+        )
+
+        val actual = generateGraalVmReflectMetadata(supportedPackages = listOf("com.expediagroup.graphql.plugin.graalvm.intf"))
+
+        val mapper = jacksonObjectMapper()
+            .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+        val writer = mapper.writerWithDefaultPrettyPrinter()
+        Assertions.assertEquals(writer.writeValueAsString(expected), writer.writeValueAsString(actual))
+    }
+}

--- a/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/test/kotlin/com/expediagroup/graphql/plugin/graalvm/intf/InterfaceQuery.kt
+++ b/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/test/kotlin/com/expediagroup/graphql/plugin/graalvm/intf/InterfaceQuery.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2023 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.plugin.graalvm.intf
+
+import com.expediagroup.graphql.generator.scalars.ID
+import com.expediagroup.graphql.server.operations.Query
+
+class InterfaceQuery : Query {
+    fun interfaceQuery(): TestInterface = TODO()
+}
+
+interface TestInterface {
+    fun common(): String
+}
+
+class FirstImpl : TestInterface {
+    override fun common(): String = TODO()
+    fun specific(): Int = TODO()
+}
+
+class SecondImpl : TestInterface {
+    override fun common(): String = TODO()
+    fun unique(): ID = TODO()
+}

--- a/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/test/kotlin/com/expediagroup/graphql/plugin/graalvm/list/GenerateGraalVmListMetadataTest.kt
+++ b/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/test/kotlin/com/expediagroup/graphql/plugin/graalvm/list/GenerateGraalVmListMetadataTest.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2023 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.plugin.graalvm.list
+
+import com.expediagroup.graphql.plugin.graalvm.ClassMetadata
+import com.expediagroup.graphql.plugin.graalvm.MethodMetadata
+import com.expediagroup.graphql.plugin.graalvm.generateGraalVmReflectMetadata
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+class GenerateGraalVmListMetadataTest {
+
+    @Test
+    fun `verifies we can generate valid reflect metadata for query referencing list`() {
+        val expected = listOf(
+            ClassMetadata(
+                name = "com.expediagroup.graphql.plugin.graalvm.list.InputOnly",
+                allPublicConstructors = true
+            ),
+            ClassMetadata(
+                name = "com.expediagroup.graphql.plugin.graalvm.list.ListQuery",
+                methods = listOf(
+                    MethodMetadata(
+                        name = "listObjectArg",
+                        parameterTypes = listOf("java.util.List")
+                    ),
+                    MethodMetadata(
+                        name = "listObjectQuery",
+                        parameterTypes = listOf()
+                    ),
+                    MethodMetadata(
+                        name = "listPrimitiveArg",
+                        parameterTypes = listOf("java.util.List")
+                    ),
+                    MethodMetadata(
+                        name = "listQuery",
+                        parameterTypes = listOf()
+                    ),
+                    MethodMetadata(
+                        name = "optionalListArg",
+                        parameterTypes = listOf("java.util.List")
+                    ),
+                    MethodMetadata(
+                        name = "optionalListArg\$default",
+                        parameterTypes = listOf("com.expediagroup.graphql.plugin.graalvm.list.ListQuery", "java.util.List", "int", "java.lang.Object")
+                    )
+                )
+            ),
+            ClassMetadata(
+                name = "com.expediagroup.graphql.plugin.graalvm.list.OutputOnly",
+                allDeclaredFields = true,
+                methods = listOf(
+                    MethodMetadata(
+                        name = "calculate",
+                        parameterTypes = listOf()
+                    ),
+                    MethodMetadata(
+                        name = "getDescription",
+                        parameterTypes = listOf()
+                    ),
+                    MethodMetadata(
+                        name = "getId",
+                        parameterTypes = listOf()
+                    )
+                )
+            )
+        )
+
+        val actual = generateGraalVmReflectMetadata(supportedPackages = listOf("com.expediagroup.graphql.plugin.graalvm.list"))
+
+        val mapper = jacksonObjectMapper()
+            .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+        val writer = mapper.writerWithDefaultPrettyPrinter()
+        Assertions.assertEquals(writer.writeValueAsString(expected), writer.writeValueAsString(actual))
+    }
+}

--- a/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/test/kotlin/com/expediagroup/graphql/plugin/graalvm/list/ListQuery.kt
+++ b/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/test/kotlin/com/expediagroup/graphql/plugin/graalvm/list/ListQuery.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.plugin.graalvm.list
+
+import com.expediagroup.graphql.server.operations.Query
+
+class ListQuery : Query {
+    fun listQuery(): List<Int>? = TODO()
+    fun listObjectQuery(): List<OutputOnly> = TODO()
+    fun listPrimitiveArg(arg: List<Int>): List<Int> = TODO()
+    fun listObjectArg(arg: List<InputOnly>): String = TODO()
+    fun optionalListArg(arg: List<String>? = null): List<String>? = TODO()
+}
+
+data class InputOnly(val id: Int)
+data class OutputOnly(val id: Int, val description: String) {
+    fun calculate(): Int = TODO()
+}

--- a/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/test/kotlin/com/expediagroup/graphql/plugin/graalvm/primitive/GenerateGraalVmPrimitiveMetadataTest.kt
+++ b/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/test/kotlin/com/expediagroup/graphql/plugin/graalvm/primitive/GenerateGraalVmPrimitiveMetadataTest.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2023 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.plugin.graalvm.primitive
+
+import com.expediagroup.graphql.plugin.graalvm.ClassMetadata
+import com.expediagroup.graphql.plugin.graalvm.MethodMetadata
+import com.expediagroup.graphql.plugin.graalvm.generateGraalVmReflectMetadata
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+class GenerateGraalVmPrimitiveMetadataTest {
+
+    @Test
+    fun `verifies we can generate valid reflect metadata for query with primitive arguments`() {
+        val expected = listOf(
+            ClassMetadata(
+                name = "com.expediagroup.graphql.plugin.graalvm.primitive.PrimitiveArgQuery",
+                methods = listOf(
+                    MethodMetadata(
+                        name = "booleanArg",
+                        parameterTypes = listOf("boolean")
+                    ),
+                    MethodMetadata(
+                        name = "doubleArg",
+                        parameterTypes = listOf("double")
+                    ),
+                    MethodMetadata(
+                        name = "intArg",
+                        parameterTypes = listOf("int")
+                    ),
+                    MethodMetadata(
+                        name = "stringArg",
+                        parameterTypes = listOf("java.lang.String")
+                    )
+                )
+            )
+        )
+
+        val actual = generateGraalVmReflectMetadata(supportedPackages = listOf("com.expediagroup.graphql.plugin.graalvm.primitive"))
+
+        val mapper = jacksonObjectMapper()
+            .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+        val writer = mapper.writerWithDefaultPrettyPrinter()
+        Assertions.assertEquals(writer.writeValueAsString(expected), writer.writeValueAsString(actual))
+    }
+}

--- a/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/test/kotlin/com/expediagroup/graphql/plugin/graalvm/primitive/PrimitiveArgQuery.kt
+++ b/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/test/kotlin/com/expediagroup/graphql/plugin/graalvm/primitive/PrimitiveArgQuery.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2023 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.plugin.graalvm.primitive
+
+import com.expediagroup.graphql.server.operations.Query
+
+class PrimitiveArgQuery : Query {
+    fun stringArg(arg: String): String = TODO()
+    fun intArg(arg: Int): Int = TODO()
+    fun doubleArg(arg: Double): Double = TODO()
+    fun booleanArg(arg: Boolean): Boolean = TODO()
+}

--- a/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/test/kotlin/com/expediagroup/graphql/plugin/graalvm/types/GenerateGraalVmTypeMetadataTest.kt
+++ b/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/test/kotlin/com/expediagroup/graphql/plugin/graalvm/types/GenerateGraalVmTypeMetadataTest.kt
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2023 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.plugin.graalvm.types
+
+import com.expediagroup.graphql.plugin.graalvm.ClassMetadata
+import com.expediagroup.graphql.plugin.graalvm.MethodMetadata
+import com.expediagroup.graphql.plugin.graalvm.generateGraalVmReflectMetadata
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+class GenerateGraalVmTypeMetadataTest {
+
+    @Test
+    fun `verifies we can generate valid reflect metadata for query referencing types`() {
+        val expected = listOf(
+            ClassMetadata(
+                name = "com.expediagroup.graphql.plugin.graalvm.types.InputAndOutput",
+                allDeclaredFields = true,
+                allPublicConstructors = true,
+                methods = listOf(
+                    MethodMetadata(
+                        name = "getFlag",
+                        parameterTypes = listOf()
+                    ),
+                    MethodMetadata(
+                        name = "getId",
+                        parameterTypes = listOf()
+                    ),
+                    MethodMetadata(
+                        name = "outputOnly",
+                        parameterTypes = listOf()
+                    )
+                )
+            ),
+            ClassMetadata(
+                name = "com.expediagroup.graphql.plugin.graalvm.types.InputOnly",
+                allPublicConstructors = true
+            ),
+            ClassMetadata(
+                name = "com.expediagroup.graphql.plugin.graalvm.types.OutputOnly",
+                allDeclaredFields = true,
+                methods = listOf(
+                    MethodMetadata(
+                        name = "calculate",
+                        parameterTypes = listOf()
+                    ),
+                    MethodMetadata(
+                        name = "getDescription",
+                        parameterTypes = listOf()
+                    ),
+                    MethodMetadata(
+                        name = "getId",
+                        parameterTypes = listOf()
+                    )
+                )
+            ),
+            ClassMetadata(
+                name = "com.expediagroup.graphql.plugin.graalvm.types.TypesQuery",
+                methods = listOf(
+                    MethodMetadata(
+                        name = "inputAndOutputQuery",
+                        parameterTypes = listOf("com.expediagroup.graphql.plugin.graalvm.types.InputAndOutput")
+                    ),
+                    MethodMetadata(
+                        name = "inputAndOutputQuery\$default",
+                        parameterTypes = listOf("com.expediagroup.graphql.plugin.graalvm.types.TypesQuery", "com.expediagroup.graphql.plugin.graalvm.types.InputAndOutput", "int", "java.lang.Object")
+                    ),
+                    MethodMetadata(
+                        name = "inputTypeQuery",
+                        parameterTypes = listOf("com.expediagroup.graphql.plugin.graalvm.types.InputOnly")
+                    ),
+                    MethodMetadata(
+                        name = "inputTypeQuery\$default",
+                        parameterTypes = listOf("com.expediagroup.graphql.plugin.graalvm.types.TypesQuery", "com.expediagroup.graphql.plugin.graalvm.types.InputOnly", "int", "java.lang.Object")
+                    ),
+                    MethodMetadata(
+                        name = "outputTypeQuery",
+                        parameterTypes = listOf()
+                    )
+                )
+            )
+        )
+
+        val actual = generateGraalVmReflectMetadata(supportedPackages = listOf("com.expediagroup.graphql.plugin.graalvm.types"))
+
+        val mapper = jacksonObjectMapper()
+            .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+        val writer = mapper.writerWithDefaultPrettyPrinter()
+        Assertions.assertEquals(writer.writeValueAsString(expected), writer.writeValueAsString(actual))
+    }
+}

--- a/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/test/kotlin/com/expediagroup/graphql/plugin/graalvm/types/TypesQuery.kt
+++ b/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/test/kotlin/com/expediagroup/graphql/plugin/graalvm/types/TypesQuery.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2023 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.plugin.graalvm.types
+
+import com.expediagroup.graphql.server.operations.Query
+
+class TypesQuery : Query {
+    fun outputTypeQuery(): OutputOnly = TODO()
+    fun inputTypeQuery(arg: InputOnly? = null): String? = TODO()
+    fun inputAndOutputQuery(arg: InputAndOutput? = null): InputAndOutput? = TODO()
+}
+
+data class InputOnly(val id: Int)
+data class OutputOnly(val id: Int, val description: String) {
+    fun calculate(): Int = TODO()
+}
+data class InputAndOutput(val id: Int, val flag: Boolean? = true) {
+    fun outputOnly(): Int = TODO()
+}

--- a/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/test/kotlin/com/expediagroup/graphql/plugin/graalvm/union/GenerateGraalVmUnionMetadataTest.kt
+++ b/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/test/kotlin/com/expediagroup/graphql/plugin/graalvm/union/GenerateGraalVmUnionMetadataTest.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2023 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.plugin.graalvm.union
+
+import com.expediagroup.graphql.plugin.graalvm.ClassMetadata
+import com.expediagroup.graphql.plugin.graalvm.MethodMetadata
+import com.expediagroup.graphql.plugin.graalvm.generateGraalVmReflectMetadata
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+class GenerateGraalVmUnionMetadataTest {
+
+    @Test
+    fun `verifies we can generate valid reflect metadata for query referencing union`() {
+        val expected = listOf(
+            ClassMetadata(
+                name = "com.expediagroup.graphql.plugin.graalvm.union.FirstUnionMember",
+                methods = listOf(
+                    MethodMetadata(
+                        name = "one",
+                        parameterTypes = listOf()
+                    )
+                )
+            ),
+            ClassMetadata(
+                name = "com.expediagroup.graphql.plugin.graalvm.union.SecondUnionMember",
+                methods = listOf(
+                    MethodMetadata(
+                        name = "two",
+                        parameterTypes = listOf()
+                    )
+                )
+            ),
+            ClassMetadata(
+                name = "com.expediagroup.graphql.plugin.graalvm.union.TestUnion"
+            ),
+            ClassMetadata(
+                name = "com.expediagroup.graphql.plugin.graalvm.union.UnionQuery",
+                methods = listOf(
+                    MethodMetadata(
+                        name = "unionQuery",
+                        parameterTypes = listOf()
+                    )
+                )
+            )
+        )
+
+        val actual = generateGraalVmReflectMetadata(supportedPackages = listOf("com.expediagroup.graphql.plugin.graalvm.union"))
+
+        val mapper = jacksonObjectMapper()
+            .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+        val writer = mapper.writerWithDefaultPrettyPrinter()
+        Assertions.assertEquals(writer.writeValueAsString(expected), writer.writeValueAsString(actual))
+    }
+}

--- a/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/test/kotlin/com/expediagroup/graphql/plugin/graalvm/union/UnionQuery.kt
+++ b/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/test/kotlin/com/expediagroup/graphql/plugin/graalvm/union/UnionQuery.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2023 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.plugin.graalvm.union
+
+import com.expediagroup.graphql.server.operations.Query
+
+class UnionQuery : Query {
+    fun unionQuery(): TestUnion = TODO()
+}
+
+interface TestUnion
+
+class FirstUnionMember : TestUnion {
+    fun one(): String = TODO()
+}
+
+class SecondUnionMember : TestUnion {
+    fun two(): Int = TODO()
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -20,6 +20,7 @@ include(":graphql-kotlin-client-generator")
 include(":graphql-kotlin-sdl-generator")
 include(":graphql-kotlin-hooks-provider")
 include(":graphql-kotlin-federated-hooks-provider")
+include(":graphql-kotlin-graalvm-metadata-generator")
 
 // Servers
 include(":graphql-kotlin-server")
@@ -53,6 +54,7 @@ project(":graphql-kotlin-client-generator").projectDir = file("plugins/client/gr
 project(":graphql-kotlin-sdl-generator").projectDir = file("plugins/schema/graphql-kotlin-sdl-generator")
 project(":graphql-kotlin-hooks-provider").projectDir = file("plugins/schema/graphql-kotlin-hooks-provider")
 project(":graphql-kotlin-federated-hooks-provider").projectDir = file("plugins/schema/graphql-kotlin-federated-hooks-provider")
+project(":graphql-kotlin-graalvm-metadata-generator").projectDir = file("plugins/server/graphql-kotlin-graalvm-metadata-generator")
 
 // Servers
 project(":graphql-kotlin-server").projectDir = file("servers/graphql-kotlin-server")


### PR DESCRIPTION
### :pencil: Description

Creates new `graphql-kotlin-graalvm-metadata-generator` project that will be used by Gradle and Maven plugins to auto-generate GraalVM reachability metadata. In order to keep the size of PRs manageable, plugin PRs will be created separately.

[GraalVM reachability metadata](https://www.graalvm.org/22.2/reference-manual/native-image/metadata/) is required by GraalVM to support reflections and resource handling. This feature will be used by plugins as way to simplify running `graphql-kotlin` servers as GraalVM native images. Without this functionality, end users have to start their applications with GraalVM agent and then manually run **ALL** possible execution paths (i.e. queries, loading graphiql, etc).

### :link: Related Issues
