### PR TITLE
Revert "chore: fix flaky subscription test"

### DIFF
--- a/servers/graphql-kotlin-ktor-server/src/test/kotlin/com/expediagroup/graphql/server/ktor/subscriptions/graphqlws/KtorGraphQLWebSocketProtocolHandlerTest.kt
+++ b/servers/graphql-kotlin-ktor-server/src/test/kotlin/com/expediagroup/graphql/server/ktor/subscriptions/graphqlws/KtorGraphQLWebSocketProtocolHandlerTest.kt
@@ -500,7 +500,6 @@ class KtorGraphQLWebSocketProtocolHandlerTest {
             block.invoke(session)
             handlerJob.cancelAndJoin()
         } finally {
-            delay(300)
             session.closeChannels()
         }
     }


### PR DESCRIPTION
Reverts ExpediaGroup/graphql-kotlin#1787

While actions running the PR checks worked it still fails on master :(