### PR TITLE
feat: pass ExecutionInput to getOrElse method

### DIFF
--- a/executions/graphql-kotlin-automatic-persisted-queries/src/main/kotlin/com/expediagroup/graphql/apq/cache/AutomaticPersistedQueriesCache.kt
+++ b/executions/graphql-kotlin-automatic-persisted-queries/src/main/kotlin/com/expediagroup/graphql/apq/cache/AutomaticPersistedQueriesCache.kt
@@ -51,6 +51,7 @@ interface AutomaticPersistedQueriesCache : PersistedQueryCache {
      * and then it should be added to the cache.
      *
      * @param key The hash of the requested query.
+     * @param executionInput the resource that GraphQL operation.
      * @param supplier that will provide the document in case there is a cache miss.
      */
     fun getOrElse(

--- a/executions/graphql-kotlin-automatic-persisted-queries/src/main/kotlin/com/expediagroup/graphql/apq/cache/AutomaticPersistedQueriesCache.kt
+++ b/executions/graphql-kotlin-automatic-persisted-queries/src/main/kotlin/com/expediagroup/graphql/apq/cache/AutomaticPersistedQueriesCache.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Expedia, Inc
+ * Copyright 2024 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ interface AutomaticPersistedQueriesCache : PersistedQueryCache {
         executionInput: ExecutionInput,
         onCacheMiss: PersistedQueryCacheMiss
     ): CompletableFuture<PreparsedDocumentEntry> =
-        getOrElse(persistedQueryId.toString()) {
+        getOrElse(persistedQueryId.toString(), executionInput) {
             onCacheMiss.apply(executionInput.query)
         }
 
@@ -55,6 +55,7 @@ interface AutomaticPersistedQueriesCache : PersistedQueryCache {
      */
     fun getOrElse(
         key: String,
+        executionInput: ExecutionInput,
         supplier: () -> PreparsedDocumentEntry
     ): CompletableFuture<PreparsedDocumentEntry>
 }

--- a/executions/graphql-kotlin-automatic-persisted-queries/src/main/kotlin/com/expediagroup/graphql/apq/cache/DefaultAutomaticPersistedQueriesCache.kt
+++ b/executions/graphql-kotlin-automatic-persisted-queries/src/main/kotlin/com/expediagroup/graphql/apq/cache/DefaultAutomaticPersistedQueriesCache.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Expedia, Inc
+ * Copyright 2024 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package com.expediagroup.graphql.apq.cache
 
+import graphql.ExecutionInput
 import graphql.execution.preparsed.PreparsedDocumentEntry
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
@@ -26,6 +27,7 @@ class DefaultAutomaticPersistedQueriesCache : AutomaticPersistedQueriesCache {
 
     override fun getOrElse(
         key: String,
+        executionInput: ExecutionInput,
         supplier: () -> PreparsedDocumentEntry
     ): CompletableFuture<PreparsedDocumentEntry> =
         cache[key]?.let { entry ->

--- a/executions/graphql-kotlin-automatic-persisted-queries/src/main/kotlin/com/expediagroup/graphql/apq/provider/AutomaticPersistedQueriesProvider.kt
+++ b/executions/graphql-kotlin-automatic-persisted-queries/src/main/kotlin/com/expediagroup/graphql/apq/provider/AutomaticPersistedQueriesProvider.kt
@@ -71,7 +71,7 @@ class AutomaticPersistedQueriesProvider(
             } ?: run {
                 // no apqExtension, not a persisted query,
                 // but we still want to cache the parsed and validated document
-                cache.getOrElse(executionInput.getQueryId()) {
+                cache.getOrElse(executionInput.getQueryId(), executionInput) {
                     parseAndValidateFunction.apply(executionInput)
                 }
             }

--- a/executions/graphql-kotlin-automatic-persisted-queries/src/main/kotlin/com/expediagroup/graphql/apq/provider/AutomaticPersistedQueriesProvider.kt
+++ b/executions/graphql-kotlin-automatic-persisted-queries/src/main/kotlin/com/expediagroup/graphql/apq/provider/AutomaticPersistedQueriesProvider.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Expedia, Inc
+ * Copyright 2024 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
### :pencil: Description
trying to implement a distributed cache mechanism for parsed and validated operations, in the `getOrElse` method is where we would be setting the operation into an external cache, for that, we need access to the actual operation, which is included in the `ExecutionInput`.

No more changes are needed given that the action of storing the parsed and validated operation is potentially async, but we don't care about the result.