### PR TITLE
feat(federation): federation v2.6 support

### DIFF
--- a/examples/federation/docker-compose.yaml
+++ b/examples/federation/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   router:
-    image: ghcr.io/apollographql/router:v1.29.1
+    image: ghcr.io/apollographql/router:v1.40.0
     volumes:
       - ./router.yaml:/dist/config/router.yaml
       - ./supergraph.graphql:/dist/config/supergraph.graphql

--- a/examples/federation/supergraph.yaml
+++ b/examples/federation/supergraph.yaml
@@ -1,4 +1,4 @@
-federation_version: =2.5.4
+federation_version: =2.6.3
 subgraphs:
   products:
     routing_url: http://products:8080/graphql

--- a/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/directives/LinkDirective.kt
+++ b/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/directives/LinkDirective.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Expedia, Inc
+ * Copyright 2024 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ const val LINK_SPEC_URL_PREFIX = "$APOLLO_SPEC_URL/$LINK_SPEC"
 const val LINK_SPEC_LATEST_URL = "$LINK_SPEC_URL_PREFIX/v$LINK_SPEC_LATEST_VERSION"
 
 const val FEDERATION_SPEC = "federation"
-const val FEDERATION_SPEC_LATEST_VERSION = "2.5"
+const val FEDERATION_SPEC_LATEST_VERSION = "2.6"
 const val FEDERATION_SPEC_URL_PREFIX = "$APOLLO_SPEC_URL/$FEDERATION_SPEC"
 const val FEDERATION_SPEC_LATEST_URL = "$FEDERATION_SPEC_URL_PREFIX/v$FEDERATION_SPEC_LATEST_VERSION"
 

--- a/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/directives/Policy.kt
+++ b/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/directives/Policy.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2024 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.generator.federation.directives
+
+import com.expediagroup.graphql.generator.annotations.GraphQLIgnore
+
+/**
+ * Annotation representing authorization policy scalar type that is used by the `@policy directive.
+ *
+ * @param value required authorization policy
+ * @see [com.expediagroup.graphql.generator.federation.types.POLICY_SCALAR_TYPE]
+ */
+@LinkedSpec(FEDERATION_SPEC)
+annotation class Policy(val value: String)
+
+// this is a workaround for JVM lack of support nested arrays as annotation values
+@GraphQLIgnore
+annotation class Policies(val value: Array<Policy>)

--- a/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/types/Policy.kt
+++ b/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/types/Policy.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2024 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.generator.federation.types
+
+import com.expediagroup.graphql.generator.federation.directives.Policy
+import com.expediagroup.graphql.generator.federation.exception.CoercingValueToLiteralException
+import graphql.GraphQLContext
+import graphql.Scalars
+import graphql.execution.CoercedVariables
+import graphql.language.StringValue
+import graphql.language.Value
+import graphql.schema.Coercing
+import graphql.schema.CoercingParseLiteralException
+import graphql.schema.CoercingSerializeException
+import graphql.schema.GraphQLScalarType
+import java.util.Locale
+
+internal const val POLICY_SCALAR_NAME = "Policy"
+
+/**
+ * Custom scalar type that is used to represent authentication policy which serializes as a String.
+ */
+internal val POLICY_SCALAR_TYPE: GraphQLScalarType = GraphQLScalarType.newScalar(Scalars.GraphQLString)
+    .name(POLICY_SCALAR_NAME)
+    .description("Federation type representing authorization policy")
+    .coercing(PolicyCoercing)
+    .build()
+
+private object PolicyCoercing : Coercing<Policy, String> {
+    override fun serialize(dataFetcherResult: Any, graphQLContext: GraphQLContext, locale: Locale): String =
+        when (dataFetcherResult) {
+            is Policy -> dataFetcherResult.value
+            else -> throw CoercingSerializeException(
+                "Cannot serialize $dataFetcherResult. Expected type 'Policy' but was '${dataFetcherResult.javaClass.simpleName}'."
+            )
+        }
+
+    override fun parseValue(input: Any, graphQLContext: GraphQLContext, locale: Locale): Policy =
+        when (input) {
+            is Policy -> input
+            is StringValue -> Policy::class.constructors.first().call(input.value)
+            else -> throw CoercingParseLiteralException(
+                "Cannot parse $input to Policy. Expected AST type 'StringValue' but was '${input.javaClass.simpleName}'."
+            )
+        }
+
+    override fun parseLiteral(input: Value<*>, variables: CoercedVariables, graphQLContext: GraphQLContext, locale: Locale): Policy =
+        when (input) {
+            is StringValue -> Policy::class.constructors.first().call(input.value)
+            else -> throw CoercingParseLiteralException(
+                "Cannot parse $input to Policy. Expected AST type 'StringValue' but was '${input.javaClass.simpleName}'."
+            )
+        }
+
+    override fun valueToLiteral(input: Any, graphQLContext: GraphQLContext, locale: Locale): Value<*> =
+        when (input) {
+            is Policy -> StringValue.newStringValue(input.value).build()
+            else -> throw CoercingValueToLiteralException(Policy::class, input)
+        }
+}

