### PR TITLE
fix(schema-generator): custom union lookup on deprecated properties

### DIFF
--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/extensions/annotationExtensions.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/extensions/annotationExtensions.kt
@@ -36,7 +36,7 @@ internal fun KAnnotatedElement.getDeprecationReason(): String? =
 
 internal fun KAnnotatedElement.isGraphQLIgnored(): Boolean = this.findAnnotation<GraphQLIgnore>() != null
 
-internal fun List<Annotation>.getUnionAnnotation(): GraphQLUnion? = this.filterIsInstance(GraphQLUnion::class.java).firstOrNull() ?: this.map { it.getMetaUnionAnnotation() }.firstOrNull()
+internal fun List<Annotation>.getUnionAnnotation(): GraphQLUnion? = this.filterIsInstance(GraphQLUnion::class.java).firstOrNull() ?: this.mapNotNull { it.getMetaUnionAnnotation() }.firstOrNull()
 
 internal fun List<Annotation>.getCustomUnionClassWithMetaUnionAnnotation(): KClass<*>? = this.firstOrNull { it.getMetaUnionAnnotation() != null }?.annotationClass
 

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/test/integration/CustomUnionAnnotationTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/test/integration/CustomUnionAnnotationTest.kt
@@ -76,6 +76,16 @@ class CustomUnionAnnotationTest {
         }
     }
 
+    @Test
+    fun `custom union annotations can be used on deprecated properties`() {
+        val schema = toSchema(testSchemaConfig(), listOf(TopLevelObject(DeprecatedPropertyQuery())))
+
+        val deprecatedListPrimes = schema.getObjectType("DeprecatedUnionHolder").getFieldDefinition("deprecatedListPrimes")
+
+        assertEquals("[Prime!]!", deprecatedListPrimes.type.deepName)
+        assertEquals("deprecated union field", deprecatedListPrimes.deprecationReason)
+    }
+
     class One(val value: String)
     class Two(val value: String)
     class Three(val value: String)
@@ -112,6 +122,16 @@ class CustomUnionAnnotationTest {
         @PrimeUnion
         fun nullableListPrimes(): List<Any?>? = null
     }
+
+    class DeprecatedPropertyQuery {
+        fun unionHolder(): DeprecatedUnionHolder = DeprecatedUnionHolder()
+    }
+
+    class DeprecatedUnionHolder(
+        @Deprecated("deprecated union field")
+        @PrimeUnion
+        val deprecatedListPrimes: List<Any> = listOf(Two("2"), Three("3"))
+    )
 
     /**
      * Each union here is valid, but using them together in the same schema means the union "Number"

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/test/integration/CustomUnionAnnotationTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/test/integration/CustomUnionAnnotationTest.kt
@@ -77,7 +77,7 @@ class CustomUnionAnnotationTest {
     }
 
     @Test
-    fun `custom union annotations can be used on deprecated properties`() {
+    fun `deprecated annotation does not prevent custom union detection`() {
         val schema = toSchema(testSchemaConfig(), listOf(TopLevelObject(DeprecatedPropertyQuery())))
 
         val deprecatedListPrimes = schema.getObjectType("DeprecatedUnionHolder").getFieldDefinition("deprecatedListPrimes")


### PR DESCRIPTION
## Problem

Custom union annotations can be missed when they are used on a property that also has another annotation, such as @Deprecated. This leads to a failing build job and user can't deprecate the union below.

```kotlin
  @GraphQLUnion(
      name = "ToolbarAction",
      possibleTypes = [IconButton::class, TextButton::class]
  )
  annotation class ToolbarAction

  data class Sheet(
      @Deprecated("Use toolbar instead")
      @ToolbarAction
      val actions: List<Any>
  )
```

The current 
```kotlin
annotations
  .map { it.getMetaUnionAnnotation() }
  .firstOrNull()
```
returns `null` as result and missing the ToolbarAction and fail build job. 

## Approach

Skip annotations that do not contain a meta-union and use the first actual match.

This keeps the existing behavior for direct @GraphQLUnion annotations and for fields without custom unions, while allowing deprecated custom-union properties to generate the expected union field and preserve the deprecation reason.