### PR TITLE
docs(plugin-client): use tasks.registering instead of deprecated tasks.creating

### DIFF
--- a/website/docs/plugins/gradle-plugin-usage-client.mdx
+++ b/website/docs/plugins/gradle-plugin-usage-client.mdx
@@ -608,12 +608,12 @@ val graphqlGenerateClient by tasks.getting(GraphQLGenerateClientTask::class) {
     dependsOn("graphqlDownloadSDL")
 }
 
-val graphqlDownloadOtherSDL by tasks.creating(GraphQLDownloadSDLTask::class) {
+val graphqlDownloadOtherSDL by tasks.registering(GraphQLDownloadSDLTask::class) {
     endpoint.set("http://localhost:8081/sdl")
 }
-val graphqlGenerateOtherClient by tasks.creating(GraphQLGenerateClientTask::class) {
+val graphqlGenerateOtherClient by tasks.registering(GraphQLGenerateClientTask::class) {
     packageName.set("com.example.generated.second")
-    schemaFile.set(graphqlDownloadOtherSDL.outputFile)
+    schemaFile.set(graphqlDownloadOtherSDL.flatMap { it.outputFile })
     queryFiles.from("${project.projectDir}/src/main/resources/queries/MySecondQuery.graphql")
     dependsOn("graphqlDownloadOtherSDL")
 }


### PR DESCRIPTION
## Description

Gradle has deprecated the eager `tasks.creating(...)` configuration in favour of the lazy `tasks.registering(...)` task configuration avoidance API. The Kotlin DSL example in the *Generating Multiple Clients* section of the gradle client plugin docs still demonstrates the eager form (lines 611 and 614 of `website/docs/plugins/gradle-plugin-usage-client.mdx`), so readers who copy the snippet into their own `build.gradle.kts` get a deprecation warning from modern Gradle.

This change:

- switches the two `val NAME by tasks.creating(...)` declarations to `tasks.registering(...)`, which preserves the property-delegate idiom familiar to Kotlin DSL readers but produces a `TaskProvider<T>` so the task is configured lazily, and
- updates the inter-task wiring `schemaFile.set(graphqlDownloadOtherSDL.outputFile)` to `schemaFile.set(graphqlDownloadOtherSDL.flatMap { it.outputFile })`, since the property delegate now resolves to a `TaskProvider` rather than the realized task. Using `flatMap` keeps the upstream task lazy.

The `dependsOn("graphqlDownloadOtherSDL")` line is unchanged because Gradle resolves the task name string regardless of whether the producing task is realized eagerly or lazily.

Only the live docs path (`website/docs/...`) is touched. The historical Docusaurus snapshots under `website/versioned_docs/version-*` are intentionally left alone — those are immutable per-release archives and should reflect what was published at the time.

## Related Issues

Fixes #2077