### PR TITLE
Upgrade federation from v5.2.0 to v5.5.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 android-plugin = "8.5.0"
 classgraph = "4.8.174"
 dataloader = "4.0.0"
-federation = "5.2.0"
+federation = "5.5.0"
 graphql-java = "23.1"
 graalvm = "0.10.2"
 jackson = "2.17.1"


### PR DESCRIPTION
### :pencil: Description
This adds Federation v2.12 support, the ability to propagate HTTP headers with callbacks, and (most urgently for my use case) rolls back the protobuf dependency from v4 to v3. (Classes generated with protobuf v3 are compatible with both v3 and v4, which is not the case for v4.)

https://github.com/apollographql/federation-jvm/releases/tag/v5.3.0
https://github.com/apollographql/federation-jvm/releases/tag/v5.4.0
https://github.com/apollographql/federation-jvm/releases/tag/v5.5.0


### :link: Related Issues
