### PR TITLE
fix(docs): update Ktor routing example to use `routing` DSL instead of `install(Routing)`

### DIFF
--- a/website/docs/server/ktor-server/ktor-overview.mdx
+++ b/website/docs/server/ktor-server/ktor-overview.mdx
@@ -63,7 +63,7 @@ fun Application.graphQLModule() {
             )
         }
     }
-    install(Routing) {
+    routing {
         graphQLPostRoute()
     }
     install(StatusPages) {


### PR DESCRIPTION
### :pencil: Description

The sample code in the Ktor overview documentation does not work:

https://opensource.expediagroup.com/graphql-kotlin/docs/server/ktor-server/ktor-overview

This appears to be related to missing support for Ktor v3.x.x (see #2037).

I updated the sample code so that it builds successfully with the current version.

### :link: Related Issues

- https://github.com/ExpediaGroup/graphql-kotlin/issues/2037