### PR TITLE
fix federation composition integration

### DIFF
--- a/examples/federation/supergraph.yaml
+++ b/examples/federation/supergraph.yaml
@@ -1,4 +1,4 @@
-federation_version: 2
+federation_version: =2.4.8
 subgraphs:
   products:
     routing_url: http://products:8080/graphql


### PR DESCRIPTION
### :pencil: Description

Pin composition to a specific version. Latest `rover` changes require either specific version or to wrap major in quotes.

