### PR TITLE
feat: implemented persisted queries for GET methods with only SHA-256 hash of query string

### DIFF
--- a/examples/server/spring-server/src/test/kotlin/com/expediagroup/graphql/examples/server/spring/query/APQQueryIT.kt
+++ b/examples/server/spring-server/src/test/kotlin/com/expediagroup/graphql/examples/server/spring/query/APQQueryIT.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2022 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.examples.server.spring.query
+
+import com.expediagroup.graphql.examples.server.spring.GRAPHQL_MEDIA_TYPE
+import com.expediagroup.graphql.examples.server.spring.verifyData
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType.APPLICATION_JSON
+import org.springframework.test.web.reactive.server.WebTestClient
+
+@SpringBootTest(
+    properties = ["graphql.automaticPersistedQueries.enabled=true"]
+)
+@AutoConfigureWebTestClient
+@TestInstance(PER_CLASS)
+class APQQueryIT(@Autowired private val testClient: WebTestClient) {
+
+    @Test
+    fun `verify GET persisted query with hash only followed by POST with hash`() {
+        val query = "simpleDeprecatedQuery"
+
+        testClient.get()
+            .uri { builder ->
+                builder.path("/graphql")
+                    .queryParam("extensions", "{extension}")
+                    .build("""{"persistedQuery":{"version":1,"sha256Hash":"aee64e0a941589ff06b717d4930405f3eafb089e687bef6ece5719ea6a4e7f35"}}""")
+            }
+            .exchange()
+            .expectBody().json(
+                """
+                    {
+                      errors: [
+                        {
+                          message: "PersistedQueryNotFound"
+                        }
+                      ]
+                    }
+                """.trimIndent()
+            )
+
+        val expectedData = "false"
+
+        testClient.post()
+            .uri { builder ->
+                builder.path("/graphql")
+                    .queryParam("extensions", "{extension}")
+                    .build("""{"persistedQuery":{"version":1,"sha256Hash":"aee64e0a941589ff06b717d4930405f3eafb089e687bef6ece5719ea6a4e7f35"}}""")
+            }
+            .accept(APPLICATION_JSON)
+            .contentType(GRAPHQL_MEDIA_TYPE)
+            .bodyValue("query { $query }")
+            .exchange()
+            .verifyData(query, expectedData)
+
+        testClient.get()
+            .uri { builder ->
+                builder.path("/graphql")
+                    .queryParam("extensions", "{extension}")
+                    .build("""{"persistedQuery":{"version":1,"sha256Hash":"aee64e0a941589ff06b717d4930405f3eafb089e687bef6ece5719ea6a4e7f35"}}""")
+            }
+            .exchange()
+            .verifyData(query, expectedData)
+    }
+}

--- a/servers/graphql-kotlin-ktor-server/src/test/kotlin/com/expediagroup/graphql/server/ktor/GraphQLPluginTest.kt
+++ b/servers/graphql-kotlin-ktor-server/src/test/kotlin/com/expediagroup/graphql/server/ktor/GraphQLPluginTest.kt
@@ -135,6 +135,16 @@ class GraphQLPluginTest {
     }
 
     @Test
+    fun `server should return Method Not Allowed for Mutation GET requests with persisted query`() {
+        testApplication {
+            val response = client.get("/graphql") {
+                parameter("query", "mutation { foo }")
+            }
+            assertEquals(HttpStatusCode.MethodNotAllowed, response.status)
+        }
+    }
+
+    @Test
     fun `server should return Bad Request for invalid GET requests`() {
         testApplication {
             val response = client.get("/graphql")


### PR DESCRIPTION
### :pencil: Description
According to the GraphQL APQ flow description, GET requests containing only SHA-256 hash of the query should be checked in cache and respond with PERSISTED_QUERY_NOT_FOUND error if request is not cached.
Both Ktor and Spring server implementations didn't handle this first query without a query param.
I tried to implement the change without breaking existing behaviours, as a query param is expected to take precedence over post body, for example, as in one of the tests in RouteConfigurationIT.


### :link: Related Issues
https://github.com/ExpediaGroup/graphql-kotlin/issues/2065