### PR TITLE
feat: FederatedTypePromiseResolver to settle all promises regardless of errors

### DIFF
--- a/executions/graphql-kotlin-dataloader-instrumentation/src/main/kotlin/com/expediagroup/graphql/dataloader/instrumentation/extensions/CompletableFutureExtensions.kt
+++ b/executions/graphql-kotlin-dataloader-instrumentation/src/main/kotlin/com/expediagroup/graphql/dataloader/instrumentation/extensions/CompletableFutureExtensions.kt
@@ -27,8 +27,9 @@ import org.dataloader.DataLoader
 import java.util.concurrent.CompletableFuture
 
 /**
- * Check if all futures collected on [KotlinDataLoaderRegistry.dispatchAll] were handled and we have more futures than we
- * had when we started to dispatch, if so, means that [DataLoader]s were chained
+ * Check if all futures collected on [KotlinDataLoaderRegistry.dispatchAll] were handled
+ * and if we have more futures than we had when we started to dispatch, if so,
+ * means that [DataLoader]s were chained so we need to dispatch the dataLoaderRegistry.
  */
 fun <V> CompletableFuture<V>.dispatchIfNeeded(
     environment: DataFetchingEnvironment

--- a/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/execution/EntitiesDataFetcher.kt
+++ b/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/execution/EntitiesDataFetcher.kt
@@ -20,7 +20,7 @@ import com.expediagroup.graphql.generator.federation.exception.InvalidFederatedR
 import com.expediagroup.graphql.generator.federation.execution.resolverexecutor.FederatedTypePromiseResolverExecutor
 import com.expediagroup.graphql.generator.federation.execution.resolverexecutor.FederatedTypeSuspendResolverExecutor
 import com.expediagroup.graphql.generator.federation.execution.resolverexecutor.ResolvableEntity
-import com.expediagroup.graphql.generator.federation.extensions.collectAll
+import com.expediagroup.graphql.generator.federation.extensions.joinAll
 import com.expediagroup.graphql.generator.federation.extensions.toDataFetcherResult
 import graphql.execution.DataFetcherResult
 import graphql.schema.DataFetcher
@@ -91,7 +91,7 @@ open class EntitiesDataFetcher(
         )
 
         return promises
-            .collectAll()
+            .joinAll()
             .thenApply { results ->
                 results.asSequence()
                     .flatten()

--- a/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/extensions/CompletableFutureExtensions.kt
+++ b/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/extensions/CompletableFutureExtensions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Expedia, Inc
+ * Copyright 2023 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 package com.expediagroup.graphql.generator.federation.extensions
 
 import java.util.concurrent.CompletableFuture
-import java.util.concurrent.CompletionException
 
 /**
  * Returns a [CompletableFuture] that completes when all the input futures have completed,

--- a/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/extensions/CompletableFutureExtensions.kt
+++ b/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/extensions/CompletableFutureExtensions.kt
@@ -16,12 +16,15 @@
 package com.expediagroup.graphql.generator.federation.extensions
 
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionException
 
 /**
- * Returns a new CompletableFuture of a list with the resolved values of the given CompletableFutures.
- * the returned completableFuture will complete when all given CompletableFutures complete.
- * If any of the given CompletableFutures complete exceptionally, then the returned CompletableFuture also does so,
- * with a CompletionException holding this exception as its cause.
+ * Returns a [CompletableFuture] that completes when all the input futures have completed,
+ * with a list of the resolved values obtained from the completed futures.
+ * If any of the input futures complete exceptionally, then the returned [CompletableFuture] also completes exceptionally
+ * with a [java.util.concurrent.CompletionException] holding the exception as its cause.
+ *
+ * @return a [CompletableFuture] that completes with a list of resolved values.
  */
 internal fun <T : Any?> List<CompletableFuture<out T>>.joinAll(): CompletableFuture<List<T>> =
     CompletableFuture.allOf(
@@ -30,6 +33,13 @@ internal fun <T : Any?> List<CompletableFuture<out T>>.joinAll(): CompletableFut
         map(CompletableFuture<out T>::join)
     }
 
+/**
+ * Returns a [CompletableFuture] that completes when all the input futures have completed,
+ * with a list of [Result] objects that indicate whether each future completed successfully or with an error.
+ * If a future completed with an error, the corresponding [Result] object will contain the exception that was thrown.
+ *
+ * @return a [CompletableFuture] that completes with a list of [Result] objects.
+ */
 @Suppress("TooGenericExceptionCaught")
 internal fun <T : Any?> List<CompletableFuture<out T>>.allSettled(): CompletableFuture<List<Result<T>>> {
     val resultFutures = map { future ->
@@ -48,4 +58,3 @@ internal fun <T : Any?> List<CompletableFuture<out T>>.allSettled(): Completable
         resultFutures.map(CompletableFuture<Result<T>>::join)
     }
 }
-

--- a/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/extensions/CompletableFutureExtensionsKtTest.kt
+++ b/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/extensions/CompletableFutureExtensionsKtTest.kt
@@ -34,7 +34,6 @@ class CompletableFutureExtensionsKtTest {
         val secondPromise = "second promise".toMono().delayElement(Duration.ofMillis(400)).toFuture()
         val thirdPromise = CompletableFuture.completedFuture("third promise")
 
-
         val result = listOf(firstPromise, secondPromise, thirdPromise).joinAll().join()
 
         assertEquals(3, result.size)
@@ -61,7 +60,6 @@ class CompletableFutureExtensionsKtTest {
         val firstPromise = "first promise".toMono().delayElement(Duration.ofMillis(500)).toFuture()
         val secondPromise = "second promise".toMono().delayElement(Duration.ofMillis(400)).toFuture()
         val thirdPromise = CompletableFuture.completedFuture("third promise")
-
 
         val result = listOf(firstPromise, secondPromise, thirdPromise).allSettled().join()
 

--- a/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/extensions/CompletableFutureExtensionsKtTest.kt
+++ b/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/extensions/CompletableFutureExtensionsKtTest.kt
@@ -16,6 +16,11 @@
 
 package com.expediagroup.graphql.generator.federation.extensions
 
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.future.asCompletableFuture
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import reactor.kotlin.core.publisher.toMono
@@ -27,11 +32,15 @@ import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
+@OptIn(DelicateCoroutinesApi::class)
 class CompletableFutureExtensionsKtTest {
     @Test
     fun `joinAll asynchronously collects a list of completable futures of elements into a completable future list of elements`() {
         val firstPromise = "first promise".toMono().delayElement(Duration.ofMillis(500)).toFuture()
-        val secondPromise = "second promise".toMono().delayElement(Duration.ofMillis(400)).toFuture()
+        val secondPromise = GlobalScope.async {
+            delay(400)
+            "second promise"
+        }.asCompletableFuture()
         val thirdPromise = CompletableFuture.completedFuture("third promise")
 
         val result = listOf(firstPromise, secondPromise, thirdPromise).joinAll().join()
@@ -45,7 +54,10 @@ class CompletableFutureExtensionsKtTest {
     @Test
     fun `joinAll throws an exception with a completableFuture completes exceptionally`() {
         val firstPromise = "first promise".toMono().delayElement(Duration.ofMillis(500)).toFuture()
-        val secondPromise = "second promise".toMono().delayElement(Duration.ofMillis(400)).toFuture()
+        val secondPromise = GlobalScope.async {
+            delay(400)
+            "second promise"
+        }.asCompletableFuture()
         val thirdPromise = CompletableFuture.supplyAsync {
             throw Exception("async exception")
         }
@@ -58,7 +70,10 @@ class CompletableFutureExtensionsKtTest {
     @Test
     fun `allSettled asynchronously collects a list of completable futures of elements into a completable future list of elements`() {
         val firstPromise = "first promise".toMono().delayElement(Duration.ofMillis(500)).toFuture()
-        val secondPromise = "second promise".toMono().delayElement(Duration.ofMillis(400)).toFuture()
+        val secondPromise = GlobalScope.async {
+            delay(400)
+            "second promise"
+        }.asCompletableFuture()
         val thirdPromise = CompletableFuture.completedFuture("third promise")
 
         val result = listOf(firstPromise, secondPromise, thirdPromise).allSettled().join()
@@ -72,7 +87,10 @@ class CompletableFutureExtensionsKtTest {
     @Test
     fun `allSettled asynchronously collects a list of completable futures of elements even if a completable future completes exceptionally`() {
         val firstPromise = "first promise".toMono().delayElement(Duration.ofMillis(500)).toFuture()
-        val secondPromise = "second promise".toMono().delayElement(Duration.ofMillis(400)).toFuture()
+        val secondPromise = GlobalScope.async {
+            delay(400)
+            "second promise"
+        }.asCompletableFuture()
         val thirdPromise = CompletableFuture.supplyAsync {
             throw Exception("async exception")
         }

--- a/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/extensions/CompletableFutureExtensionsKtTest.kt
+++ b/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/extensions/CompletableFutureExtensionsKtTest.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2023 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.generator.federation.extensions
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import reactor.kotlin.core.publisher.toMono
+import java.time.Duration
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionException
+import java.util.concurrent.ExecutionException
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+class CompletableFutureExtensionsKtTest {
+    @Test
+    fun `joinAll asynchronously collects a list of completable futures of elements into a completable future list of elements`() {
+        val firstPromise = "first promise".toMono().delayElement(Duration.ofMillis(500)).toFuture()
+        val secondPromise = "second promise".toMono().delayElement(Duration.ofMillis(400)).toFuture()
+        val thirdPromise = CompletableFuture.completedFuture("third promise")
+
+
+        val result = listOf(firstPromise, secondPromise, thirdPromise).joinAll().join()
+
+        assertEquals(3, result.size)
+        assertEquals("first promise", result[0])
+        assertEquals("second promise", result[1])
+        assertEquals("third promise", result[2])
+    }
+
+    @Test
+    fun `joinAll throws an exception with a completableFuture completes exceptionally`() {
+        val firstPromise = "first promise".toMono().delayElement(Duration.ofMillis(500)).toFuture()
+        val secondPromise = "second promise".toMono().delayElement(Duration.ofMillis(400)).toFuture()
+        val thirdPromise = CompletableFuture.supplyAsync {
+            throw Exception("async exception")
+        }
+
+        assertThrows<CompletionException> {
+            listOf(firstPromise, secondPromise, thirdPromise).joinAll().join()
+        }
+    }
+
+    @Test
+    fun `allSettled asynchronously collects a list of completable futures of elements into a completable future list of elements`() {
+        val firstPromise = "first promise".toMono().delayElement(Duration.ofMillis(500)).toFuture()
+        val secondPromise = "second promise".toMono().delayElement(Duration.ofMillis(400)).toFuture()
+        val thirdPromise = CompletableFuture.completedFuture("third promise")
+
+
+        val result = listOf(firstPromise, secondPromise, thirdPromise).allSettled().join()
+
+        assertEquals(3, result.size)
+        assertEquals("first promise", result[0].getOrNull())
+        assertEquals("second promise", result[1].getOrNull())
+        assertEquals("third promise", result[2].getOrNull())
+    }
+
+    @Test
+    fun `allSettled asynchronously collects a list of completable futures of elements even if a completable future completes exceptionally`() {
+        val firstPromise = "first promise".toMono().delayElement(Duration.ofMillis(500)).toFuture()
+        val secondPromise = "second promise".toMono().delayElement(Duration.ofMillis(400)).toFuture()
+        val thirdPromise = CompletableFuture.supplyAsync {
+            throw Exception("async exception")
+        }
+
+        val result = listOf(firstPromise, secondPromise, thirdPromise).allSettled().join()
+
+        assertEquals(3, result.size)
+        assertEquals("first promise", result[0].getOrNull())
+        assertEquals("second promise", result[1].getOrNull())
+        assertTrue(result[2].isFailure)
+        assertIs<ExecutionException>(result[2].exceptionOrNull())
+        assertEquals("async exception", result[2].exceptionOrNull()?.cause?.message)
+    }
+}


### PR DESCRIPTION
### :pencil: Description
the `FederatedTypePromiseResolver` was originally created with the `DataLoader` use case in mind, meaning that all returned `CompletableFuture`s are resolved synchronously, to let `DataLoader` dispatch mechanism to decide when to dispatch, so realistically, when using `DataLoader`s, there is not an scenario where a particular `CompletableFuture` might complete exceptionally.

However, nothing stops users to use the `FederatedTypePromiseResolver` without dataloaders, which means that now `CompletableFuture`s might complete exceptionally in a asynchronous way.

To solve that, create allSettled extension function 
```kotlin
fun List<CompletableFuture<out T>>.allSettled(): CompletableFuture<List<Result<T>>>
```

which will complete all promises even if one or more complete exceptionally. The type of each element in the returned list will be a [kotlin Result](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-result/) that encapsulates a successful outcome with a value of type `T` or a failure with the exception.

### :link: Related Issues
https://github.com/ExpediaGroup/graphql-kotlin/issues/1747