### PR TITLE
feat(6.x.x): SingletonPropertyDataFetcher, avoid allocating a PropertyDataFetcher per property per graphql operation

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -32,7 +32,7 @@ jobs:
         run: ./gradlew clean build
 
       - name: Archive failure build reports
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: build-reports
@@ -47,7 +47,7 @@ jobs:
         run: ./gradlew clean build
 
       - name: Archive examples failure build reports
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: build-examples-reports

--- a/.github/workflows/pr-check-docs.yml
+++ b/.github/workflows/pr-check-docs.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           node-version: 16
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('website/package-lock.json') }}

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -41,7 +41,7 @@ jobs:
         run: ./gradlew clean build
 
       - name: Archive failure build reports
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: build-reports
@@ -56,7 +56,7 @@ jobs:
         run: ./gradlew clean build
 
       - name: Archive examples failure build reports
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: build-examples-reports

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -31,7 +31,7 @@ jobs:
 
       # Used by maven-plugin integration tests
       - name: Set up Maven cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/publish-latest-docs.yml
+++ b/.github/workflows/publish-latest-docs.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           node-version: 16
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('website/package-lock.json') }}

--- a/.github/workflows/release-code.yml
+++ b/.github/workflows/release-code.yml
@@ -38,7 +38,7 @@ jobs:
           PLUGIN_PORTAL_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
 
       - name: Archive failure build reports
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: build-reports

--- a/generator/graphql-kotlin-schema-generator/build.gradle.kts
+++ b/generator/graphql-kotlin-schema-generator/build.gradle.kts
@@ -28,7 +28,7 @@ tasks {
                 limit {
                     counter = "BRANCH"
                     value = "COVEREDRATIO"
-                    minimum = "0.93".toBigDecimal()
+                    minimum = "0.91".toBigDecimal()
                 }
             }
         }

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/execution/KotlinDataFetcherFactoryProvider.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/execution/KotlinDataFetcherFactoryProvider.kt
@@ -62,3 +62,12 @@ open class SimpleKotlinDataFetcherFactoryProvider : KotlinDataFetcherFactoryProv
         PropertyDataFetcher(kProperty.getter)
     }
 }