--- a/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/FederatedSchemaV2GeneratorTest.kt
+++ b/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/FederatedSchemaV2GeneratorTest.kt
@@ -30,7 +30,7 @@ class FederatedSchemaV2GeneratorTest {
     fun `verify can generate federated schema`() {
         val expectedSchema =
             """
-            schema @link(import : ["@external", "@key", "@provides", "@requires", "FieldSet"], url : "https://specs.apollo.dev/federation/v2.5"){
+            schema @link(import : ["@external", "@key", "@provides", "@requires", "FieldSet"], url : "https://specs.apollo.dev/federation/v2.6"){
               query: Query
             }
 

--- a/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/directives/compose/ComposeDirectiveTest.kt
+++ b/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/directives/compose/ComposeDirectiveTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Expedia, Inc
+ * Copyright 2024 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@ class ComposeDirectiveTest {
     fun `verify we can generate valid schema with @composeDirective`() {
         val expectedSchema =
             """
-            schema @composeDirective(name : "custom") @link(as : "myspec", import : ["@custom"], url : "https://www.myspecs.dev/myspec/v1.0") @link(import : ["@composeDirective", "@key", "FieldSet"], url : "https://specs.apollo.dev/federation/v2.5"){
+            schema @composeDirective(name : "custom") @link(as : "myspec", import : ["@custom"], url : "https://www.myspecs.dev/myspec/v1.0") @link(import : ["@composeDirective", "@key", "FieldSet"], url : "https://specs.apollo.dev/federation/v2.6"){
               query: Query
             }
 

--- a/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/directives/link/LinkDirectiveTest.kt
+++ b/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/directives/link/LinkDirectiveTest.kt
@@ -45,7 +45,7 @@ class LinkDirectiveTest {
     fun `verify we can import federation spec using custom @link`() {
         val expectedSchema =
             """
-            schema @link(as : "fed", import : [{name : "@key", as : "@myKey"}], url : "https://specs.apollo.dev/federation/v2.5"){
+            schema @link(as : "fed", import : [{name : "@key", as : "@myKey"}], url : "https://specs.apollo.dev/federation/v2.6"){
               query: Query
             }
 

--- a/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/directives/requiresscope/RequiresScopesDirectiveTest.kt
+++ b/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/directives/requiresscope/RequiresScopesDirectiveTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Expedia, Inc
+ * Copyright 2024 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ class RequiresScopesDirectiveTest {
     fun `verify we can import federation spec using custom @link`() {
         val expectedSchema =
             """
-            schema @link(url : "https://specs.apollo.dev/federation/v2.5"){
+            schema @link(url : "https://specs.apollo.dev/federation/v2.6"){
               query: Query
             }
 

--- a/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/execution/ServiceQueryResolverTest.kt
+++ b/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/execution/ServiceQueryResolverTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Expedia, Inc
+ * Copyright 2024 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -90,7 +90,7 @@ scalar CustomScalar"""
 
 const val BASE_SERVICE_SDL =
 """
-schema @link(url : "https://specs.apollo.dev/federation/v2.5"){
+schema @link(url : "https://specs.apollo.dev/federation/v2.6"){
   query: Query
 }
 
@@ -118,7 +118,7 @@ scalar link__Import
 
 const val FEDERATED_SERVICE_SDL_V2 =
 """
-schema @link(import : ["@external", "@key", "@provides", "@requires", "FieldSet"], url : "https://specs.apollo.dev/federation/v2.5"){
+schema @link(import : ["@external", "@key", "@provides", "@requires", "FieldSet"], url : "https://specs.apollo.dev/federation/v2.6"){
   query: Query
 }
 

--- a/integration/gradle-plugin-integration-tests/src/integration/resources/sdl/custom.graphql
+++ b/integration/gradle-plugin-integration-tests/src/integration/resources/sdl/custom.graphql
@@ -1,4 +1,4 @@
-schema @link(url : "https://specs.apollo.dev/federation/v2.5"){
+schema @link(url : "https://specs.apollo.dev/federation/v2.6"){
   query: Query
 }
 

--- a/integration/gradle-plugin-integration-tests/src/integration/resources/sdl/federated.graphql
+++ b/integration/gradle-plugin-integration-tests/src/integration/resources/sdl/federated.graphql
@@ -1,4 +1,4 @@
-schema @link(url : "https://specs.apollo.dev/federation/v2.5"){
+schema @link(url : "https://specs.apollo.dev/federation/v2.6"){
   query: Query
 }
 

--- a/integration/maven-plugin-integration-tests/integration/generate-sdl-federated/src/test/kotlin/com/expediagroup/graphql/plugin/maven/GenerateSDLMojoTest.kt
+++ b/integration/maven-plugin-integration-tests/integration/generate-sdl-federated/src/test/kotlin/com/expediagroup/graphql/plugin/maven/GenerateSDLMojoTest.kt
@@ -36,7 +36,7 @@ class GenerateSDLMojoTest {
         assertTrue(schemaFile.exists(), "schema file was generated")
 
         val expectedSchema = """
-            schema @link(url : "https://specs.apollo.dev/federation/v2.5"){
+            schema @link(url : "https://specs.apollo.dev/federation/v2.6"){
               query: Query
             }
 

--- a/integration/maven-plugin-integration-tests/integration/generate-sdl-hooks/src/test/kotlin/com/expediagroup/graphql/plugin/maven/GenerateSDLMojoTest.kt
+++ b/integration/maven-plugin-integration-tests/integration/generate-sdl-hooks/src/test/kotlin/com/expediagroup/graphql/plugin/maven/GenerateSDLMojoTest.kt
@@ -36,7 +36,7 @@ class GenerateSDLMojoTest {
         assertTrue(schemaFile.exists(), "schema file was generated")
 
         val expectedSchema = """
-            schema @link(url : "https://specs.apollo.dev/federation/v2.5"){
+            schema @link(url : "https://specs.apollo.dev/federation/v2.6"){
               query: Query
             }
 

--- a/plugins/schema/graphql-kotlin-sdl-generator/src/integrationTest/kotlin/com/expediagroup/graphql/plugin/schema/GenerateCustomSDLTest.kt
+++ b/plugins/schema/graphql-kotlin-sdl-generator/src/integrationTest/kotlin/com/expediagroup/graphql/plugin/schema/GenerateCustomSDLTest.kt
@@ -25,7 +25,7 @@ class GenerateCustomSDLTest {
     fun `verify we can generate SDL using custom hooks provider`() {
         val expectedSchema =
             """
-                schema @link(url : "https://specs.apollo.dev/federation/v2.5"){
+                schema @link(url : "https://specs.apollo.dev/federation/v2.6"){
                   query: Query
                 }
 

--- a/website/docs/schema-generator/federation/apollo-federation.mdx
+++ b/website/docs/schema-generator/federation/apollo-federation.mdx
@@ -119,7 +119,7 @@ toFederatedSchema(
 will generate
 
 ```graphql
-schema @link(import : ["@key", "FieldSet"], url : "https://specs.apollo.dev/federation/v2.5"){
+schema @link(import : ["@key", "FieldSet"], url : "https://specs.apollo.dev/federation/v2.6"){
   query: Query
 }
 

--- a/website/docs/schema-generator/federation/federated-directives.md
+++ b/website/docs/schema-generator/federation/federated-directives.md
@@ -478,6 +478,21 @@ type Product @key(fields: "id") {
 }
 ```
 
+## `@policy` directive
+
+```graphql
+directive @policy(policies: [[Policy!]!]!) on
+    ENUM
+  | FIELD_DEFINITION
+  | INTERFACE
+  | OBJECT
+  | SCALAR
+```
+
+Directive that is used to indicate that access to the target element is restricted based on authorization policies that are evaluated in a Rhai script or coprocessor. Refer to the
+[Apollo Router documentation](https://www.apollographql.com/docs/router/configuration/authorization#policy) for additional details.
+
+
 ## `@provides` directive
 
 ```graphql


### PR DESCRIPTION
### :pencil: Description

Adds Federation v2.6 support

```graphql
directive @policy(policies: [[federation__Policy!]!]!) on
  | FIELD_DEFINITION
  | OBJECT
  | INTERFACE
  | SCALAR
  | ENUM

scalar federation__Policy
```

`@policy` directive indicates to composition that the target element is restricted based on authorization policies that are evaluated in a Rhai script or coprocessor. Refer to the [Apollo Router article](https://www.apollographql.com/docs/router/configuration/authorization#policy) for additional details.

### :link: Related Issues

N/A
