### PR TITLE
Update Jackson to 2.16.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ dataloader = "3.2.0"
 federation = "4.1.0"
 graphql-java = "21.1"
 graalvm = "0.9.28"
-jackson = "2.15.2"
+jackson = "2.16.1"
 # kotlin version has to match the compile-testing compiler version
 kotlin = "1.8.22"
 # TODO kotlin 1.9 upgrade -> kotlinx-benchaamrk 0.4.9+ uses kotlin 1.9


### PR DESCRIPTION
### :pencil: Description
2.15.1 has a vulnerability: [CVE-2023-35116](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2023-35116)

2.16.1 has a bunch of unrelated changes as well:
https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.16

It might be worth doing a small dot release with this, as I've been really struggling to force the Gradle plugin to use a newer version.

### :link: Related Issues
