### PR TITLE
feat(servers): move execution out of reactor netty threads

### DIFF
--- a/servers/graphql-kotlin-server/src/main/kotlin/com/expediagroup/graphql/server/execution/GraphQLServer.kt
+++ b/servers/graphql-kotlin-server/src/main/kotlin/com/expediagroup/graphql/server/execution/GraphQLServer.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Expedia, Inc
+ * Copyright 2024 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,8 +21,10 @@ import com.expediagroup.graphql.generator.extensions.plus
 import com.expediagroup.graphql.server.types.GraphQLResponse
 import com.expediagroup.graphql.server.types.GraphQLServerResponse
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.withContext
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
 
@@ -48,18 +50,20 @@ open class GraphQLServer<Request>(
     ): GraphQLServerResponse? =
         coroutineScope {
             requestParser.parseRequest(request)?.let { graphQLRequest ->
-                val graphQLContext = contextFactory.generateContext(request)
+                withContext(Dispatchers.Default) {
+                    val graphQLContext = contextFactory.generateContext(request)
 
-                val customCoroutineContext = (graphQLContext.get<CoroutineContext>() ?: EmptyCoroutineContext)
-                val graphQLExecutionScope = CoroutineScope(
-                    coroutineContext + customCoroutineContext + SupervisorJob()
-                )
+                    val customCoroutineContext = (graphQLContext.get<CoroutineContext>() ?: EmptyCoroutineContext)
+                    val graphQLExecutionScope = CoroutineScope(
+                        coroutineContext + customCoroutineContext + SupervisorJob()
+                    )
 
-                val graphQLContextWithCoroutineScope = graphQLContext + mapOf(
-                    CoroutineScope::class to graphQLExecutionScope
-                )
+                    val graphQLContextWithCoroutineScope = graphQLContext + mapOf(
+                        CoroutineScope::class to graphQLExecutionScope
+                    )
 
-                requestHandler.executeRequest(graphQLRequest, graphQLContextWithCoroutineScope)
+                    requestHandler.executeRequest(graphQLRequest, graphQLContextWithCoroutineScope)
+                }
             }
         }
 }


### PR DESCRIPTION
### :pencil: Description
as soon as request was deserialized, move execution of operation out of the thread that routed the request (reactor netty http epoll thread in case of spring).
