### PR TITLE
fix(federation): Federation errors should not return invalid locations

### DIFF
--- a/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/exception/FederatedRequestFailure.kt
+++ b/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/exception/FederatedRequestFailure.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Expedia, Inc
+ * Copyright 2024 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ class FederatedRequestFailure(private val errorMessage: String, private val erro
 
     override fun getErrorType(): ErrorClassification = ErrorType.DataFetchingException
 
-    override fun getLocations(): List<SourceLocation> = listOf(SourceLocation(-1, -1))
+    override fun getLocations(): List<SourceLocation>? = null
 
     override fun getExtensions(): Map<String, Any>? =
         if (error != null) {

--- a/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/exception/InvalidFederatedRequest.kt
+++ b/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/exception/InvalidFederatedRequest.kt
@@ -29,5 +29,5 @@ class InvalidFederatedRequest(private val errorMessage: String) : GraphQLError {
 
     override fun getErrorType(): ErrorClassification = ErrorType.ValidationError
 
-    override fun getLocations(): List<SourceLocation> = listOf(SourceLocation(-1, -1))
+    override fun getLocations(): List<SourceLocation>? = null
 }

--- a/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/exception/InvalidFederatedRequest.kt
+++ b/generator/graphql-kotlin-federation/src/main/kotlin/com/expediagroup/graphql/generator/federation/exception/InvalidFederatedRequest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Expedia, Inc
+ * Copyright 2024 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/exception/FederatedRequestFailureTest.kt
+++ b/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/exception/FederatedRequestFailureTest.kt
@@ -17,7 +17,6 @@
 package com.expediagroup.graphql.generator.federation.exception
 
 import graphql.ErrorType
-import graphql.language.SourceLocation
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull

--- a/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/exception/FederatedRequestFailureTest.kt
+++ b/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/exception/FederatedRequestFailureTest.kt
@@ -38,7 +38,7 @@ internal class FederatedRequestFailureTest {
 
     @Test
     fun getLocations() {
-        assertEquals(expected = listOf(SourceLocation(-1, -1)), actual = simpleFailure.locations)
+        assertNull(simpleFailure.locations)
     }
 
     @Test

--- a/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/exception/FederatedRequestFailureTest.kt
+++ b/generator/graphql-kotlin-federation/src/test/kotlin/com/expediagroup/graphql/generator/federation/exception/FederatedRequestFailureTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Expedia, Inc
+ * Copyright 2024 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
### :pencil: Description

Per GraphQL spec error location should only be specified IF it can point to a valid location (i.e. starting with positive column/row). We were incorrectly returning `-1,-1` location.

### :link: Related Issues
