### PR TITLE
fix: Improve alias handling in client generation

### DIFF
--- a/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/types/generateTypeName.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/types/generateTypeName.kt
@@ -229,9 +229,10 @@ private fun calculateSelectedFields(
     selectionSet.selections.forEach { selection ->
         when (selection) {
             is Field -> {
-                result.add(path + selection.name)
+                val fieldName = selection.alias ?: selection.name
+                result.add(path + fieldName)
                 if (selection.selectionSet != null) {
-                    result.addAll(calculateSelectedFields(context, targetType, selection.selectionSet, "$path${selection.name}."))
+                    result.addAll(calculateSelectedFields(context, targetType, selection.selectionSet, "$path$fieldName."))
                 }
             }
             is InlineFragment -> {

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/alias_nested/AliasNestedQuery.graphql
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/alias_nested/AliasNestedQuery.graphql
@@ -1,0 +1,8 @@
+query AliasNestedQuery {
+  first: complexObjectQuery {
+    nameA: name
+  }
+  second: complexObjectQuery {
+    nameB: name
+  }
+}

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/alias_nested/AliasNestedQuery.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/alias_nested/AliasNestedQuery.kt
@@ -1,0 +1,33 @@
+package com.expediagroup.graphql.generated
+
+import com.expediagroup.graphql.client.Generated
+import com.expediagroup.graphql.client.types.GraphQLClientRequest
+import com.expediagroup.graphql.generated.aliasnestedquery.ComplexObject
+import com.expediagroup.graphql.generated.aliasnestedquery.ComplexObject2
+import kotlin.String
+import kotlin.reflect.KClass
+
+public const val ALIAS_NESTED_QUERY: String =
+    "query AliasNestedQuery {\n  first: complexObjectQuery {\n    nameA: name\n  }\n  second: complexObjectQuery {\n    nameB: name\n  }\n}"
+
+@Generated
+public class AliasNestedQuery : GraphQLClientRequest<AliasNestedQuery.Result> {
+  public override val query: String = ALIAS_NESTED_QUERY
+
+  public override val operationName: String = "AliasNestedQuery"
+
+  public override fun responseType(): KClass<AliasNestedQuery.Result> =
+      AliasNestedQuery.Result::class
+
+  @Generated
+  public data class Result(
+    /**
+     * Query returning an object that references another object
+     */
+    public val first: ComplexObject,
+    /**
+     * Query returning an object that references another object
+     */
+    public val second: ComplexObject2,
+  )
+}

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/alias_nested/aliasnestedquery/ComplexObject.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/alias_nested/aliasnestedquery/ComplexObject.kt
@@ -1,0 +1,17 @@
+package com.expediagroup.graphql.generated.aliasnestedquery
+
+import com.expediagroup.graphql.client.Generated
+import kotlin.String
+
+/**
+ * Multi line description of a complex type.
+ * This is a second line of the paragraph.
+ * This is final line of the description.
+ */
+@Generated
+public data class ComplexObject(
+  /**
+   * Some object name
+   */
+  public val nameA: String,
+)

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/alias_nested/aliasnestedquery/ComplexObject2.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/alias_nested/aliasnestedquery/ComplexObject2.kt
@@ -1,0 +1,17 @@
+package com.expediagroup.graphql.generated.aliasnestedquery
+
+import com.expediagroup.graphql.client.Generated
+import kotlin.String
+
+/**
+ * Multi line description of a complex type.
+ * This is a second line of the paragraph.
+ * This is final line of the description.
+ */
+@Generated
+public data class ComplexObject2(
+  /**
+   * Some object name
+   */
+  public val nameB: String,
+)


### PR DESCRIPTION
### :pencil: Description
See #1760 for a description of the problem this PR tries to fix.

I first created the new test case and then worked through the code to figure out where `ComplexObject` was wrongly deduplicated. `verifySelectionSet` in `generateTypeName.kt` came to the conclusion, that 
```gql
  first: complexObjectQuery {
    nameA: name
  }
```
and
```gql
  second: complexObjectQuery {
    nameB: name
  }
```
contain the same fields although they do not. Using `selection.alias` (if it exists) instead of `selection.name` in `calculateSelectedFields`  fixed the issue.

### :link: Related Issues
fixes #1760 