### PR TITLE
Rewrite CompletableFutureExtension.allSettled to not use CompletableFuture.supplyAsync

### DIFF
--- a/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/extensions/CompletableFutureExtensionsKtTest.kt
+++ b/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/extensions/CompletableFutureExtensionsKtTest.kt
@@ -27,7 +27,6 @@ import reactor.kotlin.core.publisher.toMono
 import java.time.Duration
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionException
-import java.util.concurrent.ExecutionException
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
@@ -101,7 +100,7 @@ class CompletableFutureExtensionsKtTest {
         assertEquals("first promise", result[0].getOrNull())
         assertEquals("second promise", result[1].getOrNull())
         assertTrue(result[2].isFailure)
-        assertIs<ExecutionException>(result[2].exceptionOrNull())
+        assertIs<CompletionException>(result[2].exceptionOrNull())
         assertEquals("async exception", result[2].exceptionOrNull()?.cause?.message)
     }
 }


### PR DESCRIPTION
We noticed a big drop in performance after switching to the new `CompletableFuture` based `FederatedTypeResolver`. Our investigations led us to the implementation of `CompletableFutureExtension.allSettled` which has the following issues:

- Bug: It uses `CompletableFuture.supplyAsync` which looses all thread local data (as we switch to another thread pool we have no control over), which breaks most tracing frameworks and all other thread local usages
- Performance: 100 futures get wrapped into 100 separately scheduled futures, this is unnecessary as `thenApply` and `exceptionally` work without nesting of futures. This avoids non-neglegible overhead

I changed the accompanying test to expect another exception type as only `get()` throw a `ExecutionException`. This should not affect your public API as its an internal method and I could not find any other references to `ExecutionException` in `graphql-kotlin`s codebase.

