### PR TITLE
feat(generator): introduce new didGenerateDirective hook

### DIFF
--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/hooks/SchemaGeneratorHooks.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/hooks/SchemaGeneratorHooks.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Expedia, Inc
+ * Copyright 2023 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -145,6 +145,11 @@ interface SchemaGeneratorHooks {
             else -> generatedType
         }
     }
+
+    /**
+     * Called after auto-generating the directive from the annotation that allows final transformation before it is applied to a target location.
+     */
+    fun didGenerateDirective(directiveInfo: DirectiveMetaInformation, directive: GraphQLDirective): GraphQLDirective = directive
 
     /**
      * Called after converting the function to a field definition but before adding to the query object to allow customization


### PR DESCRIPTION
### :pencil: Description

Adds new `didGenerateDirective` hook that is invoked AFTER generating the directive. This PR also fix directive generation logic to ensure hooks are only called once (when generating the directive). Previously we were always invoking `willGenerateDirective` hook regardless whether the directive was already generated or not (which lead to creation of new directive when modifying the directive in the new `didGenerateDirective` hook).

### :link: Related Issues

Type generation still suffers from the same bug (#1815)
