### PR TITLE
feat: honor LightDataFetcher on by level batching logic (#1795)

### DIFF
--- a/executions/graphql-kotlin-dataloader-instrumentation/src/main/kotlin/com/expediagroup/graphql/dataloader/instrumentation/level/state/ManualDataFetcher.kt
+++ b/executions/graphql-kotlin-dataloader-instrumentation/src/main/kotlin/com/expediagroup/graphql/dataloader/instrumentation/level/state/ManualDataFetcher.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.dataloader.instrumentation.level.state
+
+import graphql.schema.DataFetcher
+import java.util.concurrent.CompletableFuture
+
+/**
+ * DataFetcher Decorator that allows manual completion of dataFetchers
+ */
+abstract class ManualDataFetcher : DataFetcher<CompletableFuture<Any?>> {
+    val manualFuture: CompletableFuture<Any?> = CompletableFuture()
+    var originalFuture: CompletableFuture<Any?>? = null
+    var originalExpressionException: Exception? = null
+
+    /**
+     * Manually complete the [manualFuture] by handling the [originalFuture]
+     */
+    fun complete() {
+        when {
+            originalExpressionException != null -> manualFuture.completeExceptionally(originalExpressionException)
+            else -> originalFuture?.handle { result, exception ->
+                when {
+                    exception != null -> manualFuture.completeExceptionally(exception)
+                    else -> manualFuture.complete(result)
+                }
+            }
+        }
+    }
+}

--- a/executions/graphql-kotlin-dataloader-instrumentation/src/main/kotlin/com/expediagroup/graphql/dataloader/instrumentation/level/state/ManuallyCompletableLightDataFetcher.kt
+++ b/executions/graphql-kotlin-dataloader-instrumentation/src/main/kotlin/com/expediagroup/graphql/dataloader/instrumentation/level/state/ManuallyCompletableLightDataFetcher.kt
@@ -17,32 +17,48 @@
 package com.expediagroup.graphql.dataloader.instrumentation.level.state
 
 import graphql.execution.Async
-import graphql.schema.DataFetcher
 import graphql.schema.DataFetchingEnvironment
+import graphql.schema.GraphQLFieldDefinition
+import graphql.schema.LightDataFetcher
 import java.util.concurrent.CompletableFuture
+import java.util.function.Supplier
 
 /**
- * DataFetcher Decorator that stores the original dataFetcher result (it's always a completable future)
+ * LightDataFetcher Decorator that stores the original dataFetcher result (it's always a completable future)
  * it stores the [originalFuture] as property and returns an uncompleted [manualFuture]
  * then at later point manually call [complete] to complete the [manualFuture] with the [originalFuture] result
  * to let ExecutionStrategy handle all futures
  *
  * @param originalDataFetcher original dataFetcher to be decorated
  */
-class ManuallyCompletableDataFetcher(
-    private val originalDataFetcher: DataFetcher<*>
-) : ManualDataFetcher() {
+class ManuallyCompletableLightDataFetcher(
+    private val originalDataFetcher: LightDataFetcher<*>
+) : ManualDataFetcher(), LightDataFetcher<CompletableFuture<Any?>> {
+
+    override fun get(environment: DataFetchingEnvironment): CompletableFuture<Any?> =
+        get(environment.fieldDefinition, environment.getSource()) { environment }
+
     /**
-     * when attempting to get the value from dataFetcher, execute the [originalDataFetcher]
+     * when attempting to get the value from LightDataFetcher, execute the [originalDataFetcher]
      * and store the resulting future [originalFuture] and a possible [originalExpressionException] if
      * a synchronous exception was thrown during the execution
      *
-     * @param environment dataFetchingEnvironment with information about the field
+     * @param fieldDefinition the graphql field definition
+     * @param sourceObject the source object to get a value from
+     * @param environmentSupplier a supplier of the [DataFetchingEnvironment] that creates it lazily
      * @return an uncompleted manualFuture that can be completed at later time
      */
-    override fun get(environment: DataFetchingEnvironment): CompletableFuture<Any?> {
+    override fun get(
+        fieldDefinition: GraphQLFieldDefinition,
+        sourceObject: Any?,
+        environmentSupplier: Supplier<DataFetchingEnvironment>
+    ): CompletableFuture<Any?> {
         try {
-            val fetchedValueRaw = originalDataFetcher.get(environment)
+            val fetchedValueRaw = originalDataFetcher.get(
+                fieldDefinition,
+                sourceObject,
+                environmentSupplier
+            )
             originalFuture = Async.toCompletableFuture(fetchedValueRaw)
         } catch (e: Exception) {
             originalExpressionException = e


### PR DESCRIPTION
### :pencil: Description
Now that [PropertyDataFetcher](https://github.com/ExpediaGroup/graphql-kotlin/blob/master/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/execution/PropertyDataFetcher.kt#L31) implements `LightDataFetcher` we need to make sure we respect that and on the `LEVEL_DISPATCHED` batching mechanism, decorate the DataFetcher properly depending if its `LightDataFetcher`, or just `DataFetcher`