### PR TITLE
fix(client): Include deprecated input fields in introspection query

### DIFF
--- a/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/introspectSchema.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/introspectSchema.kt
@@ -73,7 +73,7 @@ private const val INTROSPECTION_QUERY =
         isDeprecated
         deprecationReason
       }
-      inputFields {
+      inputFields(includeDeprecated: true) {
         ...InputValue
       }
       interfaces {


### PR DESCRIPTION
### :pencil: Description

If an introspection query runs against a schema where all fields on an object are deprecated then an empty object is returned which will fail to print via graphql-java when doing `SchemaPrinter(options).print(graphQLDocument)` which is done in the graphql-kotlin client. By including those deprecated fields, we avoid the invalid object.

Stack trace example:

```
Caused by: graphql.schema.validation.InvalidSchemaException: invalid schema:
"InputTypeWithAllDeprecatedFields" must define one or more fields.
        at graphql.schema.GraphQLSchema$Builder.validateSchema(GraphQLSchema.java:886)
        at graphql.schema.GraphQLSchema$Builder.buildImpl(GraphQLSchema.java:874)
        at graphql.schema.GraphQLSchema$Builder.build(GraphQLSchema.java:841)
        at graphql.schema.idl.SchemaGenerator.makeExecutableSchemaImpl(SchemaGenerator.java:143)
        at graphql.schema.idl.SchemaGenerator.makeExecutableSchema(SchemaGenerator.java:113)
        at graphql.schema.idl.SchemaGenerator.makeExecutableSchema(SchemaGenerator.java:84)
        at graphql.schema.idl.UnExecutableSchemaGenerator.makeUnExecutableSchema(UnExecutableSchemaGenerator.java:28)
        at graphql.schema.idl.SchemaPrinter.print(SchemaPrinter.java:496)
        at com.expediagroup.graphql.plugin.client.IntrospectSchemaKt$introspectSchema$2$1.invokeSuspend(introspectSchema.kt:182)
        at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
        at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:104)
        at kotlinx.coroutines.EventLoopImplBase.processNextEvent(EventLoop.common.kt:277)
        at kotlinx.coroutines.BlockingCoroutine.joinBlocking(Builders.kt:95)
        at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking(Builders.kt:69)
        at kotlinx.coroutines.BuildersKt.runBlocking(Unknown Source)
        at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking$default(Builders.kt:48)
        at kotlinx.coroutines.BuildersKt.runBlocking$default(Unknown Source)
        at com.expediagroup.graphql.plugin.client.IntrospectSchemaKt.introspectSchema(introspectSchema.kt:150)
        at com.expediagroup.graphql.plugin.gradle.actions.IntrospectSchemaAction.execute(IntrospectSchemaAction.kt:37)
```

And an example schema that causes the problem:

```sdl
schema {
  query: Query
}

type Query {
  hello(input: HelloInput): String!
}

input HelloInput {
  legacyField: String @deprecated(reason: "Use `newField` instead.")
}
```

### :link: Related Issues