### PR TITLE
fix(federation): skip fieldset validation when it includes type reference

### DIFF
--- a/generator/graphql-kotlin-federation/build.gradle.kts
+++ b/generator/graphql-kotlin-federation/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
 dependencies {
     api(projects.graphqlKotlinSchemaGenerator)
     api(libs.federation)
+    implementation(libs.slf4j)
     testImplementation(libs.reactor.core)
     testImplementation(libs.reactor.extensions)
     testImplementation(libs.junit.params)

--- a/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/validation/validateFieldSetSelection.kt
+++ b/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/validation/validateFieldSetSelection.kt
@@ -21,7 +21,13 @@ import com.expediagroup.graphql.generator.federation.directives.REQUIRES_DIRECTI
 import graphql.schema.GraphQLDirectiveContainer
 import graphql.schema.GraphQLFieldDefinition
 import graphql.schema.GraphQLNamedType
+import graphql.schema.GraphQLType
+import graphql.schema.GraphQLTypeReference
 import graphql.schema.GraphQLTypeUtil
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+private val logger: Logger = LoggerFactory.getLogger("ValidateFieldSetSelection")
 
 internal fun validateFieldSetSelection(
     validatedDirective: DirectiveInfo,
@@ -36,14 +42,27 @@ internal fun validateFieldSetSelection(
             errors.add("$validatedDirective specifies invalid field set - field set specifies field that does not exist, field=${selection.field}")
         } else {
             val currentFieldType = currentField.type
-            val isExternal = isExternalPath || GraphQLTypeUtil.unwrapAll(currentFieldType).isExternalPath() || currentField.isExternalType()
-            if (REQUIRES_DIRECTIVE_NAME == validatedDirective.directiveName && GraphQLTypeUtil.isLeaf(currentFieldType) && !isExternal) {
-                errors.add("$validatedDirective specifies invalid field set - @requires should reference only @external fields, field=${selection.field}")
+            if (currentFieldType.isReferenceType()) {
+                logger.warn("Unable to validate field set selection as one of the fields is a type reference.")
+            } else {
+                val isExternal = isExternalPath || GraphQLTypeUtil.unwrapAll(currentFieldType).isExternalPath() || currentField.isExternalType()
+                if (REQUIRES_DIRECTIVE_NAME == validatedDirective.directiveName && GraphQLTypeUtil.isLeaf(currentFieldType) && !isExternal) {
+                    errors.add("$validatedDirective specifies invalid field set - @requires should reference only @external fields, field=${selection.field}")
+                }
+                validateFieldSelection(validatedDirective, selection, currentFieldType, errors, isExternal)
             }
-            validateFieldSelection(validatedDirective, selection, currentFieldType, errors, isExternal)
         }
     }
 }
 
 private fun GraphQLDirectiveContainer.isExternalType(): Boolean = this.getAppliedDirectives(EXTERNAL_DIRECTIVE_NAME).isNotEmpty()
 private fun GraphQLNamedType.isExternalPath(): Boolean = this is GraphQLDirectiveContainer && this.isExternalType()
+
+// workaround to GraphQLType.unwrapAll() which tries to cast GraphQLTypeReference to GraphQLUnmodifiedType
+private fun GraphQLType.isReferenceType(): Boolean {
+    var type = this
+    while (GraphQLTypeUtil.isWrapped(type)) {
+        type = GraphQLTypeUtil.unwrapOne(type)
+    }
+    return type is GraphQLTypeReference
+}

--- a/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/data/integration/key/success/_6/EntityReferencingParent.kt
+++ b/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/data/integration/key/success/_6/EntityReferencingParent.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.expediagroup.graphql.generator.federation.data.integration.key.success._6
+
+import com.expediagroup.graphql.generator.federation.directives.FieldSet
+import com.expediagroup.graphql.generator.federation.directives.KeyDirective
+import com.expediagroup.graphql.generator.scalars.ID
+import io.mockk.mockk
+
+/*
+# example usage of a @key referencing parent
+type Child @key(fields: "parent { id }") {
+  parent: Parent
+}
+
+type Parent {
+  id: ID!
+  someChild: Child!
+}
+
+type Query {
+  parent: Parent!
+}
+ */
+data class Parent(
+    val id: ID,
+    val someChild: Child,
+)
+
+@KeyDirective(fields = FieldSet("parent { id }"))
+data class Child(
+    val parent: Parent,
+)
+
+class EntityReferencingParent {
+    fun parent(): Parent = mockk()
+}

--- a/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/validation/integration/FederatedKeyDirectiveIT.kt
+++ b/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/validation/integration/FederatedKeyDirectiveIT.kt
@@ -30,6 +30,7 @@ import com.expediagroup.graphql.generator.federation.data.integration.key.succes
 import com.expediagroup.graphql.generator.federation.data.integration.key.success._2.KeyWithMultipleFieldsQuery
 import com.expediagroup.graphql.generator.federation.data.integration.key.success._3.KeyWithNestedFieldsQuery
 import com.expediagroup.graphql.generator.federation.data.integration.key.success._4.MultipleKeyQuery
+import com.expediagroup.graphql.generator.federation.data.integration.key.success._6.EntityReferencingParent
 import com.expediagroup.graphql.generator.federation.exception.InvalidFederatedSchema
 import com.expediagroup.graphql.generator.federation.toFederatedSchema
 import graphql.schema.GraphQLSchema
@@ -215,5 +216,14 @@ class FederatedKeyDirectiveIT {
         val expected = "Invalid federated schema:\n" +
             " - @key(fields = \"upc\") directive on MultipleKeysOneInvalid specifies invalid field set - field set specifies field that does not exist, field=upc"
         assertEquals(expected, exception.message)
+    }
+
+    @Test
+    fun `verifies validations are skipped when processing GraphQL references`() {
+        val schema = toFederatedSchema(
+            config = federatedTestConfig("com.expediagroup.graphql.generator.federation.data.integration.key.success._6"),
+            queries = listOf(TopLevelObject(EntityReferencingParent()))
+        )
+        validateTypeWasCreatedWithKeyDirective(schema, "Child")
     }
 }


### PR DESCRIPTION
### :pencil: Description

We are performing federated directive validations when generating GraphQL schema. This is an extra convenience as it gives us information about invalid schema sooner. Subgraph schemas will then be re-validated during the supergraph composition logic.

Currently it is possible to create `@key` that references the type still under construction (`GraphQLReferenceType`). Since we cannot validate fields on the type that doesn't exist yet, we cannot validate it either. Updating logic to log a warning when this happens and skip validation logic.

### :link: Related Issues
Resolves: https://github.com/ExpediaGroup/graphql-kotlin/issues/1858