### PR TITLE
docs: include name when creating GraphQLEnumValueDefinition

### DIFF
--- a/website/docs/schema-generator/writing-schemas/enums.md
+++ b/website/docs/schema-generator/writing-schemas/enums.md
@@ -46,6 +46,7 @@ val statusEnumType = GraphQLEnumType.newEnum()
     .name("Status")
     .values(Status.values().map {
       GraphQLEnumValueDefinition.newEnumValueDefinition()
+          .name(it.name)
           .value(it.name)
           .build()
     })


### PR DESCRIPTION
### :pencil: Description

Was using the docs and this caught me out, you have to set the enum name when building a new GraphQLEnumValueDefinition otherwise you will receive `Name must be non-null, non-empty and match [_A-Za-z][_0-9A-Za-z]* - was 'null'`

### :link: Related Issues
