### PR TITLE
Make GraphQLGenerateClientTask and GraphQLGenerateTestClientTask cacheable

### DIFF
--- a/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/AbstractGenerateClientTask.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/AbstractGenerateClientTask.kt
@@ -34,6 +34,8 @@ import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.options.Option
 import org.gradle.workers.ClassLoaderWorkerSpec
 import org.gradle.workers.WorkQueue
@@ -55,6 +57,7 @@ abstract class AbstractGenerateClientTask : DefaultTask() {
      * **Required Property**
      */
     @InputFile
+    @PathSensitive(PathSensitivity.RELATIVE)
     val schemaFile: RegularFileProperty = project.objects.fileProperty()
 
     /**
@@ -97,6 +100,7 @@ abstract class AbstractGenerateClientTask : DefaultTask() {
      */
     @InputDirectory
     @Optional
+    @PathSensitive(PathSensitivity.RELATIVE)
     val queryFileDirectory: DirectoryProperty = project.objects.directoryProperty()
 
     /**
@@ -105,6 +109,7 @@ abstract class AbstractGenerateClientTask : DefaultTask() {
      */
     @InputFiles
     @Optional
+    @PathSensitive(PathSensitivity.RELATIVE)
     val queryFiles: ConfigurableFileCollection = project.objects.fileCollection()
 
     @Input

--- a/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/GraphQLGenerateClientTask.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/GraphQLGenerateClientTask.kt
@@ -16,12 +16,15 @@
 
 package com.expediagroup.graphql.plugin.gradle.tasks
 
+import org.gradle.api.tasks.CacheableTask
+
 internal const val GENERATE_CLIENT_TASK_NAME: String = "graphqlGenerateClient"
 
 /**
  * Generate GraphQL Kotlin client and corresponding data classes based on the provided GraphQL queries.
  */
 @Suppress("UnstableApiUsage")
+@CacheableTask
 abstract class GraphQLGenerateClientTask : AbstractGenerateClientTask() {
 
     init {

--- a/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/GraphQLGenerateTestClientTask.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/GraphQLGenerateTestClientTask.kt
@@ -16,12 +16,15 @@
 
 package com.expediagroup.graphql.plugin.gradle.tasks
 
+import org.gradle.api.tasks.CacheableTask
+
 internal const val GENERATE_TEST_CLIENT_TASK_NAME: String = "graphqlGenerateTestClient"
 
 /**
  * Generate GraphQL Kotlin test client and corresponding data classes based on the provided GraphQL queries.
  */
 @Suppress("UnstableApiUsage")
+@CacheableTask
 abstract class GraphQLGenerateTestClientTask : AbstractGenerateClientTask() {
 
     init {


### PR DESCRIPTION
### :pencil: Description
- We can leverage caching in Gradle for `GraphQLGenerateClientTask` and `GraphQLGenerateTestClientTask` by annotating them with `@CacheableTask` 
- Also annotate `schemaFile`, `queryFileDirectory`, `queryFiles` with `@PathSensitive(PathSensitivity.RELATIVE)` for the purposes of normalization so that outputs can be reused for caching
- Gradle docs: https://docs.gradle.org/current/javadoc/org/gradle/api/tasks/CacheableTask.html