### PR TITLE
fix(6.x.x): custom union lookup on deprecated properties

### DIFF
--- a/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/extensions/annotationExtensions.kt
+++ b/generator/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/generator/internal/extensions/annotationExtensions.kt
@@ -36,7 +36,7 @@ internal fun KAnnotatedElement.getDeprecationReason(): String? =
 
 internal fun KAnnotatedElement.isGraphQLIgnored(): Boolean = this.findAnnotation<GraphQLIgnore>() != null
 
-internal fun List<Annotation>.getUnionAnnotation(): GraphQLUnion? = this.filterIsInstance(GraphQLUnion::class.java).firstOrNull() ?: this.map { it.getMetaUnionAnnotation() }.firstOrNull()
+internal fun List<Annotation>.getUnionAnnotation(): GraphQLUnion? = this.filterIsInstance(GraphQLUnion::class.java).firstOrNull() ?: this.mapNotNull { it.getMetaUnionAnnotation() }.firstOrNull()
 
 internal fun List<Annotation>.getCustomUnionClassWithMetaUnionAnnotation(): KClass<*>? = this.firstOrNull { it.getMetaUnionAnnotation() != null }?.annotationClass
 

--- a/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/test/integration/CustomUnionAnnotationTest.kt
+++ b/generator/graphql-kotlin-schema-generator/src/test/kotlin/com/expediagroup/graphql/generator/test/integration/CustomUnionAnnotationTest.kt
@@ -97,6 +97,16 @@ class CustomUnionAnnotationTest {
         assertSame(metaUnion, (types.find { it.deepName != "Prime" } as GraphQLObjectType).getField("union").type.unwrapType())
     }
 
+    @Test
+    fun `custom union annotations can be used on deprecated properties`() {
+        val schema = toSchema(testSchemaConfig(), listOf(TopLevelObject(DeprecatedPropertyQuery())))
+
+        val deprecatedListPrimes = schema.getObjectType("DeprecatedUnionHolder").getFieldDefinition("deprecatedListPrimes")
+
+        assertEquals("[Prime!]!", deprecatedListPrimes.type.deepName)
+        assertEquals("deprecated union field", deprecatedListPrimes.deprecationReason)
+    }
+
     class One(val value: String)
     class Two(val value: String)
     class Three(val value: String)
@@ -133,6 +143,16 @@ class CustomUnionAnnotationTest {
         @PrimeUnion
         fun nullableListPrimes(): List<Any?>? = null
     }
+
+    class DeprecatedPropertyQuery {
+        fun unionHolder(): DeprecatedUnionHolder = DeprecatedUnionHolder()
+    }
+
+    class DeprecatedUnionHolder(
+        @Deprecated("deprecated union field")
+        @PrimeUnion
+        val deprecatedListPrimes: List<Any> = listOf(Two("2"), Three("3"))
+    )
 
     /**
      * Each union here is valid, but using them together in the same schema means the union "Number"

--- a/plugins/schema/graphql-kotlin-sdl-generator/build.gradle.kts
+++ b/plugins/schema/graphql-kotlin-sdl-generator/build.gradle.kts
@@ -36,10 +36,12 @@ tasks {
     }
 
     jacocoTestReport {
+        dependsOn(integrationTest)
         // we need to explicitly add integrationTest coverage info
         executionData.setFrom(fileTree(buildDir).include("/jacoco/*.exec"))
     }
     jacocoTestCoverageVerification {
+        dependsOn(integrationTest)
         // we need to explicitly add integrationTest coverage info
         executionData.setFrom(fileTree(buildDir).include("/jacoco/*.exec"))
         violationRules {


### PR DESCRIPTION
Back port #2178 to v6 
Coverage always run before integration and cause constant failing in PR check. 7+ version doesn't have such issue. 