### PR TITLE
fix: remove additional supplier invoke on APQ after caching entries

### DIFF
--- a/executions/graphql-kotlin-automatic-persisted-queries/src/main/kotlin/com/expediagroup/graphql/apq/cache/DefaultAutomaticPersistedQueriesCache.kt
+++ b/executions/graphql-kotlin-automatic-persisted-queries/src/main/kotlin/com/expediagroup/graphql/apq/cache/DefaultAutomaticPersistedQueriesCache.kt
@@ -35,6 +35,6 @@ class DefaultAutomaticPersistedQueriesCache : AutomaticPersistedQueriesCache {
         } ?: run {
             val entry = supplier.invoke()
             cache[key] = entry
-            CompletableFuture.completedFuture(supplier.invoke())
+            CompletableFuture.completedFuture(entry)
         }
 }


### PR DESCRIPTION
### :pencil: Description
Fixes duplicate call of supplier on APQ caching.

### :link: Related Issues
https://github.com/ExpediaGroup/graphql-kotlin/issues/2072