### PR TITLE
feat: Add extension, public method for coercing DataFetchingEnvironment arguments with Kotlin reflection

### DIFF
--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/execution/convertArgumentValue.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/execution/convertArgumentValue.kt
@@ -39,11 +39,14 @@ import kotlin.reflect.full.primaryConstructor
  * (e.g. custom scalars that graphql-java has already parsed) are passed through as-is.
  *
  * This is the same coercion path used internally by [FunctionDataFetcher] for resolver parameters.
- * For use in instrumentation or custom data fetcher code, prefer the
- * `getArgumentsAs` extension on `DataFetchingEnvironment` in
+ *
+ * Use this when you have already extracted a specific argument value from
+ * [graphql.schema.DataFetchingEnvironment.getArguments] and need to coerce it to a typed object.
+ * When coercing the full arguments map (e.g. in a custom [graphql.schema.DataFetcher]),
+ * prefer the `getArgumentsAs` extension on `DataFetchingEnvironment` in
  * `com.expediagroup.graphql.generator.extensions`.
  */
-internal fun <T : Any> convertInputMap(input: Map<String, *>, targetClass: KClass<T>): T =
+fun <T : Any> convertInputMap(input: Map<String, *>, targetClass: KClass<T>): T =
     mapToKotlinObject(input, targetClass)
 
 /**

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/execution/convertArgumentValue.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/execution/convertArgumentValue.kt
@@ -31,9 +31,25 @@ import kotlin.reflect.KType
 import kotlin.reflect.full.primaryConstructor
 
 /**
+ * Convert a raw GraphQL argument map into a typed Kotlin object using Kotlin reflection.
+ *
+ * Uses [KClass.primaryConstructor] (Kotlin-side reflection) to construct the target object.
+ * Field names are resolved using [@GraphQLName][com.expediagroup.graphql.generator.annotations.GraphQLName]
+ * or the Kotlin parameter name — the same logic used to build the schema. Already-coerced values
+ * (e.g. custom scalars that graphql-java has already parsed) are passed through as-is.
+ *
+ * This is the same coercion path used internally by [FunctionDataFetcher] for resolver parameters.
+ * For use in instrumentation or custom data fetcher code, prefer the
+ * `getArgumentsAs` extension on `DataFetchingEnvironment` in
+ * `com.expediagroup.graphql.generator.extensions`.
+ */
+internal fun <T : Any> convertInputMap(input: Map<String, *>, targetClass: KClass<T>): T =
+    mapToKotlinObject(input, targetClass)
+
+/**
  * Convert the argument from the argument map to a class we can pass to the Kotlin function.
  */
