### PR TITLE
feat: update fastjson2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ kotlinx-coroutines = "1.9.0"
 # TODO kotlin 1.9 upgrade: fix GraphQLTestUtils and GenerateKotlinxClientIT
 kotlinx-serialization = "1.6.3"
 ktor = "3.0.3"
-fastjson2 = "2.0.53"
+fastjson2 = "2.0.56"
 maven-plugin-annotation = "3.13.1"
 maven-plugin-api = "3.9.8"
 maven-project = "2.2.1"

--- a/servers/graphql-kotlin-server/src/benchmarks/kotlin/GraphQLServerRequestBatchDeserializationBenchmark.kt
+++ b/servers/graphql-kotlin-server/src/benchmarks/kotlin/GraphQLServerRequestBatchDeserializationBenchmark.kt
@@ -32,33 +32,38 @@ import org.openjdk.jmh.annotations.Warmup
 import java.util.concurrent.TimeUnit
 
 @State(Scope.Benchmark)
-@Fork(value = 5, jvmArgsAppend = ["--add-modules=jdk.incubator.vector", "-Dfastjson2.readerVector=true"])
+@Fork(value = 5, jvmArgsAppend = ["--add-modules=jdk.incubator.vector"])
 @Warmup(iterations = 1, time = 1, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 4, time = 5, timeUnit = TimeUnit.SECONDS)
 open class GraphQLServerRequestBatchDeserializationBenchmark {
     private val mapper = jacksonObjectMapper()
-    private lateinit var request: String
     private lateinit var batchRequest: String
 
     @Setup
     fun setUp() {
         JSON.config(JSONWriter.Feature.WriteNulls)
         val loader = this::class.java.classLoader
-        val operation = loader.getResource("StarWarsDetails.graphql")!!.readText().replace("\n", "\\n")
-        val variables = loader.getResource("StarWarsDetailsVariables.json")!!.readText()
+        val operation1 = loader.getResource("StarWarsDetails.graphql")!!.readText().replace("\n", "\\n")
+        val operation2 = loader.getResource("StarWarsDetails.graphql")!!.readText().replace("\n", "\\n")
+        val operation3 = loader.getResource("StarWarsDetails.graphql")!!.readText().replace("\n", "\\n")
+        val operation4 = loader.getResource("StarWarsDetails.graphql")!!.readText().replace("\n", "\\n")
+        val variables1 = loader.getResource("StarWarsDetailsVariables.json")!!.readText()
+        val variables2 = loader.getResource("StarWarsDetailsVariables.json")!!.readText()
+        val variables3 = loader.getResource("StarWarsDetailsVariables.json")!!.readText()
+        val variables4 = loader.getResource("StarWarsDetailsVariables.json")!!.readText()
         batchRequest = """
             [
-                { "operationName": "StarWarsDetails", "query": "$operation", "variables": $variables },
-                { "operationName": "StarWarsDetails", "query": "$operation", "variables": $variables },
-                { "operationName": "StarWarsDetails", "query": "$operation", "variables": $variables },
-                { "operationName": "StarWarsDetails", "query": "$operation", "variables": $variables }
+                { "operationName": "StarWarsDetails", "query": "$operation1", "variables": $variables1 },
+                { "operationName": "StarWarsDetails", "query": "$operation2", "variables": $variables2 },
+                { "operationName": "StarWarsDetails", "query": "$operation3", "variables": $variables3 },
+                { "operationName": "StarWarsDetails", "query": "$operation4", "variables": $variables4 }
             ]
         """.trimIndent()
     }
 
     @Benchmark
-    fun JacksonDeserializeGraphQLBatchRequest(): GraphQLServerRequest = mapper.readValue(batchRequest)
+    fun jackson(): GraphQLServerRequest = mapper.readValue(batchRequest)
 
     @Benchmark
-    fun FastJsonDeserializeGraphQLBatchRequest(): GraphQLServerRequest = batchRequest.to<GraphQLServerRequest>()
+    fun fastjson2(): GraphQLServerRequest = batchRequest.to<GraphQLServerRequest>()
 }

--- a/servers/graphql-kotlin-server/src/benchmarks/kotlin/GraphQLServerRequestDeserializationBenchmark.kt
+++ b/servers/graphql-kotlin-server/src/benchmarks/kotlin/GraphQLServerRequestDeserializationBenchmark.kt
@@ -32,7 +32,7 @@ import org.openjdk.jmh.annotations.Warmup
 import java.util.concurrent.TimeUnit
 
 @State(Scope.Benchmark)
