### PR TITLE
feat: ensure synchronization of dataloader load calls when batching is disabled and caching enabled

### DIFF
--- a/executions/graphql-kotlin-dataloader/src/main/kotlin/com/expediagroup/graphql/dataloader/KotlinDataLoaderRegistryFactory.kt
+++ b/executions/graphql-kotlin-dataloader/src/main/kotlin/com/expediagroup/graphql/dataloader/KotlinDataLoaderRegistryFactory.kt
@@ -40,10 +40,17 @@ class KotlinDataLoaderRegistryFactory(
         dataLoaderInstrumentation?.let {
             builder.instrumentation(dataLoaderInstrumentation)
         }
+
         dataLoaders.forEach { kotlinDataLoader ->
             builder.register(
                 kotlinDataLoader.dataLoaderName,
-                kotlinDataLoader.getDataLoader(graphQLContext)
+                kotlinDataLoader.getDataLoader(graphQLContext).let { dataLoader ->
+                    if (!dataLoader.options.batchingEnabled() && dataLoader.options.cachingEnabled()) {
+                        SynchronizedDataLoader(dataLoader)
+                    } else {
+                        dataLoader
+                    }
+                }
             )
         }
         return builder.build().also {

--- a/executions/graphql-kotlin-dataloader/src/main/kotlin/com/expediagroup/graphql/dataloader/SynchronizedDataLoader.kt
+++ b/executions/graphql-kotlin-dataloader/src/main/kotlin/com/expediagroup/graphql/dataloader/SynchronizedDataLoader.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 Expedia, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.graphql.dataloader
+
+import org.dataloader.DataLoader
+import org.dataloader.DelegatingDataLoader
+import java.util.concurrent.CompletableFuture
+
+/**
+ *
+ * [java-data-loader 6](https://github.com/graphql-java/java-dataloader/pull/241) removed synchronization from [DataLoader.load],
+ * allowing concurrent cache misses to invoke the loader more than once before either result future is cached.
+ */
+internal class SynchronizedDataLoader<K : Any, V : Any>(
+    delegate: DataLoader<K, V>
+) : DelegatingDataLoader<K, V>(delegate) {
+    override fun load(key: K): CompletableFuture<V> =
+        synchronized(this) {
+            super.load(key)
+        }
+
+    override fun load(key: K, keyContext: Any?): CompletableFuture<V> =
+        synchronized(this) {
+            super.load(key, keyContext)
+        }
+}

--- a/executions/graphql-kotlin-dataloader/src/test/kotlin/com/expediagroup/graphql/dataloader/KotlinDataLoaderRegistryFactoryTest.kt
+++ b/executions/graphql-kotlin-dataloader/src/test/kotlin/com/expediagroup/graphql/dataloader/KotlinDataLoaderRegistryFactoryTest.kt
@@ -18,11 +18,19 @@ package com.expediagroup.graphql.dataloader
 
 import graphql.GraphQLContext
 import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.future.await
+import kotlinx.coroutines.runBlocking
 import org.dataloader.DataLoader
 import org.dataloader.DataLoaderFactory
+import org.dataloader.DataLoaderOptions
 import org.dataloader.instrumentation.DataLoaderInstrumentation
 import org.junit.jupiter.api.Test
 import reactor.kotlin.core.publisher.toFlux
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
@@ -53,5 +61,37 @@ class KotlinDataLoaderRegistryFactoryTest {
         )
         assertEquals(1, registry.dataLoaders.size)
         assertEquals(customInstrumentation, registry.instrumentation)
+    }
+
+    @Test
+    fun `cached and non-batched data loader is invoked once for concurrent loads of the same key`() {
+        runBlocking {
+            val invocations = AtomicInteger()
+            val kotlinDataLoader = object : KotlinDataLoader<String, String> {
+                override val dataLoaderName = "NonBatchingDataLoader"
+                override fun getDataLoader(graphQLContext: GraphQLContext): DataLoader<String, String> =
+                    DataLoaderFactory.newMappedDataLoader(
+                        { keys ->
+                            invocations.incrementAndGet()
+                            Thread.sleep(100)
+                            CompletableFuture.completedFuture(keys.associateWith { it })
+                        },
+                        DataLoaderOptions.newOptions()
+                            .setBatchingEnabled(false)
+                            .build()
+                    )
+            }
+            val registry = KotlinDataLoaderRegistryFactory(kotlinDataLoader).generate(mockk(relaxed = true))
+
+            val dataLoader = requireNotNull(registry.getDataLoader<String, String>(kotlinDataLoader.dataLoaderName))
+
+            List(2) {
+                async(Dispatchers.Default) {
+                    dataLoader.load("same-key").await()
+                }
+            }.awaitAll()
+
+            assertEquals(1, invocations.get())
+        }
     }
 }

--- a/servers/graphql-kotlin-server/src/main/kotlin/com/expediagroup/graphql/server/execution/GraphQLRequestHandler.kt
+++ b/servers/graphql-kotlin-server/src/main/kotlin/com/expediagroup/graphql/server/execution/GraphQLRequestHandler.kt
@@ -55,7 +55,7 @@ open class GraphQLRequestHandler(
 ) {
 
     private val batchDataLoaderInstrumentationType: Class<Instrumentation>? =
-        graphQL.instrumentation?.let { instrumentation ->
+        graphQL.instrumentation.let { instrumentation ->
             when {
                 instrumentation is ChainedInstrumentation -> {
                     instrumentation.instrumentations

--- a/servers/graphql-kotlin-server/src/test/kotlin/com/expediagroup/graphql/server/extensions/RequestExtensionsKtTest.kt
+++ b/servers/graphql-kotlin-server/src/test/kotlin/com/expediagroup/graphql/server/extensions/RequestExtensionsKtTest.kt
@@ -23,7 +23,9 @@ import com.expediagroup.graphql.server.types.GraphQLRequest
 import graphql.GraphQLContext
 import io.mockk.mockk
 import org.dataloader.DataLoader
+import org.dataloader.DataLoaderFactory
 import org.junit.jupiter.api.Test
+import java.util.concurrent.CompletableFuture
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
@@ -66,7 +68,8 @@ class RequestExtensionsKtTest {
         val dataLoaderRegistry = KotlinDataLoaderRegistryFactory(
             object : KotlinDataLoader<String, String> {
                 override val dataLoaderName: String = "abc"
-                override fun getDataLoader(graphQLContext: GraphQLContext): DataLoader<String, String> = mockk()
+                override fun getDataLoader(graphQLContext: GraphQLContext): DataLoader<String, String> =
+                    DataLoaderFactory.newDataLoader { keys -> CompletableFuture.completedFuture(keys) }
             }
         ).generate(mockk(relaxed = true))
 


### PR DESCRIPTION
### :pencil: Description

https://github.com/graphql-java/java-dataloader/pull/241

java-dataloader 6 removed synchronization from DataLoader.load(). For cached loaders with batching disabled, concurrent calls using the same key can both observe a cache
  miss and invoke the underlying loader before either future is cached. This results in duplicate downstream requests even though callers ultimately receive the same cached
  future.

  This change:

  - Adds an internal SynchronizedDataLoader wrapper that synchronizes both load overloads.
  - Applies the wrapper only when caching is enabled and batching is disabled.
  - Adds a coroutine-based regression test verifying concurrent same-key loads invoke the underlying loader once.