### PR TITLE
Don't swallow root server exceptions

### DIFF
--- a/servers/graphql-kotlin-ktor-server/src/main/kotlin/com/expediagroup/graphql/server/ktor/GraphQL.kt
+++ b/servers/graphql-kotlin-ktor-server/src/main/kotlin/com/expediagroup/graphql/server/ktor/GraphQL.kt
@@ -195,6 +195,4 @@ internal suspend inline fun KtorGraphQLServer.executeRequest(call: ApplicationCa
     } ?: call.respond(HttpStatusCode.BadRequest)
 } catch (e: UnsupportedOperationException) {
     call.respond(HttpStatusCode.MethodNotAllowed)
-} catch (e: Exception) {
-    call.respond(HttpStatusCode.BadRequest)
 }


### PR DESCRIPTION
Let root level bootstrap exceptions go to the ktor exception handler rather than being swallowed.

### :pencil: Description
Exceptions that happen when building the context are swallowed obscuring what actually went wrong and making it hard to fix.

### :link: Related Issues
#1920