### PR TITLE
Fix dropped properties from multiple fragment selections

### DIFF
--- a/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/types/generateInterfaceTypeSpec.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/main/kotlin/com/expediagroup/graphql/plugin/client/generator/types/generateInterfaceTypeSpec.kt
@@ -40,6 +40,7 @@ import graphql.language.FragmentSpread
 import graphql.language.InlineFragment
 import graphql.language.Selection
 import graphql.language.SelectionSet
+import graphql.language.TypeName
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import org.slf4j.Logger
@@ -80,11 +81,12 @@ internal fun generateInterfaceTypeSpec(
         interfaceTypeSpec.addKdoc("%L", kdoc)
     }
 
+    // multiple fragments may share a type condition, so they are grouped rather than keyed - keying would discard all but the last and drop the other fragments' fields entirely
     val namedFragments = selectionSet.getSelectionsOfType(FragmentSpread::class.java).map { fragment ->
         // polymorphic selection set can contain selection set against interface or concrete types
         context.queryDocument.getDefinitionsOfType(FragmentDefinition::class.java)
             .find { it.name == fragment.name } ?: throw InvalidFragmentException(context.operationName, fragment.name, interfaceName)
-    }.associateBy { checkNotNull(checkNotNull(it.typeCondition).name) }
+    }.groupBy { checkNotNull(checkNotNull(it.typeCondition).name) }
 
     // find super selection set that contains
     // - directly selected fields
