### PR TITLE
feat: update graphql-java version with backwards compatible changes

### DIFF
--- a/examples/server/spring-server/src/test/kotlin/com/expediagroup/graphql/examples/server/spring/query/PolymorphicQueryIT.kt
+++ b/examples/server/spring-server/src/test/kotlin/com/expediagroup/graphql/examples/server/spring/query/PolymorphicQueryIT.kt
@@ -84,8 +84,9 @@ class PolymorphicQueryIT(@Autowired private val testClient: WebTestClient) {
             .verifyError("Validation error")
             .verifyError("WrongType")
             .verifyError(
-                "argument 'type' with value 'EnumValue{name='$unknownType'}' is not a valid 'AnimalType' - " +
-                    "Expected enum literal value not in allowable values -  'EnumValue{name='HELLO'}'"
+                "Validation error (WrongType@[animal]) : " +
+                    "argument 'type' with value 'EnumValue{name='HELLO'}' is not a valid 'AnimalType' - " +
+                    "Literal value not in allowable values for enum 'AnimalType' - 'EnumValue{name='HELLO'}'"
             )
     }
 

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/execution/PropertyDataFetcher.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/execution/PropertyDataFetcher.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Expedia, Inc
+ * Copyright 2023 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,22 +16,36 @@
 
 package com.expediagroup.graphql.generator.execution
 
-import graphql.TrivialDataFetcher
 import graphql.schema.DataFetcher
 import graphql.schema.DataFetchingEnvironment
+import graphql.schema.GraphQLFieldDefinition
+import graphql.schema.LightDataFetcher
+import java.util.function.Supplier
 import kotlin.reflect.KProperty
 
 /**
  * Property [DataFetcher] that directly invokes underlying property getter.
  *
- * @param propertyGetter Kotlin property getter that will be invoked to resolve a field
+ * @param propertyGetter Kotlin's property getter that will be invoked to resolve a field
  */
-class PropertyDataFetcher(private val propertyGetter: KProperty.Getter<*>) : TrivialDataFetcher<Any?> {
+class PropertyDataFetcher(private val propertyGetter: KProperty.Getter<*>) : LightDataFetcher<Any?> {
+    /**
+     * Invokes target getter function without instantiating a [DataFetchingEnvironment]
+     */
+    override fun get(
+        fieldDefinition: GraphQLFieldDefinition,
+        sourceObject: Any?,
+        environmentSupplier: Supplier<DataFetchingEnvironment>
+    ): Any? =
+        sourceObject?.let { instance ->
+            propertyGetter.call(instance)
+        }
 
     /**
      * Invokes target getter function.
      */
-    override fun get(environment: DataFetchingEnvironment): Any? = environment.getSource<Any?>()?.let { instance ->
-        propertyGetter.call(instance)
-    }
+    override fun get(environment: DataFetchingEnvironment): Any? =
+        environment.getSource<Any?>()?.let { instance ->
+            propertyGetter.call(instance)
+        }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,8 +22,8 @@ kotlinxSerializationVersion = 1.3.2
 
 androidPluginVersion = 7.1.2
 classGraphVersion = 4.8.149
-federationGraphQLVersion = 2.2.0
-graphQLJavaVersion = 19.2
+federationGraphQLVersion = 3.0.0
+graphQLJavaVersion = 20.3
 graphQLJavaDataLoaderVersion = 3.2.0
 jacksonVersion = 2.13.3
 # KotlinPoet v1.12.0+ requires Kotlin v1.7


### PR DESCRIPTION
### :pencil: Description
This is an special PR that will update [graphql-java version to 20.3](https://github.com/graphql-java/graphql-java/releases/tag/v20.3) which is an special release of graphql java with a change that reverts the stricter `parseValue` scalar coercion, since this was the only breaking change in v20, im updating `6.x.x`.

Have special interest in checking the performance improvements graphql-java 20 provides, like the `LightDataFetcher` interface and Performance Improvements by avoid object allocations.

more info
https://github.com/graphql-java/graphql-java/releases/tag/v20.0