### PR TITLE
fix(6.x.x): publish through Central staging API

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -199,6 +199,7 @@ tasks {
             sonatype {
                 username.set(System.getenv("SONATYPE_USERNAME"))
                 password.set(System.getenv("SONATYPE_PASSWORD"))
+                nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
             }
         }
 


### PR DESCRIPTION
The 6.11.1 release failed while initializing Sonatype staging because this branch still used the old OSSRH endpoint. This pins the staging API to the same Central endpoint used by newer maintenance branches, so recreating the release publishes through ossrh-staging-api.central.sonatype.com.

Verified with ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository publishPlugins -Pversion=6.11.1 --dry-run.