### PR TITLE
Update Ktor to 2.3.7

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ kotlinx-benchmark = "0.4.8"
 kotlinx-coroutines = "1.7.3"
 # TODO kotlin 1.9 upgrade -> kotlinx-serialization 1.6.0+ uses kotlin 1.9
 kotlinx-serialization = "1.5.1"
-ktor = "2.3.4"
+ktor = "2.3.7"
 maven-plugin-annotation = "3.9.0"
 maven-plugin-api = "3.9.4"
 maven-project = "2.2.1"


### PR DESCRIPTION
### :pencil: Description
Ktor prior to 2.3.5 has a vulnerability: [CVE-2023-45613](https://ossindex.sonatype.org/vulnerability/CVE-2023-45613?component-type=maven&component-name=io.ktor%2Fktor-network-tls-jvm)


### :link: Related Issues
