### PR TITLE
chore: fix flaky subscription test

### DIFF
--- a/servers/graphql-kotlin-ktor-server/src/test/kotlin/com/expediagroup/graphql/server/ktor/subscriptions/graphqlws/KtorGraphQLWebSocketProtocolHandlerTest.kt
+++ b/servers/graphql-kotlin-ktor-server/src/test/kotlin/com/expediagroup/graphql/server/ktor/subscriptions/graphqlws/KtorGraphQLWebSocketProtocolHandlerTest.kt
@@ -500,6 +500,7 @@ class KtorGraphQLWebSocketProtocolHandlerTest {
             block.invoke(session)
             handlerJob.cancelAndJoin()
         } finally {
+            delay(300)
             session.closeChannels()
         }
     }


### PR DESCRIPTION
### :pencil: Description
Add artificial delay to Ktor subscription test to ensure coroutines can complete successfully within the timeout.

### :link: Related Issues
