### PR TITLE
feat: allow additional parser options in the gradle and maven plugins

### DIFF
--- a/integration/maven-plugin-integration-tests/integration/generate-client/pom.xml
+++ b/integration/maven-plugin-integration-tests/integration/generate-client/pom.xml
@@ -81,6 +81,8 @@
                             <parserOptions>
                                 <maxTokens>15000</maxTokens>
                                 <maxWhitespaceTokens>200000</maxWhitespaceTokens>
+                                <maxCharacters>1048576</maxCharacters>
+                                <maxRuleDepth>500</maxRuleDepth>
                                 <captureIgnoredChars>false</captureIgnoredChars>
                                 <captureLineComments>false</captureLineComments>
                                 <captureSourceLocation>true</captureSourceLocation>

--- a/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/actions/GenerateClientAction.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/actions/GenerateClientAction.kt
@@ -51,6 +51,8 @@ abstract class GenerateClientAction : WorkAction<GenerateClientParameters> {
             parserOptions = {
                 parserOptions.maxTokens?.let { maxTokens(it) }
                 parserOptions.maxWhitespaceTokens?.let { maxWhitespaceTokens(it) }
+                parserOptions.maxCharacters?.let { maxCharacters(it) }
+                parserOptions.maxRuleDepth?.let { maxRuleDepth(it) }
                 parserOptions.captureIgnoredChars?.let { captureIgnoredChars(it) }
                 parserOptions.captureSourceLocation?.let { captureSourceLocation(it) }
                 parserOptions.captureLineComments?.let { captureLineComments(it) }

--- a/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/config/GraphQLParserOptions.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/config/GraphQLParserOptions.kt
@@ -11,6 +11,10 @@ data class GraphQLParserOptions(
     var maxTokens: Int? = null,
     /** Modify the maximum number of whitespace tokens read to prevent processing extremely large queries */
     var maxWhitespaceTokens: Int? = null,
+    /** Modify the maximum number of characters in a document to prevent malicious documents consuming CPU */
+    val maxCharacters: Int? = null,
+    /** Modify the maximum grammar rule depth to negate malicious documents that can cause stack overflows */
+    val maxRuleDepth: Int? = null,
     /** Memory usage is significantly reduced by not capturing ignored characters, especially in SDL parsing. */
     var captureIgnoredChars: Boolean? = null,
     /** Single-line comments do not have any semantic meaning in GraphQL source documents and can be ignored */

--- a/plugins/graphql-kotlin-maven-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/maven/GenerateClientAbstractMojo.kt
+++ b/plugins/graphql-kotlin-maven-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/maven/GenerateClientAbstractMojo.kt
@@ -81,6 +81,8 @@ abstract class GenerateClientAbstractMojo : AbstractMojo() {
      * <parserOptions>
      *     <maxTokens>15000</maxTokens>
      *     <maxWhitespaceTokens>200000</maxWhitespaceTokens>
+     *     <maxCharacters>1048576</maxCharacters>
+     *     <maxRuleDepth>500</maxRuleDepth>
      *     <captureIgnoredChars>false</captureIgnoredChars>
      *     <captureLineComments>false</captureLineComments>
      *     <captureSourceLocation>true</captureSourceLocation>
@@ -137,6 +139,8 @@ abstract class GenerateClientAbstractMojo : AbstractMojo() {
             parserOptions?.apply {
                 maxTokens?.let { maxTokens(it) }
                 maxWhitespaceTokens?.let { maxWhitespaceTokens(it) }
+                maxCharacters?.let { maxCharacters(it) }
+                maxRuleDepth?.let { maxRuleDepth(it) }
                 captureIgnoredChars?.let { captureIgnoredChars(it) }
                 captureLineComments?.let { captureLineComments(it) }
                 captureSourceLocation?.let { captureSourceLocation(it) }
@@ -178,6 +182,8 @@ abstract class GenerateClientAbstractMojo : AbstractMojo() {
             log.debug("  parserOptions")
             maxTokens?.let { log.debug("    maxTokens = $it") }
             maxWhitespaceTokens?.let { log.debug("    maxWhitespaceTokens = $it") }
+            maxCharacters?.let { log.debug("    maxCharacters = $it") }
+            maxRuleDepth?.let { log.debug("    maxRuleDepth = $it") }
             captureIgnoredChars?.let { log.debug("    captureIgnoredChars = $it") }
             captureLineComments?.let { log.debug("    captureLineComments = $it") }
             captureSourceLocation?.let { log.debug("    captureSourceLocation = $it") }
@@ -223,6 +229,14 @@ class ParserOptions {
     /** Modify the maximum number of whitespace tokens read to prevent processing extremely large queries */
     @Parameter
     var maxWhitespaceTokens: Int? = null
+
+    /** Modify the maximum number of characters in a document to prevent malicious documents consuming CPU */
+    @Parameter
+    val maxCharacters: Int? = null
+
+    /** Modify the maximum grammar rule depth to negate malicious documents that can cause stack overflows */
+    @Parameter
+    val maxRuleDepth: Int? = null
 
     /** Memory usage is significantly reduced by not capturing ignored characters, especially in SDL parsing. */
     @Parameter

--- a/website/docs/plugins/gradle-plugin-tasks.mdx
+++ b/website/docs/plugins/gradle-plugin-tasks.mdx
@@ -148,6 +148,10 @@ graphql {
         maxTokens = 15000
         // Override the maximum number of whitespace tokens read to prevent processing extremely large queries.
         maxWhitespaceTokens = 200000
+        // Modify the maximum number of characters in a document to prevent malicious documents consuming CPU
+        maxCharacters = 1048576
+        // Modify the maximum grammar rule depth to negate malicious documents that can cause stack overflows
+        maxRuleDepth = 500
         // Single-line comments do not have any semantic meaning in GraphQL source documents and can be ignored
         captureLineComments = false
         // Memory usage is significantly reduced by not capturing ignored characters, especially in SDL parsing.
@@ -213,6 +217,10 @@ graphql {
             options.maxTokens = 15000
             // Override the maximum number of whitespace tokens read to prevent processing extremely large queries.
             options.maxWhitespaceTokens = 200000
+            // Modify the maximum number of characters in a document to prevent malicious documents consuming CPU
+            options.maxCharacters = 1048576
+            // Modify the maximum grammar rule depth to negate malicious documents that can cause stack overflows
+            options.maxRuleDepth = 500
             // Memory usage is significantly reduced by not capturing ignored characters, especially in SDL parsing.
             options.captureIgnoredChars = false
             // Memory usage is reduced by not setting SourceLocations on AST nodes, especially in SDL parsing.
@@ -318,6 +326,10 @@ for details on how to update this process to use `kotlinx.serialization` instead
         maxTokens = 15000
         // Override the maximum number of whitespace tokens read to prevent processing extremely large queries.
         maxWhitespaceTokens = 200000
+        // Modify the maximum number of characters in a document to prevent malicious documents consuming CPU
+        maxCharacters = 1048576
+        // Modify the maximum grammar rule depth to negate malicious documents that can cause stack overflows
+        maxRuleDepth = 500
         // Memory usage is significantly reduced by not capturing ignored characters, especially in SDL parsing.
         captureIgnoredChars = false
         // Memory usage is reduced by not setting SourceLocations on AST nodes, especially in SDL parsing.
@@ -388,6 +400,10 @@ for details on how to update this process to use `kotlinx.serialization` instead
         maxTokens = 15000
         // Override the maximum number of whitespace tokens read to prevent processing extremely large queries.
         maxWhitespaceTokens = 200000
+        // Modify the maximum number of characters in a document to prevent malicious documents consuming CPU
+        maxCharacters = 1048576
+        // Modify the maximum grammar rule depth to negate malicious documents that can cause stack overflows
+        maxRuleDepth = 500
         // Memory usage is significantly reduced by not capturing ignored characters, especially in SDL parsing.
         captureIgnoredChars = false
         // Memory usage is reduced by not setting SourceLocations on AST nodes, especially in SDL parsing.

--- a/website/docs/plugins/maven-plugin-goals.md
+++ b/website/docs/plugins/maven-plugin-goals.md
@@ -101,6 +101,10 @@ Generate GraphQL client code based on the provided GraphQL schema and target que
         <maxTokens>15000</maxTokens>
         <!-- Modify the maximum number of whitespace tokens read to prevent processing extremely large queries -->
         <maxWhitespaceTokens>200000</maxWhitespaceTokens>
+        <!-- Modify the maximum number of characters in a document to prevent malicious documents consuming CPU -->
+        <maxCharacters>1048576</maxCharacters>
+        <!-- Modify the maximum grammar rule depth to negate malicious documents that can cause stack overflows -->
+        <maxRuleDepth>500</maxRuleDepth>
         <!-- Memory usage is significantly reduced by not capturing ignored characters, especially in SDL parsing -->
         <captureIgnoredChars>false</captureIgnoredChars>
         <!-- Single-line comments do not have any semantic meaning in GraphQL source documents and can be ignored -->
@@ -209,6 +213,10 @@ Generate GraphQL test client code based on the provided GraphQL schema and targe
         <maxTokens>15000</maxTokens>
         <!-- Modify the maximum number of whitespace tokens read to prevent processing extremely large queries -->
         <maxWhitespaceTokens>200000</maxWhitespaceTokens>
+        <!-- Modify the maximum number of characters in a document to prevent malicious documents consuming CPU -->
+        <maxCharacters>1048576</maxCharacters>
+        <!-- Modify the maximum grammar rule depth to negate malicious documents that can cause stack overflows -->
+        <maxRuleDepth>500</maxRuleDepth>
         <!-- Memory usage is significantly reduced by not capturing ignored characters, especially in SDL parsing -->
         <captureIgnoredChars>false</captureIgnoredChars>
         <!-- Single-line comments do not have any semantic meaning in GraphQL source documents and can be ignored -->


### PR DESCRIPTION
Enables configuration of the maxCharacters and maxParserDepth parser options for GraphQL Java. 

### :pencil: Description

See [ParserOptions](https://github.com/graphql-java/graphql-java/blob/7c381cc9d61c1e1838a2487d9b24974c451f23a2/src/main/java/graphql/parser/ParserOptions.java#L13) for the values configured in graphql-java.

### :link: Related Issues

Extensions of #1586 with additional parameters that have been added to graphql-java.