### PR TITLE
feat(batching): remove execution if a given operation completes with an exception

### DIFF
--- a/executions/graphql-kotlin-dataloader-instrumentation/src/main/kotlin/com/expediagroup/graphql/dataloader/instrumentation/syncexhaustion/state/SyncExecutionExhaustedState.kt
+++ b/executions/graphql-kotlin-dataloader-instrumentation/src/main/kotlin/com/expediagroup/graphql/dataloader/instrumentation/syncexhaustion/state/SyncExecutionExhaustedState.kt
@@ -52,6 +52,7 @@ class SyncExecutionExhaustedState(
      * for example:
      * - parsing, validation errors
      * - persisted query errors
+     * - an exception during execution was thrown
      */
     private fun removeExecution(executionId: ExecutionId) {
         if (executions.containsKey(executionId)) {
@@ -74,10 +75,8 @@ class SyncExecutionExhaustedState(
         }
         return object : SimpleInstrumentationContext<ExecutionResult>() {
             override fun onCompleted(result: ExecutionResult?, t: Throwable?) {
-                result?.let {
-                    if (result.errors.size > 0) {
-                        removeExecution(parameters.executionInput.executionId)
-                    }
+                if ((result != null && result.errors.size > 0) || t != null) {
+                    removeExecution(parameters.executionInput.executionId)
                 }
             }
         }


### PR DESCRIPTION
### :pencil: Description
Example: a persisted query is found, but operationName in the http request is not in the persisted document, causing an unknown operation exception (UnknownOperationException).

Exceptions are converted into graphQL errors at later point, initially thought those errors from exceptions would be in the execution result.