### PR TITLE
Ktor Server:  set "graphql-transport-ws" as default protocol to graphQLSubscriptionsRoute

### DIFF
--- a/servers/graphql-kotlin-ktor-server/src/main/kotlin/com/expediagroup/graphql/server/ktor/GraphQLRoutes.kt
+++ b/servers/graphql-kotlin-ktor-server/src/main/kotlin/com/expediagroup/graphql/server/ktor/GraphQLRoutes.kt
@@ -80,7 +80,7 @@ fun Route.graphQLPostRoute(endpoint: String = "graphql", streamingResponse: Bool
  */
 fun Route.graphQLSubscriptionsRoute(
     endpoint: String = "subscriptions",
-    protocol: String? = null,
+    protocol: String? = "graphql-transport-ws",
     handlerOverride: KtorGraphQLSubscriptionHandler? = null,
 ) {
     val handler = handlerOverride ?: run {

--- a/servers/graphql-kotlin-ktor-server/src/test/kotlin/com/expediagroup/graphql/server/ktor/GraphQLPluginTest.kt
+++ b/servers/graphql-kotlin-ktor-server/src/test/kotlin/com/expediagroup/graphql/server/ktor/GraphQLPluginTest.kt
@@ -27,8 +27,10 @@ import io.ktor.client.request.get
 import io.ktor.client.request.parameter
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
+import io.ktor.client.request.url
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import io.ktor.serialization.jackson.jackson
@@ -195,7 +197,10 @@ class GraphQLPluginTest {
                 install(WebSockets)
             }
 
-            client.webSocket("/subscriptions") {
+            client.webSocket({
+                url("/subscriptions")
+                headers[HttpHeaders.SecWebSocketProtocol] = "graphql-transport-ws"
+            }) {
                 outgoing.send(Frame.Text("""{"type": "connection_init"}"""))
 
                 val ack = incoming.receive()


### PR DESCRIPTION
### :pencil: Description

This is a small fix to set `graphql-transport-ws` subprotocol as (sensible) default for Ktor server `graphQLSubscriptionsRoute`. 

Without that line, users may encounter issues when sending requests using popular GQL clients like Apollo or even bundled GraphiQL UI, because of they are sending `Sec-Websocket-Protocol=graphql-transport-ws` header and that is being rejected by Ktor.

Users may still override this value, if needed

### :link: Related Issues

#1756