### PR TITLE
feat(plugin): new GraalVm metadata Gradle task

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@ classgraph = "4.8.149"
 dataloader = "3.2.0"
 federation = "2.2.0"
 graphql-java = "19.2"
+graalvm = "0.9.20"
 jackson = "2.14.1"
 kotlin = "1.7.21"
 kotlinx-benchmark = "0.4.4"
@@ -108,6 +109,7 @@ wiremock-standalone = { group = "com.github.tomakehurst", name = "wiremock-jre8-
 # build src plugin libraries
 detekt-plugin = { group = "io.gitlab.arturbosch.detekt", name = "detekt-gradle-plugin", version.ref = "detekt" }
 dokka-plugin = { group = "org.jetbrains.dokka", name = "dokka-gradle-plugin", version.ref = "dokka" }
+graalvm-plugin = { group = "org.graalvm.buildtools.native", name = "org.graalvm.buildtools.native.gradle.plugin", version.ref = "graalvm" }
 kotlin-gradle-plugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
 ktlint-plugin = { group = "org.jlleitschuh.gradle", name = "ktlint-gradle", version.ref = "ktlint-plugin" }
 
@@ -135,5 +137,6 @@ plugin-publish = { id = "com.gradle.plugin-publish", version.ref = "plugin-publi
 spring-boot = { id = "org.springframework.boot", version.ref = "spring-boot" }
 
 # test projects
-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 android-application = { id = "com.android.application", version.ref = "android-plugin" }
+graalvm-native = { id = "org.graalvm.buildtools.native", version.ref = "graalvm" }
+kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }

--- a/plugins/graphql-kotlin-gradle-plugin/build.gradle.kts
+++ b/plugins/graphql-kotlin-gradle-plugin/build.gradle.kts
@@ -9,10 +9,12 @@ plugins {
 
 dependencies {
     implementation(libs.kotlin.gradle.api)
-    compileOnly(libs.android.plugin)
 
+    compileOnly(libs.android.plugin)
+    compileOnly(libs.graalvm.plugin)
     compileOnly(projects.graphqlKotlinClientGenerator)
     compileOnly(projects.graphqlKotlinSdlGenerator)
+    compileOnly(projects.graphqlKotlinGraalvmMetadataGenerator)
 
     testImplementation(libs.wiremock.jre8)
     testImplementation(libs.junit.params)

--- a/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLPluginExtension.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLPluginExtension.kt
@@ -40,6 +40,12 @@ open class GraphQLPluginExtension {
         GraphQLPluginSchemaExtension()
     }
 
+    private var graalVmExtensionConfigured: Boolean = false
+    internal val graalVmExtension: GraphQLPluginGraalVmExtension by lazy {
+        graalVmExtensionConfigured = true
+        GraphQLPluginGraalVmExtension()
+    }
+
     /** Plugin configuration for generating GraphQL client. */
     fun client(action: Action<GraphQLPluginClientExtension>) {
         action.execute(clientExtension)
@@ -49,9 +55,15 @@ open class GraphQLPluginExtension {
 
     internal fun isSchemaConfigurationAvailable(): Boolean = schemaExtensionConfigured
 
+    internal fun isGraalVmConfigurationAvailable(): Boolean = graalVmExtensionConfigured
+
     /** Plugin configuration for generating GraphQL schema artifact. */
     fun schema(action: Action<GraphQLPluginSchemaExtension>) {
         action.execute(schemaExtension)
+    }
+
+    fun graalVm(action: Action<GraphQLPluginGraalVmExtension>) {
+        action.execute(graalVmExtension)
     }
 }
 
@@ -101,4 +113,11 @@ open class GraphQLPluginClientExtension {
 open class GraphQLPluginSchemaExtension {
     /** List of supported packages that can contain GraphQL schema type definitions. */
     var packages: List<String> = emptyList()
+}
+
+open class GraphQLPluginGraalVmExtension {
+    /** List of supported packages that can contain GraphQL schema type definitions. */
+    var packages: List<String> = emptyList()
+    /** Application main class name. */
+    var mainClassName: String? = null
 }

--- a/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/actions/GenerateGraalVmMetadataAction.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/actions/GenerateGraalVmMetadataAction.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.plugin.gradle.actions
+
+import com.expediagroup.graphql.plugin.graalvm.generateGraalVmMetadata
+import com.expediagroup.graphql.plugin.gradle.parameters.GenerateGraalVmMetadataParameters
+import org.gradle.workers.WorkAction
+import java.io.File
+
+abstract class GenerateGraalVmMetadataAction : WorkAction<GenerateGraalVmMetadataParameters> {
+
+    /**
+     * Generate GraphQL GraalVM reachability metadata.
+     */
+    override fun execute() {
+        val supportedPackages: List<String> = parameters.supportedPackages.get()
+        val mainClassName: String? = parameters.mainClassName.orNull
+        val targetDirectory: File = parameters.outputDirectory.get()
+
+        generateGraalVmMetadata(targetDirectory = targetDirectory, supportedPackages = supportedPackages, mainClassName = mainClassName)
+    }
+}

--- a/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/parameters/GenerateGraalVmMetadataParameters.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/parameters/GenerateGraalVmMetadataParameters.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.plugin.gradle.parameters
+
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import org.gradle.workers.WorkParameters
+import java.io.File
+
+/**
+ * WorkParameters used for generating GraalVM reachability metadata for GraphQL schema.
+ */
+interface GenerateGraalVmMetadataParameters : WorkParameters {
+    /** List of supported packages that can contain GraphQL schema type definitions. */
+    val supportedPackages: ListProperty<String>
+    /** Main application class name. */
+    val mainClassName: Property<String>
+    /** Directory where to store generated reachability metadata. */
+    val outputDirectory: Property<File>
+}

--- a/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/GraphQLGraalVmMetadataTask.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/GraphQLGraalVmMetadataTask.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2023 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.plugin.gradle.tasks
+
+import com.expediagroup.graphql.plugin.gradle.actions.GenerateGraalVmMetadataAction
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Classpath
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.SourceTask
+import org.gradle.api.tasks.TaskAction
+import org.gradle.workers.ClassLoaderWorkerSpec
+import org.gradle.workers.WorkQueue
+import org.gradle.workers.WorkerExecutor
+import javax.inject.Inject
+
+internal const val GRAALVM_METADATA_TASK_NAME: String = "graphQLGraalVmMetadata"
+
+abstract class GraphQLGraalVmMetadataTask : SourceTask() {
+
+    @get:Classpath
+    val pluginClasspath: ConfigurableFileCollection = project.objects.fileCollection()
+
+    @get:Classpath
+    val projectClasspath: ConfigurableFileCollection = project.objects.fileCollection()
+
+    /**
+     * List of supported packages that can contain GraphQL schema type definitions.
+     */
+    @Input
+    val packages: ListProperty<String> = project.objects.listProperty(String::class.java)
+
+    /**
+     * Application main class name.
+     */
+    @Input
+    @Optional
+    val mainClassName: Property<String> = project.objects.property(String::class.java)
+
+    @Inject
+    abstract fun getWorkerExecutor(): WorkerExecutor
+
+    @OutputDirectory
+    val outputDirectory: DirectoryProperty = project.objects.directoryProperty()
+
+    init {
+        description = "Generate GraalVM reflect metadata for GraphQL Kotlin servers."
+        outputDirectory.convention(
+            project.layout.buildDirectory.dir(
+                "generated/graphqlGraalVmResources"
+            )
+        )
+    }
+
+    @TaskAction
+    fun generateMetadata() {
+        println("executing task")
+        val packages = packages.get()
+        if (packages.isEmpty()) {
+            throw RuntimeException("attempt to generate SDL failed - missing required supportedPackages property")
+        }
+
+        val targetDirectory = outputDirectory.dir("META-INF/native-image/${project.group}/${project.name}").get().asFile
+        if (!targetDirectory.isDirectory && !targetDirectory.mkdirs()) {
+            throw RuntimeException("failed to generate target resource directory = $targetDirectory")
+        }
+
+        val workQueue: WorkQueue = getWorkerExecutor().classLoaderIsolation { workerSpec: ClassLoaderWorkerSpec ->
+            val workerClasspath = pluginClasspath.plus(projectClasspath).plus(source.files)
+            workerSpec.classpath.from(workerClasspath)
+            logger.debug("worker classpath: \n${workerSpec.classpath.files.joinToString("\n")}")
+        }
+
+        logger.debug("submitting work item to generate GraalVM for the schema included in packages = $packages")
+        workQueue.submit(GenerateGraalVmMetadataAction::class.java) { parameters ->
+            parameters.supportedPackages.set(packages)
+            parameters.mainClassName.set(mainClassName.orNull)
+            parameters.outputDirectory.set(targetDirectory)
+        }
+        workQueue.await()
+        logger.debug("successfully generated GraalVM metadata")
+    }
+}

--- a/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/GraphQLDownloadSDLTaskIT.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/GraphQLDownloadSDLTaskIT.kt
@@ -23,6 +23,7 @@ import org.gradle.testkit.runner.TaskOutcome
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
+import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -40,6 +41,9 @@ class GraphQLDownloadSDLTaskIT : WireMockAbstractIT() {
 
         // version catalog setup
         File("../../gradle/libs.versions.toml").copyTo(File(testProjectDirectory, "gradle/libs.versions.toml"))
+        // main project dir
+        val compositeProjectDir = File("../../")
+        Files.writeString(tempDir.resolve("settings.gradle.kts"), """includeBuild("${compositeProjectDir.absolutePath}")""")
 
         WireMock.reset()
         WireMock.stubFor(stubSdlEndpoint(delay = 10_000))

--- a/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/GraphQLDownloadSDLTaskIT.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/GraphQLDownloadSDLTaskIT.kt
@@ -49,6 +49,7 @@ class GraphQLDownloadSDLTaskIT : WireMockAbstractIT() {
             .withPluginClasspath()
             .withArguments(DOWNLOAD_SDL_TASK_NAME, "--stacktrace")
             .withEnvironment(mapOf("wireMockServerUrl" to wireMockServer.baseUrl()))
+            .forwardOutput()
             .buildAndFail()
 
         assertEquals(TaskOutcome.FAILED, result.task(":$DOWNLOAD_SDL_TASK_NAME")?.outcome)

--- a/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/GraphQLGenerateClientTaskIT.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/GraphQLGenerateClientTaskIT.kt
@@ -22,6 +22,7 @@ import org.gradle.testkit.runner.TaskOutcome
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
+import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -40,10 +41,15 @@ class GraphQLGenerateClientTaskIT : WireMockAbstractIT() {
         // version catalog setup
         File("../../gradle/libs.versions.toml").copyTo(File(testProjectDirectory, "gradle/libs.versions.toml"))
 
+        // main project dir
+        val compositeProjectDir = File("../../")
+        Files.writeString(tempDir.resolve("settings.gradle.kts"), """includeBuild("${compositeProjectDir.absolutePath}")""")
+
         val buildResult = GradleRunner.create()
             .withProjectDir(testProjectDirectory)
             .withPluginClasspath()
             .withArguments(GENERATE_CLIENT_TASK_NAME, "--stacktrace")
+            .forwardOutput()
             .buildAndFail()
 
         assertEquals(TaskOutcome.FAILED, buildResult.task(":$GENERATE_CLIENT_TASK_NAME")?.outcome)

--- a/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/GraphQLIntrospectSchemaTaskIT.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/GraphQLIntrospectSchemaTaskIT.kt
@@ -49,6 +49,7 @@ class GraphQLIntrospectSchemaTaskIT : WireMockAbstractIT() {
             .withPluginClasspath()
             .withArguments(INTROSPECT_SCHEMA_TASK_NAME, "--stacktrace")
             .withEnvironment(mapOf("wireMockServerUrl" to wireMockServer.baseUrl()))
+            .forwardOutput()
             .buildAndFail()
 
         assertEquals(TaskOutcome.FAILED, result.task(":$INTROSPECT_SCHEMA_TASK_NAME")?.outcome)

--- a/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/GraphQLIntrospectSchemaTaskIT.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/test/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/GraphQLIntrospectSchemaTaskIT.kt
@@ -23,6 +23,7 @@ import org.gradle.testkit.runner.TaskOutcome
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
+import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -40,6 +41,9 @@ class GraphQLIntrospectSchemaTaskIT : WireMockAbstractIT() {
 
         // version catalog setup
         File("../../gradle/libs.versions.toml").copyTo(File(testProjectDirectory, "gradle/libs.versions.toml"))
+        // main project dir
+        val compositeProjectDir = File("../../")
+        Files.writeString(tempDir.resolve("settings.gradle.kts"), """includeBuild("${compositeProjectDir.absolutePath}")""")
 
         WireMock.reset()
         WireMock.stubFor(stubIntrospectionResult(delay = 10_000))

--- a/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/integrationTest/kotlin/com/expediagroup/graphql/plugin/graalvm/custom/GenerateGraalVmCustomScalarMetadataTest.kt
+++ b/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/integrationTest/kotlin/com/expediagroup/graphql/plugin/graalvm/custom/GenerateGraalVmCustomScalarMetadataTest.kt
@@ -17,9 +17,8 @@
 package com.expediagroup.graphql.plugin.graalvm.custom
 
 import com.expediagroup.graphql.plugin.graalvm.ClassMetadata
-import com.expediagroup.graphql.plugin.graalvm.DefaultMetadataLoader.loadDefaultReflectMetadata
 import com.expediagroup.graphql.plugin.graalvm.MethodMetadata
-import com.expediagroup.graphql.plugin.graalvm.generateGraalVmMetadata
+import com.expediagroup.graphql.plugin.graalvm.generateGraalVmReflectMetadata
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.junit.jupiter.api.Assertions
@@ -53,12 +52,11 @@ class GenerateGraalVmCustomScalarMetadataTest {
             )
         )
 
-        val actual = generateGraalVmMetadata(supportedPackages = listOf("com.expediagroup.graphql.plugin.graalvm.custom"))
-        val defaults = loadDefaultReflectMetadata()
+        val actual = generateGraalVmReflectMetadata(supportedPackages = listOf("com.expediagroup.graphql.plugin.graalvm.custom"))
 
         val mapper = jacksonObjectMapper()
             .setSerializationInclusion(JsonInclude.Include.NON_NULL)
         val writer = mapper.writerWithDefaultPrettyPrinter()
-        Assertions.assertEquals(writer.writeValueAsString(expected + defaults), writer.writeValueAsString(actual))
+        Assertions.assertEquals(writer.writeValueAsString(expected), writer.writeValueAsString(actual))
     }
 }

--- a/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/integrationTest/kotlin/com/expediagroup/graphql/plugin/graalvm/federated/GenerateGraalVmEntityMetadataTest.kt
+++ b/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/integrationTest/kotlin/com/expediagroup/graphql/plugin/graalvm/federated/GenerateGraalVmEntityMetadataTest.kt
@@ -17,9 +17,8 @@
 package com.expediagroup.graphql.plugin.graalvm.federated
 
 import com.expediagroup.graphql.plugin.graalvm.ClassMetadata
-import com.expediagroup.graphql.plugin.graalvm.DefaultMetadataLoader.loadDefaultReflectMetadata
 import com.expediagroup.graphql.plugin.graalvm.MethodMetadata
-import com.expediagroup.graphql.plugin.graalvm.generateGraalVmMetadata
+import com.expediagroup.graphql.plugin.graalvm.generateGraalVmReflectMetadata
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.junit.jupiter.api.Assertions
@@ -50,12 +49,11 @@ class GenerateGraalVmEntityMetadataTest {
             )
         )
 
-        val actual = generateGraalVmMetadata(supportedPackages = listOf("com.expediagroup.graphql.plugin.graalvm.federated"))
-        val defaults = loadDefaultReflectMetadata()
+        val actual = generateGraalVmReflectMetadata(supportedPackages = listOf("com.expediagroup.graphql.plugin.graalvm.federated"))
 
         val mapper = jacksonObjectMapper()
             .setSerializationInclusion(JsonInclude.Include.NON_NULL)
         val writer = mapper.writerWithDefaultPrettyPrinter()
-        Assertions.assertEquals(writer.writeValueAsString(expected + defaults), writer.writeValueAsString(actual))
+        Assertions.assertEquals(writer.writeValueAsString(expected), writer.writeValueAsString(actual))
     }
 }

--- a/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/main/kotlin/com/expediagroup/graphql/plugin/graalvm/DefaultMetadataLoader.kt
+++ b/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/main/kotlin/com/expediagroup/graphql/plugin/graalvm/DefaultMetadataLoader.kt
@@ -37,6 +37,7 @@ object DefaultMetadataLoader {
     /**
      * Open up InputStream to default GraalVM resource config file to be used with graphql-kotlin servers.
      */
+    // TODO we could find application.properties/yaml/conf files using class scanner and add it to the resources
     fun defaultResourceMetadataStream(): InputStream =
         DefaultMetadataLoader.javaClass.classLoader.getResourceAsStream(DEFAULT_RESOURCE_CONFIG)
             ?: throw IllegalStateException("Unable to load graphql-kotlin GraalVM resources metadata")

--- a/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/main/kotlin/com/expediagroup/graphql/plugin/graalvm/GenerateNativeImageConfiguration.kt
+++ b/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/main/kotlin/com/expediagroup/graphql/plugin/graalvm/GenerateNativeImageConfiguration.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2023 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.plugin.graalvm
+
+fun generateNativeImageConfiguration(mainClassName: String): String = """Args = -H:Class=$mainClassName \
+--report-unsupported-elements-at-runtime \
+--no-fallback \
+--install-exit-handlers"""

--- a/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/main/kotlin/com/expediagroup/graphql/plugin/graalvm/ReflectMetadata.kt
+++ b/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/main/kotlin/com/expediagroup/graphql/plugin/graalvm/ReflectMetadata.kt
@@ -21,8 +21,11 @@ package com.expediagroup.graphql.plugin.graalvm
  */
 data class ClassMetadata(
     val name: String,
+    val allDeclaredConstructors: Boolean? = null,
     val allDeclaredFields: Boolean? = null,
+    val allDeclaredMethods: Boolean? = null,
     val allPublicConstructors: Boolean? = null,
+    val allPublicMethods: Boolean? = null,
     val queryAllDeclaredMethods: Boolean? = null,
     val queryAllDeclaredConstructors: Boolean? = null,
     val fields: List<FieldMetadata>? = null,
@@ -31,8 +34,11 @@ data class ClassMetadata(
 
 internal data class MutableClassMetadata(
     val name: String,
+    var allDeclaredConstructors: Boolean? = null,
     var allDeclaredFields: Boolean? = null,
+    var allDeclaredMethods: Boolean? = null,
     var allPublicConstructors: Boolean? = null,
+    var allPublicMethods: Boolean? = null,
     var queryAllDeclaredMethods: Boolean? = null,
     var queryAllDeclaredConstructors: Boolean? = null,
     val fields: List<FieldMetadata>? = null,
@@ -41,8 +47,11 @@ internal data class MutableClassMetadata(
 
 internal fun MutableClassMetadata.toClassMetadata() = ClassMetadata(
     name,
+    allDeclaredConstructors,
     allDeclaredFields,
+    allDeclaredMethods,
     allPublicConstructors,
+    allPublicMethods,
     queryAllDeclaredMethods,
     queryAllDeclaredConstructors,
     fields,

--- a/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/main/resources/default-reflect-config.json
+++ b/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/main/resources/default-reflect-config.json
@@ -1,76 +1,187 @@
 [
-{
-  "name":"com.expediagroup.graphql.generator.scalars.ID",
-  "methods":[
-    {"name":"box-impl","parameterTypes":["java.lang.String"] },
-    {"name":"constructor-impl","parameterTypes":["java.lang.String"] },
-    {"name":"unbox-impl","parameterTypes":[] }
-  ]
-},
-{
-  "name":"com.expediagroup.graphql.server.operations.Mutation"
-},
-{
-  "name":"com.expediagroup.graphql.server.operations.Query"
-},
-{
-  "name":"com.expediagroup.graphql.server.types.GraphQLRequest",
-  "allDeclaredFields":true,
-  "queryAllDeclaredMethods":true,
-  "queryAllDeclaredConstructors":true,
-  "methods":[
-    {"name":"<init>","parameterTypes":["java.lang.String","java.lang.String","java.util.Map","java.util.Map"] },
-    {"name":"<init>","parameterTypes":["java.lang.String","java.lang.String","java.util.Map","java.util.Map","int","kotlin.jvm.internal.DefaultConstructorMarker"] }
-  ]
-},
-{
-  "name":"com.expediagroup.graphql.server.types.GraphQLResponse",
-  "allDeclaredFields":true,
-  "queryAllDeclaredMethods":true,
-  "queryAllDeclaredConstructors":true,
-  "methods":[
-    {"name":"<init>","parameterTypes":["java.lang.Object","java.util.List","java.util.Map"] },
-    {"name":"getData","parameterTypes":[] },
-    {"name":"getErrors","parameterTypes":[] },
-    {"name":"getExtensions","parameterTypes":[] }
-  ]
-},
-{
-  "name":"com.expediagroup.graphql.server.types.GraphQLServerError",
-  "allDeclaredFields":true,
-  "queryAllDeclaredMethods":true,
-  "queryAllDeclaredConstructors":true,
-  "methods":[
-    {"name":"<init>","parameterTypes":["java.lang.String","java.util.List","java.util.List","java.util.Map"] },
-    {"name":"getExtensions","parameterTypes":[] },
-    {"name":"getLocations","parameterTypes":[] },
-    {"name":"getMessage","parameterTypes":[] },
-    {"name":"getPath","parameterTypes":[] }
-  ]
-},
-{
-  "name":"com.expediagroup.graphql.server.types.GraphQLServerRequest",
-  "allDeclaredFields":true,
-  "queryAllDeclaredMethods":true
-},
-{
-  "name":"com.expediagroup.graphql.server.types.GraphQLServerRequestDeserializer",
-  "methods":[{"name":"<init>","parameterTypes":[] }]
-},
-{
-  "name":"com.expediagroup.graphql.server.types.GraphQLServerResponse",
-  "allDeclaredFields":true,
-  "queryAllDeclaredMethods":true
-},
-{
-  "name":"com.expediagroup.graphql.server.types.GraphQLSourceLocation",
-  "allDeclaredFields":true,
-  "queryAllDeclaredMethods":true,
-  "queryAllDeclaredConstructors":true,
-  "methods":[
-    {"name":"<init>","parameterTypes":["int","int"] },
-    {"name":"getColumn","parameterTypes":[] },
-    {"name":"getLine","parameterTypes":[] }
-  ]
-}
+  {
+    "name": "com.expediagroup.graphql.generator.scalars.ID",
+    "methods": [
+      {
+        "name": "box-impl",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "constructor-impl",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "unbox-impl",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.expediagroup.graphql.server.operations.Mutation"
+  },
+  {
+    "name": "com.expediagroup.graphql.server.operations.Query"
+  },
+  {
+    "name": "com.expediagroup.graphql.server.types.GraphQLRequest",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queryAllDeclaredConstructors": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.lang.String",
+          "java.lang.String",
+          "java.util.Map",
+          "java.util.Map"
+        ]
+      },
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.lang.String",
+          "java.lang.String",
+          "java.util.Map",
+          "java.util.Map",
+          "int",
+          "kotlin.jvm.internal.DefaultConstructorMarker"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "com.expediagroup.graphql.server.types.GraphQLResponse",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queryAllDeclaredConstructors": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.util.List",
+          "java.util.Map"
+        ]
+      },
+      {
+        "name": "getData",
+        "parameterTypes": []
+      },
+      {
+        "name": "getErrors",
+        "parameterTypes": []
+      },
+      {
+        "name": "getExtensions",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.expediagroup.graphql.server.types.GraphQLServerError",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queryAllDeclaredConstructors": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.lang.String",
+          "java.util.List",
+          "java.util.List",
+          "java.util.Map"
+        ]
+      },
+      {
+        "name": "getExtensions",
+        "parameterTypes": []
+      },
+      {
+        "name": "getLocations",
+        "parameterTypes": []
+      },
+      {
+        "name": "getMessage",
+        "parameterTypes": []
+      },
+      {
+        "name": "getPath",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.expediagroup.graphql.server.types.GraphQLServerRequest",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true
+  },
+  {
+    "name": "com.expediagroup.graphql.server.types.GraphQLServerRequestDeserializer",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.expediagroup.graphql.server.types.GraphQLServerResponse",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true
+  },
+  {
+    "name": "com.expediagroup.graphql.server.types.GraphQLSourceLocation",
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queryAllDeclaredConstructors": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "int",
+          "int"
+        ]
+      },
+      {
+        "name": "getColumn",
+        "parameterTypes": []
+      },
+      {
+        "name": "getLine",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "kotlin.reflect.jvm.internal.ReflectionFactoryImpl",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "kotlin.KotlinVersion",
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "kotlin.KotlinVersion[]"
+  },
+  {
+    "name": "kotlin.KotlinVersion$Companion"
+  },
+  {
+    "name": "kotlin.KotlinVersion$Companion[]"
+  },
+  {
+    "name": "kotlin.internal.jdk8.JDK8PlatformImplementations",
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  }
 ]

--- a/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/test/kotlin/com/expediagroup/graphql/plugin/graalvm/integration/GenerateGraalVmMetadataTest.kt
+++ b/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/test/kotlin/com/expediagroup/graphql/plugin/graalvm/integration/GenerateGraalVmMetadataTest.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2023 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.plugin.graalvm.integration
+
+import com.expediagroup.graphql.plugin.graalvm.generateGraalVmMetadata
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import kotlin.io.path.exists
+
+class GenerateGraalVmMetadataTest {
+
+    @Test
+    fun `verifies GraalVm metadata can be generated`(@TempDir tmpDir: Path) {
+        val targetDir = tmpDir.toFile()
+        generateGraalVmMetadata(targetDirectory = targetDir, supportedPackages = listOf("com.expediagroup.graphql.plugin.graalvm.integration"), mainClassName = "com.example.ApplicationKt")
+
+        Assertions.assertTrue(targetDir.exists())
+        Assertions.assertTrue(tmpDir.resolve("native-image.properties").exists())
+        Assertions.assertTrue(tmpDir.resolve("reflect-config.json").exists())
+        Assertions.assertTrue(tmpDir.resolve("resource-config.json").exists())
+    }
+}

--- a/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/test/kotlin/com/expediagroup/graphql/plugin/graalvm/integration/HelloWorldQuery.kt
+++ b/plugins/server/graphql-kotlin-graalvm-metadata-generator/src/test/kotlin/com/expediagroup/graphql/plugin/graalvm/integration/HelloWorldQuery.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2023 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.plugin.graalvm.integration
+
+import com.expediagroup.graphql.server.operations.Query
+
+class HelloWorldQuery : Query {
+    fun helloWorld(): String = TODO()
+}

--- a/servers/graphql-kotlin-ktor-server/src/main/kotlin/com/expediagroup/graphql/server/ktor/GraphQLConfiguration.kt
+++ b/servers/graphql-kotlin-ktor-server/src/main/kotlin/com/expediagroup/graphql/server/ktor/GraphQLConfiguration.kt
@@ -38,6 +38,7 @@ import graphql.execution.preparsed.PreparsedDocumentProvider
 import io.ktor.server.config.ApplicationConfig
 import io.ktor.server.config.tryGetString
 import io.ktor.server.config.tryGetStringList
+import kotlin.reflect.KClass
 
 /**
  * Configuration properties that define supported GraphQL configuration options.
@@ -128,6 +129,8 @@ class GraphQLConfiguration(config: ApplicationConfig) {
         fun federation(federationConfig: FederationConfiguration.() -> Unit) {
             federation.apply(federationConfig)
         }
+
+        var typeHierarchy: Map<KClass<*>, List<KClass<*>>>? = null
     }
 
     /**
@@ -138,6 +141,9 @@ class GraphQLConfiguration(config: ApplicationConfig) {
          * Boolean flag indicating whether to generate federated GraphQL model
          */
         var enabled: Boolean = config.tryGetString("graphql.schema.federation.enabled").toBoolean()
+
+        /** Explicit list of entity classes */
+        var entities: List<KClass<*>>? = null
 
         /**
          * Federation tracing config


### PR DESCRIPTION
### :pencil: Description

Create new Gradle task that automatically generates GraalVm reachability metadata for GraphQL Kotlin servers.

Following metadata files are generated:
* `native-image.properties`
* `reflect-config.json`
* `resource-config.json`

Usage:

```
plugins {
  kotlin("jvm") version "1.7.21"
  application
  id("org.graalvm.buildtools.native") version "0.9.20"
  id("com.expediagroup.graphql") version $graphQLKotlinVersion
}

// other build configuration goes here

graphql {
  graalVm {
    packages = listOf("com.example")
  }
}
```

### :link: Related Issues
