### PR TITLE
Keep response content type to application/json as default instead of application/graphql-response+json

### DIFF
--- a/servers/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/server/spring/GraphQLRoutesConfiguration.kt
+++ b/servers/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/server/spring/GraphQLRoutesConfiguration.kt
@@ -49,7 +49,7 @@ class GraphQLRoutesConfiguration(
                 val acceptMediaType = serverRequest
                     .headers()
                     .accept()
-                    .find { it.includes(MediaType.APPLICATION_GRAPHQL_RESPONSE) }
+                    .find { it != MediaType.ALL && it.includes(MediaType.APPLICATION_GRAPHQL_RESPONSE) }
                     ?.let { MediaType.APPLICATION_GRAPHQL_RESPONSE }
                     ?: MediaType.APPLICATION_JSON
                 if (graphQLResponse != null) {

--- a/servers/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/server/spring/routes/RouteConfigurationIT.kt
+++ b/servers/graphql-kotlin-spring-server/src/test/kotlin/com/expediagroup/graphql/server/spring/routes/RouteConfigurationIT.kt
@@ -206,6 +206,18 @@ class RouteConfigurationIT(@Autowired private val testClient: WebTestClient) {
     }
 
     @Test
+    fun `verify POST graphQL request without response content type`() {
+        testClient.post()
+            .uri("/graphql")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(GraphQLRequest("query { hello(name: \"POST application/graphql\") }"))
+            .exchange()
+            .expectHeader()
+            .contentType(MediaType.APPLICATION_JSON)
+            .verifyGraphQLRoute("Hello POST application/graphql!")
+    }
+
+    @Test
     fun `verify POST request with XML content type will result in HTTP 400 bad request`() {
         testClient.post()
             .uri("/graphql")


### PR DESCRIPTION
### :pencil: Description
Most clients will request with `*/*` unless an any MediaType is specified.
However, the `*/*` was not taken into account in current implementation.

I change to keep `application/json` as default instead of `application/graphql-response+json`.

### :link: Related Issues
https://github.com/ExpediaGroup/graphql-kotlin/issues/1831
https://github.com/ExpediaGroup/graphql-kotlin/issues/1573
https://github.com/ExpediaGroup/graphql-kotlin/pull/1699