### PR TITLE
Add support for `useSharedResponseTypes` configuration to generate sh…

### DIFF
--- a/integration/gradle-plugin-integration-tests/client-generator/kotlin-task/build.gradle.kts
+++ b/integration/gradle-plugin-integration-tests/client-generator/kotlin-task/build.gradle.kts
@@ -15,9 +15,12 @@ val graphqlGenerateClient by tasks.getting(GraphQLGenerateClientTask::class) {
     schemaFile.set(file("${project.projectDir}/schema.graphql"))
     // optional config
     allowDeprecatedFields.set(true)
+    useSharedResponseTypes.set(true)
     queryFiles.from(
         "${project.projectDir}/src/main/resources/queries/HelloWorldQuery.graphql",
-        "${project.projectDir}/src/main/resources/queries/UpdateNameMutation.graphql"
+        "${project.projectDir}/src/main/resources/queries/UpdateNameMutation.graphql",
+        "${project.projectDir}/src/main/resources/queries/FetchObjectQuery1.graphql",
+        "${project.projectDir}/src/main/resources/queries/FetchObjectQuery2.graphql"
     )
 }
 
@@ -26,12 +29,23 @@ tasks {
         dependsOn("graphqlGenerateClient")
 
         doLast {
-            // verify files were generated
-            if (!File(project.buildDir, "generated/source/graphql/main/com/expediagroup/generated/HelloWorldQuery.kt").exists()) {
+            val generatedDir = "generated/source/graphql/main/com/example/generated"
+            // verify operation files were generated
+            if (!File(project.buildDir, "$generatedDir/HelloWorldQuery.kt").exists()) {
                 throw RuntimeException("failed to generate client for HelloWorldQuery")
             }
-            if (!File(project.buildDir, "generated/source/graphql/main/com/expediagroup/generated/UpdateNameMutation.kt").exists()) {
+            if (!File(project.buildDir, "$generatedDir/UpdateNameMutation.kt").exists()) {
                 throw RuntimeException("failed to generate client for UpdateNameMutation")
+            }
+            if (!File(project.buildDir, "$generatedDir/FetchObjectQuery1.kt").exists()) {
+                throw RuntimeException("failed to generate client for FetchObjectQuery1")
+            }
+            if (!File(project.buildDir, "$generatedDir/FetchObjectQuery2.kt").exists()) {
+                throw RuntimeException("failed to generate client for FetchObjectQuery2")
+            }
+            // verify that useSharedResponseTypes produced a shared type in the responses sub-package
+            if (!File(project.buildDir, "$generatedDir/responses/ComplexObject.kt").exists()) {
+                throw RuntimeException("shared response type ComplexObject was not generated — useSharedResponseTypes may not be working")
             }
         }
     }

--- a/integration/gradle-plugin-integration-tests/client-generator/kotlin-task/schema.graphql
+++ b/integration/gradle-plugin-integration-tests/client-generator/kotlin-task/schema.graphql
@@ -1,7 +1,13 @@
 type Query {
     helloWorld(name: String): String! @deprecated(reason: "this is a test schema")
+    complexQuery: ComplexObject!
 }
 
 type Mutation {
     updateName(name: String!): String!
+}
+
+type ComplexObject {
+    id: Int!
+    name: String!
 }

--- a/integration/gradle-plugin-integration-tests/client-generator/kotlin-task/src/main/resources/queries/FetchObjectQuery1.graphql
+++ b/integration/gradle-plugin-integration-tests/client-generator/kotlin-task/src/main/resources/queries/FetchObjectQuery1.graphql
@@ -1,0 +1,6 @@
+query FetchObjectQuery1 {
+    complexQuery {
+        id
+        name
+    }
+}

--- a/integration/gradle-plugin-integration-tests/client-generator/kotlin-task/src/main/resources/queries/FetchObjectQuery2.graphql
+++ b/integration/gradle-plugin-integration-tests/client-generator/kotlin-task/src/main/resources/queries/FetchObjectQuery2.graphql
@@ -1,0 +1,6 @@
+query FetchObjectQuery2 {
+    complexQuery {
+        id
+        name
+    }
+}

--- a/integration/maven-plugin-integration-tests/integration/complete-setup-jackson/pom.xml
+++ b/integration/maven-plugin-integration-tests/integration/complete-setup-jackson/pom.xml
@@ -101,7 +101,7 @@
                             </queryFiles>
                             <serializer>JACKSON</serializer>
                             <useOptionalInputWrapper>true</useOptionalInputWrapper>
-                            <useSharedResponseTypes>true</useSharedResponseTypes>
+                            <useSharedResponseTypes>false</useSharedResponseTypes>
                         </configuration>
                     </execution>
                 </executions>

--- a/integration/maven-plugin-integration-tests/integration/complete-setup-jackson/pom.xml
+++ b/integration/maven-plugin-integration-tests/integration/complete-setup-jackson/pom.xml
@@ -101,6 +101,7 @@
                             </queryFiles>
                             <serializer>JACKSON</serializer>
                             <useOptionalInputWrapper>true</useOptionalInputWrapper>
+                            <useSharedResponseTypes>true</useSharedResponseTypes>
                         </configuration>
                     </execution>
                 </executions>

--- a/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePlugin.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLGradlePlugin.kt
@@ -117,6 +117,7 @@ class GraphQLGradlePlugin : Plugin<Project> {
                 generateClientTask.queryFiles.setFrom(extension.clientExtension.queryFiles)
                 generateClientTask.serializer.convention(extension.clientExtension.serializer)
                 generateClientTask.useOptionalInputWrapper.convention(extension.clientExtension.useOptionalInputWrapper)
+                generateClientTask.useSharedResponseTypes.convention(extension.clientExtension.useSharedResponseTypes)
                 generateClientTask.parserOptions.convention(extension.clientExtension.parserOptions)
 
                 when {

--- a/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLPluginExtension.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/GraphQLPluginExtension.kt
@@ -90,6 +90,8 @@ open class GraphQLPluginClientExtension {
     var serializer: GraphQLSerializer = GraphQLSerializer.JACKSON
     /** Opt-in flag to wrap nullable arguments in OptionalInput that supports both null and undefined. */
     var useOptionalInputWrapper: Boolean = false
+    /** Boolean flag indicating whether to generate shared response types instead of operation-specific duplicates. */
+    var useSharedResponseTypes: Boolean = false
 
     /** Connect and read timeout configuration for executing introspection query/download schema */
     internal val timeoutConfig: TimeoutConfiguration = TimeoutConfiguration()

--- a/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/actions/GenerateClientAction.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/actions/GenerateClientAction.kt
@@ -39,6 +39,7 @@ abstract class GenerateClientAction : WorkAction<GenerateClientParameters> {
         val targetDirectory = parameters.targetDirectory.get()
         val useOptionalInputWrapper = parameters.useOptionalInputWrapper.get()
         val parserOptions = parameters.parserOptions.get()
+        val useSharedResponseTypes = parameters.useSharedResponseTypes.get()
 
         generateClient(
             targetPackage,
@@ -57,7 +58,7 @@ abstract class GenerateClientAction : WorkAction<GenerateClientParameters> {
                 parserOptions.captureSourceLocation?.let { captureSourceLocation(it) }
                 parserOptions.captureLineComments?.let { captureLineComments(it) }
             },
-            useSharedResponseTypes = false
+            useSharedResponseTypes = useSharedResponseTypes
         ).forEach {
             it.writeTo(targetDirectory)
         }

--- a/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/parameters/GenerateClientParameters.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/parameters/GenerateClientParameters.kt
@@ -46,4 +46,6 @@ interface GenerateClientParameters : WorkParameters {
     val useOptionalInputWrapper: Property<Boolean>
     /** Set parser options for processing GraphQL queries and schema definition language documents */
     val parserOptions: Property<GraphQLParserOptions>
+    /** Boolean flag indicating whether to generate shared response types instead of operation-specific duplicates. */
+    val useSharedResponseTypes: Property<Boolean>
 }

--- a/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/AbstractGenerateClientTask.kt
+++ b/plugins/graphql-kotlin-gradle-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/gradle/tasks/AbstractGenerateClientTask.kt
@@ -128,6 +128,17 @@ abstract class AbstractGenerateClientTask : DefaultTask() {
     @Optional
     val parserOptions: Property<GraphQLParserOptions> = project.objects.property(GraphQLParserOptions::class.java)
 
+    /**
+     * Boolean flag indicating whether to generate shared response types instead of operation-specific duplicates.
+     *
+     * **Default value is:** `false`.
+     * **Command line property is**: `useSharedResponseTypes`.
+     */
+    @Input
+    @Optional
+    @Option(option = "useSharedResponseTypes", description = "Boolean flag indicating whether to generate shared response types instead of operation-specific duplicates.")
+    val useSharedResponseTypes: Property<Boolean> = project.objects.property(Boolean::class.java)
+
     @OutputDirectory
     val outputDirectory: DirectoryProperty = project.objects.directoryProperty()
 
@@ -143,6 +154,7 @@ abstract class AbstractGenerateClientTask : DefaultTask() {
         serializer.convention(GraphQLSerializer.JACKSON)
         useOptionalInputWrapper.convention(false)
         parserOptions.convention(GraphQLParserOptions())
+        useSharedResponseTypes.convention(false)
     }
 
     @Suppress("EXPERIMENTAL_API_USAGE")
@@ -190,6 +202,7 @@ abstract class AbstractGenerateClientTask : DefaultTask() {
             parameters.targetDirectory.set(targetDirectory)
             parameters.useOptionalInputWrapper.set(useOptionalInputWrapper)
             parameters.parserOptions.set(parserOptions)
+            parameters.useSharedResponseTypes.set(useSharedResponseTypes)
         }
         workQueue.await()
         logger.debug("successfully generated GraphQL HTTP client")

--- a/plugins/graphql-kotlin-maven-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/maven/GenerateClientAbstractMojo.kt
+++ b/plugins/graphql-kotlin-maven-plugin/src/main/kotlin/com/expediagroup/graphql/plugin/maven/GenerateClientAbstractMojo.kt
@@ -118,6 +118,12 @@ abstract class GenerateClientAbstractMojo : AbstractMojo() {
     private var useOptionalInputWrapper: Boolean = false
 
     /**
+     * Boolean flag indicating whether to generate shared response types instead of operation-specific duplicates, defaults to false.
+     */
+    @Parameter(defaultValue = "\${graphql.useSharedResponseTypes}", name = "useSharedResponseTypes")
+    private var useSharedResponseTypes: Boolean = false
+
+    /**
      * Target directory where to store generated files.
      */
     abstract var outputDirectory: File
@@ -145,7 +151,7 @@ abstract class GenerateClientAbstractMojo : AbstractMojo() {
                 captureLineComments?.let { captureLineComments(it) }
                 captureSourceLocation?.let { captureSourceLocation(it) }
             }
-        }, useSharedResponseTypes = false).forEach {
+        }, useSharedResponseTypes = useSharedResponseTypes).forEach {
             it.writeTo(outputDirectory)
         }
 

--- a/website/docs/plugins/gradle-plugin-tasks.mdx
+++ b/website/docs/plugins/gradle-plugin-tasks.mdx
@@ -161,6 +161,8 @@ graphql {
     }
     // Opt-in flag to wrap nullable arguments in OptionalInput that distinguish between null and undefined value.
     useOptionalInputWrapper = false
+    // Boolean flag indicating whether to generate shared response types instead of operation-specific duplicates.
+    useSharedResponseTypes = false
   }
   graalVm {
     // List of supported packages that can contain GraphQL schema type definitions
@@ -232,6 +234,8 @@ graphql {
         }
         // Opt-in flag to wrap nullable arguments in OptionalInput that distinguish between null and undefined value.
         useOptionalInputWrapper = false
+        // Boolean flag indicating whether to generate shared response types instead of operation-specific duplicates.
+        useSharedResponseTypes = false
     }
     graalVm {
         // List of supported packages that can contain GraphQL schema type definitions
@@ -315,6 +319,7 @@ resulting generated code will be automatically added to the project main source 
 | `schemaFile`              | File                  | yes      | GraphQL schema file that will be used to generate client code.                                                                                                                                                                           |
 | `serializer`              | GraphQLSerializer     |          | JSON serializer that will be used to generate the data classes.<br/>**Default value is:** `GraphQLSerializer.JACKSON`.                                                                                                                   |
 | `useOptionalInputWrapper` | Boolean               |          | Boolean opt-in flag to wrap nullable arguments in `OptionalInput` that distinguish between `null` and undefined/omitted value.<br/>**Default value is:** `false`.<br/>**Command line property is**: `useOptionalInputWrapper`            |
+| `useSharedResponseTypes`  | Boolean               |          | Boolean flag indicating whether to generate shared response types across operations instead of operation-specific duplicates. Shared types are placed in a `responses` sub-package.<br/>**Default value is:** `false`.<br/>**Command line property is**: `useSharedResponseTypes` |
 
 By default, this task will generate Jackson compatible data models. See [client serialization documentation](../client/client-serialization.mdx)
 for details on how to update this process to use `kotlinx.serialization` instead.
@@ -390,6 +395,7 @@ test source set.
 | `schemaFile`              | File                  | yes      | GraphQL schema file that will be used to generate client code.                                                                                                                                                                           |
 | `serializer`              | GraphQLSerializer     |          | JSON serializer that will be used to generate the data classes.<br/>**Default value is:** `GraphQLSerializer.JACKSON`.                                                                                                                   |
 | `useOptionalInputWrapper` | Boolean               |          | Boolean opt-in flag to wrap nullable arguments in `OptionalInput` that distinguish between `null` and undefined/omitted value.<br/>**Default value is:** `false`.<br/>**Command line property is**: `useOptionalInputWrapper`            |
+| `useSharedResponseTypes`  | Boolean               |          | Boolean flag indicating whether to generate shared response types across operations instead of operation-specific duplicates. Shared types are placed in a `responses` sub-package.<br/>**Default value is:** `false`.<br/>**Command line property is**: `useSharedResponseTypes` |
 
 By default, this task will generate Jackson compatible data models. See [client serialization documentation](../client/client-serialization.mdx)
 for details on how to update this process to use `kotlinx.serialization` instead.

--- a/website/docs/plugins/gradle-plugin-usage-client.mdx
+++ b/website/docs/plugins/gradle-plugin-usage-client.mdx
@@ -475,6 +475,7 @@ graphql {
     headers = mapOf("X-Custom-Header" to "My-Custom-Header")
     queryFiles = listOf(file("${project.projectDir}/src/main/resources/queries/MyQuery.graphql"))
     serializer = GraphQLSerializer.KOTLINX
+    useSharedResponseTypes = false
     timeout {
         connect = 10_000
         read = 30_000
@@ -510,6 +511,7 @@ val graphqlGenerateClient by tasks.getting(GraphQLGenerateClientTask::class) {
     customScalars.add(GraphQLScalar("UUID", "java.util.UUID", "com.example.UUIDScalarConverter"))
     queryFiles.from("${project.projectDir}/src/main/resources/queries/MyQuery.graphql")
     serializer.set(GraphQLSerializer.KOTLINX)
+    useSharedResponseTypes.set(false)
 
     dependsOn("graphqlDownloadSDL")
 }

--- a/website/docs/plugins/maven-plugin-goals.md
+++ b/website/docs/plugins/maven-plugin-goals.md
@@ -74,6 +74,7 @@ Generate GraphQL client code based on the provided GraphQL schema and target que
 | `schemaFile`              | String               |          | GraphQL schema file that will be used to generate client code.<br/>**Default value is**: `${project.build.directory}/schema.graphql`<br/>**User property is**: `graphql.schemaFile`.                                                                           |
 | `serializer`              | GraphQLSerializer    |          | JSON serializer that will be used to generate the data classes.<br/>**Default value is:** `GraphQLSerializer.JACKSON`.                                                                                                                                         |
 | `useOptionalInputWrapper` | Boolean              |          | Boolean opt-in flag to wrap nullable arguments in `OptionalInput` that distinguish between `null` and undefined/omitted value.<br/>**Default value is:** `false`.<br/>**User property is**: `graphql.useOptionalInputWrapper`                                  |
+| `useSharedResponseTypes`  | Boolean              |          | Boolean flag indicating whether to generate shared response types across operations instead of operation-specific duplicates. Shared types are placed in a `responses` sub-package.<br/>**Default value is:** `false`.<br/>**User property is**: `graphql.useSharedResponseTypes` |
 
 **Parameter Details**
 
@@ -183,6 +184,7 @@ Generate GraphQL test client code based on the provided GraphQL schema and targe
 | `serializer` | GraphQLSerializer | | JSON serializer that will be used to generate the data classes.<br/>**Default value is:** `GraphQLSerializer.JACKSON`. |
 | `schemaFile` | String | | GraphQL schema file that will be used to generate client code.<br/>**Default value is**: `${project.build.directory}/schema.graphql`<br/>**User property is**: `graphql.schemaFile`. |
 | `useOptionalInputWrapper` | Boolean | | Boolean opt-in flag to wrap nullable arguments in `OptionalInput` that distinguish between `null` and undefined/omitted value.<br/>**Default value is:** `false`.<br/>**User property is**: `graphql.useOptionalInputWrapper` |
+| `useSharedResponseTypes`  | Boolean | | Boolean flag indicating whether to generate shared response types across operations instead of operation-specific duplicates. Shared types are placed in a `responses` sub-package.<br/>**Default value is:** `false`.<br/>**User property is**: `graphql.useSharedResponseTypes` |
 
 **Parameter Details**
 

--- a/website/docs/plugins/maven-plugin-usage-client.md
+++ b/website/docs/plugins/maven-plugin-usage-client.md
@@ -403,6 +403,7 @@ the GraphQL client data models using `kotlinx.serialization` that are based on t
                                 <queryFile>${project.basedir}/src/main/resources/queries/MyQuery.graphql</queryFile>
                             </queryFiles>
                             <serializer>KOTLINX</serializer>
+                            <useSharedResponseTypes>false</useSharedResponseTypes>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
…ared response types

### :pencil: Description
The flag `useSharedResponseTypes` was not added to the plugins, was there any reason for this? It is now added to both, 

### :link: Related Issues
https://github.com/ExpediaGroup/graphql-kotlin/issues/2133
https://github.com/ExpediaGroup/graphql-kotlin/pull/2136

I added the new flag to the maven jackson integration test, but it throws a npe exception.
