### PR TITLE
fix(federation): update federated hooks to support flow

### DIFF
--- a/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/FederatedSchemaGeneratorHooks.kt
+++ b/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/FederatedSchemaGeneratorHooks.kt
@@ -73,7 +73,7 @@ import com.expediagroup.graphql.generator.federation.types.SERVICE_FIELD_DEFINIT
 import com.expediagroup.graphql.generator.federation.types._Service
 import com.expediagroup.graphql.generator.federation.types.generateEntityFieldDefinition
 import com.expediagroup.graphql.generator.federation.validation.FederatedSchemaValidator
-import com.expediagroup.graphql.generator.hooks.SchemaGeneratorHooks
+import com.expediagroup.graphql.generator.hooks.FlowSubscriptionSchemaGeneratorHooks
 import graphql.TypeResolutionEnvironment
 import graphql.schema.DataFetcher
 import graphql.schema.FieldCoordinates
@@ -97,7 +97,7 @@ import kotlin.reflect.full.findAnnotation
 open class FederatedSchemaGeneratorHooks(
     private val resolvers: List<FederatedTypeResolver>,
     private val optInFederationV2: Boolean = true
-) : SchemaGeneratorHooks {
+) : FlowSubscriptionSchemaGeneratorHooks() {
     private val validator: FederatedSchemaValidator = FederatedSchemaValidator()
     data class LinkSpec(val namespace: String, val imports: Map<String, String>)
     private val linkSpecs: MutableMap<String, LinkSpec> = HashMap()


### PR DESCRIPTION
### :pencil: Description

As of v2.4, Federation supports subscriptions. Our servers automatically configure hooks for subscription `Flow` support for non-federated schemas. We should update federated hooks to also support `Flow`.

### :link: Related Issues

Resolves: https://github.com/ExpediaGroup/graphql-kotlin/issues/1862