### PR TITLE
BREAKING(generator): use new willBuildSchema/didBuildSchema

### DIFF
--- a/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/FederatedSchemaGeneratorHooks.kt
+++ b/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/FederatedSchemaGeneratorHooks.kt
@@ -144,7 +144,7 @@ open class FederatedSchemaGeneratorHooks(
         return super.didGenerateGraphQLType(type, generatedType)
     }
 
-    override fun willBuildSchema(builder: GraphQLSchema.Builder): GraphQLSchema.Builder {
+    override fun didBuildSchema(builder: GraphQLSchema.Builder): GraphQLSchema.Builder {
         val originalSchema = builder.build()
         val originalQuery = originalSchema.queryType
 
@@ -206,7 +206,7 @@ open class FederatedSchemaGeneratorHooks(
 
     /**
      * Federated service may not have any regular queries but will have federated queries. In order to ensure that we
-     * have a valid GraphQL schema that can be modified in the [willBuildSchema], query has to have at least one single field.
+     * have a valid GraphQL schema that can be modified in the [didBuildSchema], query has to have at least one single field.
      *
      * Add federated _service query to ensure it is a valid GraphQL schema.
      */

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/hooks/SchemaGeneratorHooks.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/hooks/SchemaGeneratorHooks.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Expedia, Inc
+ * Copyright 2023 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package com.expediagroup.graphql.generator.hooks
 
+import com.expediagroup.graphql.generator.TopLevelObject
 import com.expediagroup.graphql.generator.directives.DirectiveMetaInformation
 import com.expediagroup.graphql.generator.directives.KotlinDirectiveWiringFactory
 import com.expediagroup.graphql.generator.exceptions.EmptyInputObjectTypeException
@@ -50,11 +51,20 @@ import kotlin.reflect.KType
  * that allow users to customize the schema.
  */
 interface SchemaGeneratorHooks {
+
     /**
-     * Called before the final GraphQL schema is built.
-     * This doesn't prevent the called from rebuilding the final schema using java-graphql's functionality
+     * Called before any generation of GraphQL schema.
+     *
+     * Allows users to do some preprocessing and generate custom schema builder instance.
      */
-    fun willBuildSchema(builder: GraphQLSchema.Builder): GraphQLSchema.Builder = builder
+    fun willBuildSchema(
+        queries: List<TopLevelObject>,
+        mutations: List<TopLevelObject>,
+        subscriptions: List<TopLevelObject>,
+        additionalTypes: Set<KType>,
+        additionalInputTypes: Set<KType>,
+        schemaObject: TopLevelObject?
+    ): GraphQLSchema.Builder = GraphQLSchema.newSchema()
 
     /**
      * Called before using reflection to generate the graphql object type for the given KType.
@@ -187,6 +197,12 @@ interface SchemaGeneratorHooks {
     } else {
         type
     }
+
+    /**
+     * Called after generation of schema but before returning it to the user.
+     * This doesn't prevent the called from rebuilding the final schema using java-graphql's functionality
+     */
+    fun didBuildSchema(builder: GraphQLSchema.Builder): GraphQLSchema.Builder = builder
 
     val wiringFactory: KotlinDirectiveWiringFactory
         get() = KotlinDirectiveWiringFactory()

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/hooks/SchemaGeneratorHooksTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/hooks/SchemaGeneratorHooksTest.kt
@@ -64,7 +64,7 @@ class SchemaGeneratorHooksTest {
     fun `calls hook before schema is built`() {
         class MockSchemaGeneratorHooks : SchemaGeneratorHooks {
             var willBuildSchemaCalled = false
-            override fun willBuildSchema(builder: GraphQLSchema.Builder): GraphQLSchema.Builder {
+            override fun didBuildSchema(builder: GraphQLSchema.Builder): GraphQLSchema.Builder {
                 willBuildSchemaCalled = true
                 builder.additionalTypes(
                     setOf(


### PR DESCRIPTION
### :pencil: Description

Cleanup schema generation hooks to have proper BEFORE and AFTER generation hooks.

Changes:
* Rename existing `willBuildSchema` hook to `didBuildSchema` hook to indicate that it executes AFTER generating the schema.
* Add new `willBuildSchema` hook that executes BEFORE any schema generation logic kicks in
