### PR TITLE
fix(federation): relaxes `@requires` and `@external` constraints

### DIFF
--- a/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/validation/ValidateFieldSelection.kt
+++ b/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/validation/ValidateFieldSelection.kt
@@ -26,7 +26,7 @@ import graphql.schema.GraphQLType
 import graphql.schema.GraphQLTypeUtil
 import graphql.schema.GraphQLUnionType
 
-internal fun validateFieldSelection(validatedDirective: DirectiveInfo, selection: FieldSetSelection, targetType: GraphQLType, errors: MutableList<String>) {
+internal fun validateFieldSelection(validatedDirective: DirectiveInfo, selection: FieldSetSelection, targetType: GraphQLType, errors: MutableList<String>, isExternalPath: Boolean = false) {
     when (val unwrapped = GraphQLTypeUtil.unwrapNonNull(targetType)) {
         is GraphQLScalarType, is GraphQLEnumType -> {
             if (selection.subSelections.isNotEmpty()) {
@@ -38,7 +38,7 @@ internal fun validateFieldSelection(validatedDirective: DirectiveInfo, selection
             if (KEY_DIRECTIVE_NAME == validatedDirective.directiveName) {
                 errors.add("$validatedDirective specifies invalid field set - field set references GraphQLList, field=${selection.field}")
             } else {
-                validateFieldSelection(validatedDirective, selection, GraphQLTypeUtil.unwrapOne(targetType), errors)
+                validateFieldSelection(validatedDirective, selection, GraphQLTypeUtil.unwrapOne(targetType), errors, isExternalPath)
             }
         }
         is GraphQLInterfaceType -> {
@@ -51,7 +51,8 @@ internal fun validateFieldSelection(validatedDirective: DirectiveInfo, selection
                     validatedDirective,
                     selection.subSelections,
                     unwrapped.fieldDefinitions.associateBy { it.name },
-                    errors
+                    errors,
+                    isExternalPath
                 )
             }
         }
@@ -63,7 +64,8 @@ internal fun validateFieldSelection(validatedDirective: DirectiveInfo, selection
                     validatedDirective,
                     selection.subSelections,
                     unwrapped.fieldDefinitions.associateBy { it.name },
-                    errors
+                    errors,
+                    isExternalPath
                 )
             }
         }

--- a/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/validation/validateDirective.kt
+++ b/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/validation/validateDirective.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Expedia, Inc
+ * Copyright 2023 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ internal fun validateDirective(
     validatedType: String,
     targetDirective: String,
     directiveMap: Map<String, List<GraphQLAppliedDirective>>,
-    fieldMap: Map<String, GraphQLFieldDefinition>,
+    fieldMap: Map<String, GraphQLFieldDefinition>
 ): List<String> {
     val validationErrors = mutableListOf<String>()
     val directives = directiveMap[targetDirective]

--- a/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/data/integration/requires/success/_5/LeafRequires.kt
+++ b/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/data/integration/requires/success/_5/LeafRequires.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2023 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.generator.federation.data.integration.requires.success._5
+
+import com.expediagroup.graphql.generator.federation.directives.ExternalDirective
+import com.expediagroup.graphql.generator.federation.directives.FieldSet
+import com.expediagroup.graphql.generator.federation.directives.KeyDirective
+import com.expediagroup.graphql.generator.federation.directives.RequiresDirective
+import kotlin.properties.Delegates
+
+/*
+# only leaf fields have to be external when @requires references complex types
+type LeafRequires @key(fields : "id") {
+  complexType: ComplexType!
+  description: String!
+  id: String!
+  shippingCost: String! @requires(fields : "complexType { weight }")
+}
+
+type ComplexType {
+  localField: String
+  weight: Float! @external
+}
+ */
+@KeyDirective(fields = FieldSet("id"))
+class LeafRequires(val id: String, val description: String, val complexType: ComplexType) {
+
+    @RequiresDirective(FieldSet("complexType { weight }"))
+    fun shippingCost(): String = "$${complexType.weight * 9.99}"
+}
+
+class ComplexType(val localField: String) {
+    @ExternalDirective
+    var weight: Double by Delegates.notNull()
+}

--- a/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/data/integration/requires/success/_6/RecursiveExternalRequires.kt
+++ b/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/data/integration/requires/success/_6/RecursiveExternalRequires.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2023 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.generator.federation.data.integration.requires.success._6
+
+import com.expediagroup.graphql.generator.federation.directives.ExternalDirective
+import com.expediagroup.graphql.generator.federation.directives.FieldSet
+import com.expediagroup.graphql.generator.federation.directives.KeyDirective
+import com.expediagroup.graphql.generator.federation.directives.RequiresDirective
+import kotlin.properties.Delegates
+
+/*
+# @external information is applied recursively through parent fields
+type RecursiveExternalRequires @key(fields : "id") {
+  complexType: ComplexType! @external
+  description: String!
+  id: String!
+  shippingCost: String! @requires(fields : "complexType { weight }")
+}
+
+type ComplexType {
+  potentiallyExternal: String
+  weight: Float!
+}
+ */
+@KeyDirective(fields = FieldSet("id"))
+class RecursiveExternalRequires(val id: String, val description: String, @ExternalDirective val complexType: ComplexType) {
+
+    @RequiresDirective(FieldSet("complexType { weight }"))
+    fun shippingCost(): String = "$${complexType.weight * 9.99}"
+}
+
+class ComplexType(val potentiallyExternal: String) {
+    var weight: Double by Delegates.notNull()
+}

--- a/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/data/integration/requires/success/_7/ExternalRequiresType.kt
+++ b/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/data/integration/requires/success/_7/ExternalRequiresType.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2023 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.generator.federation.data.integration.requires.success._7
+
+import com.expediagroup.graphql.generator.federation.directives.ExternalDirective
+import com.expediagroup.graphql.generator.federation.directives.FieldSet
+import com.expediagroup.graphql.generator.federation.directives.KeyDirective
+import com.expediagroup.graphql.generator.federation.directives.RequiresDirective
+import kotlin.properties.Delegates
+
+/*
+# @external information is applied to fields within type
+type RecursiveExternalRequires @key(fields : "id") {
+  externalType: ExternalType!
+  description: String!
+  id: String!
+  shippingCost: String! @requires(fields : "complexType { weight }")
+}
+
+type ExternalType @external {
+  allExternal: String
+  weight: Float!
+}
+ */
+@KeyDirective(fields = FieldSet("id"))
+class ExternalRequiresType(val id: String, val description: String, val externalType: ExternalType) {
+
+    @RequiresDirective(FieldSet("externalType { weight }"))
+    fun shippingCost(): String = "$${externalType.weight * 9.99}"
+}
+
+@ExternalDirective
+class ExternalType(val allExternal: String) {
+    var weight: Double by Delegates.notNull()
+}

--- a/website/docs/schema-generator/federation/federated-directives.md
+++ b/website/docs/schema-generator/federation/federated-directives.md
@@ -500,6 +500,8 @@ The `@requires` directive is used to specify external (provided by other subgrap
 the required fields may not be needed by the client, but the service may need additional information from other subgraphs. Required fields specified in the directive field set should
 correspond to a valid field on the underlying GraphQL interface/object and should be instrumented with `@external` directive.
 
+All the leaf fields from the specified in the `@requires` selection set have to be marked as `@external` OR any of the parent fields on the path to the leaf is marked as `@external`.
+
 Fields specified in the `@requires` directive will only be specified in the queries that reference those fields. This is problematic for Kotlin as the non-nullable primitive properties
 have to be initialized when they are declared. Simplest workaround for this problem is to initialize the underlying property to some default value (e.g. null) that will be used if
 it is not specified. This approach might become problematic though as it might be impossible to determine whether fields was initialized with the default value or the invalid/default


### PR DESCRIPTION
### :pencil: Description

Relaxing `@requires` and `@external` constraints. Previously ALL fields referenced from the `@requires` selection set had to be marked `@external`. This was too strict as it is possible to define `@requires` selection set against **local** object type with some `@external` fields. As a result only leaf fields (i.e. scalar/enum fields) have to be explicitly marked `@external` OR implicitly inherit `@external` characteristic through any of the leaf field ancestors.

### :link: Related Issues
