### PR TITLE
feat(ktor-server): skip internal ContentNegotiation install when already configured

### DIFF
--- a/servers/graphql-kotlin-ktor-server/src/main/kotlin/com/expediagroup/graphql/server/ktor/GraphQLRoutes.kt
+++ b/servers/graphql-kotlin-ktor-server/src/main/kotlin/com/expediagroup/graphql/server/ktor/GraphQLRoutes.kt
@@ -21,6 +21,7 @@ import com.expediagroup.graphql.server.execution.subscription.GRAPHQL_WS_PROTOCO
 import io.ktor.http.ContentType
 import io.ktor.serialization.jackson3.jackson
 import io.ktor.server.application.plugin
+import io.ktor.server.application.pluginOrNull
 import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.server.response.respondText
 import io.ktor.server.routing.Route
@@ -33,40 +34,59 @@ import kotlinx.coroutines.flow.collect
 import tools.jackson.databind.json.JsonMapper
 
 /**
- * Configures GraphQL GET route
+ * Configures GraphQL GET route.
+ *
+ * Installs the Jackson `ContentNegotiation` plugin on the route scope. If the application has
+ * already installed `ContentNegotiation` at the application level, the route-scoped install is
+ * skipped and the existing configuration is reused — this avoids Ktor's `DuplicatePluginException`
+ * when the host application serves other JSON endpoints. In that case the provided
+ * [streamingResponse] and [jacksonConfiguration] arguments are not applied; callers that need
+ * custom Jackson settings should configure them on their application-level install.
  *
  * @param endpoint GraphQL server GET endpoint, defaults to 'graphql'
- * @param streamingResponse Enable streaming response body without keeping it fully in memory. If set to true (default) it will set `Transfer-Encoding: chunked` header on the responses.
- * @param jacksonConfiguration a configuration block for [JsonMapper.Builder], passed to ktor
+ * @param streamingResponse Enable streaming response body without keeping it fully in memory. If set to true (default) it will set `Transfer-Encoding: chunked` header on the responses. Ignored if `ContentNegotiation` is already installed at the application level.
+ * @param jacksonConfiguration a configuration block for [JsonMapper.Builder], passed to ktor. Ignored if `ContentNegotiation` is already installed at the application level.
  */
 fun Route.graphQLGetRoute(endpoint: String = "graphql", streamingResponse: Boolean = true, jacksonConfiguration: JsonMapper.Builder.() -> Unit = {}): Route {
     val graphQLPlugin = this.application.plugin(GraphQL)
     val route = get(endpoint) {
         graphQLPlugin.server.executeRequest(call)
     }
-    route.install(ContentNegotiation) {
-        jackson(streamRequestBody = streamingResponse) {
-            apply(jacksonConfiguration)
+    if (this.application.pluginOrNull(ContentNegotiation) == null) {
+        route.install(ContentNegotiation) {
+            jackson(streamRequestBody = streamingResponse) {
+                apply(jacksonConfiguration)
+            }
         }
     }
     return route
 }
 
 /**
- * Configures GraphQL POST route
+ * Configures GraphQL POST route.
+ *
+ * Installs the Jackson `ContentNegotiation` plugin on the route scope. If the application has
+ * already installed `ContentNegotiation` at the application level, the route-scoped install is
+ * skipped and the existing configuration is reused — this avoids Ktor's `DuplicatePluginException`
+ * when the host application serves other JSON endpoints (e.g. a global `StatusPages` handler
+ * returning JSON error responses). In that case the provided [streamingResponse] and
+ * [jacksonConfiguration] arguments are not applied; callers that need custom Jackson settings
+ * should configure them on their application-level install.
  *
  * @param endpoint GraphQL server POST endpoint, defaults to 'graphql'
- * @param streamingResponse Enable streaming response body without keeping it fully in memory. If set to true (default) it will set `Transfer-Encoding: chunked` header on the responses.
- * @param jacksonConfiguration a configuration block for [JsonMapper.Builder], passed to ktor
+ * @param streamingResponse Enable streaming response body without keeping it fully in memory. If set to true (default) it will set `Transfer-Encoding: chunked` header on the responses. Ignored if `ContentNegotiation` is already installed at the application level.
+ * @param jacksonConfiguration a configuration block for [JsonMapper.Builder], passed to ktor. Ignored if `ContentNegotiation` is already installed at the application level.
  */
 fun Route.graphQLPostRoute(endpoint: String = "graphql", streamingResponse: Boolean = true, jacksonConfiguration: JsonMapper.Builder.() -> Unit = {}): Route {
     val graphQLPlugin = this.application.plugin(GraphQL)
     val route = post(endpoint) {
         graphQLPlugin.server.executeRequest(call)
     }
-    route.install(ContentNegotiation) {
-        jackson(streamRequestBody = streamingResponse) {
-            apply(jacksonConfiguration)
+    if (this.application.pluginOrNull(ContentNegotiation) == null) {
+        route.install(ContentNegotiation) {
+            jackson(streamRequestBody = streamingResponse) {
+                apply(jacksonConfiguration)
+            }
         }
     }
     return route

--- a/servers/graphql-kotlin-ktor-server/src/main/kotlin/com/expediagroup/graphql/server/ktor/GraphQLRoutes.kt
+++ b/servers/graphql-kotlin-ktor-server/src/main/kotlin/com/expediagroup/graphql/server/ktor/GraphQLRoutes.kt
@@ -44,8 +44,11 @@ import tools.jackson.databind.json.JsonMapper
  * custom Jackson settings should configure them on their application-level install.
  *
  * @param endpoint GraphQL server GET endpoint, defaults to 'graphql'
- * @param streamingResponse Enable streaming response body without keeping it fully in memory. If set to true (default) it will set `Transfer-Encoding: chunked` header on the responses. Ignored if `ContentNegotiation` is already installed at the application level.
- * @param jacksonConfiguration a configuration block for [JsonMapper.Builder], passed to ktor. Ignored if `ContentNegotiation` is already installed at the application level.
+ * @param streamingResponse Enable streaming response body without keeping it fully in memory. If set to true (default)
+ *   it will set `Transfer-Encoding: chunked` header on the responses. Ignored if `ContentNegotiation` is already
+ *   installed at the application level.
+ * @param jacksonConfiguration a configuration block for [JsonMapper.Builder], passed to ktor. Ignored if
+ *   `ContentNegotiation` is already installed at the application level.
  */
 fun Route.graphQLGetRoute(endpoint: String = "graphql", streamingResponse: Boolean = true, jacksonConfiguration: JsonMapper.Builder.() -> Unit = {}): Route {
     val graphQLPlugin = this.application.plugin(GraphQL)
@@ -74,8 +77,11 @@ fun Route.graphQLGetRoute(endpoint: String = "graphql", streamingResponse: Boole
  * should configure them on their application-level install.
  *
  * @param endpoint GraphQL server POST endpoint, defaults to 'graphql'
- * @param streamingResponse Enable streaming response body without keeping it fully in memory. If set to true (default) it will set `Transfer-Encoding: chunked` header on the responses. Ignored if `ContentNegotiation` is already installed at the application level.
- * @param jacksonConfiguration a configuration block for [JsonMapper.Builder], passed to ktor. Ignored if `ContentNegotiation` is already installed at the application level.
+ * @param streamingResponse Enable streaming response body without keeping it fully in memory. If set to true (default)
+ *   it will set `Transfer-Encoding: chunked` header on the responses. Ignored if `ContentNegotiation` is already
+ *   installed at the application level.
+ * @param jacksonConfiguration a configuration block for [JsonMapper.Builder], passed to ktor. Ignored if
+ *   `ContentNegotiation` is already installed at the application level.
  */
 fun Route.graphQLPostRoute(endpoint: String = "graphql", streamingResponse: Boolean = true, jacksonConfiguration: JsonMapper.Builder.() -> Unit = {}): Route {
     val graphQLPlugin = this.application.plugin(GraphQL)

--- a/servers/graphql-kotlin-ktor-server/src/test/kotlin/com/expediagroup/graphql/server/ktor/GraphQLPluginTest.kt
+++ b/servers/graphql-kotlin-ktor-server/src/test/kotlin/com/expediagroup/graphql/server/ktor/GraphQLPluginTest.kt
@@ -256,6 +256,66 @@ class GraphQLPluginTest {
             assertContains(html, """var subscriptionUrl = new URL("/subscriptions", location.href);""")
         }
     }
+
+    @Test
+    fun `graphQLPostRoute should not duplicate ContentNegotiation when already installed at application level`() {
+        // Reproduces https://github.com/ExpediaGroup/graphql-kotlin/issues/2025: installing
+        // ContentNegotiation at both application and route scope would throw
+        // DuplicatePluginException. The route helpers now detect an existing application-level
+        // install and skip the route-scoped install.
+        testApplication {
+            application {
+                install(io.ktor.server.plugins.contentnegotiation.ContentNegotiation) {
+                    jackson()
+                }
+                install(GraphQL) {
+                    schema {
+                        packages = listOf("com.expediagroup.graphql.server.ktor")
+                        queries = listOf(TestQuery())
+                    }
+                }
+                routing {
+                    graphQLPostRoute()
+                }
+            }
+            val client = createClient {
+                install(ContentNegotiation) {
+                    jackson()
+                }
+            }
+            val response = client.post("/graphql") {
+                contentType(ContentType.Application.Json)
+                setBody(GraphQLRequest(query = "query HelloWorldQuery { hello }"))
+            }
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertEquals("""{"data":{"hello":"Hello World"}}""", response.bodyAsText().trim())
+        }
+    }
+
+    @Test
+    fun `graphQLGetRoute should not duplicate ContentNegotiation when already installed at application level`() {
+        testApplication {
+            application {
+                install(io.ktor.server.plugins.contentnegotiation.ContentNegotiation) {
+                    jackson()
+                }
+                install(GraphQL) {
+                    schema {
+                        packages = listOf("com.expediagroup.graphql.server.ktor")
+                        queries = listOf(TestQuery())
+                    }
+                }
+                routing {
+                    graphQLGetRoute()
+                }
+            }
+            val response = client.get("/graphql") {
+                parameter("query", "query HelloWorldQuery { hello }")
+            }
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertEquals("""{"data":{"hello":"Hello World"}}""", response.bodyAsText().trim())
+        }
+    }
 }
 
 fun Application.testGraphQLModule() {


### PR DESCRIPTION
### :pencil: Description

`Route.graphQLGetRoute()` and `Route.graphQLPostRoute()` unconditionally install `ContentNegotiation` on the route scope. When the host application has already installed `ContentNegotiation` at the application level — a common pattern when the app serves other JSON endpoints or uses `StatusPages` with JSON error responses — Ktor throws `DuplicatePluginException`:

```
Installing RouteScopedPlugin to application and route is not supported.
Consider moving application level install to routing root.
```

This PR makes the internal install conditional on `application.pluginOrNull(ContentNegotiation)`:

- If `ContentNegotiation` is already installed at the application level, the route-scoped install is skipped and the existing global configuration is reused.
- If no global install is present, behaviour is unchanged: the route-scoped install proceeds exactly as today, honouring `streamingResponse` and `jacksonConfiguration`.

When the global install wins, `streamingResponse` and `jacksonConfiguration` are not applied, since the application-level configuration takes precedence; this trade-off is documented in the KDoc for both routes.

No API change; fully backward compatible.

Added two regression tests in `GraphQLPluginTest` covering the globally-installed case for both the GET and POST routes.

### :link: Related Issues

Fixes #2025