### PR TITLE
fix: fix integration test with missing junit-platform-launcher

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,6 +32,7 @@ commons-codec = { strictly = "[1.13, 2[", prefer = "1.16.0" }
 compile-testing = "0.5.1"
 icu = "75.1"
 junit = "5.10.2"
+junit-platform = "1.10.1"
 logback = "1.5.6"
 mockk = "1.13.13"
 rxjava = "3.1.8"
@@ -89,6 +90,7 @@ spring-webflux = { group = "org.springframework", name = "spring-webflux", versi
 spring-context = { group = "org.springframework", name = "spring-context", version.ref = "spring" }
 fastjson2 = { group = "com.alibaba.fastjson2", name = "fastjson2-kotlin", version.ref = "fastjson2" }
 fastjson2-spring = { group = "com.alibaba.fastjson2", name = "fastjson2-extension-spring6", version.ref = "fastjson2" }
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junit-platform" }
 
 # security vulnerabilities overrides
 commons-codec = { group = "commons-codec", name = "commons-codec", version.ref = "commons-codec" }

--- a/integration/graalvm/maven-graalvm-server/build.gradle.kts
+++ b/integration/graalvm/maven-graalvm-server/build.gradle.kts
@@ -23,7 +23,7 @@ tasks {
     val mavenEnvironmentVariables = mapOf(
         "graphqlKotlinVersion" to project.ext["version"],
         "graphqlJavaVersion" to libs.versions.graphql.java.get(),
-        "junitVersion" to libs.versions.junit.get(),
+        "junitVersion" to libs.versions.junit.asProvider().get(),
         "kotlinJvmTarget" to kotlinJvmVersion,
         "kotlinVersion" to libs.versions.kotlin.get(),
         "ktorVersion" to libs.versions.ktor.get(),

--- a/integration/maven-plugin-integration-tests/build.gradle.kts
+++ b/integration/maven-plugin-integration-tests/build.gradle.kts
@@ -44,7 +44,7 @@ tasks {
         "kotlinxSerializationVersion" to libs.versions.kotlinx.serialization.get(),
         "ktorVersion" to libs.versions.ktor.get(),
         "reactorVersion" to libs.versions.reactor.core.get(),
-        "junitVersion" to libs.versions.junit.get()
+        "junitVersion" to libs.versions.junit.asProvider().get()
     )
     var wireMockServer: WireMockServerRunner? = null
     var wireMockServerPort: Int? = null

--- a/plugins/schema/graphql-kotlin-sdl-generator/build.gradle.kts
+++ b/plugins/schema/graphql-kotlin-sdl-generator/build.gradle.kts
@@ -22,6 +22,7 @@ testing {
         val integrationTest by registering(JvmTestSuite::class) {
             dependencies {
                 implementation(project())
+                implementation(libs.junit.platform.launcher)
             }
 
             targets {

--- a/plugins/server/graphql-kotlin-graalvm-metadata-generator/build.gradle.kts
+++ b/plugins/server/graphql-kotlin-graalvm-metadata-generator/build.gradle.kts
@@ -21,6 +21,7 @@ testing {
         val integrationTest by registering(JvmTestSuite::class) {
             dependencies {
                 implementation(project())
+                implementation(libs.junit.platform.launcher)
             }
 
             targets {


### PR DESCRIPTION
Fix integration test

Keep running issues with this error for `:graphql-kotlin-sdl-generator:integrationTest` and `:graphql-kotlin-graalvm-metadata-generator:integrationTest`

<img width="1395" alt="image" src="https://github.com/user-attachments/assets/f9dbc2af-0036-4ac2-a510-fa50e99f9dfd" />
