### PR TITLE
Add support for generated @deprecated arguments from @GraphQLDeprecated

### DIFF
--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateArgument.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateArgument.kt
@@ -18,6 +18,7 @@ package com.expediagroup.graphql.generator.internal.types
 
 import com.expediagroup.graphql.generator.SchemaGenerator
 import com.expediagroup.graphql.generator.exceptions.InvalidInputFieldTypeException
+import com.expediagroup.graphql.generator.internal.extensions.getDeprecationReason
 import com.expediagroup.graphql.generator.internal.extensions.getGraphQLDescription
 import com.expediagroup.graphql.generator.internal.extensions.getKClass
 import com.expediagroup.graphql.generator.internal.extensions.getName
@@ -51,10 +52,15 @@ internal fun generateArgument(generator: SchemaGenerator, parameter: KParameter)
     val graphQLType = generateGraphQLType(generator = generator, type = unwrappedType, typeInfo)
 
     // Deprecation of arguments is currently unsupported: https://youtrack.jetbrains.com/issue/KT-25643
+
     val builder = GraphQLArgument.newArgument()
         .name(parameter.getName())
         .description(parameter.getGraphQLDescription())
         .type(graphQLType.safeCast())
+
+    parameter.getDeprecationReason()?.let {
+        builder.deprecate(it)
+    }
 
     generateDirectives(generator, parameter, DirectiveLocation.ARGUMENT_DEFINITION).forEach {
         builder.withAppliedDirective(it)

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateArgument.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/types/generateArgument.kt
@@ -51,8 +51,6 @@ internal fun generateArgument(generator: SchemaGenerator, parameter: KParameter)
     val typeInfo = GraphQLKTypeMetadata(inputType = true, fieldName = parameter.getName(), fieldAnnotations = parameter.annotations)
     val graphQLType = generateGraphQLType(generator = generator, type = unwrappedType, typeInfo)
 
-    // Deprecation of arguments is currently unsupported: https://youtrack.jetbrains.com/issue/KT-25643
-
     val builder = GraphQLArgument.newArgument()
         .name(parameter.getName())
         .description(parameter.getGraphQLDescription())

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/directives/DirectiveTests.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/directives/DirectiveTests.kt
@@ -24,10 +24,12 @@ import com.expediagroup.graphql.generator.hooks.SchemaGeneratorHooks
 import com.expediagroup.graphql.generator.testSchemaConfig
 import com.expediagroup.graphql.generator.toSchema
 import graphql.Scalars
+import graphql.schema.GraphQLArgument
 import graphql.schema.GraphQLNonNull
 import graphql.schema.GraphQLObjectType
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
@@ -72,6 +74,18 @@ class DirectiveTests {
         assertTrue(graphqlDeprecatedQuery.isDeprecated)
         assertEquals("this query is deprecated", query.deprecationReason)
         assertEquals("this query is also deprecated", graphqlDeprecatedQuery.deprecationReason)
+    }
+
+    @Test
+    fun `SchemaGenerator marks deprecated fields within queries`() {
+        val schema = toSchema(queries = listOf(TopLevelObject(QueryWithDeprecatedFields())), config = testSchemaConfig())
+        val topLevelQuery = schema.getObjectType("Query")
+        val query = topLevelQuery.getFieldDefinition("graphqlQueryWithDeprecatedFields")
+
+        assertFalse(query.isDeprecated)
+        val deprecatedArgument = query.getArgument("something")
+        assertTrue(deprecatedArgument.isDeprecated)
+        assertEquals("This field is deprecated", deprecatedArgument.deprecationReason)
     }
 
     @Test
@@ -155,6 +169,8 @@ class QueryWithDeprecatedFields {
 
     @Deprecated("this query is also deprecated", replaceWith = ReplaceWith("shinyNewQuery"))
     fun graphqlDeprecatedQueryWithReplacement(something: String) = something
+
+    fun graphqlQueryWithDeprecatedFields(@GraphQLDeprecated("This field is deprecated") something: String, replacement: String) = "$something -> $replacement"
 }
 
 data class ClassWithDeprecatedField(

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/directives/DirectiveTests.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/directives/DirectiveTests.kt
@@ -24,7 +24,6 @@ import com.expediagroup.graphql.generator.hooks.SchemaGeneratorHooks
 import com.expediagroup.graphql.generator.testSchemaConfig
 import com.expediagroup.graphql.generator.toSchema
 import graphql.Scalars
-import graphql.schema.GraphQLArgument
 import graphql.schema.GraphQLNonNull
 import graphql.schema.GraphQLObjectType
 import org.junit.jupiter.api.Test

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/types/GenerateArgumentTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/internal/types/GenerateArgumentTest.kt
@@ -16,6 +16,7 @@
 
 package com.expediagroup.graphql.generator.internal.types
 
+import com.expediagroup.graphql.generator.annotations.GraphQLDeprecated
 import com.expediagroup.graphql.generator.annotations.GraphQLDescription
 import com.expediagroup.graphql.generator.annotations.GraphQLName
 import com.expediagroup.graphql.generator.exceptions.InvalidInputFieldTypeException
@@ -33,6 +34,7 @@ import kotlin.reflect.full.findParameterByName
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 class GenerateArgumentTest : TypeTestHelper() {
 
@@ -50,6 +52,8 @@ class GenerateArgumentTest : TypeTestHelper() {
         fun directive(@SimpleDirective input: String) = input
 
         fun changeName(@GraphQLName("newName") input: String) = input
+
+        fun deprecate(@GraphQLDeprecated("Deprecated") input: String, replacement: String) = "$input -> $replacement"
 
         fun idClass(idArg: ID) = "Your id is $idArg"
 
@@ -106,6 +110,16 @@ class GenerateArgumentTest : TypeTestHelper() {
 
         assertEquals(Scalars.GraphQLString, (result.type as? GraphQLNonNull)?.wrappedType)
         assertEquals("newName", result.name)
+    }
+
+    @Test
+    fun `Argument can be deprecated with @GraphqlDeprecated`() {
+        val kParameter = ArgumentTestClass::deprecate.findParameterByName("input")
+        assertNotNull(kParameter)
+        val result = generateArgument(generator, kParameter)
+
+        assertTrue(result.isDeprecated, "The argument should be marked as deprecated")
+        assertEquals("Deprecated", result.deprecationReason, "The deprecation reason should match")
     }
 
     @Test

--- a/website/versioned_docs/version-8.x.x/schema-generator/customizing-schemas/deprecating-schema.md
+++ b/website/versioned_docs/version-8.x.x/schema-generator/customizing-schemas/deprecating-schema.md
@@ -37,6 +37,7 @@ type Query {
 
 A side-effect of using `@Deprecated` is that it marks your own Kotlin code as being deprecated, which may not be what you want. Using `@GraphQLDeprecated` you can add the `@deprecated` directive to the GraphQL schema, but not have your Kotlin code show up as deprecated in your editor.
 
+### Deprecating Fields
 ```kotlin
 class SimpleQuery {
   @GraphQLDeprecated(message = "this query is deprecated", replaceWith = ReplaceWith("shinyNewQuery"))
@@ -44,3 +45,15 @@ class SimpleQuery {
 
   fun shinyNewQuery(): Boolean = true
 }
+```
+
+### Deprecating Arguments
+You can also use `@GraphQLDeprecated` to deprecate individual arguments in your GraphQL schema. This allows you to notify clients that a specific argument is deprecated and optionally provide them with guidance on replacement arguments.
+
+```kotlin
+class QueryWithDeprecatedArgument {
+  fun exampleQuery(@GraphQLDeprecated(message = "Use 'newArg' instead") oldArg: String?, newArg: String): String {
+    return "Received: ${newArg}"
+  }
+}
+```


### PR DESCRIPTION
### :pencil: Description  
This PR enables support for using the `@GraphQLDeprecated` annotation on arguments, allowing the generated GraphQL schema to include the `@deprecated` directive.  

#### Changes:  
- Updated `generateArgument.kt ` to mark argument as deprecated if the DeprecationReason is present.
- Added tests to validate the correct behavior when marking arguments as deprecated.  

#### Why?  
The GraphQL spec now officially supports applying `@deprecated` on arguments, enabling better API evolution without breaking existing clients. This change aligns the library with the latest spec, giving developers a built-in way to signal argument deprecations.  

- [GraphQL Spec - Deprecated Arguments](https://spec.graphql.org/October2021/#sec--deprecated) ](https://spec.graphql.org/draft/#sec--deprecated) 

### :link: Related Issues  
https://github.com/ExpediaGroup/graphql-kotlin/pull/1361

