### PR TITLE
[Documentation] Fixed error in GraalVM native image docs

### DIFF
--- a/website/docs/plugins/gradle-plugin-usage-graalvm.mdx
+++ b/website/docs/plugins/gradle-plugin-usage-graalvm.mdx
@@ -38,9 +38,9 @@ fun Application.graphQLModule() {
             queries = listOf(
                 HelloWorldQuery()
             )
+            // mapping between interfaces/union KClass and their implementation KClasses
+            typeHierarchy = mapOf()
         }
-        // mapping between interfaces/union KClass and their implementation KClasses
-        typeHierarchy = mapOf()
     }
     install(Routing) {
         graphQLPostRoute()

--- a/website/docs/plugins/maven-plugin-usage-graalvm.md
+++ b/website/docs/plugins/maven-plugin-usage-graalvm.md
@@ -38,9 +38,9 @@ fun Application.graphQLModule() {
             queries = listOf(
                 HelloWorldQuery()
             )
+            // mapping between interfaces/union KClass and their implementation KClasses
+            typeHierarchy = mapOf()
         }
-        // mapping between interfaces/union KClass and their implementation KClasses
-        typeHierarchy = mapOf()
     }
     install(Routing) {
         graphQLPostRoute()


### PR DESCRIPTION
### :pencil: Description

There is a small error in the Maven/Gradle native image documentation. The attribute `typeHierarchy` is part of the `schema` block but was previously in the `install(GraphQL)` scope

### :link: Related Issues

no issue