### PR TITLE
chore(build): gradle script cleanups

### DIFF
--- a/buildSrc/src/main/kotlin/com.expediagroup.graphql.conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/com.expediagroup.graphql.conventions.gradle.kts
@@ -53,9 +53,6 @@ tasks {
             attributes["Implementation-Title"] = project.name
             attributes["Implementation-Version"] = project.version
         }
-
-        // NOTE: in order to run gradle and maven plugin integration tests we need to have our build artifacts available in local repo
-        finalizedBy("publishToMavenLocal")
     }
 
     // published sources and javadoc artifacts

--- a/plugins/schema/graphql-kotlin-sdl-generator/build.gradle.kts
+++ b/plugins/schema/graphql-kotlin-sdl-generator/build.gradle.kts
@@ -13,29 +13,41 @@ dependencies {
     testImplementation(projects.graphqlKotlinSpringServer)
 }
 
-sourceSets {
-    create("integrationTest") {
-        withConvention(org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet::class) {
-            kotlin.srcDir("src/integrationTest/kotlin")
-            resources.srcDir("src/integrationTest/resources")
-            compileClasspath += sourceSets["main"].output + sourceSets["test"].compileClasspath
-            runtimeClasspath += output + compileClasspath + sourceSets["test"].runtimeClasspath
+
+testing {
+    suites {
+        val test by getting(JvmTestSuite::class) {
+            useJUnitJupiter()
+        }
+
+        val integrationTest by registering(JvmTestSuite::class) {
+            dependencies {
+                implementation(project())
+            }
+
+            targets {
+                all {
+                    testTask.configure {
+                        shouldRunAfter(test)
+                    }
+                }
+            }
+
+            sources {
+                java {
+                    setSrcDirs(listOf("src/integrationTest/kotlin"))
+                }
+                resources {
+                    setSrcDirs(listOf("src/integrationTest/resources"))
+                }
+                compileClasspath += sourceSets["test"].compileClasspath
+                runtimeClasspath += compileClasspath + sourceSets["test"].runtimeClasspath
+            }
         }
     }
 }
 
 tasks {
-    val integrationTest by registering(Test::class) {
-        description = "Runs the integration tests"
-        group = "verification"
-
-        testClassesDirs = sourceSets["integrationTest"].output.classesDirs
-        classpath = sourceSets["integrationTest"].runtimeClasspath
-        mustRunAfter("test")
-        finalizedBy("jacocoTestReport")
-        useJUnitPlatform()
-    }
-
     jacocoTestReport {
         // we need to explicitly add integrationTest coverage info
         executionData.setFrom(fileTree(buildDir).include("/jacoco/*.exec"))
@@ -59,6 +71,6 @@ tasks {
         }
     }
     check {
-        dependsOn("integrationTest")
+        dependsOn(testing.suites.named("integrationTest"))
     }
 }

--- a/plugins/schema/graphql-kotlin-sdl-generator/build.gradle.kts
+++ b/plugins/schema/graphql-kotlin-sdl-generator/build.gradle.kts
@@ -13,7 +13,6 @@ dependencies {
     testImplementation(projects.graphqlKotlinSpringServer)
 }
 
-
 testing {
     suites {
         val test by getting(JvmTestSuite::class) {


### PR DESCRIPTION
### :pencil: Description

* remove unnecessary publish to maven local on each jar build (it was required BEFORE we move moved all plugin integration tests to separate composite projects)
* use JVM test suite instead of a custom `Test` task

### :link: Related Issues