-@Fork(value = 5, jvmArgsAppend = ["--add-modules=jdk.incubator.vector", "-Dfastjson2.readerVector=true"])
+@Fork(value = 5, jvmArgsAppend = ["--add-modules=jdk.incubator.vector"])
 @Warmup(iterations = 1, time = 1, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 4, time = 5, timeUnit = TimeUnit.SECONDS)
 open class GraphQLServerRequestDeserializationBenchmark {
@@ -55,8 +55,8 @@ open class GraphQLServerRequestDeserializationBenchmark {
     }
 
     @Benchmark
-    fun JacksonDeserializeGraphQLRequest(): GraphQLServerRequest = mapper.readValue(request)
+    fun jackson(): GraphQLServerRequest = mapper.readValue(request)
 
     @Benchmark
-    fun FastJsonDeserializeGraphQLRequest(): GraphQLServerRequest = request.to()
+    fun fastjson2(): GraphQLServerRequest = request.to()
 }

--- a/servers/graphql-kotlin-server/src/benchmarks/kotlin/GraphQLServerResponseBatchSerializationBenchmark.kt
+++ b/servers/graphql-kotlin-server/src/benchmarks/kotlin/GraphQLServerResponseBatchSerializationBenchmark.kt
@@ -32,7 +32,7 @@ import org.openjdk.jmh.annotations.Warmup
 import java.util.concurrent.TimeUnit
 
 @State(Scope.Benchmark)
