### PR TITLE
fix(server): Absolute urls for graphiql subscriptions

### DIFF
--- a/servers/graphql-kotlin-server/src/main/resources/graphql-graphiql.html
+++ b/servers/graphql-kotlin-server/src/main/resources/graphql-graphiql.html
@@ -45,7 +45,8 @@
 
 <script>
     var serverUrl = '/${graphQLEndpoint}';
-    var subscriptionUrl = '/${subscriptionsEndpoint}';
+    var subscriptionUrl = new URL("/${subscriptionsEndpoint}", location.href);
+    subscriptionUrl.protocol = location.protocol === "https:" ? "wss" : "ws";
     var fetcher = GraphiQL.createFetcher({
         url: serverUrl,
         subscriptionUrl


### PR DESCRIPTION
### :pencil: Description
Resolve absolute url for graphiql subscriptions using window.location.href.

### :link: Related Issues
#1754
