### PR TITLE
Support built-in `ID` type serialization in `GraphQLServerRequest`

### DIFF
--- a/servers/graphql-kotlin-server/src/main/kotlin/com/expediagroup/graphql/server/types/serializers/AnyNullableKSerializer.kt
+++ b/servers/graphql-kotlin-server/src/main/kotlin/com/expediagroup/graphql/server/types/serializers/AnyNullableKSerializer.kt
@@ -1,5 +1,6 @@
 package com.expediagroup.graphql.server.types.serializers
 
+import com.expediagroup.graphql.generator.scalars.ID
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.descriptors.buildClassSerialDescriptor
@@ -41,6 +42,7 @@ object AnyNullableKSerializer : KSerializer<Any?> {
             is Number -> JsonPrimitive(value)
             is Boolean -> JsonPrimitive(value)
             is String -> JsonPrimitive(value)
+            is ID -> JsonPrimitive(value.value)
             else -> JsonNull
         }
 

--- a/servers/graphql-kotlin-server/src/test/kotlin/com/expediagroup/graphql/server/types/GraphQLServerRequestTest.kt
+++ b/servers/graphql-kotlin-server/src/test/kotlin/com/expediagroup/graphql/server/types/GraphQLServerRequestTest.kt
@@ -16,6 +16,7 @@
 
 package com.expediagroup.graphql.server.types
 
+import com.expediagroup.graphql.generator.scalars.ID
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Test
@@ -47,6 +48,20 @@ class GraphQLServerRequestTest {
 
         val expectedJson =
             """{"query":"query FooQuery(${'$'}input: Int) { foo(${'$'}input) }","operationName":"FooQuery","variables":{"input":1}}"""
+
+        assertEquals(expectedJson, Json.encodeToString(request))
+    }
+
+    @Test
+    fun `verify complete serialization including ID`() {
+        val request = GraphQLRequest(
+            query = "query FooQuery(\$input: ID) { foo(\$input) }",
+            operationName = "FooQuery",
+            variables = mapOf("input" to ID("1"))
+        )
+
+        val expectedJson =
+            """{"query":"query FooQuery(${'$'}input: ID) { foo(${'$'}input) }","operationName":"FooQuery","variables":{"input":"1"}}"""
 
         assertEquals(expectedJson, Json.encodeToString(request))
     }


### PR DESCRIPTION
### :pencil: Description

#### Problem
after graphql-kotlin 7.1.0, the following `GraphQLRequest` our team uses started to fail.

```kotlin
GraphQLRequest(
    "query(${'$'}id: ID!) { ... }",
    variables = mapOf("id" to ID("1"))
)
```

this is because `kotlinx.serialization` is recently introduced instead of Jackson, but `ID` serialization is missing, so it is converted to `JsonNull`.

since `ID` is built-in scalar type, i think `ID` serialization should be supported.

#### Solution
add serialization logic to `AnyNullableKSerializer` 

### :link: Related Issues
N/A
