### PR TITLE
docs: Update Apollo Federation link

### DIFF
--- a/website/docs/getting-started.mdx
+++ b/website/docs/getting-started.mdx
@@ -50,7 +50,7 @@ See the docs in [Schema Generator Getting Started](./schema-generator/schema-gen
 
 ### Apollo Federation
 
-Using `graphql-kotlin-federation`, you can generate an [Apollo Federation](https://www.apollographql.com/docs/apollo-server/federation/federation-spec/) compliant schema.
+Using `graphql-kotlin-federation`, you can generate an [Apollo Federation](https://www.apollographql.com/docs/graphos/schema-design/federated-schemas/federation) compliant schema.
 
 See the docs in [Apollo Federation](./schema-generator/federation/apollo-federation.mdx).
 


### PR DESCRIPTION
### :pencil: Description

Hi, I noticed that the Apollo Federation link is broken on the Getting Started page. This PR is to update the link.

![CleanShot 2024-11-20 at 19 05 34@2x](https://github.com/user-attachments/assets/f3720cfb-bff8-4115-ac81-8b03993e31be)

### :link: Related Issues