@@ -92,7 +94,7 @@ internal fun generateInterfaceTypeSpec(
     val selections: MutableList<Selection<*>> = selectionSet.getSelectionsOfType(Field::class.java).toMutableList()
 
     // interface fields
-    namedFragments[interfaceName]?.let {
+    namedFragments[interfaceName]?.forEach {
         selections.addAll(it.selectionSet.selections)
     }
     val superSelectionSet = SelectionSet.newSelectionSet(selections).build()
@@ -115,18 +117,17 @@ internal fun generateInterfaceTypeSpec(
     // - super selections
     // - named fragment selections
     // - inline fragment selections
-    val implementationSelections = namedFragments.filterKeys { it != interfaceName }
-        .mapValues { (_, namedFragment) ->
+    val implementationSelections: MutableMap<String, MutableList<Selection<*>>> = namedFragments.filterKeys { it != interfaceName }
+        .mapValues { (_, fragmentsOnImplementation) ->
             val fragmentSelections = superSelectionSet.selections.toMutableList()
-            fragmentSelections.addAll(namedFragment.selectionSet.selections)
-            namedFragment.typeCondition to fragmentSelections
+            fragmentsOnImplementation.flatMapTo(fragmentSelections) { it.selectionSet.selections }
         }.toMutableMap()
+
     selectionSet.getSelectionsOfType(InlineFragment::class.java).forEach { fragment ->
-        val typeCondition = checkNotNull(fragment.typeCondition)
-        val existing = implementationSelections.computeIfAbsent(checkNotNull(typeCondition.name)) {
-            typeCondition to superSelectionSet.selections.toMutableList()
-        }
-        existing.second.addAll(fragment.selectionSet.selections)
+        val typeConditionName = checkNotNull(checkNotNull(fragment.typeCondition).name)
+        implementationSelections
+            .computeIfAbsent(typeConditionName) { superSelectionSet.selections.toMutableList() }
+            .addAll(fragment.selectionSet.selections)
     }
 
     // log warning if not all implementations are selected
@@ -137,12 +138,12 @@ internal fun generateInterfaceTypeSpec(
 
     // generate implementations with final selection set
     val jsonSubTypesCodeBlock = CodeBlock.builder()
-    implementationSelections.forEach { implementationName, (typeCondition, selections) ->
+    implementationSelections.forEach { implementationName, selections ->
         val distinctSelections = selections.filterIsInstance(Field::class.java).distinctBy { if (it.alias != null) it.alias else it.name }
         if (!verifyTypeNameIsSelected(distinctSelections)) {
             throw MissingTypeNameException(context.operationName, implementationName, interfaceName)
         }
-        var implementationClassName = generateTypeName(context, typeCondition, SelectionSet.newSelectionSet(distinctSelections).build())
+        var implementationClassName = generateTypeName(context, TypeName(implementationName), SelectionSet.newSelectionSet(distinctSelections).build())
         if (implementationClassName.isNullable) {
             implementationClassName = implementationClassName.copy(nullable = false)
         }

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/interface_fragments_sharing_type_condition/InterfaceWithFragmentsSharingTypeConditionQuery.graphql
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/interface_fragments_sharing_type_condition/InterfaceWithFragmentsSharingTypeConditionQuery.graphql
@@ -1,0 +1,30 @@
+query InterfaceWithFragmentsSharingTypeConditionQuery {
+  interfaceQuery {
+    __typename
+    ...interfaceIdFields
+    ...interfaceNameFields
+    ...firstImplementationIdFields
+    ...firstImplementationValueFields
+    ...secondImplementationFields
+  }
+}
+
+fragment interfaceIdFields on BasicInterface {
+  id
+}
+
+fragment interfaceNameFields on BasicInterface {
+  name
+}
+
+fragment firstImplementationIdFields on FirstInterfaceImplementation {
+  id
+}
+
+fragment firstImplementationValueFields on FirstInterfaceImplementation {
+  intValue
+}
+
+fragment secondImplementationFields on SecondInterfaceImplementation {
+  floatValue
+}

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/interface_fragments_sharing_type_condition/InterfaceWithFragmentsSharingTypeConditionQuery.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/interface_fragments_sharing_type_condition/InterfaceWithFragmentsSharingTypeConditionQuery.kt
@@ -1,0 +1,31 @@
+package com.expediagroup.graphql.generated
+
+import com.expediagroup.graphql.client.Generated
+import com.expediagroup.graphql.client.types.GraphQLClientRequest
+import com.expediagroup.graphql.generated.interfacewithfragmentssharingtypeconditionquery.BasicInterface
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import kotlin.String
+import kotlin.reflect.KClass
+
+public const val INTERFACE_WITH_FRAGMENTS_SHARING_TYPE_CONDITION_QUERY: String =
+    "query InterfaceWithFragmentsSharingTypeConditionQuery {\n  interfaceQuery {\n    __typename\n    ...interfaceIdFields\n    ...interfaceNameFields\n    ...firstImplementationIdFields\n    ...firstImplementationValueFields\n    ...secondImplementationFields\n  }\n}\n\nfragment interfaceIdFields on BasicInterface {\n  id\n}\n\nfragment interfaceNameFields on BasicInterface {\n  name\n}\n\nfragment firstImplementationIdFields on FirstInterfaceImplementation {\n  id\n}\n\nfragment firstImplementationValueFields on FirstInterfaceImplementation {\n  intValue\n}\n\nfragment secondImplementationFields on SecondInterfaceImplementation {\n  floatValue\n}"
+
+@Generated
+public class InterfaceWithFragmentsSharingTypeConditionQuery :
+    GraphQLClientRequest<InterfaceWithFragmentsSharingTypeConditionQuery.Result> {
+  override val query: String = INTERFACE_WITH_FRAGMENTS_SHARING_TYPE_CONDITION_QUERY
+
+  override val operationName: String = "InterfaceWithFragmentsSharingTypeConditionQuery"
+
+  override fun responseType(): KClass<InterfaceWithFragmentsSharingTypeConditionQuery.Result> =
+      InterfaceWithFragmentsSharingTypeConditionQuery.Result::class
+
+  @Generated
+  public data class Result(
+    /**
+     * Query returning an interface
+     */
+    @get:JsonProperty(value = "interfaceQuery")
+    public val interfaceQuery: BasicInterface,
+  )
+}

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/interface_fragments_sharing_type_condition/interfacewithfragmentssharingtypeconditionquery/BasicInterface.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/interface_fragments_sharing_type_condition/interfacewithfragmentssharingtypeconditionquery/BasicInterface.kt
@@ -1,0 +1,101 @@
+package com.expediagroup.graphql.generated.interfacewithfragmentssharingtypeconditionquery
+
+import com.expediagroup.graphql.client.Generated
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import com.fasterxml.jackson.`annotation`.JsonSubTypes
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo.As.PROPERTY
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo.Id.NAME
+import kotlin.Double
+import kotlin.Int
+import kotlin.String
+
+/**
+ * Very basic interface
+ */
+@Generated
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "__typename",
+  defaultImpl = DefaultBasicInterfaceImplementation::class,
+)
+@JsonSubTypes(value = [com.fasterxml.jackson.annotation.JsonSubTypes.Type(value =
+    FirstInterfaceImplementation::class,
+    name="FirstInterfaceImplementation"),com.fasterxml.jackson.annotation.JsonSubTypes.Type(value =
+    SecondInterfaceImplementation::class, name="SecondInterfaceImplementation")])
+public interface BasicInterface {
+  /**
+   * Unique identifier of an interface
+   */
+  @get:JsonProperty(value = "id")
+  public val id: Int
+
+  /**
+   * Name field
+   */
+  @get:JsonProperty(value = "name")
+  public val name: String
+}
+
+/**
+ * Example interface implementation where value is an integer
+ */
+@Generated
+public data class FirstInterfaceImplementation(
+  /**
+   * Unique identifier of the first implementation
+   */
+  @get:JsonProperty(value = "id")
+  override val id: Int,
+  /**
+   * Name of the first implementation
+   */
+  @get:JsonProperty(value = "name")
+  override val name: String,
+  /**
+   * Custom field integer value
+   */
+  @get:JsonProperty(value = "intValue")
+  public val intValue: Int,
+) : BasicInterface
+
+/**
+ * Example interface implementation where value is a float
+ */
+@Generated
+public data class SecondInterfaceImplementation(
+  /**
+   * Unique identifier of the second implementation
+   */
+  @get:JsonProperty(value = "id")
+  override val id: Int,
+  /**
+   * Name of the second implementation
+   */
+  @get:JsonProperty(value = "name")
+  override val name: String,
+  /**
+   * Custom field float value
+   */
+  @get:JsonProperty(value = "floatValue")
+  public val floatValue: Double,
+) : BasicInterface
+
+/**
+ * Fallback BasicInterface implementation that will be used when unknown/unhandled type is
+ * encountered.
+ */
+@Generated
+public data class DefaultBasicInterfaceImplementation(
+  /**
+   * Unique identifier of an interface
+   */
+  @get:JsonProperty(value = "id")
+  override val id: Int,
+  /**
+   * Name field
+   */
+  @get:JsonProperty(value = "name")
+  override val name: String,
+) : BasicInterface

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/union_fragments_sharing_type_condition/UnionWithFragmentsSharingTypeConditionQuery.graphql
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/union_fragments_sharing_type_condition/UnionWithFragmentsSharingTypeConditionQuery.graphql
@@ -1,0 +1,25 @@
+query UnionWithFragmentsSharingTypeConditionQuery {
+  unionQuery {
+    __typename
+    ...basicObjectIdFields
+    ...basicObjectNameFields
+    ...complexObjectIdFields
+    ...complexObjectOptionalFields
+  }
+}
+
+fragment basicObjectIdFields on BasicObject {
+  id
+}
+
+fragment basicObjectNameFields on BasicObject {
+  name
+}
+
+fragment complexObjectIdFields on ComplexObject {
+  id
+}
+
+fragment complexObjectOptionalFields on ComplexObject {
+  optional
+}

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/union_fragments_sharing_type_condition/UnionWithFragmentsSharingTypeConditionQuery.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/union_fragments_sharing_type_condition/UnionWithFragmentsSharingTypeConditionQuery.kt
@@ -1,0 +1,31 @@
+package com.expediagroup.graphql.generated
+
+import com.expediagroup.graphql.client.Generated
+import com.expediagroup.graphql.client.types.GraphQLClientRequest
+import com.expediagroup.graphql.generated.unionwithfragmentssharingtypeconditionquery.BasicUnion
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import kotlin.String
+import kotlin.reflect.KClass
+
+public const val UNION_WITH_FRAGMENTS_SHARING_TYPE_CONDITION_QUERY: String =
+    "query UnionWithFragmentsSharingTypeConditionQuery {\n  unionQuery {\n    __typename\n    ...basicObjectIdFields\n    ...basicObjectNameFields\n    ...complexObjectIdFields\n    ...complexObjectOptionalFields\n  }\n}\n\nfragment basicObjectIdFields on BasicObject {\n  id\n}\n\nfragment basicObjectNameFields on BasicObject {\n  name\n}\n\nfragment complexObjectIdFields on ComplexObject {\n  id\n}\n\nfragment complexObjectOptionalFields on ComplexObject {\n  optional\n}"
+
+@Generated
+public class UnionWithFragmentsSharingTypeConditionQuery :
+    GraphQLClientRequest<UnionWithFragmentsSharingTypeConditionQuery.Result> {
+  override val query: String = UNION_WITH_FRAGMENTS_SHARING_TYPE_CONDITION_QUERY
+
+  override val operationName: String = "UnionWithFragmentsSharingTypeConditionQuery"
+
+  override fun responseType(): KClass<UnionWithFragmentsSharingTypeConditionQuery.Result> =
+      UnionWithFragmentsSharingTypeConditionQuery.Result::class
+
+  @Generated
+  public data class Result(
+    /**
+     * Query returning union
+     */
+    @get:JsonProperty(value = "unionQuery")
+    public val unionQuery: BasicUnion,
+  )
+}

--- a/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/union_fragments_sharing_type_condition/unionwithfragmentssharingtypeconditionquery/BasicUnion.kt
+++ b/plugins/client/graphql-kotlin-client-generator/src/test/data/generator/union_fragments_sharing_type_condition/unionwithfragmentssharingtypeconditionquery/BasicUnion.kt
@@ -1,0 +1,65 @@
+package com.expediagroup.graphql.generated.unionwithfragmentssharingtypeconditionquery
+
+import com.expediagroup.graphql.client.Generated
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import com.fasterxml.jackson.`annotation`.JsonSubTypes
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo.As.PROPERTY
+import com.fasterxml.jackson.`annotation`.JsonTypeInfo.Id.NAME
+import kotlin.Int
+import kotlin.String
+
+/**
+ * Very basic union of BasicObject and ComplexObject
+ */
+@Generated
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "__typename",
+  defaultImpl = DefaultBasicUnionImplementation::class,
+)
+@JsonSubTypes(value = [com.fasterxml.jackson.annotation.JsonSubTypes.Type(value =
+    BasicObject::class, name="BasicObject"),com.fasterxml.jackson.annotation.JsonSubTypes.Type(value
+    = ComplexObject::class, name="ComplexObject")])
+public interface BasicUnion
+
+/**
+ * Some basic description
+ */
+@Generated
+public data class BasicObject(
+  @get:JsonProperty(value = "id")
+  public val id: Int,
+  /**
+   * Object name
+   */
+  @get:JsonProperty(value = "name")
+  public val name: String,
+) : BasicUnion
+
+/**
+ * Multi line description of a complex type.
+ * This is a second line of the paragraph.
+ * This is final line of the description.
+ */
+@Generated
+public data class ComplexObject(
+  /**
+   * Some unique identifier
+   */
+  @get:JsonProperty(value = "id")
+  public val id: Int,
+  /**
+   * Optional value
+   * Second line of the description
+   */
+  @get:JsonProperty(value = "optional")
+  public val optional: String?,
+) : BasicUnion
+
+/**
+ * Fallback BasicUnion implementation that will be used when unknown/unhandled type is encountered.
+ */
+@Generated
+public class DefaultBasicUnionImplementation() : BasicUnion


### PR DESCRIPTION
### :pencil: Description

As the issue describes, previously the generator would only work on one fragment per type, silently ignoring properties contributed by other fragments. The first commit adds (failing) regression tests, the second one fixes them.

### :link: Related Issues

Fixes #2209