### PR TITLE
fix: register getter on runtime when field is of a parent type (#2091)

### DIFF
--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/execution/KotlinDataFetcherFactoryProvider.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/execution/KotlinDataFetcherFactoryProvider.kt
@@ -64,10 +64,12 @@ open class SimpleKotlinDataFetcherFactoryProvider : KotlinDataFetcherFactoryProv
 }
 
 /**
- * [SimpleSingletonKotlinDataFetcherFactoryProvider] is a specialization of [SimpleKotlinDataFetcherFactoryProvider] that will provide a
+ * [SimpleSingletonKotlinDataFetcherFactoryProvider] is a specialization of [SimpleKotlinDataFetcherFactoryProvider] that will provide
  * a [SingletonPropertyDataFetcher] that should be used to target property resolutions without allocating a DataFetcher per property
  */
 open class SimpleSingletonKotlinDataFetcherFactoryProvider : SimpleKotlinDataFetcherFactoryProvider() {
     override fun propertyDataFetcherFactory(kClass: KClass<*>, kProperty: KProperty<*>): DataFetcherFactory<Any?> =
-        SingletonPropertyDataFetcher.getFactoryAndRegister(kClass, kProperty)
+        SingletonPropertyDataFetcher.factory.also {
+            SingletonPropertyDataFetcher.register(kClass, kProperty)
+        }
 }

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/execution/SingletonPropertyDataFetcher.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/execution/SingletonPropertyDataFetcher.kt
@@ -5,25 +5,26 @@ import graphql.schema.DataFetcherFactory
 import graphql.schema.DataFetchingEnvironment
 import graphql.schema.GraphQLFieldDefinition
 import graphql.schema.LightDataFetcher
+import org.slf4j.LoggerFactory
 import java.util.concurrent.ConcurrentHashMap
 import java.util.function.Supplier
 import kotlin.reflect.KClass
 import kotlin.reflect.KProperty
+import kotlin.reflect.full.memberProperties
 
 /**
  * Singleton Property [DataFetcher] that stores references to underlying properties getters.
  */
 internal object SingletonPropertyDataFetcher : LightDataFetcher<Any?> {
 
-    private val factory: DataFetcherFactory<Any?> = DataFetcherFactory<Any?> { SingletonPropertyDataFetcher }
-
+    private val logger = LoggerFactory.getLogger(SingletonPropertyDataFetcher::class.java)
+    val factory: DataFetcherFactory<Any?> = DataFetcherFactory<Any?> { SingletonPropertyDataFetcher }
     private val getters: ConcurrentHashMap<String, KProperty.Getter<*>> = ConcurrentHashMap()
 
-    fun getFactoryAndRegister(kClass: KClass<*>, kProperty: KProperty<*>): DataFetcherFactory<Any?> {
+    fun register(kClass: KClass<*>, kProperty: KProperty<*>) {
         getters.computeIfAbsent("${kClass.java.name}.${kProperty.name}") {
             kProperty.getter
         }
-        return factory
     }
 
     override fun get(
@@ -32,7 +33,17 @@ internal object SingletonPropertyDataFetcher : LightDataFetcher<Any?> {
         environmentSupplier: Supplier<DataFetchingEnvironment>
     ): Any? =
         sourceObject?.let {
-            getters["${sourceObject.javaClass.name}.${fieldDefinition.name}"]?.call(sourceObject)
+            getters["${sourceObject.javaClass.name}.${fieldDefinition.name}"]?.call(sourceObject) ?: run {
+                sourceObject::class.memberProperties
+                    .find { it.name == fieldDefinition.name }
+                    ?.let { kProperty ->
+                        kProperty.getter.call(sourceObject).also {
+                            register(sourceObject::class, kProperty)
+                        }
+                    }
+            } ?: run {
+                logger.error("getter method not found: ${sourceObject.javaClass.name}.${fieldDefinition.name}")
+            }
         }
 
     override fun get(environment: DataFetchingEnvironment): Any? =


### PR DESCRIPTION
### :pencil: Description
Adding a missing use case when the registered resolver during schema generation is from a Parent class, while on runtime the resolve object could be an instance of a Child class, as a result, the resolver won't be available in the getters cache.

This PR will attempt to resolve the getter using reflection and it will store it in the getters cache, if not getter found after checking the cache and checking the object class with reflection then a message log will be printed

cherry pick https://github.com/ExpediaGroup/graphql-kotlin/pull/2091