-internal fun convertArgumentValue(
+fun convertArgumentValue(
     argumentName: String,
     param: KParameter,
     argumentMap: Map<String, Any?>

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/extensions/DataFetchingEnvironmentExtensions.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/extensions/DataFetchingEnvironmentExtensions.kt
@@ -23,6 +23,9 @@ import kotlin.reflect.KClass
 /**
  * Coerces [DataFetchingEnvironment.getArguments] into a typed Kotlin object using Kotlin reflection.
  *
+ * The target class must match the top-level shape of the arguments map: its constructor parameters
+ * must correspond to GraphQL argument names.
+ *
  * Field names are resolved using [@GraphQLName][com.expediagroup.graphql.generator.annotations.GraphQLName]
  * or the Kotlin parameter name — the same logic used to build the schema. Already-coerced values
  * (e.g. custom scalars that graphql-java has already parsed) are passed through as-is.

--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/extensions/DataFetchingEnvironmentExtensions.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/extensions/DataFetchingEnvironmentExtensions.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2024 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.generator.extensions
+
+import com.expediagroup.graphql.generator.execution.convertInputMap
+import graphql.schema.DataFetchingEnvironment
+import kotlin.reflect.KClass
+
+/**
+ * Coerces [DataFetchingEnvironment.getArguments] into a typed Kotlin object using Kotlin reflection.
+ *
+ * Field names are resolved using [@GraphQLName][com.expediagroup.graphql.generator.annotations.GraphQLName]
+ * or the Kotlin parameter name — the same logic used to build the schema. Already-coerced values
+ * (e.g. custom scalars that graphql-java has already parsed) are passed through as-is.
+ *
+ * This is the same coercion path that [com.expediagroup.graphql.generator.execution.FunctionDataFetcher]
+ * uses internally for resolver parameters, and is the correct alternative to `ObjectMapper.convertValue`
+ * for use in instrumentation or custom data fetcher code.
+ */
+fun <T : Any> DataFetchingEnvironment.getArgumentsAs(targetClass: KClass<T>): T =
+    convertInputMap(arguments, targetClass)
+
+/**
+ * Coerces [DataFetchingEnvironment.getArguments] into a typed Kotlin object using Kotlin reflection.
+ *
+ * @see getArgumentsAs
+ */
+inline fun <reified T : Any> DataFetchingEnvironment.getArgumentsAs(): T =
+    getArgumentsAs(T::class)

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/execution/ConvertArgumentValueTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/execution/ConvertArgumentValueTest.kt
@@ -28,6 +28,46 @@ import kotlin.test.assertNotNull
 
 class ConvertArgumentValueTest {
     @Test
+    fun `convertInputMap converts flat map to data class`() {
+        val result = convertInputMap(mapOf("foo" to "hello", "bar" to "world"), TestInput::class)
+        assertEquals("hello", result.foo)
+        assertEquals("world", result.bar)
+    }
+
+    @Test
+    fun `convertInputMap uses default values for missing fields`() {
+        val result = convertInputMap(mapOf("foo" to "hello"), TestInput::class)
+        assertEquals("hello", result.foo)
+        assertEquals(null, result.bar)
+        assertEquals(null, result.baz)
+    }
+
+    @Test
+    fun `convertInputMap handles nested objects`() {
+        val result = convertInputMap(
+            mapOf("nested" to mapOf("value" to "custom")),
+            TestInputNested::class
+        )
+        assertEquals("foo", result.foo)
+        assertEquals("custom", result.nested?.value)
+    }
+
+    @Test
+    fun `convertInputMap passes through already-coerced field values`() {
+        // Simulates what environment.arguments looks like in instrumentation code after
+        // graphql-java has run custom scalar coercers: the scalar field is already the
+        // target type object, not a raw string.  convertInputMap passes it through as-is
+        // via the "value is already parsed" branch.
+        val preCoercedId = ID("already-coerced")
+        val result = convertInputMap(
+            mapOf("foo" to "hello", "id" to preCoercedId),
+            TestInputNullableScalar::class
+        )
+        assertEquals("hello", result.foo)
+        assertEquals(preCoercedId, result.id)
+    }
+
+    @Test
     fun `string input is parsed`() {
         val kParam = assertNotNull(TestFunctions::stringInput.findParameterByName("input"))
         val result = convertArgumentValue("input", kParam, mapOf("input" to "hello"))

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/extensions/DataFetchingEnvironmentExtensionsTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/extensions/DataFetchingEnvironmentExtensionsTest.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2024 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.generator.extensions
+
+import com.expediagroup.graphql.generator.annotations.GraphQLName
+import graphql.schema.DataFetchingEnvironment
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class DataFetchingEnvironmentExtensionsTest {
+
+    data class SimpleInput(val foo: String, val bar: String? = null)
+    data class RenamedInput(@GraphQLName("baz") val foo: String)
+    data class NestedInput(val inner: SimpleInput, val tag: String)
+
+    @Test
+    fun `getArgumentsAs coerces arguments to typed Kotlin object`() {
+        val environment = mockk<DataFetchingEnvironment> {
+            every { arguments } returns mapOf("foo" to "hello", "bar" to "world")
+        }
+
+        val result = environment.getArgumentsAs<SimpleInput>()
+
+        assertEquals("hello", result.foo)
+        assertEquals("world", result.bar)
+    }
+
+    @Test
+    fun `getArgumentsAs respects default parameter values for absent fields`() {
+        val environment = mockk<DataFetchingEnvironment> {
+            every { arguments } returns mapOf("foo" to "hello")
+        }
+
+        val result = environment.getArgumentsAs(SimpleInput::class)
+
+        assertEquals("hello", result.foo)
+        assertEquals(null, result.bar)
+    }
+
+    @Test
+    fun `getArgumentsAs resolves field names via GraphQLName`() {
+        val environment = mockk<DataFetchingEnvironment> {
+            every { arguments } returns mapOf("baz" to "renamed")
+        }
+
+        val result = environment.getArgumentsAs<RenamedInput>()
+
+        assertEquals("renamed", result.foo)
+    }
+
+    @Test
+    fun `getArgumentsAs passes through already-coerced field values`() {
+        // Simulates what environment.arguments looks like after graphql-java has run
+        // custom scalar coercers — the field value is already the target type, not a raw string.
+        val preCoerced = SimpleInput("already", "coerced")
+        val environment = mockk<DataFetchingEnvironment> {
+            every { arguments } returns mapOf("inner" to preCoerced, "tag" to "test")
+        }
+
+        val result = environment.getArgumentsAs<NestedInput>()
+
+        assertEquals(preCoerced, result.inner)
+        assertEquals("test", result.tag)
+    }
+}

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/test/integration/PlainKotlinInputWithCustomScalarTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/test/integration/PlainKotlinInputWithCustomScalarTest.kt
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2024 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.generator.test.integration
+
+import com.expediagroup.graphql.generator.TopLevelObject
+import com.expediagroup.graphql.generator.execution.convertInputMap
+import com.expediagroup.graphql.generator.getTestSchemaConfigWithHooks
+import com.expediagroup.graphql.generator.hooks.SchemaGeneratorHooks
+import com.expediagroup.graphql.generator.test.utils.graphqlUUIDType
+import com.expediagroup.graphql.generator.toSchema
+import graphql.GraphQL
+import graphql.schema.GraphQLType
+import org.junit.jupiter.api.Test
+import java.util.UUID
+import kotlin.reflect.KClass
+import kotlin.reflect.KType
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Verifies that plain Kotlin data classes whose fields include custom scalars are correctly
+ * coerced by both:
+ *
+ *   1. [FunctionDataFetcher] (the resolver parameter path, via KClass.primaryConstructor), and
+ *
+ *   2. [getArgumentsAs] called on a [DataFetchingEnvironment] (the instrumentation path,
+ *      which uses the same Kotlin reflection coercion as the resolver path).
+ *
+ * UUID is used as a stand-in for any custom scalar that graphql-java coerces before
+ * instrumentation code accesses environment.arguments.
+ */
+class PlainKotlinInputWithCustomScalarTest {
+
+    // No @GraphQLName — field names resolve to Kotlin parameter names.
+    data class RequestContext(
+        val requestId: UUID,
+        val userId: String,
+        val depth: Int = 0
+    )
+
+    data class NestedContext(
+        val outer: RequestContext,
+        val tag: String
+    )
+
+    class ContextQuery {
+        fun processContext(context: RequestContext): String =
+            "id=${context.requestId},user=${context.userId},depth=${context.depth}"
+
+        fun processNestedContext(context: NestedContext): String =
+            "tag=${context.tag},id=${context.outer.requestId},user=${context.outer.userId}"
+    }
+
+    private val schema = toSchema(
+        queries = listOf(TopLevelObject(ContextQuery())),
+        config = getTestSchemaConfigWithHooks(object : SchemaGeneratorHooks {
+            override fun willGenerateGraphQLType(type: KType): GraphQLType? =
+                when (type.classifier as? KClass<*>) {
+                    UUID::class -> graphqlUUIDType
+                    else -> null
+                }
+        })
+    )
+
+    private val graphQL = GraphQL.newGraphQL(schema).build()
+
+    @Test
+    fun `plain data class with custom scalar field resolves correctly end-to-end`() {
+        val result = graphQL.execute(
+            """{ processContext(context: { requestId: "550e8400-e29b-41d4-a716-446655440000", userId: "alice", depth: 0 }) }"""
+        )
+        assertNull(result.errors.firstOrNull(), "Expected no errors but got: ${result.errors}")
+        val data: Map<String, String> = result.getData()
+        assertEquals(
+            "id=550e8400-e29b-41d4-a716-446655440000,user=alice,depth=0",
+            data["processContext"]
+        )
+    }
+
+    @Test
+    fun `plain data class with nested custom scalar resolves correctly end-to-end`() {
+        val result = graphQL.execute(
+            """{ processNestedContext(context: { outer: { requestId: "550e8400-e29b-41d4-a716-446655440000", userId: "bob", depth: 0 }, tag: "test" }) }"""
+        )
+        assertNull(result.errors.firstOrNull(), "Expected no errors but got: ${result.errors}")
+        val data: Map<String, String> = result.getData()
+        assertEquals(
+            "tag=test,id=550e8400-e29b-41d4-a716-446655440000,user=bob",
+            data["processNestedContext"]
+        )
+    }
+
+    @Test
+    fun `coercion correctly handles pre-coerced custom scalar field`() {
+        // This is the instrumentation scenario: by the time beginFieldFetch is called,
+        // graphql-java has already run the scalar coercer so the UUID field in
+        // environment.arguments is already a UUID object, not a string.
+        val preCoercedId = UUID.fromString("550e8400-e29b-41d4-a716-446655440000")
+        val result = convertInputMap(
+            mapOf("requestId" to preCoercedId, "userId" to "alice"),
+            RequestContext::class
+        )
+
+        assertEquals(preCoercedId, result.requestId)
+        assertEquals("alice", result.userId)
+        assertEquals(0, result.depth)
+    }
+
+    @Test
+    fun `coercion correctly handles nested pre-coerced custom scalar field`() {
+        val preCoercedId = UUID.fromString("550e8400-e29b-41d4-a716-446655440000")
+        val result = convertInputMap(
+            mapOf("outer" to mapOf("requestId" to preCoercedId, "userId" to "bob"), "tag" to "instrumentation"),
+            NestedContext::class
+        )
+
+        assertEquals(preCoercedId, result.outer.requestId)
+        assertEquals("bob", result.outer.userId)
+        assertEquals("instrumentation", result.tag)
+    }
+}

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/test/integration/PlainKotlinInputWithCustomScalarTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/test/integration/PlainKotlinInputWithCustomScalarTest.kt
@@ -33,15 +33,18 @@ import kotlin.test.assertNull
 
 /**
  * Verifies that plain Kotlin data classes whose fields include custom scalars are correctly
- * coerced by both:
+ * coerced in both of the scenarios covered by this test class:
  *
- *   1. [FunctionDataFetcher] (the resolver parameter path, via KClass.primaryConstructor), and
+ *   1. the resolver parameter path exercised end-to-end via [graphql.GraphQL.execute], where
+ *      [com.expediagroup.graphql.generator.execution.FunctionDataFetcher] maps GraphQL input
+ *      objects to Kotlin constructor parameters, and
  *
- *   2. [getArgumentsAs] called on a [DataFetchingEnvironment] (the instrumentation path,
- *      which uses the same Kotlin reflection coercion as the resolver path).
+ *   2. the direct input-map conversion path exercised through
+ *      [com.expediagroup.graphql.generator.execution.convertInputMap], which uses the same
+ *      Kotlin reflection-based coercion logic for nested input objects and custom scalars.
  *
- * UUID is used as a stand-in for any custom scalar that graphql-java coerces before
- * instrumentation code accesses environment.arguments.
+ * UUID is used as a stand-in for any custom scalar that graphql-java coerces before these
+ * coercion paths consume the input values.
  */
 class PlainKotlinInputWithCustomScalarTest {
 

--- a/website/docs/schema-generator/execution/data-fetching-environment.md
+++ b/website/docs/schema-generator/execution/data-fetching-environment.md
@@ -76,15 +76,22 @@ For example an SQL backed system may be able to use the field selection to only 
 
 `environment.arguments` returns a `Map<String, Any?>`. By the time your code sees this map, graphql-java has already run all custom scalar coercers, so scalar fields are already in their target JVM types — not raw strings.
 
-If you need to coerce this map into a typed Kotlin object (for example, in instrumentation or a custom `DataFetcher`), use the `getArgumentsAs` extension function from `graphql-kotlin-schema-generator`:
+These utilities use `KClass.primaryConstructor` (Kotlin-side reflection), which means they:
+- correctly pass through field values that graphql-java has already coerced (custom scalars, etc.)
+- resolve field names using `@GraphQLName` or the Kotlin parameter name — the same logic used to build the schema
+- respect Kotlin default parameter values for fields absent from the map
+
+This is the same coercion path that `FunctionDataFetcher` uses internally for resolver parameters.
+
+`ObjectMapper.convertValue` is not a suitable alternative: it resolves field names via Jackson annotations or naming strategies rather than `@GraphQLName`, and it will attempt to re-deserialize values that graphql-java has already coerced.
+
+### Coercing the full arguments map
+
+Use `getArgumentsAs` from `com.expediagroup.graphql.generator.extensions` when you want to coerce all arguments on a field at once. The target class constructor parameters must correspond directly to the GraphQL argument names on the field.
 
 ```kotlin
 import com.expediagroup.graphql.generator.extensions.getArgumentsAs
 ```
-
-`getArgumentsAs` coerces the **full** `environment.arguments` map. The target class constructor parameters must correspond directly to the GraphQL argument names on the field.
-
-For a field with multiple scalar arguments:
 
 ```graphql
 type Query {
@@ -98,26 +105,24 @@ data class SearchArgs(val query: String, val limit: Int)
 val args = environment.getArgumentsAs<SearchArgs>()
 ```
 
-For a field with a single complex input argument, wrap it:
+### Coercing a single argument value
 
-```graphql
-type Query {
-  processContext(context: RequestContext!): String!
-}
+In instrumentation or library code where you dynamically inspect a field's arguments, you often need to coerce a specific argument's value rather than the full arguments map. Use `convertInputMap` from `com.expediagroup.graphql.generator.execution` for this:
+
+```kotlin
+import com.expediagroup.graphql.generator.execution.convertInputMap
 ```
 
 ```kotlin
-data class ProcessContextArgs(val context: RequestContext)
+// In an Instrumentation.beginFieldFetch implementation:
+val targetArgument = parameters.environment.fieldDefinition.arguments
+    .find { it.type.deepName == "MyInput!" }
 
-val args = environment.getArgumentsAs<ProcessContextArgs>()
-val context = args.context
+targetArgument?.let {
+    val rawMap = parameters.environment.arguments[it.name] as? Map<String, *>
+    if (rawMap != null) {
+        val input = convertInputMap(rawMap, MyInput::class)
+        // use input ...
+    }
+}
 ```
-
-`getArgumentsAs` uses `KClass.primaryConstructor` (Kotlin-side reflection), which means it:
-- correctly passes through field values that graphql-java has already coerced (custom scalars, etc.)
-- resolves field names using `@GraphQLName` or the Kotlin parameter name — the same logic used to build the schema
-- respects Kotlin default parameter values for fields absent from the map
-
-This is the same coercion path that `FunctionDataFetcher` uses internally for resolver parameters.
-
-`ObjectMapper.convertValue` is not a suitable alternative here: it resolves field names via Jackson annotations or naming strategies rather than `@GraphQLName`, and it will attempt to re-deserialize values that graphql-java has already coerced.

--- a/website/docs/schema-generator/execution/data-fetching-environment.md
+++ b/website/docs/schema-generator/execution/data-fetching-environment.md
@@ -71,3 +71,24 @@ class ProductQueryService : Query {
 You can also use `selectionSet` to access the selected fields of the current field. It can be useful to know which selections have been requested so the data fetcher can optimize the data access queries. For example, in an SQL-backed system, the data fetcher can access the database and use the field selection criteria to specifically retrieve only the columns that have been requested by the client.
 what selection has been asked for so the data fetcher can optimise the data access queries.
 For example an SQL backed system may be able to use the field selection to only retrieve the columns that have been asked for.
+
+## Coercing Arguments to Typed Objects
+
+`environment.arguments` returns a `Map<String, Any?>`. By the time your code sees this map, graphql-java has already run all custom scalar coercers, so scalar fields are already their target JVM types — not raw strings.
+
+If you need to coerce this map into a typed Kotlin object (for example, in instrumentation or a custom `DataFetcher`), use the `getArgumentsAs` extension function from `graphql-kotlin-schema-generator`:
+
+```kotlin
+import com.expediagroup.graphql.generator.extensions.getArgumentsAs
+
+val context = environment.getArgumentsAs<MyInputClass>()
+```
+
+`getArgumentsAs` uses `KClass.primaryConstructor` (Kotlin-side reflection), which means it:
+- correctly passes through field values that graphql-java has already coerced (custom scalars, etc.)
+- resolves field names using `@GraphQLName` or the Kotlin parameter name — the same logic used to build the schema
+- respects Kotlin default parameter values for fields absent from the map
+
+This is the same coercion path that `FunctionDataFetcher` uses internally for resolver parameters.
+
+`ObjectMapper.convertValue` is not a suitable alternative here: it resolves field names via Jackson annotations or naming strategies rather than `@GraphQLName`, and it will attempt to re-deserialize values that graphql-java has already coerced.

--- a/website/docs/schema-generator/execution/data-fetching-environment.md
+++ b/website/docs/schema-generator/execution/data-fetching-environment.md
@@ -80,8 +80,37 @@ If you need to coerce this map into a typed Kotlin object (for example, in instr
 
 ```kotlin
 import com.expediagroup.graphql.generator.extensions.getArgumentsAs
+```
 
-val context = environment.getArgumentsAs<MyInputClass>()
+`getArgumentsAs` coerces the **full** `environment.arguments` map. The target class constructor parameters must correspond directly to the GraphQL argument names on the field.
+
+For a field with multiple scalar arguments:
+
+```graphql
+type Query {
+  search(query: String!, limit: Int!): [Result!]!
+}
+```
+
+```kotlin
+data class SearchArgs(val query: String, val limit: Int)
+
+val args = environment.getArgumentsAs<SearchArgs>()
+```
+
+For a field with a single complex input argument, wrap it:
+
+```graphql
+type Query {
+  processContext(context: RequestContext!): String!
+}
+```
+
+```kotlin
+data class ProcessContextArgs(val context: RequestContext)
+
+val args = environment.getArgumentsAs<ProcessContextArgs>()
+val context = args.context
 ```
 
 `getArgumentsAs` uses `KClass.primaryConstructor` (Kotlin-side reflection), which means it:

--- a/website/docs/schema-generator/execution/data-fetching-environment.md
+++ b/website/docs/schema-generator/execution/data-fetching-environment.md
@@ -74,7 +74,7 @@ For example an SQL backed system may be able to use the field selection to only 
 
 ## Coercing Arguments to Typed Objects
 
-`environment.arguments` returns a `Map<String, Any?>`. By the time your code sees this map, graphql-java has already run all custom scalar coercers, so scalar fields are already their target JVM types — not raw strings.
+`environment.arguments` returns a `Map<String, Any?>`. By the time your code sees this map, graphql-java has already run all custom scalar coercers, so scalar fields are already in their target JVM types — not raw strings.
 
 If you need to coerce this map into a typed Kotlin object (for example, in instrumentation or a custom `DataFetcher`), use the `getArgumentsAs` extension function from `graphql-kotlin-schema-generator`:
 


### PR DESCRIPTION
### :pencil: Description

Jackson 3's `jackson-module-kotlin` fails to construct Kotlin classes that lack proper creator
metadata when using `ObjectMapper.convertValue`. The failure path is in
[`ReflectionCache.valueCreatorFromJava`](https://github.com/FasterXML/jackson-module-kotlin/blob/448850e595e3a3f430e4622022bd0366db2521ac/src/main/kotlin/tools/jackson/module/kotlin/ReflectionCache.kt#L63-L79):
when `Constructor.kotlinFunction` returns `null` for a class (which occurs for classes compiled
with older Kotlin metadata under a newer `kotlin-reflect` runtime),
[`valueClassAwareKotlinFunction`](https://github.com/FasterXML/jackson-module-kotlin/blob/448850e595e3a3f430e4622022bd0366db2521ac/src/main/kotlin/tools/jackson/module/kotlin/ReflectionCache.kt#L115-L130)
propagates `null` up through `valueCreatorFromJava`, causing `KotlinValueInstantiator` to fall
back to a Java creator path that finds nothing — resulting in "no Creators... cannot deserialize
from Object value".

`FunctionDataFetcher` has never had this problem because it uses `KClass.primaryConstructor`
(Kotlin-side reflection) directly. This PR exposes that same coercion path as a public API.

**Changes:**
- Adds `DataFetchingEnvironment.getArgumentsAs<T>()` / `getArgumentsAs(KClass)` extension in
  `graphql-kotlin-schema-generator`'s `extensions` package — coerces the full arguments map
- Makes `convertInputMap(map, KClass)` public — coerces a single extracted argument value,
  for use in instrumentation or library code that inspects fields dynamically
- Both paths resolve field names via `@GraphQLName` or Kotlin parameter names and correctly
  pass through values already coerced by graphql-java's scalar pipeline
- Documents both utilities on the Data Fetching Environment page

**Migration:**
- To coerce all arguments on a field: replace `objectMapper.convertValue<MyArgs>(environment.arguments)`
  with `environment.getArgumentsAs<MyArgs>()`
- To coerce a single extracted argument value: replace `objectMapper.convertValue<MyInput>(rawMap)`
  with `convertInputMap(rawMap, MyInput::class)`

### :link: Related Issues
