### PR TITLE
fix: allow maven and gradle plugins to have new parser options values configurable

### DIFF
--- a/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/config/GraphQLParserOptions.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/config/GraphQLParserOptions.kt
@@ -12,9 +12,9 @@ data class GraphQLParserOptions(
     /** Modify the maximum number of whitespace tokens read to prevent processing extremely large queries */
     var maxWhitespaceTokens: Int? = null,
     /** Modify the maximum number of characters in a document to prevent malicious documents consuming CPU */
-    val maxCharacters: Int? = null,
+    var maxCharacters: Int? = null,
     /** Modify the maximum grammar rule depth to negate malicious documents that can cause stack overflows */
-    val maxRuleDepth: Int? = null,
+    var maxRuleDepth: Int? = null,
     /** Memory usage is significantly reduced by not capturing ignored characters, especially in SDL parsing. */
     var captureIgnoredChars: Boolean? = null,
     /** Single-line comments do not have any semantic meaning in GraphQL source documents and can be ignored */

--- a/plugins/graphql-kotlin-maven-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/maven/GenerateClientAbstractMojo.kt
+++ b/plugins/graphql-kotlin-maven-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/maven/GenerateClientAbstractMojo.kt
@@ -232,11 +232,11 @@ class ParserOptions {
 
     /** Modify the maximum number of characters in a document to prevent malicious documents consuming CPU */
     @Parameter
-    val maxCharacters: Int? = null
+    var maxCharacters: Int? = null
 
     /** Modify the maximum grammar rule depth to negate malicious documents that can cause stack overflows */
     @Parameter
-    val maxRuleDepth: Int? = null
+    var maxRuleDepth: Int? = null
 
     /** Memory usage is significantly reduced by not capturing ignored characters, especially in SDL parsing. */
     @Parameter


### PR DESCRIPTION
### :pencil: Description

Previous val declaration for the additional parser options cannot be reassigned - they should be a var and not val.

### :link: Related Issues

#1925
#1586