### PR TITLE
fix: Ktor Subscriptions wrong url #1863

### DIFF
--- a/website/docs/server/server-subscriptions.md
+++ b/website/docs/server/server-subscriptions.md
@@ -10,4 +10,4 @@ specific details on how to read incoming messages from the WebSocket session as 
 If you are using one of the official server implementations for GraphQL Kotlin, it will have subscription handling setup for you.
 
 -   See `graphql-kotlin-spring-server` [subscriptions](spring-server/spring-subscriptions.md)
--   See `graphql-kotlin-ktor-server` [subscriptions](spring-server/spring-subscriptions.md)
+-   See `graphql-kotlin-ktor-server` [subscriptions](ktor-server/ktor-subscriptions.md)


### PR DESCRIPTION
### :pencil: Description
Replaced Spring subscriptions URL with Ktor subscriptions.

### :link: Related Issues
#1863