### PR TITLE
docs: update versioned docs (9.x.x, 10.x.x) with useSharedResponseTypes

### DIFF
--- a/website/versioned_docs/version-10.x.x/plugins/gradle-plugin-tasks.mdx
+++ b/website/versioned_docs/version-10.x.x/plugins/gradle-plugin-tasks.mdx
@@ -161,6 +161,8 @@ graphql {
     }
     // Opt-in flag to wrap nullable arguments in OptionalInput that distinguish between null and undefined value.
     useOptionalInputWrapper = false
+    // Boolean flag indicating whether to generate shared response types instead of operation-specific duplicates.
+    useSharedResponseTypes = false
   }
   graalVm {
     // List of supported packages that can contain GraphQL schema type definitions
@@ -232,6 +234,8 @@ graphql {
         }
         // Opt-in flag to wrap nullable arguments in OptionalInput that distinguish between null and undefined value.
         useOptionalInputWrapper = false
+        // Boolean flag indicating whether to generate shared response types instead of operation-specific duplicates.
+        useSharedResponseTypes = false
     }
     graalVm {
         // List of supported packages that can contain GraphQL schema type definitions
@@ -315,6 +319,7 @@ resulting generated code will be automatically added to the project main source 
 | `schemaFile`              | File                  | yes      | GraphQL schema file that will be used to generate client code.                                                                                                                                                                           |
 | `serializer`              | GraphQLSerializer     |          | JSON serializer that will be used to generate the data classes.<br/>**Default value is:** `GraphQLSerializer.JACKSON`.                                                                                                                   |
 | `useOptionalInputWrapper` | Boolean               |          | Boolean opt-in flag to wrap nullable arguments in `OptionalInput` that distinguish between `null` and undefined/omitted value.<br/>**Default value is:** `false`.<br/>**Command line property is**: `useOptionalInputWrapper`            |
+| `useSharedResponseTypes`  | Boolean               |          | Boolean flag indicating whether to generate shared response types across operations instead of operation-specific duplicates. Shared types are placed in a `responses` sub-package.<br/>**Default value is:** `false`.<br/>**Command line property is**: `useSharedResponseTypes` |
 
 By default, this task will generate Jackson compatible data models. See [client serialization documentation](../client/client-serialization.mdx)
 for details on how to update this process to use `kotlinx.serialization` instead.
@@ -390,6 +395,7 @@ test source set.
 | `schemaFile`              | File                  | yes      | GraphQL schema file that will be used to generate client code.                                                                                                                                                                           |
 | `serializer`              | GraphQLSerializer     |          | JSON serializer that will be used to generate the data classes.<br/>**Default value is:** `GraphQLSerializer.JACKSON`.                                                                                                                   |
 | `useOptionalInputWrapper` | Boolean               |          | Boolean opt-in flag to wrap nullable arguments in `OptionalInput` that distinguish between `null` and undefined/omitted value.<br/>**Default value is:** `false`.<br/>**Command line property is**: `useOptionalInputWrapper`            |
+| `useSharedResponseTypes`  | Boolean               |          | Boolean flag indicating whether to generate shared response types across operations instead of operation-specific duplicates. Shared types are placed in a `responses` sub-package.<br/>**Default value is:** `false`.<br/>**Command line property is**: `useSharedResponseTypes` |
 
 By default, this task will generate Jackson compatible data models. See [client serialization documentation](../client/client-serialization.mdx)
 for details on how to update this process to use `kotlinx.serialization` instead.

--- a/website/versioned_docs/version-10.x.x/plugins/gradle-plugin-usage-client.mdx
+++ b/website/versioned_docs/version-10.x.x/plugins/gradle-plugin-usage-client.mdx
@@ -475,6 +475,7 @@ graphql {
     headers = mapOf("X-Custom-Header" to "My-Custom-Header")
     queryFiles = listOf(file("${project.projectDir}/src/main/resources/queries/MyQuery.graphql"))
     serializer = GraphQLSerializer.KOTLINX
+    useSharedResponseTypes = false
     timeout {
         connect = 10_000
         read = 30_000
@@ -510,6 +511,7 @@ val graphqlGenerateClient by tasks.getting(GraphQLGenerateClientTask::class) {
     customScalars.add(GraphQLScalar("UUID", "java.util.UUID", "com.example.UUIDScalarConverter"))
     queryFiles.from("${project.projectDir}/src/main/resources/queries/MyQuery.graphql")
     serializer.set(GraphQLSerializer.KOTLINX)
+    useSharedResponseTypes.set(false)
 
     dependsOn("graphqlDownloadSDL")
 }

--- a/website/versioned_docs/version-10.x.x/plugins/maven-plugin-goals.md
+++ b/website/versioned_docs/version-10.x.x/plugins/maven-plugin-goals.md
@@ -74,6 +74,7 @@ Generate GraphQL client code based on the provided GraphQL schema and target que
 | `schemaFile`              | String               |          | GraphQL schema file that will be used to generate client code.<br/>**Default value is**: `${project.build.directory}/schema.graphql`<br/>**User property is**: `graphql.schemaFile`.                                                                           |
 | `serializer`              | GraphQLSerializer    |          | JSON serializer that will be used to generate the data classes.<br/>**Default value is:** `GraphQLSerializer.JACKSON`.                                                                                                                                         |
 | `useOptionalInputWrapper` | Boolean              |          | Boolean opt-in flag to wrap nullable arguments in `OptionalInput` that distinguish between `null` and undefined/omitted value.<br/>**Default value is:** `false`.<br/>**User property is**: `graphql.useOptionalInputWrapper`                                  |
+| `useSharedResponseTypes`  | Boolean              |          | Boolean flag indicating whether to generate shared response types across operations instead of operation-specific duplicates. Shared types are placed in a `responses` sub-package.<br/>**Default value is:** `false`.<br/>**User property is**: `graphql.useSharedResponseTypes` |
 
 **Parameter Details**
 
@@ -183,6 +184,7 @@ Generate GraphQL test client code based on the provided GraphQL schema and targe
 | `serializer` | GraphQLSerializer | | JSON serializer that will be used to generate the data classes.<br/>**Default value is:** `GraphQLSerializer.JACKSON`. |
 | `schemaFile` | String | | GraphQL schema file that will be used to generate client code.<br/>**Default value is**: `${project.build.directory}/schema.graphql`<br/>**User property is**: `graphql.schemaFile`. |
 | `useOptionalInputWrapper` | Boolean | | Boolean opt-in flag to wrap nullable arguments in `OptionalInput` that distinguish between `null` and undefined/omitted value.<br/>**Default value is:** `false`.<br/>**User property is**: `graphql.useOptionalInputWrapper` |
+| `useSharedResponseTypes`  | Boolean | | Boolean flag indicating whether to generate shared response types across operations instead of operation-specific duplicates. Shared types are placed in a `responses` sub-package.<br/>**Default value is:** `false`.<br/>**User property is**: `graphql.useSharedResponseTypes` |
 
 **Parameter Details**
 

--- a/website/versioned_docs/version-10.x.x/plugins/maven-plugin-usage-client.md
+++ b/website/versioned_docs/version-10.x.x/plugins/maven-plugin-usage-client.md
@@ -403,6 +403,7 @@ the GraphQL client data models using `kotlinx.serialization` that are based on t
                                 <queryFile>${project.basedir}/src/main/resources/queries/MyQuery.graphql</queryFile>
                             </queryFiles>
                             <serializer>KOTLINX</serializer>
+                            <useSharedResponseTypes>false</useSharedResponseTypes>
                         </configuration>
                     </execution>
                 </executions>

--- a/website/versioned_docs/version-9.x.x/plugins/gradle-plugin-tasks.mdx
+++ b/website/versioned_docs/version-9.x.x/plugins/gradle-plugin-tasks.mdx
@@ -161,6 +161,8 @@ graphql {
     }
     // Opt-in flag to wrap nullable arguments in OptionalInput that distinguish between null and undefined value.
     useOptionalInputWrapper = false
+    // Boolean flag indicating whether to generate shared response types instead of operation-specific duplicates.
+    useSharedResponseTypes = false
   }
   graalVm {
     // List of supported packages that can contain GraphQL schema type definitions
@@ -230,6 +232,8 @@ graphql {
         }
         // Opt-in flag to wrap nullable arguments in OptionalInput that distinguish between null and undefined value.
         useOptionalInputWrapper = false
+        // Boolean flag indicating whether to generate shared response types instead of operation-specific duplicates.
+        useSharedResponseTypes = false
     }
     graalVm {
         // List of supported packages that can contain GraphQL schema type definitions
@@ -311,6 +315,7 @@ resulting generated code will be automatically added to the project main source 
 | `schemaFile`              | File                  | yes      | GraphQL schema file that will be used to generate client code.                                                                                                                                                                           |
 | `serializer`              | GraphQLSerializer     |          | JSON serializer that will be used to generate the data classes.<br/>**Default value is:** `GraphQLSerializer.JACKSON`.                                                                                                                   |
 | `useOptionalInputWrapper` | Boolean               |          | Boolean opt-in flag to wrap nullable arguments in `OptionalInput` that distinguish between `null` and undefined/omitted value.<br/>**Default value is:** `false`.<br/>**Command line property is**: `useOptionalInputWrapper`            |
+| `useSharedResponseTypes`  | Boolean               |          | Boolean flag indicating whether to generate shared response types across operations instead of operation-specific duplicates. Shared types are placed in a `responses` sub-package.<br/>**Default value is:** `false`.<br/>**Command line property is**: `useSharedResponseTypes` |
 
 By default, this task will generate Jackson compatible data models. See [client serialization documentation](../client/client-serialization.mdx)
 for details on how to update this process to use `kotlinx.serialization` instead.
@@ -385,6 +390,7 @@ test source set.
 | `schemaFile`              | File                  | yes      | GraphQL schema file that will be used to generate client code.                                                                                                                                                                           |
 | `serializer`              | GraphQLSerializer     |          | JSON serializer that will be used to generate the data classes.<br/>**Default value is:** `GraphQLSerializer.JACKSON`.                                                                                                                   |
 | `useOptionalInputWrapper` | Boolean               |          | Boolean opt-in flag to wrap nullable arguments in `OptionalInput` that distinguish between `null` and undefined/omitted value.<br/>**Default value is:** `false`.<br/>**Command line property is**: `useOptionalInputWrapper`            |
+| `useSharedResponseTypes`  | Boolean               |          | Boolean flag indicating whether to generate shared response types across operations instead of operation-specific duplicates. Shared types are placed in a `responses` sub-package.<br/>**Default value is:** `false`.<br/>**Command line property is**: `useSharedResponseTypes` |
 
 By default, this task will generate Jackson compatible data models. See [client serialization documentation](../client/client-serialization.mdx)
 for details on how to update this process to use `kotlinx.serialization` instead.

--- a/website/versioned_docs/version-9.x.x/plugins/gradle-plugin-usage-client.mdx
+++ b/website/versioned_docs/version-9.x.x/plugins/gradle-plugin-usage-client.mdx
@@ -475,6 +475,7 @@ graphql {
     headers = mapOf("X-Custom-Header" to "My-Custom-Header")
     queryFiles = listOf(file("${project.projectDir}/src/main/resources/queries/MyQuery.graphql"))
     serializer = GraphQLSerializer.KOTLINX
+    useSharedResponseTypes = false
     timeout {
         connect = 10_000
         read = 30_000
@@ -510,6 +511,7 @@ val graphqlGenerateClient by tasks.getting(GraphQLGenerateClientTask::class) {
     customScalars.add(GraphQLScalar("UUID", "java.util.UUID", "com.example.UUIDScalarConverter"))
     queryFiles.from("${project.projectDir}/src/main/resources/queries/MyQuery.graphql")
     serializer.set(GraphQLSerializer.KOTLINX)
+    useSharedResponseTypes.set(false)
 
     dependsOn("graphqlDownloadSDL")
 }

--- a/website/versioned_docs/version-9.x.x/plugins/maven-plugin-goals.md
+++ b/website/versioned_docs/version-9.x.x/plugins/maven-plugin-goals.md
@@ -74,6 +74,7 @@ Generate GraphQL client code based on the provided GraphQL schema and target que
 | `schemaFile`              | String               |          | GraphQL schema file that will be used to generate client code.<br/>**Default value is**: `${project.build.directory}/schema.graphql`<br/>**User property is**: `graphql.schemaFile`.                                                                           |
 | `serializer`              | GraphQLSerializer    |          | JSON serializer that will be used to generate the data classes.<br/>**Default value is:** `GraphQLSerializer.JACKSON`.                                                                                                                                         |
 | `useOptionalInputWrapper` | Boolean              |          | Boolean opt-in flag to wrap nullable arguments in `OptionalInput` that distinguish between `null` and undefined/omitted value.<br/>**Default value is:** `false`.<br/>**User property is**: `graphql.useOptionalInputWrapper`                                  |
+| `useSharedResponseTypes`  | Boolean              |          | Boolean flag indicating whether to generate shared response types across operations instead of operation-specific duplicates. Shared types are placed in a `responses` sub-package.<br/>**Default value is:** `false`.<br/>**User property is**: `graphql.useSharedResponseTypes` |
 
 **Parameter Details**
 
@@ -183,6 +184,7 @@ Generate GraphQL test client code based on the provided GraphQL schema and targe
 | `serializer` | GraphQLSerializer | | JSON serializer that will be used to generate the data classes.<br/>**Default value is:** `GraphQLSerializer.JACKSON`. |
 | `schemaFile` | String | | GraphQL schema file that will be used to generate client code.<br/>**Default value is**: `${project.build.directory}/schema.graphql`<br/>**User property is**: `graphql.schemaFile`. |
 | `useOptionalInputWrapper` | Boolean | | Boolean opt-in flag to wrap nullable arguments in `OptionalInput` that distinguish between `null` and undefined/omitted value.<br/>**Default value is:** `false`.<br/>**User property is**: `graphql.useOptionalInputWrapper` |
+| `useSharedResponseTypes`  | Boolean | | Boolean flag indicating whether to generate shared response types across operations instead of operation-specific duplicates. Shared types are placed in a `responses` sub-package.<br/>**Default value is:** `false`.<br/>**User property is**: `graphql.useSharedResponseTypes` |
 
 **Parameter Details**
 

--- a/website/versioned_docs/version-9.x.x/plugins/maven-plugin-usage-client.md
+++ b/website/versioned_docs/version-9.x.x/plugins/maven-plugin-usage-client.md
@@ -403,6 +403,7 @@ the GraphQL client data models using `kotlinx.serialization` that are based on t
                                 <queryFile>${project.basedir}/src/main/resources/queries/MyQuery.graphql</queryFile>
                             </queryFiles>
                             <serializer>KOTLINX</serializer>
+                            <useSharedResponseTypes>false</useSharedResponseTypes>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
Applies the documentation changes from master PR #2204 to the versioned docs directories for version-9.x.x and version-10.x.x.

### :pencil: Description


### :link: Related Issues