-@Fork(value = 5, jvmArgsAppend = ["--add-modules=jdk.incubator.vector", "-Dfastjson2.readerVector=true"])
+@Fork(value = 5, jvmArgsAppend = ["--add-modules=jdk.incubator.vector"])
 @Warmup(iterations = 1, time = 1, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 4, time = 5, timeUnit = TimeUnit.SECONDS)
 open class GraphQLServerResponseBatchSerializationBenchmark {
@@ -42,22 +42,35 @@ open class GraphQLServerResponseBatchSerializationBenchmark {
     @Setup
     fun setUp() {
         JSON.config(JSONWriter.Feature.WriteNulls)
-        val data = mapper.readValue<Map<String, Any?>>(
-            this::class.java.classLoader.getResourceAsStream("StarWarsDetailsResponse.json")!!
-        )
         batchResponse = GraphQLBatchResponse(
             listOf(
-                GraphQLResponse(data),
-                GraphQLResponse(data),
-                GraphQLResponse(data),
-                GraphQLResponse(data)
+                GraphQLResponse(
+                    mapper.readValue<Map<String, Any?>>(
+                        this::class.java.classLoader.getResourceAsStream("StarWarsDetailsResponse.json")!!
+                    )
+                ),
+                GraphQLResponse(
+                    mapper.readValue<Map<String, Any?>>(
+                        this::class.java.classLoader.getResourceAsStream("StarWarsDetailsResponse.json")!!
+                    )
+                ),
+                GraphQLResponse(
+                    mapper.readValue<Map<String, Any?>>(
+                        this::class.java.classLoader.getResourceAsStream("StarWarsDetailsResponse.json")!!
+                    )
+                ),
+                GraphQLResponse(
+                    mapper.readValue<Map<String, Any?>>(
+                        this::class.java.classLoader.getResourceAsStream("StarWarsDetailsResponse.json")!!
+                    )
+                )
             )
         )
     }
 
     @Benchmark
-    fun JacksonSerializeGraphQLBatchResponse(): String = mapper.writeValueAsString(batchResponse)
+    fun jackson(): String = mapper.writeValueAsString(batchResponse)
 
     @Benchmark
-    fun FastJsonSerializeGraphQLBatchResponse(): String = JSON.toJSONString(batchResponse)
+    fun fastjson2(): String = JSON.toJSONString(batchResponse)
 }

--- a/servers/graphql-kotlin-server/src/benchmarks/kotlin/GraphQLServerResponseSerializationBenchmark.kt
+++ b/servers/graphql-kotlin-server/src/benchmarks/kotlin/GraphQLServerResponseSerializationBenchmark.kt
@@ -31,7 +31,7 @@ import org.openjdk.jmh.annotations.Warmup
 import java.util.concurrent.TimeUnit
 
 @State(Scope.Benchmark)
-@Fork(value = 5, jvmArgsAppend = ["--add-modules=jdk.incubator.vector", "-Dfastjson2.readerVector=true"])
+@Fork(value = 5, jvmArgsAppend = ["--add-modules=jdk.incubator.vector"])
 @Warmup(iterations = 1, time = 1, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 4, time = 5, timeUnit = TimeUnit.SECONDS)
 open class GraphQLServerResponseSerializationBenchmark {
@@ -41,9 +41,6 @@ open class GraphQLServerResponseSerializationBenchmark {
     @Setup
     fun setUp() {
         JSON.config(JSONWriter.Feature.WriteNulls)
-        val data = mapper.readValue<Map<String, Any?>>(
-            this::class.java.classLoader.getResourceAsStream("StarWarsDetailsResponse.json")!!
-        )
         response = GraphQLResponse(
             mapper.readValue<Map<String, Any?>>(
                 this::class.java.classLoader.getResourceAsStream("StarWarsDetailsResponse.json")!!
@@ -52,8 +49,8 @@ open class GraphQLServerResponseSerializationBenchmark {
     }
 
     @Benchmark
-    fun JacksonSerializeGraphQLResponse(): String = mapper.writeValueAsString(response)
+    fun jackson(): String = mapper.writeValueAsString(response)
 
     @Benchmark
-    fun FastJsonSerializeGraphQLResponse(): String = JSON.toJSONString(response)
+    fun fastjson2(): String = JSON.toJSONString(response)
 }

--- a/servers/graphql-kotlin-server/src/benchmarks/resources/StarWarsDetailsResponse.json
+++ b/servers/graphql-kotlin-server/src/benchmarks/resources/StarWarsDetailsResponse.json
@@ -1,411 +1,409 @@
 {
-  "data": {
-    "person1": {
-      "name": "Luke Skywalker",
-      "birthYear": "19BBY",
-      "eyeColor": "blue",
-      "gender": "male",
-      "hairColor": "blond",
-      "height": 172,
-      "mass": 77,
-      "skinColor": "fair",
-      "starships": {
-        "edges": [
-          {
-            "node": {
-              "name": "X-wing",
-              "model": "T-65 X-wing",
-              "starshipClass": "Starfighter",
-              "manufacturers": ["Incom Corporation"],
-              "costInCredits": 149999,
-              "length": 13.4,
-              "crew": 1,
-              "passengers": 0,
-              "maxAtmospheringSpeed": 1050,
-              "hyperdriveRating": 1.0,
-              "MGLT": 100,
-              "cargoCapacity": 110,
-              "consumables": "1 week"
-            }
+  "person1": {
+    "name": "Luke Skywalker",
+    "birthYear": "19BBY",
+    "eyeColor": "blue",
+    "gender": "male",
+    "hairColor": "blond",
+    "height": 172,
+    "mass": 77,
+    "skinColor": "fair",
+    "starships": {
+      "edges": [
+        {
+          "node": {
+            "name": "X-wing",
+            "model": "T-65 X-wing",
+            "starshipClass": "Starfighter",
+            "manufacturers": ["Incom Corporation"],
+            "costInCredits": 149999,
+            "length": 13.4,
+            "crew": 1,
+            "passengers": 0,
+            "maxAtmospheringSpeed": 1050,
+            "hyperdriveRating": 1.0,
+            "MGLT": 100,
+            "cargoCapacity": 110,
+            "consumables": "1 week"
           }
-        ]
-      },
-      "homeworld": {
-        "name": "Tatooine",
-        "diameter": 10465,
-        "rotationPeriod": 23,
-        "orbitalPeriod": 304,
-        "gravity": "1 standard",
-        "population": 200000,
-        "climates": ["arid"],
-        "terrains": ["desert"],
-        "surfaceWater": 1
-      },
-      "filmConnection": {
-        "edges": [
-          {
-            "node": {
-              "title": "A New Hope"
-            }
-          }
-        ]
-      }
+        }
+      ]
     },
-    "person2": {
-      "name": "Leia Organa",
-      "birthYear": "19BBY",
-      "eyeColor": "brown",
-      "gender": "female",
-      "hairColor": "brown",
-      "height": 150,
-      "mass": 49,
-      "skinColor": "light",
-      "starships": {
-        "edges": []
-      },
-      "homeworld": {
-        "name": "Alderaan",
-        "diameter": 12500,
-        "rotationPeriod": 24,
-        "orbitalPeriod": 364,
-        "gravity": "1 standard",
-        "population": 2000000000,
-        "climates": ["temperate"],
-        "terrains": ["grasslands", "mountains"],
-        "surfaceWater": 40
-      },
-      "filmConnection": {
-        "edges": [
-          {
-            "node": {
-              "title": "The Empire Strikes Back"
-            }
-          }
-        ]
-      }
+    "homeworld": {
+      "name": "Tatooine",
+      "diameter": 10465,
+      "rotationPeriod": 23,
+      "orbitalPeriod": 304,
+      "gravity": "1 standard",
+      "population": 200000,
+      "climates": ["arid"],
+      "terrains": ["desert"],
+      "surfaceWater": 1
     },
-    "person3": {
-      "name": "Luke Skywalker",
-      "birthYear": "19BBY",
-      "eyeColor": "blue",
-      "gender": "male",
-      "hairColor": "blond",
-      "height": 172,
-      "mass": 77,
-      "skinColor": "fair",
-      "starships": {
-        "edges": [
-          {
-            "node": {
-              "name": "X-wing",
-              "model": "T-65 X-wing",
-              "starshipClass": "Starfighter",
-              "manufacturers": ["Incom Corporation"],
-              "costInCredits": 149999,
-              "length": 13.4,
-              "crew": 1,
-              "passengers": 0,
-              "maxAtmospheringSpeed": 1050,
-              "hyperdriveRating": 1.0,
-              "MGLT": 100,
-              "cargoCapacity": 110,
-              "consumables": "1 week"
-            }
+    "filmConnection": {
+      "edges": [
+        {
+          "node": {
+            "title": "A New Hope"
           }
-        ]
-      },
-      "homeworld": {
-        "name": "Tatooine",
-        "diameter": 10465,
-        "rotationPeriod": 23,
-        "orbitalPeriod": 304,
-        "gravity": "1 standard",
-        "population": 200000,
-        "climates": ["arid"],
-        "terrains": ["desert"],
-        "surfaceWater": 1
-      },
-      "filmConnection": {
-        "edges": [
-          {
-            "node": {
-              "title": "A New Hope"
-            }
-          }
-        ]
-      }
+        }
+      ]
+    }
+  },
+  "person2": {
+    "name": "Leia Organa",
+    "birthYear": "19BBY",
+    "eyeColor": "brown",
+    "gender": "female",
+    "hairColor": "brown",
+    "height": 150,
+    "mass": 49,
+    "skinColor": "light",
+    "starships": {
+      "edges": []
     },
-    "person4": {
-      "name": "Luke Skywalker",
-      "birthYear": "19BBY",
-      "eyeColor": "blue",
-      "gender": "male",
-      "hairColor": "blond",
-      "height": 172,
-      "mass": 77,
-      "skinColor": "fair",
-      "starships": {
-        "edges": [
-          {
-            "node": {
-              "name": "X-wing",
-              "model": "T-65 X-wing",
-              "starshipClass": "Starfighter",
-              "manufacturers": ["Incom Corporation"],
-              "costInCredits": 149999,
-              "length": 13.4,
-              "crew": 1,
-              "passengers": 0,
-              "maxAtmospheringSpeed": 1050,
-              "hyperdriveRating": 1.0,
-              "MGLT": 100,
-              "cargoCapacity": 110,
-              "consumables": "1 week"
-            }
-          }
-        ]
-      },
-      "homeworld": {
-        "name": "Tatooine",
-        "diameter": 10465,
-        "rotationPeriod": 23,
-        "orbitalPeriod": 304,
-        "gravity": "1 standard",
-        "population": 200000,
-        "climates": ["arid"],
-        "terrains": ["desert"],
-        "surfaceWater": 1
-      },
-      "filmConnection": {
-        "edges": [
-          {
-            "node": {
-              "title": "A New Hope"
-            }
-          }
-        ]
-      }
+    "homeworld": {
+      "name": "Alderaan",
+      "diameter": 12500,
+      "rotationPeriod": 24,
+      "orbitalPeriod": 364,
+      "gravity": "1 standard",
+      "population": 2000000000,
+      "climates": ["temperate"],
+      "terrains": ["grasslands", "mountains"],
+      "surfaceWater": 40
     },
-    "person5": {
-      "name": "Luke Skywalker",
-      "birthYear": "19BBY",
-      "eyeColor": "blue",
-      "gender": "male",
-      "hairColor": "blond",
-      "height": 172,
-      "mass": 77,
-      "skinColor": "fair",
-      "starships": {
-        "edges": [
-          {
-            "node": {
-              "name": "X-wing",
-              "model": "T-65 X-wing",
-              "starshipClass": "Starfighter",
-              "manufacturers": ["Incom Corporation"],
-              "costInCredits": 149999,
-              "length": 13.4,
-              "crew": 1,
-              "passengers": 0,
-              "maxAtmospheringSpeed": 1050,
-              "hyperdriveRating": 1.0,
-              "MGLT": 100,
-              "cargoCapacity": 110,
-              "consumables": "1 week"
-            }
+    "filmConnection": {
+      "edges": [
+        {
+          "node": {
+            "title": "The Empire Strikes Back"
           }
-        ]
-      },
-      "homeworld": {
-        "name": "Tatooine",
-        "diameter": 10465,
-        "rotationPeriod": 23,
-        "orbitalPeriod": 304,
-        "gravity": "1 standard",
-        "population": 200000,
-        "climates": ["arid"],
-        "terrains": ["desert"],
-        "surfaceWater": 1
-      },
-      "filmConnection": {
-        "edges": [
-          {
-            "node": {
-              "title": "A New Hope"
-            }
+        }
+      ]
+    }
+  },
+  "person3": {
+    "name": "Luke Skywalker",
+    "birthYear": "19BBY",
+    "eyeColor": "blue",
+    "gender": "male",
+    "hairColor": "blond",
+    "height": 172,
+    "mass": 77,
+    "skinColor": "fair",
+    "starships": {
+      "edges": [
+        {
+          "node": {
+            "name": "X-wing",
+            "model": "T-65 X-wing",
+            "starshipClass": "Starfighter",
+            "manufacturers": ["Incom Corporation"],
+            "costInCredits": 149999,
+            "length": 13.4,
+            "crew": 1,
+            "passengers": 0,
+            "maxAtmospheringSpeed": 1050,
+            "hyperdriveRating": 1.0,
+            "MGLT": 100,
+            "cargoCapacity": 110,
+            "consumables": "1 week"
           }
-        ]
-      }
+        }
+      ]
     },
-    "film1": {
-      "title": "A New Hope",
-      "episodeID": 4,
-      "director": "George Lucas",
-      "producers": ["Gary Kurtz", "Rick McCallum"],
-      "releaseDate": "1977-05-25",
-      "characterConnection": {
-        "edges": [
-          {
-            "node": {
-              "name": "Luke Skywalker"
-            }
-          }
-        ]
-      },
-      "starshipConnection": {
-        "edges": [
-          {
-            "node": {
-              "name": "X-wing"
-            }
-          }
-        ]
-      },
-      "planetConnection": {
-        "edges": [
-          {
-            "node": {
-              "name": "Tatooine"
-            }
-          }
-        ]
-      }
+    "homeworld": {
+      "name": "Tatooine",
+      "diameter": 10465,
+      "rotationPeriod": 23,
+      "orbitalPeriod": 304,
+      "gravity": "1 standard",
+      "population": 200000,
+      "climates": ["arid"],
+      "terrains": ["desert"],
+      "surfaceWater": 1
     },
-    "film2": {
-      "title": "A New Hope",
-      "episodeID": 4,
-      "director": "George Lucas",
-      "producers": ["Gary Kurtz", "Rick McCallum"],
-      "releaseDate": "1977-05-25",
-      "characterConnection": {
-        "edges": [
-          {
-            "node": {
-              "name": "Luke Skywalker"
-            }
+    "filmConnection": {
+      "edges": [
+        {
+          "node": {
+            "title": "A New Hope"
           }
-        ]
-      },
-      "starshipConnection": {
-        "edges": [
-          {
-            "node": {
-              "name": "X-wing"
-            }
+        }
+      ]
+    }
+  },
+  "person4": {
+    "name": "Luke Skywalker",
+    "birthYear": "19BBY",
+    "eyeColor": "blue",
+    "gender": "male",
+    "hairColor": "blond",
+    "height": 172,
+    "mass": 77,
+    "skinColor": "fair",
+    "starships": {
+      "edges": [
+        {
+          "node": {
+            "name": "X-wing",
+            "model": "T-65 X-wing",
+            "starshipClass": "Starfighter",
+            "manufacturers": ["Incom Corporation"],
+            "costInCredits": 149999,
+            "length": 13.4,
+            "crew": 1,
+            "passengers": 0,
+            "maxAtmospheringSpeed": 1050,
+            "hyperdriveRating": 1.0,
+            "MGLT": 100,
+            "cargoCapacity": 110,
+            "consumables": "1 week"
           }
-        ]
-      },
-      "planetConnection": {
-        "edges": [
-          {
-            "node": {
-              "name": "Tatooine"
-            }
-          }
-        ]
-      }
+        }
+      ]
     },
-    "film3": {
-      "title": "A New Hope",
-      "episodeID": 4,
-      "director": "George Lucas",
-      "producers": ["Gary Kurtz", "Rick McCallum"],
-      "releaseDate": "1977-05-25",
-      "characterConnection": {
-        "edges": [
-          {
-            "node": {
-              "name": "Luke Skywalker"
-            }
-          }
-        ]
-      },
-      "starshipConnection": {
-        "edges": [
-          {
-            "node": {
-              "name": "X-wing"
-            }
-          }
-        ]
-      },
-      "planetConnection": {
-        "edges": [
-          {
-            "node": {
-              "name": "Tatooine"
-            }
-          }
-        ]
-      }
+    "homeworld": {
+      "name": "Tatooine",
+      "diameter": 10465,
+      "rotationPeriod": 23,
+      "orbitalPeriod": 304,
+      "gravity": "1 standard",
+      "population": 200000,
+      "climates": ["arid"],
+      "terrains": ["desert"],
+      "surfaceWater": 1
     },
-    "film4": {
-      "title": "A New Hope",
-      "episodeID": 4,
-      "director": "George Lucas",
-      "producers": ["Gary Kurtz", "Rick McCallum"],
-      "releaseDate": "1977-05-25",
-      "characterConnection": {
-        "edges": [
-          {
-            "node": {
-              "name": "Luke Skywalker"
-            }
+    "filmConnection": {
+      "edges": [
+        {
+          "node": {
+            "title": "A New Hope"
           }
-        ]
-      },
-      "starshipConnection": {
-        "edges": [
-          {
-            "node": {
-              "name": "X-wing"
-            }
+        }
+      ]
+    }
+  },
+  "person5": {
+    "name": "Luke Skywalker",
+    "birthYear": "19BBY",
+    "eyeColor": "blue",
+    "gender": "male",
+    "hairColor": "blond",
+    "height": 172,
+    "mass": 77,
+    "skinColor": "fair",
+    "starships": {
+      "edges": [
+        {
+          "node": {
+            "name": "X-wing",
+            "model": "T-65 X-wing",
+            "starshipClass": "Starfighter",
+            "manufacturers": ["Incom Corporation"],
+            "costInCredits": 149999,
+            "length": 13.4,
+            "crew": 1,
+            "passengers": 0,
+            "maxAtmospheringSpeed": 1050,
+            "hyperdriveRating": 1.0,
+            "MGLT": 100,
+            "cargoCapacity": 110,
+            "consumables": "1 week"
           }
-        ]
-      },
-      "planetConnection": {
-        "edges": [
-          {
-            "node": {
-              "name": "Tatooine"
-            }
-          }
-        ]
-      }
+        }
+      ]
     },
-    "film5": {
-      "title": "A New Hope",
-      "episodeID": 4,
-      "director": "George Lucas",
-      "producers": ["Gary Kurtz", "Rick McCallum"],
-      "releaseDate": "1977-05-25",
-      "characterConnection": {
-        "edges": [
-          {
-            "node": {
-              "name": "Luke Skywalker"
-            }
+    "homeworld": {
+      "name": "Tatooine",
+      "diameter": 10465,
+      "rotationPeriod": 23,
+      "orbitalPeriod": 304,
+      "gravity": "1 standard",
+      "population": 200000,
+      "climates": ["arid"],
+      "terrains": ["desert"],
+      "surfaceWater": 1
+    },
+    "filmConnection": {
+      "edges": [
+        {
+          "node": {
+            "title": "A New Hope"
           }
-        ]
-      },
-      "starshipConnection": {
-        "edges": [
-          {
-            "node": {
-              "name": "X-wing"
-            }
+        }
+      ]
+    }
+  },
+  "film1": {
+    "title": "A New Hope",
+    "episodeID": 4,
+    "director": "George Lucas",
+    "producers": ["Gary Kurtz", "Rick McCallum"],
+    "releaseDate": "1977-05-25",
+    "characterConnection": {
+      "edges": [
+        {
+          "node": {
+            "name": "Luke Skywalker"
           }
-        ]
-      },
-      "planetConnection": {
-        "edges": [
-          {
-            "node": {
-              "name": "Tatooine"
-            }
+        }
+      ]
+    },
+    "starshipConnection": {
+      "edges": [
+        {
+          "node": {
+            "name": "X-wing"
           }
-        ]
-      }
+        }
+      ]
+    },
+    "planetConnection": {
+      "edges": [
+        {
+          "node": {
+            "name": "Tatooine"
+          }
+        }
+      ]
+    }
+  },
+  "film2": {
+    "title": "A New Hope",
+    "episodeID": 4,
+    "director": "George Lucas",
+    "producers": ["Gary Kurtz", "Rick McCallum"],
+    "releaseDate": "1977-05-25",
+    "characterConnection": {
+      "edges": [
+        {
+          "node": {
+            "name": "Luke Skywalker"
+          }
+        }
+      ]
+    },
+    "starshipConnection": {
+      "edges": [
+        {
+          "node": {
+            "name": "X-wing"
+          }
+        }
+      ]
+    },
+    "planetConnection": {
+      "edges": [
+        {
+          "node": {
+            "name": "Tatooine"
+          }
+        }
+      ]
+    }
+  },
+  "film3": {
+    "title": "A New Hope",
+    "episodeID": 4,
+    "director": "George Lucas",
+    "producers": ["Gary Kurtz", "Rick McCallum"],
+    "releaseDate": "1977-05-25",
+    "characterConnection": {
+      "edges": [
+        {
+          "node": {
+            "name": "Luke Skywalker"
+          }
+        }
+      ]
+    },
+    "starshipConnection": {
+      "edges": [
+        {
+          "node": {
+            "name": "X-wing"
+          }
+        }
+      ]
+    },
+    "planetConnection": {
+      "edges": [
+        {
+          "node": {
+            "name": "Tatooine"
+          }
+        }
+      ]
+    }
+  },
+  "film4": {
+    "title": "A New Hope",
+    "episodeID": 4,
+    "director": "George Lucas",
+    "producers": ["Gary Kurtz", "Rick McCallum"],
+    "releaseDate": "1977-05-25",
+    "characterConnection": {
+      "edges": [
+        {
+          "node": {
+            "name": "Luke Skywalker"
+          }
+        }
+      ]
+    },
+    "starshipConnection": {
+      "edges": [
+        {
+          "node": {
+            "name": "X-wing"
+          }
+        }
+      ]
+    },
+    "planetConnection": {
+      "edges": [
+        {
+          "node": {
+            "name": "Tatooine"
+          }
+        }
+      ]
+    }
+  },
+  "film5": {
+    "title": "A New Hope",
+    "episodeID": 4,
+    "director": "George Lucas",
+    "producers": ["Gary Kurtz", "Rick McCallum"],
+    "releaseDate": "1977-05-25",
+    "characterConnection": {
+      "edges": [
+        {
+          "node": {
+            "name": "Luke Skywalker"
+          }
+        }
+      ]
+    },
+    "starshipConnection": {
+      "edges": [
+        {
+          "node": {
+            "name": "X-wing"
+          }
+        }
+      ]
+    },
+    "planetConnection": {
+      "edges": [
+        {
+          "node": {
+            "name": "Tatooine"
+          }
+        }
+      ]
     }
   }
 }

--- a/servers/graphql-kotlin-server/src/main/kotlin/com/expediagroup/graphql/server/types/GraphQLServerResponse.kt
+++ b/servers/graphql-kotlin-server/src/main/kotlin/com/expediagroup/graphql/server/types/GraphQLServerResponse.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Expedia, Inc
+ * Copyright 2025 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servers/graphql-kotlin-server/src/test/kotlin/com/expediagroup/graphql/server/types/GraphQLServerResponseTest.kt
+++ b/servers/graphql-kotlin-server/src/test/kotlin/com/expediagroup/graphql/server/types/GraphQLServerResponseTest.kt
@@ -44,7 +44,6 @@ class GraphQLServerResponseTest {
         val expectedJson =
             """{"data":{"foo":1}}"""
         assertEquals(expectedJson, mapper.writeValueAsString(response))
-
     }
 
     @Test

--- a/servers/graphql-kotlin-server/src/test/kotlin/com/expediagroup/graphql/server/types/GraphQLServerResponseTest.kt
+++ b/servers/graphql-kotlin-server/src/test/kotlin/com/expediagroup/graphql/server/types/GraphQLServerResponseTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Expedia, Inc
+ * Copyright 2025 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,35 +37,53 @@ class GraphQLServerResponseTest {
     private val mapper = jacksonObjectMapper()
 
     @Test
-    fun `verify simple serialization`() {
+    fun `jackson verify simple serialization`() {
         val response = GraphQLResponse(
             data = MyQuery(1)
         )
-
         val expectedJson =
             """{"data":{"foo":1}}"""
-
         assertEquals(expectedJson, mapper.writeValueAsString(response))
+
+    }
+
+    @Test
+    fun `fastjson2 verify simple serialization`() {
+        val response = GraphQLResponse(
+            data = MyQuery(1)
+        )
+        val expectedJson =
+            """{"data":{"foo":1}}"""
         assertEquals(expectedJson, JSON.toJSONString(response))
     }
 
     @Test
-    fun `verify complete serialization`() {
+    fun `jackson verify complete serialization`() {
         val response = GraphQLResponse(
             data = MyQuery(1),
             errors = listOf(GraphQLServerError("my error")),
             extensions = mapOf("bar" to 2)
         )
-
         val expectedJson =
             """{"data":{"foo":1},"errors":[{"message":"my error"}],"extensions":{"bar":2}}"""
-
         assertEquals(expectedJson, mapper.writeValueAsString(response))
         assertEquals(expectedJson, JSON.toJSONString(response))
     }
 
     @Test
-    fun `verify batch response serialization`() {
+    fun `fastjson2 verify complete serialization`() {
+        val response = GraphQLResponse(
+            data = MyQuery(1),
+            errors = listOf(GraphQLServerError("my error")),
+            extensions = mapOf("bar" to 2)
+        )
+        val expectedJson =
+            """{"data":{"foo":1},"errors":[{"message":"my error"}],"extensions":{"bar":2}}"""
+        assertEquals(expectedJson, JSON.toJSONString(response))
+    }
+
+    @Test
+    fun `jackson verify batch response serialization`() {
         val batchResponse = GraphQLBatchResponse(
             responses = listOf(
                 GraphQLResponse(
@@ -81,7 +99,68 @@ class GraphQLServerResponseTest {
         val expectedJson =
             """[{"data":{"foo":1}},{"data":{"foo":2},"errors":[{"message":"my error"}],"extensions":{"bar":2}}]"""
         assertEquals(expectedJson, mapper.writeValueAsString(batchResponse))
+    }
+
+    @Test
+    fun `fastjson2 verify batch response serialization`() {
+        val batchResponse = GraphQLBatchResponse(
+            responses = listOf(
+                GraphQLResponse(
+                    data = MyQuery(1)
+                ),
+                GraphQLResponse(
+                    data = MyQuery(2),
+                    errors = listOf(GraphQLServerError("my error")),
+                    extensions = mapOf("bar" to 2)
+                )
+            )
+        )
+        val expectedJson =
+            """[{"data":{"foo":1}},{"data":{"foo":2},"errors":[{"message":"my error"}],"extensions":{"bar":2}}]"""
         assertEquals(expectedJson, JSON.toJSONString(batchResponse))
+    }
+
+    @Test
+    fun `jackson serializes null values from data property, not null values from GraphQLResponse and GraphQLResponseError`() {
+        val response =
+            GraphQLResponse(
+                mapOf(
+                    "1" to null,
+                    "1.1" to
+                        mapOf(
+                            "1.1.k1" to "1.1.v1",
+                            "1.1.k2" to null,
+                        ),
+                ),
+                listOf(GraphQLServerError("test")),
+                null,
+            )
+        assertEquals(
+            """{"data":{"1":null,"1.1":{"1.1.k1":"1.1.v1","1.1.k2":null}},"errors":[{"message":"test"}]}""",
+            mapper.writeValueAsString(response),
+        )
+    }
+
+    @Test
+    fun `fastjson2 serializes null values from data property, not null values from GraphQLResponse and GraphQLResponseError`() {
+        val response =
+            GraphQLResponse(
+                mapOf(
+                    "1" to null,
+                    "1.1" to
+                        mapOf(
+                            "1.1.k1" to "1.1.v1",
+                            "1.1.k2" to null,
+                        ),
+                ),
+                listOf(GraphQLServerError("test")),
+                null,
+            )
+        val json = JSON.toJSONString(response)
+        assertEquals(
+            """{"data":{"1":null,"1.1":{"1.1.k1":"1.1.v1","1.1.k2":null}},"errors":[{"message":"test"}]}""",
+            json,
+        )
     }
 
     @Test


### PR DESCRIPTION
benchmarks 

GraphQLRequest deserialization jackson vs fastjson2
![image](https://github.com/user-attachments/assets/aa31c409-ec2c-4d3e-b447-690da2c00980)


GraphQLResponse serialization Jackson vs fastjson2
![image](https://github.com/user-attachments/assets/45934224-5e20-447f-955f-9736ae931aab)
