### PR TITLE
chore: update to use new Gradle actions

### DIFF
--- a/.github/workflows/build-examples.yml
+++ b/.github/workflows/build-examples.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@v1
+        uses: gradle/actions/wrapper-validation@v3
 
       - name: Set up Java 17
         uses: actions/setup-java@v4
@@ -24,7 +24,7 @@ jobs:
           distribution: 'zulu'
 
       - name: Set up Gradle cache
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
 
       - name: Set up Maven cache
         uses: actions/cache@v4

--- a/.github/workflows/build-libraries.yml
+++ b/.github/workflows/build-libraries.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@v1
+        uses: gradle/actions/wrapper-validation@v3
 
       - name: Set up Java 17
         uses: actions/setup-java@v4
@@ -21,7 +21,7 @@ jobs:
           distribution: 'zulu'
 
       - name: Set up Gradle cache
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
 
       - name: Build libraries with Gradle
         run: ./gradlew clean build

--- a/.github/workflows/federation-integration.yml
+++ b/.github/workflows/federation-integration.yml
@@ -25,7 +25,7 @@ jobs:
           distribution: 'zulu'
 
       - name: Set up Gradle cache
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
 
       - name: Build Subgraphs
         working-directory: examples
@@ -80,7 +80,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@v1
+        uses: gradle/actions/wrapper-validation@v3
 
       - name: Set up Java 17
         uses: actions/setup-java@v4
@@ -89,7 +89,7 @@ jobs:
           distribution: 'zulu'
 
       - name: Set up Gradle cache
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
 
       - name: Build compatibility app with Gradle
         run: ./gradlew bootJar graphqlGenerateSDL

--- a/.github/workflows/graalvm-integration.yml
+++ b/.github/workflows/graalvm-integration.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@v1
+        uses: gradle/actions/wrapper-validation@v3
 
       - name: Setup GraalVM
         uses: graalvm/setup-graalvm@v1
@@ -36,7 +36,7 @@ jobs:
           native-image-job-reports: 'true'
 
       - name: Set up Gradle cache
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
 
       - name: Build native image
         timeout-minutes: 20

--- a/.github/workflows/http-spec-compliance.yml
+++ b/.github/workflows/http-spec-compliance.yml
@@ -40,7 +40,7 @@ jobs:
         run: npm install
 
       - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@v1
+        uses: gradle/actions/wrapper-validation@v3
 
       - name: Set up Java 17
         uses: actions/setup-java@v4
@@ -49,7 +49,7 @@ jobs:
           distribution: 'zulu'
 
       - name: Set up Gradle cache
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
 
       - name: Start server
         id: start_server

--- a/.github/workflows/plugin-it.yml
+++ b/.github/workflows/plugin-it.yml
@@ -14,14 +14,14 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@v1
+        uses: gradle/actions/wrapper-validation@v3
       - name: Set up Java 17
         uses: actions/setup-java@v4
         with:
           java-version: 17
           distribution: 'zulu'
       - name: Set up Gradle cache
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
       - name: Android Test
         run: ./gradlew build
       - name: Archive failures
@@ -42,14 +42,14 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@v1
+        uses: gradle/actions/wrapper-validation@v3
       - name: Set up Java 17
         uses: actions/setup-java@v4
         with:
           java-version: 17
           distribution: 'zulu'
       - name: Set up Gradle cache
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
       - name: Integration Tests
         run: ./gradlew build
       - name: Archive failures
@@ -70,7 +70,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@v1
+        uses: gradle/actions/wrapper-validation@v3
       - name: Set up Java 17
         uses: actions/setup-java@v4
         with:
@@ -78,7 +78,7 @@ jobs:
           distribution: 'zulu'
           cache: 'maven'
       - name: Set up Gradle cache
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
       - name: Integration Tests
         run: ./gradlew build
       - name: Archive failures

--- a/.github/workflows/release-code.yml
+++ b/.github/workflows/release-code.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: gradle/wrapper-validation-action@v1
+      - uses: gradle/actions/wrapper-validation@v3
 
       - name: Set up Java 17
         uses: actions/setup-java@v4


### PR DESCRIPTION
### :pencil: Description

Old actions were deprecated.

### :link: Related Issues

Supersedes https://github.com/ExpediaGroup/graphql-kotlin/pull/1982
Supersedes https://github.com/ExpediaGroup/graphql-kotlin/pull/1981