+
+/**
+ * [SimpleSingletonKotlinDataFetcherFactoryProvider] is a specialization of [SimpleKotlinDataFetcherFactoryProvider] that will provide a
+ * a [SingletonPropertyDataFetcher] that should be used to target property resolutions without allocating a DataFetcher per property
+ */
+open class SimpleSingletonKotlinDataFetcherFactoryProvider : SimpleKotlinDataFetcherFactoryProvider() {
+    override fun propertyDataFetcherFactory(kClass: KClass<*>, kProperty: KProperty<*>): DataFetcherFactory<Any?> =
+        SingletonPropertyDataFetcher.getFactoryAndRegister(kClass, kProperty)
+}

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/execution/SingletonPropertyDataFetcher.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/execution/SingletonPropertyDataFetcher.kt
@@ -1,0 +1,42 @@
+package com.expediagroup.graphql.generator.execution
+
+import graphql.schema.DataFetcher
+import graphql.schema.DataFetcherFactory
+import graphql.schema.DataFetchingEnvironment
+import graphql.schema.GraphQLFieldDefinition
+import graphql.schema.LightDataFetcher
+import java.util.concurrent.ConcurrentHashMap
+import java.util.function.Supplier
+import kotlin.reflect.KClass
+import kotlin.reflect.KProperty
+
+/**
+ * Singleton Property [DataFetcher] that stores references to underlying properties getters.
+ */
+internal object SingletonPropertyDataFetcher : LightDataFetcher<Any?> {
+
+    private val factory: DataFetcherFactory<Any?> = DataFetcherFactory<Any?> { SingletonPropertyDataFetcher }
+
+    private val getters: ConcurrentHashMap<String, KProperty.Getter<*>> = ConcurrentHashMap()
+
+    fun getFactoryAndRegister(kClass: KClass<*>, kProperty: KProperty<*>): DataFetcherFactory<Any?> {
+        getters.computeIfAbsent("${kClass.java.name}.${kProperty.name}") {
+            kProperty.getter
+        }
+        return factory
+    }
+
+    override fun get(
+        fieldDefinition: GraphQLFieldDefinition,
+        sourceObject: Any?,
+        environmentSupplier: Supplier<DataFetchingEnvironment>
+    ): Any? =
+        sourceObject?.let {
+            getters["${sourceObject.javaClass.name}.${fieldDefinition.name}"]?.call(sourceObject)
+        }
+
+    override fun get(environment: DataFetchingEnvironment): Any? =
+        environment.getSource<Any?>()?.let { sourceObject ->
+            getters["${sourceObject.javaClass.name}.${environment.fieldDefinition.name}"]?.call(sourceObject)
+        }
+}

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/PolymorphicTests.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/PolymorphicTests.kt
@@ -37,7 +37,7 @@ class PolymorphicTests {
 
     @Test
     fun `Schema generator creates union types from marked up interface`() {
-        val schema = toSchema(queries = listOf(TopLevelObject(QueryWithUnion())), config = testSchemaConfig)
+        val schema = toSchema(queries = listOf(TopLevelObject(QueryWithUnion())), config = testSchemaConfig())
 
         val graphqlType = schema.getType("BodyPart") as? GraphQLUnionType
         assertNotNull(graphqlType)
@@ -54,7 +54,7 @@ class PolymorphicTests {
 
     @Test
     fun `SchemaGenerator can expose an interface and its implementations`() {
-        val schema = toSchema(queries = listOf(TopLevelObject(QueryWithInterface())), config = testSchemaConfig)
+        val schema = toSchema(queries = listOf(TopLevelObject(QueryWithInterface())), config = testSchemaConfig())
 
         val interfaceType = schema.getType("AnInterface") as? GraphQLInterfaceType
         assertNotNull(interfaceType)
@@ -68,20 +68,20 @@ class PolymorphicTests {
     @Test
     fun `Interfaces cannot be used as input field types`() {
         assertThrows(InvalidInputFieldTypeException::class.java) {
-            toSchema(queries = listOf(TopLevelObject(QueryWithUnAuthorizedInterfaceArgument())), config = testSchemaConfig)
+            toSchema(queries = listOf(TopLevelObject(QueryWithUnAuthorizedInterfaceArgument())), config = testSchemaConfig())
         }
     }
 
     @Test
     fun `Union cannot be used as input field types`() {
         assertThrows(InvalidInputFieldTypeException::class.java) {
-            toSchema(queries = listOf(TopLevelObject(QueryWithUnAuthorizedUnionArgument())), config = testSchemaConfig)
+            toSchema(queries = listOf(TopLevelObject(QueryWithUnAuthorizedUnionArgument())), config = testSchemaConfig())
         }
     }
 
     @Test
     fun `Object types implementing union and interfaces are only created once`() {
-        val schema = toSchema(queries = listOf(TopLevelObject(QueryWithInterfaceAndUnion())), config = testSchemaConfig)
+        val schema = toSchema(queries = listOf(TopLevelObject(QueryWithInterfaceAndUnion())), config = testSchemaConfig())
 
         val carType = schema.getType("Car") as? GraphQLObjectType
         assertNotNull(carType)
@@ -95,7 +95,7 @@ class PolymorphicTests {
 
     @Test
     fun `Interfaces can declare properties of their own type`() {
-        val schema = toSchema(queries = listOf(TopLevelObject(QueryWithRecursiveType())), config = testSchemaConfig)
+        val schema = toSchema(queries = listOf(TopLevelObject(QueryWithRecursiveType())), config = testSchemaConfig())
 
         val personType = schema.getType("Person")
         assertNotNull(personType)
@@ -103,7 +103,7 @@ class PolymorphicTests {
 
     @Test
     fun `Abstract classes should be converted to interfaces`() {
-        val schema = toSchema(queries = listOf(TopLevelObject(QueryWithAbstract())), config = testSchemaConfig)
+        val schema = toSchema(queries = listOf(TopLevelObject(QueryWithAbstract())), config = testSchemaConfig())
 
         val abstractInterface = schema.getType("MyAbstract") as? GraphQLInterfaceType
         assertNotNull(abstractInterface)
@@ -116,7 +116,7 @@ class PolymorphicTests {
 
     @Test
     fun `Interface types can be correctly resolved`() {
-        val schema = toSchema(queries = listOf(TopLevelObject(QueryWithRenamedAbstracts())), config = testSchemaConfig)
+        val schema = toSchema(queries = listOf(TopLevelObject(QueryWithRenamedAbstracts())), config = testSchemaConfig())
 
         val cakeInterface = schema.getType("Cake") as? GraphQLInterfaceType
         assertNotNull(cakeInterface)
@@ -132,7 +132,7 @@ class PolymorphicTests {
 
     @Test
     fun `Union types can be correctly resolved`() {
-        val schema = toSchema(queries = listOf(TopLevelObject(QueryWithRenamedAbstracts())), config = testSchemaConfig)
+        val schema = toSchema(queries = listOf(TopLevelObject(QueryWithRenamedAbstracts())), config = testSchemaConfig())
 
         val dessertUnion = schema.getType("Dessert") as? GraphQLUnionType
         assertNotNull(dessertUnion)
@@ -148,7 +148,7 @@ class PolymorphicTests {
 
     @Test
     fun `Interface implementations are not computed when marked with GraphQLIgnore annotation`() {
-        val schema = toSchema(queries = listOf(TopLevelObject(QueryWithIgnoredInfo())), config = testSchemaConfig)
+        val schema = toSchema(queries = listOf(TopLevelObject(QueryWithIgnoredInfo())), config = testSchemaConfig())
         val service = schema.getType("Service") as? GraphQLInterfaceType
         assertNotNull(service)
 
@@ -161,7 +161,7 @@ class PolymorphicTests {
 
     @Test
     fun `Ignored interface properties should not appear in the subtype`() {
-        val schema = toSchema(queries = listOf(TopLevelObject(QueryWithIgnoredInfo())), config = testSchemaConfig)
+        val schema = toSchema(queries = listOf(TopLevelObject(QueryWithIgnoredInfo())), config = testSchemaConfig())
         val service = schema.getType("Service") as? GraphQLInterfaceType
         assertNotNull(service)
         val interfaceIgnoredField = service.getFieldDefinition("shouldNotBeInTheSchema")

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/SchemaGeneratorAsyncTests.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/SchemaGeneratorAsyncTests.kt
@@ -42,7 +42,7 @@ class SchemaGeneratorAsyncTests {
 
     @Test
     fun `SchemaGenerator strips type argument from CompletableFuture to support async servlet`() {
-        val schema = toSchema(queries = listOf(TopLevelObject(AsyncQuery())), config = testSchemaConfig)
+        val schema = toSchema(queries = listOf(TopLevelObject(AsyncQuery())), config = testSchemaConfig())
         val returnType =
             (schema.getObjectType("Query").getFieldDefinition("asynchronouslyDo").type as? GraphQLNonNull)?.wrappedType
         assertNotNull(returnType)

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/directives/DirectiveTests.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/directives/DirectiveTests.kt
@@ -35,7 +35,7 @@ class DirectiveTests {
 
     @Test
     fun `SchemaGenerator marks deprecated fields in the return objects`() {
-        val schema = toSchema(queries = listOf(TopLevelObject(QueryWithDeprecatedFields())), config = testSchemaConfig)
+        val schema = toSchema(queries = listOf(TopLevelObject(QueryWithDeprecatedFields())), config = testSchemaConfig())
         val topLevelQuery = schema.getObjectType("Query")
         val query = topLevelQuery.getFieldDefinition("deprecatedFieldQuery")
         val result = (query.type as? GraphQLNonNull)?.wrappedType as? GraphQLObjectType
@@ -50,7 +50,7 @@ class DirectiveTests {
 
     @Test
     fun `SchemaGenerator marks deprecated queries and documents replacement`() {
-        val schema = toSchema(queries = listOf(TopLevelObject(QueryWithDeprecatedFields())), config = testSchemaConfig)
+        val schema = toSchema(queries = listOf(TopLevelObject(QueryWithDeprecatedFields())), config = testSchemaConfig())
         val topLevelQuery = schema.getObjectType("Query")
         val deprecatedQueryWithReplacement = topLevelQuery.getFieldDefinition("deprecatedQueryWithReplacement")
         val graphqlDeprecatedQueryWithReplacement = topLevelQuery.getFieldDefinition("graphqlDeprecatedQueryWithReplacement")
@@ -63,7 +63,7 @@ class DirectiveTests {
 
     @Test
     fun `SchemaGenerator marks deprecated queries`() {
-        val schema = toSchema(queries = listOf(TopLevelObject(QueryWithDeprecatedFields())), config = testSchemaConfig)
+        val schema = toSchema(queries = listOf(TopLevelObject(QueryWithDeprecatedFields())), config = testSchemaConfig())
         val topLevelQuery = schema.getObjectType("Query")
         val query = topLevelQuery.getFieldDefinition("deprecatedQuery")
         val graphqlDeprecatedQuery = topLevelQuery.getFieldDefinition("graphqlDeprecatedQuery")

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/execution/PropertyDataFetcherTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/execution/PropertyDataFetcherTest.kt
@@ -32,7 +32,7 @@ class PropertyDataFetcherTest {
 
     private val schema = toSchema(
         queries = listOf(TopLevelObject(PrefixedQuery())),
-        config = testSchemaConfig
+        config = testSchemaConfig()
     )
     private val graphQL = GraphQL.newGraphQL(schema).build()
 

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/extensions/GraphQLSchemaExtensionsTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/extensions/GraphQLSchemaExtensionsTest.kt
@@ -42,7 +42,7 @@ class GraphQLSchemaExtensionsTest {
 
     @Test
     fun `verify print result of a simple schema`() {
-        val schema: GraphQLSchema = toSchema(queries = listOf(TopLevelObject(SimpleQuery())), config = testSchemaConfig)
+        val schema: GraphQLSchema = toSchema(queries = listOf(TopLevelObject(SimpleQuery())), config = testSchemaConfig())
 
         val sdl = schema.print(includeDirectives = false).trim()
         val expected =
@@ -61,7 +61,7 @@ class GraphQLSchemaExtensionsTest {
 
     @Test
     fun `verify print result of a simple schema with no scalars`() {
-        val schema: GraphQLSchema = toSchema(queries = listOf(TopLevelObject(SimpleQuery())), config = testSchemaConfig)
+        val schema: GraphQLSchema = toSchema(queries = listOf(TopLevelObject(SimpleQuery())), config = testSchemaConfig())
 
         val sdl = schema.print(includeDirectives = false, includeScalarTypes = false).trim()
         val expected =
@@ -91,7 +91,7 @@ class GraphQLSchemaExtensionsTest {
 
     @Test
     fun `verify print result of a schema with renamed fields`() {
-        val schema: GraphQLSchema = toSchema(queries = listOf(TopLevelObject(RenamedQuery())), config = testSchemaConfig)
+        val schema: GraphQLSchema = toSchema(queries = listOf(TopLevelObject(RenamedQuery())), config = testSchemaConfig())
 
         val sdl = schema.print(includeDefaultSchemaDefinition = false, includeDirectives = false).trim()
         val expected =
@@ -118,7 +118,7 @@ class GraphQLSchemaExtensionsTest {
 
     @Test
     fun `verify print result of a schema with GraphQL ID`() {
-        val schema: GraphQLSchema = toSchema(queries = listOf(TopLevelObject(QueryWithId())), config = testSchemaConfig)
+        val schema: GraphQLSchema = toSchema(queries = listOf(TopLevelObject(QueryWithId())), config = testSchemaConfig())
 
         val sdl = schema.print(includeDefaultSchemaDefinition = false, includeDirectives = false).trim()
         val expected =
@@ -153,7 +153,7 @@ class GraphQLSchemaExtensionsTest {
 
     @Test
     fun `verify print result of a schema with ignored elements`() {
-        val schema: GraphQLSchema = toSchema(queries = listOf(TopLevelObject(QueryWithExcludedFields())), config = testSchemaConfig)
+        val schema: GraphQLSchema = toSchema(queries = listOf(TopLevelObject(QueryWithExcludedFields())), config = testSchemaConfig())
 
         val sdl = schema.print(includeDefaultSchemaDefinition = false, includeDirectives = false).trim()
         val expected =
@@ -189,7 +189,7 @@ class GraphQLSchemaExtensionsTest {
 
     @Test
     fun `verify print result of a documented schema`() {
-        val schema: GraphQLSchema = toSchema(queries = listOf(TopLevelObject(DocumentedQuery())), config = testSchemaConfig)
+        val schema: GraphQLSchema = toSchema(queries = listOf(TopLevelObject(DocumentedQuery())), config = testSchemaConfig())
 
         val sdl = schema.print(includeDefaultSchemaDefinition = false, includeDirectives = false).trim()
         val expected =

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/hooks/SchemaGeneratorHooksTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/hooks/SchemaGeneratorHooksTest.kt
@@ -193,7 +193,7 @@ class SchemaGeneratorHooksTest {
         assertThrows<EmptyObjectTypeException> {
             toSchema(
                 queries = listOf(TopLevelObject(TestWithEmptyObjectQuery())),
-                config = testSchemaConfig
+                config = testSchemaConfig()
             )
         }
     }
@@ -203,7 +203,7 @@ class SchemaGeneratorHooksTest {
         assertThrows<EmptyInputObjectTypeException> {
             toSchema(
                 queries = listOf(TopLevelObject(TestWithEmptyInputObjectQuery())),
-                config = testSchemaConfig
+                config = testSchemaConfig()
             )
         }
     }
@@ -213,7 +213,7 @@ class SchemaGeneratorHooksTest {
         assertThrows<EmptyInterfaceTypeException> {
             toSchema(
                 queries = listOf(TopLevelObject(TestWithEmptyInterfaceQuery())),
-                config = testSchemaConfig
+                config = testSchemaConfig()
             )
         }
     }

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/test/integration/CompletableFutureTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/test/integration/CompletableFutureTest.kt
@@ -30,7 +30,7 @@ class CompletableFutureTest {
     @Test
     fun validateSchema() {
         val queries = listOf(TopLevelObject(SimpleQuery()))
-        val schema = toSchema(testSchemaConfig, queries)
+        val schema = toSchema(testSchemaConfig(), queries)
         assertNotNull(schema)
         assertEquals("String!", schema.queryType.getFieldDefinition("getString").type.toString())
         assertEquals("String!", schema.queryType.getFieldDefinition("getDataFetcherResultString").type.toString())

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/test/integration/ConcurrentAdditionalTypesTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/test/integration/ConcurrentAdditionalTypesTest.kt
@@ -27,7 +27,7 @@ class ConcurrentAdditionalTypesTest {
     @Test
     fun `verify a concurrent exception is not thrown if there are additionalTypes added when generating the additionalTypes`() {
         val queries = listOf(TopLevelObject(SimpleQuery()))
-        val schema = toSchema(testSchemaConfig, queries)
+        val schema = toSchema(testSchemaConfig(), queries)
         assertNotNull(schema)
         assertNotNull(schema.getType("InterfaceOne"))
         assertNotNull(schema.getType("InterfaceTwo"))

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/test/integration/CustomFieldTypeTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/test/integration/CustomFieldTypeTest.kt
@@ -41,7 +41,7 @@ class CustomFieldTypeTest {
     @Test
     fun `generate a custom nullable by default scalar type`() {
         val queries = listOf(TopLevelObject(CustomScalar()))
-        val schema = toSchema(testSchemaConfig, queries)
+        val schema = toSchema(testSchemaConfig(), queries)
         val returnType = schema.queryType.getField("scalarType").type
         assertIsNot<GraphQLNonNull>(returnType)
         assertEquals("String", returnType.deepName)
@@ -50,7 +50,7 @@ class CustomFieldTypeTest {
     @Test
     fun `generate a custom non-null scalar type`() {
         val queries = listOf(TopLevelObject(CustomNonNullScalar()))
-        val schema = toSchema(testSchemaConfig, queries)
+        val schema = toSchema(testSchemaConfig(), queries)
         val returnType = schema.queryType.getField("nonNullScalarType").type
         assertIs<GraphQLNonNull>(returnType)
         assertEquals("String!", returnType.deepName)

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/test/integration/CustomUnionAnnotationTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/test/integration/CustomUnionAnnotationTest.kt
@@ -38,7 +38,7 @@ class CustomUnionAnnotationTest {
 
     @Test
     fun `custom unions can be defined with a variety of return types`() {
-        val schema = toSchema(testSchemaConfig, listOf(TopLevelObject(Query())))
+        val schema = toSchema(testSchemaConfig(), listOf(TopLevelObject(Query())))
         assertNotNull(schema)
         assertNotNull(schema.getType("One"))
         assertNotNull(schema.getType("Two"))
@@ -68,23 +68,23 @@ class CustomUnionAnnotationTest {
     @Test
     fun `verify exception is thrown when union returns different types`() {
         assertFails {
-            toSchema(testSchemaConfig, listOf(TopLevelObject(InvalidQuery())))
+            toSchema(testSchemaConfig(), listOf(TopLevelObject(InvalidQuery())))
         }
     }
 
     @Test
     fun `verify exception is thrown when custom union return type is not Any`() {
         assertFails {
-            toSchema(testSchemaConfig, listOf(TopLevelObject(InvalidReturnTypeNumber())))
+            toSchema(testSchemaConfig(), listOf(TopLevelObject(InvalidReturnTypeNumber())))
         }
         assertFails {
-            toSchema(testSchemaConfig, listOf(TopLevelObject(InvalidReturnTypePrime())))
+            toSchema(testSchemaConfig(), listOf(TopLevelObject(InvalidReturnTypePrime())))
         }
     }
 
     @Test
     fun `verify Meta Union Annotation when adding as additional type`() {
-        val generator = CustomSchemaGenerator(testSchemaConfig)
+        val generator = CustomSchemaGenerator(testSchemaConfig())
         generator.addTypes(MyAnnotation::class)
         val types = generator.generateCustomAdditionalTypes()
 

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/test/integration/DataFetcherResultListTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/test/integration/DataFetcherResultListTest.kt
@@ -29,7 +29,7 @@ class DataFetcherResultListTest {
     @Test
     fun validateSchema() {
         val queries = listOf(TopLevelObject(SimpleQuery()))
-        val schema = toSchema(testSchemaConfig, queries)
+        val schema = toSchema(testSchemaConfig(), queries)
         assertNotNull(schema)
         assertEquals("String!", schema.queryType.getFieldDefinition("getString").type.toString())
         assertEquals("String!", schema.queryType.getFieldDefinition("getDataFetcherResultString").type.toString())

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/test/integration/InterfaceOfInterfaceTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/test/integration/InterfaceOfInterfaceTest.kt
@@ -32,7 +32,7 @@ class InterfaceOfInterfaceTest {
     @Test
     fun `interface of interface`() {
         val queries = listOf(TopLevelObject(InterfaceOfInterfaceQuery()))
-        val schema = toSchema(queries = queries, config = testSchemaConfig)
+        val schema = toSchema(queries = queries, config = testSchemaConfig())
         assertEquals(expected = 2, actual = schema.queryType.fieldDefinitions.size)
 
         val implementation = schema.getObjectType("MyClass")
@@ -55,7 +55,7 @@ class InterfaceOfInterfaceTest {
     @Test
     fun `ignore class and use interface as type`() {
         val queries = listOf(TopLevelObject(InterfaceOfInterfaceQuery()))
-        val schema = toSchema(queries = queries, config = testSchemaConfig)
+        val schema = toSchema(queries = queries, config = testSchemaConfig())
 
         // The ignored class should not be in the schema at all
         assertNull(schema.getType("IgnoredClass"))

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/test/integration/NodeGraphTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/test/integration/NodeGraphTest.kt
@@ -32,7 +32,7 @@ class NodeGraphTest {
     fun nodeGraph() {
         val queries = listOf(TopLevelObject(NodeQuery()))
 
-        val schema = toSchema(queries = queries, config = testSchemaConfig)
+        val schema = toSchema(queries = queries, config = testSchemaConfig())
 
         assertEquals(expected = 1, actual = schema.queryType.fieldDefinitions.size)
         assertEquals(expected = "nodeGraph", actual = schema.queryType.fieldDefinitions.first().name)

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/test/integration/OptionalInputSchemaTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/test/integration/OptionalInputSchemaTest.kt
@@ -28,7 +28,7 @@ class OptionalInputSchemaTest {
 
     @Test
     fun `SchemaGenerator generates a simple GraphQL schema`() {
-        val generator = SchemaGenerator(testSchemaConfig)
+        val generator = SchemaGenerator(testSchemaConfig())
         val schema = generator.generateSchema(
             queries = listOf(TopLevelObject(Query())),
             additionalInputTypes = setOf(MyAdditionalInput::class.createType())

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/test/integration/OptionalInputTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/test/integration/OptionalInputTest.kt
@@ -16,7 +16,7 @@ class OptionalInputTest {
 
     private val schema = toSchema(
         queries = listOf(TopLevelObject(OptionalInputQuery())),
-        config = testSchemaConfig
+        config = testSchemaConfig()
     )
 
     private val graphQL = GraphQL.newGraphQL(schema).build()

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/test/integration/OptionalResultsTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/test/integration/OptionalResultsTest.kt
@@ -31,7 +31,7 @@ class OptionalResultsTest {
         val schema = toSchema(
             queries = listOf(TopLevelObject(QueryObject())),
             mutations = listOf(),
-            config = testSchemaConfig
+            config = testSchemaConfig()
         )
         val graphQL = GraphQL.newGraphQL(schema).build()
 

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/test/integration/OutputTypeWithRecursiveInputTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/test/integration/OutputTypeWithRecursiveInputTest.kt
@@ -27,7 +27,7 @@ class OutputTypeWithRecursiveInputTest {
     @Test
     fun `An output type that gets generated first and then has fields with arguments of itself generates properly`() {
         val queries = listOf(TopLevelObject(Query()))
-        val schema = toSchema(testSchemaConfig, queries)
+        val schema = toSchema(testSchemaConfig(), queries)
         assertNotNull(schema)
         assertNotNull(schema.getType("MyObject"))
         assertNotNull(schema.getType("MyObjectInput"))

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/test/integration/RecursiveInputTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/test/integration/RecursiveInputTest.kt
@@ -28,7 +28,7 @@ class RecursiveInputTest {
     @Test
     fun `Input type with a recursive argument should work`() {
         val queries = listOf(TopLevelObject(RecursiveInputQueries()))
-        val schema = toSchema(testSchemaConfig, queries)
+        val schema = toSchema(testSchemaConfig(), queries)
         assertNotNull(schema)
         assertNotNull(schema.getType("RecursivePerson"))
         assertNotNull(schema.getType("RecursivePersonInput"))

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/test/integration/RecursiveInterfaceTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/test/integration/RecursiveInterfaceTest.kt
@@ -27,7 +27,7 @@ class RecursiveInterfaceTest {
     @Test
     fun recursiveInterface() {
         val queries = listOf(TopLevelObject(RecursiveInterfaceQuery()))
-        val schema = toSchema(queries = queries, config = testSchemaConfig)
+        val schema = toSchema(queries = queries, config = testSchemaConfig())
         assertEquals(1, schema.queryType.fieldDefinitions.size)
         val field = schema.queryType.fieldDefinitions.first()
         assertEquals("getRoot", field.name)
@@ -36,7 +36,7 @@ class RecursiveInterfaceTest {
     @Test
     fun `interface with self field`() {
         val queries = listOf(TopLevelObject(InterfaceWithSelfFieldQuery()))
-        val schema = toSchema(queries = queries, config = testSchemaConfig)
+        val schema = toSchema(queries = queries, config = testSchemaConfig())
         assertEquals(1, schema.queryType.fieldDefinitions.size)
         val field = schema.queryType.fieldDefinitions.first()
         assertEquals("getInterface", field.name)

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/test/integration/RecursiveUnionTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/test/integration/RecursiveUnionTest.kt
@@ -27,7 +27,7 @@ class RecursiveUnionTest {
     @Test
     fun recursiveUnion() {
         val queries = listOf(TopLevelObject(RecursiveUnionQuery()))
-        val schema = toSchema(queries = queries, config = testSchemaConfig)
+        val schema = toSchema(queries = queries, config = testSchemaConfig())
         assertEquals(1, schema.queryType.fieldDefinitions.size)
         val field = schema.queryType.fieldDefinitions.first()
         assertEquals("getRoot", field.name)

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/testSchemaConfig.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/testSchemaConfig.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Expedia, Inc
+ * Copyright 2023 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,12 +18,19 @@ package com.expediagroup.graphql.generator
 
 import com.expediagroup.graphql.generator.directives.KotlinDirectiveWiringFactory
 import com.expediagroup.graphql.generator.directives.KotlinSchemaDirectiveWiring
+import com.expediagroup.graphql.generator.execution.KotlinDataFetcherFactoryProvider
+import com.expediagroup.graphql.generator.execution.SimpleKotlinDataFetcherFactoryProvider
 import com.expediagroup.graphql.generator.hooks.SchemaGeneratorHooks
 import io.mockk.every
 import io.mockk.spyk
 
 val defaultSupportedPackages = listOf("com.expediagroup.graphql.generator")
-val testSchemaConfig = SchemaGeneratorConfig(defaultSupportedPackages)
+fun testSchemaConfig(
+    dataFetcherFactoryProvider: KotlinDataFetcherFactoryProvider = SimpleKotlinDataFetcherFactoryProvider()
+) = SchemaGeneratorConfig(
+    defaultSupportedPackages,
+    dataFetcherFactoryProvider = dataFetcherFactoryProvider
+)
 
 fun getTestSchemaConfigWithHooks(hooks: SchemaGeneratorHooks) = SchemaGeneratorConfig(defaultSupportedPackages, hooks = hooks)
 

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/union_same_selections/UnionSameSelections.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/union_same_selections/UnionSameSelections.kt
@@ -13,11 +13,11 @@ public const val UNION_SAME_SELECTIONS: String =
 
 @Generated
 public class UnionSameSelections : GraphQLClientRequest<UnionSameSelections.Result> {
-  override val query: String = UNION_SAME_SELECTIONS
+  public override val query: String = UNION_SAME_SELECTIONS
 
-  override val operationName: String = "UnionSameSelections"
+  public override val operationName: String = "UnionSameSelections"
 
-  override fun responseType(): KClass<UnionSameSelections.Result> =
+  public override fun responseType(): KClass<UnionSameSelections.Result> =
       UnionSameSelections.Result::class
 
   @Generated

--- a/servers/graphql-kotlin-spring-server/build.gradle.kts
+++ b/servers/graphql-kotlin-spring-server/build.gradle.kts
@@ -32,7 +32,11 @@ tasks {
                 limit {
                     counter = "INSTRUCTION"
                     value = "COVEREDRATIO"
+<<<<<<< HEAD
                     minimum = "0.91".toBigDecimal()
+=======
+                    minimum = "0.85".toBigDecimal()
+>>>>>>> ad727d45e (feat: SingletonPropertyDataFetcher, avoid allocating a PropertyDataFetcher per property per graphql operation)
                 }
                 limit {
                     counter = "BRANCH"

--- a/servers/graphql-kotlin-spring-server/build.gradle.kts
+++ b/servers/graphql-kotlin-spring-server/build.gradle.kts
@@ -32,11 +32,7 @@ tasks {
                 limit {
                     counter = "INSTRUCTION"
                     value = "COVEREDRATIO"
-<<<<<<< HEAD
-                    minimum = "0.91".toBigDecimal()
-=======
                     minimum = "0.85".toBigDecimal()
->>>>>>> ad727d45e (feat: SingletonPropertyDataFetcher, avoid allocating a PropertyDataFetcher per property per graphql operation)
                 }
                 limit {
                     counter = "BRANCH"

--- a/servers/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/server/spring/GraphQLExecutionConfiguration.kt
+++ b/servers/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/server/spring/GraphQLExecutionConfiguration.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Expedia, Inc
+ * Copyright 2025 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servers/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/server/spring/execution/SpringKotlinDataFetcherFactoryProvider.kt
+++ b/servers/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/server/spring/execution/SpringKotlinDataFetcherFactoryProvider.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Expedia, Inc
+ * Copyright 2025 Expedia, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,17 +17,30 @@
 package com.expediagroup.graphql.server.spring.execution
 
 import com.expediagroup.graphql.generator.execution.SimpleKotlinDataFetcherFactoryProvider
+import com.expediagroup.graphql.generator.execution.SimpleSingletonKotlinDataFetcherFactoryProvider
 import graphql.schema.DataFetcherFactory
 import org.springframework.context.ApplicationContext
+import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
 
 /**
  * This provides a wrapper around the [SimpleKotlinDataFetcherFactoryProvider] to call the [SpringDataFetcher] on functions.
- * This allows you to use Spring beans as function arugments and they will be populated by the data fetcher.
+ * This allows you to use Spring beans as function arguments, and they will be populated by the data fetcher.
  */
-class SpringKotlinDataFetcherFactoryProvider(
+open class SpringKotlinDataFetcherFactoryProvider(
     private val applicationContext: ApplicationContext
 ) : SimpleKotlinDataFetcherFactoryProvider() {
+    override fun functionDataFetcherFactory(target: Any?, kFunction: KFunction<*>): DataFetcherFactory<Any?> =
+        DataFetcherFactory { SpringDataFetcher(target, kFunction, applicationContext) }
+}
+
+/**
+ * This provides a wrapper around the [SimpleSingletonKotlinDataFetcherFactoryProvider] to call the [SpringDataFetcher] on functions.
+ * This allows you to use Spring beans as function arguments, and they will be populated by the data fetcher.
+ */
+open class SpringSingletonKotlinDataFetcherFactoryProvider(
+    private val applicationContext: ApplicationContext
+) : SimpleSingletonKotlinDataFetcherFactoryProvider() {
     override fun functionDataFetcherFactory(target: Any?, kFunction: KFunction<*>): DataFetcherFactory<Any?> =
         DataFetcherFactory { SpringDataFetcher(target, kFunction, applicationContext) }
 }

--- a/servers/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/server/spring/execution/SpringKotlinDataFetcherFactoryProvider.kt
+++ b/servers/graphql-kotlin-spring-server/src/main/kotlin/com/expediagroup/graphql/server/spring/execution/SpringKotlinDataFetcherFactoryProvider.kt
@@ -20,7 +20,6 @@ import com.expediagroup.graphql.generator.execution.SimpleKotlinDataFetcherFacto
 import com.expediagroup.graphql.generator.execution.SimpleSingletonKotlinDataFetcherFactoryProvider
 import graphql.schema.DataFetcherFactory
 import org.springframework.context.ApplicationContext
-import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
 
 /**


### PR DESCRIPTION
### :pencil: Description
cherry-pick https://github.com/ExpediaGroup/graphql-kotlin/pull/2079